### PR TITLE
feat: multi-GPU support, lazy model downloads, and Helm chart

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,0 +1,91 @@
+name: Release Helm Chart
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Bootstrap gh-pages branch if missing
+        run: |
+          if ! git ls-remote --exit-code origin gh-pages; then
+            git checkout --orphan gh-pages
+            git rm -rf .
+            {
+              echo "theme: jekyll-theme-tactile"
+              echo "title: ashim"
+              echo "description: Helm chart repository for ashim — self-hosted ML image processing"
+            } > _config.yml
+            {
+              echo "## ashim Helm Chart"
+              echo ""
+              echo "Self-hosted image processing with background removal, inpainting, upscaling,"
+              echo "face enhancement, colorization, and OCR."
+              echo ""
+              echo "### Install"
+              echo ""
+              echo '```bash'
+              echo "helm repo add ashim https://ashim-hq.github.io/ashim"
+              echo "helm repo update"
+              echo "helm install ashim ashim/ashim --namespace ashim --create-namespace"
+              echo '```'
+              echo ""
+              echo "### GPU variants"
+              echo ""
+              echo '```bash'
+              echo "# NVIDIA"
+              echo "helm install ashim ashim/ashim --set image.tag=latest-cuda"
+              echo "# AMD"
+              echo "helm install ashim ashim/ashim --set image.tag=latest-rocm"
+              echo '```'
+              echo ""
+              echo "### Source"
+              echo ""
+              echo "[github.com/ashim-hq/ashim](https://github.com/ashim-hq/ashim)"
+            } > index.md
+            git add _config.yml index.md
+            git commit -m "chore: init gh-pages for Helm chart repo"
+            git push origin gh-pages
+            git checkout main
+          fi
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Ensure Tactile theme and landing page on gh-pages
+        run: |
+          git fetch origin gh-pages
+          git checkout gh-pages
+          {
+            echo "theme: jekyll-theme-tactile"
+            echo "title: ashim"
+            echo "description: Helm chart repository for ashim — self-hosted ML image processing"
+          } > _config.yml
+          git add _config.yml
+          git diff --cached --quiet || git commit -m "chore: refresh gh-pages theme config"
+          git push origin gh-pages || true
+          git checkout main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,5 +113,5 @@ jobs:
           push: false
           tags: ashim:ci
           build-args: SKIP_MODEL_DOWNLOADS=true
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:cache-linux-amd64
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:cache-linux-amd64-cpu
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:cache-ci,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ on:
       - "apps/docs/**"
       - "docs/**"
 
+permissions:
+  contents: read
+  packages: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -106,7 +110,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,6 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR (for registry cache)
-        id: ghcr-login
-        continue-on-error: true
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -119,5 +117,5 @@ jobs:
           push: false
           tags: ashim:ci
           build-args: SKIP_MODEL_DOWNLOADS=true
-          cache-from: ${{ steps.ghcr-login.outcome == 'success' && format('type=registry,ref=ghcr.io/{0}:cache-linux-amd64-cpu', github.repository) || '' }}
-          cache-to: ${{ steps.ghcr-login.outcome == 'success' && format('type=registry,ref=ghcr.io/{0}:cache-ci,mode=max', github.repository) || '' }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:cache-linux-amd64-cpu
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:cache-ci,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR (for registry cache)
+        id: ghcr-login
+        continue-on-error: true
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -113,5 +115,5 @@ jobs:
           push: false
           tags: ashim:ci
           build-args: SKIP_MODEL_DOWNLOADS=true
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:cache-linux-amd64-cpu
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:cache-ci,mode=max
+          cache-from: ${{ steps.ghcr-login.outcome == 'success' && format('type=registry,ref=ghcr.io/{0}:cache-linux-amd64-cpu', github.repository) || '' }}
+          cache-to: ${{ steps.ghcr-login.outcome == 'success' && format('type=registry,ref=ghcr.io/{0}:cache-ci,mode=max', github.repository) || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
@@ -197,7 +197,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # ---- latest (cpu, multi-arch) ----
       - name: Extract metadata (latest)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,16 +59,24 @@ jobs:
           fi
 
   docker:
-    name: Build (${{ matrix.platform }})
+    name: Build (${{ matrix.platform }}, ${{ matrix.gpu }})
     needs: release
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
+            gpu: cpu
             runner: ubuntu-latest
           - platform: linux/arm64
+            gpu: cpu
             runner: ubuntu-24.04-arm
+          - platform: linux/amd64
+            gpu: cuda
+            runner: ubuntu-latest
+          - platform: linux/amd64
+            gpu: rocm
+            runner: ubuntu-latest
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Free disk space
@@ -81,7 +89,7 @@ jobs:
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "PLATFORM_PAIR=${platform//\//-}-${{ matrix.gpu }}" >> $GITHUB_ENV
 
       - name: Checkout release tag
         uses: actions/checkout@v4
@@ -120,6 +128,7 @@ jobs:
           file: docker/Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: GPU_BACKEND=${{ matrix.gpu }}
           outputs: type=image,"name=ashimhq/ashim,ghcr.io/${{ github.repository }}",push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:cache-${{ env.PLATFORM_PAIR }}
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:cache-${{ env.PLATFORM_PAIR }},mode=max
@@ -141,14 +150,41 @@ jobs:
   manifest:
     name: Create Multi-Arch Manifests
     needs: [release, docker]
+    # Run even if some GPU builds fail so that `latest` (cpu) is always published
+    # as long as both cpu builds succeeded.
+    if: always() && needs.release.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Download digests
+      - name: Download cpu digests (amd64 + arm64 → latest)
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
-          path: /tmp/digests
-          pattern: digests-*
+          path: /tmp/digests/cpu
+          pattern: digests-*-cpu
           merge-multiple: true
+
+      - name: Download cuda digests (amd64 → latest-cuda)
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          path: /tmp/digests/cuda
+          pattern: digests-linux-amd64-cuda
+          merge-multiple: true
+
+      - name: Download rocm digests (amd64 → latest-rocm)
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          path: /tmp/digests/rocm
+          pattern: digests-linux-amd64-rocm
+          merge-multiple: true
+
+      - name: Check available digests
+        id: check
+        run: |
+          [ -n "$(ls -A /tmp/digests/cpu 2>/dev/null)" ] && echo "has_cpu=true" >> "$GITHUB_OUTPUT" || echo "has_cpu=false" >> "$GITHUB_OUTPUT"
+          [ -n "$(ls -A /tmp/digests/cuda 2>/dev/null)" ] && echo "has_cuda=true" >> "$GITHUB_OUTPUT" || echo "has_cuda=false" >> "$GITHUB_OUTPUT"
+          [ -n "$(ls -A /tmp/digests/rocm 2>/dev/null)" ] && echo "has_rocm=true" >> "$GITHUB_OUTPUT" || echo "has_rocm=false" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -163,8 +199,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
+      # ---- latest (cpu, multi-arch) ----
+      - name: Extract metadata (latest)
+        id: meta-cpu
+        if: steps.check.outputs.has_cpu == 'true'
         uses: docker/metadata-action@v5
         with:
           images: |
@@ -176,16 +214,88 @@ jobs:
             type=semver,pattern={{major}},value=v${{ needs.release.outputs.new_version }}
             type=raw,value=latest
 
-      - name: Create Docker Hub manifest
-        working-directory: /tmp/digests
+      - name: Create Docker Hub manifest (latest)
+        if: steps.check.outputs.has_cpu == 'true'
+        working-directory: /tmp/digests/cpu
+        env:
+          META_JSON: ${{ steps.meta-cpu.outputs.json }}
         run: |
           docker buildx imagetools create \
-            $(jq -cr '.tags | map(select(startswith("ashimhq/")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(jq -cr '.tags | map(select(startswith("ashimhq/")) | "-t " + .) | join(" ")' <<< "$META_JSON") \
             $(printf 'ashimhq/ashim@sha256:%s ' *)
 
-      - name: Create GHCR manifest
-        working-directory: /tmp/digests
+      - name: Create GHCR manifest (latest)
+        if: steps.check.outputs.has_cpu == 'true'
+        working-directory: /tmp/digests/cpu
+        env:
+          META_JSON: ${{ steps.meta-cpu.outputs.json }}
         run: |
           docker buildx imagetools create \
-            $(jq -cr '.tags | map(select(startswith("ghcr.io/")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io/")) | "-t " + .) | join(" ")' <<< "$META_JSON") \
+            $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
+
+      # ---- latest-cuda (NVIDIA, amd64 only) ----
+      - name: Extract metadata (cuda)
+        id: meta-cuda
+        if: steps.check.outputs.has_cuda == 'true'
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ashimhq/ashim
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}-cuda,value=v${{ needs.release.outputs.new_version }}
+            type=raw,value=latest-cuda
+
+      - name: Create Docker Hub manifest (cuda)
+        if: steps.check.outputs.has_cuda == 'true'
+        working-directory: /tmp/digests/cuda
+        env:
+          META_JSON: ${{ steps.meta-cuda.outputs.json }}
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ashimhq/")) | "-t " + .) | join(" ")' <<< "$META_JSON") \
+            $(printf 'ashimhq/ashim@sha256:%s ' *)
+
+      - name: Create GHCR manifest (cuda)
+        if: steps.check.outputs.has_cuda == 'true'
+        working-directory: /tmp/digests/cuda
+        env:
+          META_JSON: ${{ steps.meta-cuda.outputs.json }}
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io/")) | "-t " + .) | join(" ")' <<< "$META_JSON") \
+            $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
+
+      # ---- latest-rocm (AMD, amd64 only) ----
+      - name: Extract metadata (rocm)
+        id: meta-rocm
+        if: steps.check.outputs.has_rocm == 'true'
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ashimhq/ashim
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}-rocm,value=v${{ needs.release.outputs.new_version }}
+            type=raw,value=latest-rocm
+
+      - name: Create Docker Hub manifest (rocm)
+        if: steps.check.outputs.has_rocm == 'true'
+        working-directory: /tmp/digests/rocm
+        env:
+          META_JSON: ${{ steps.meta-rocm.outputs.json }}
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ashimhq/")) | "-t " + .) | join(" ")' <<< "$META_JSON") \
+            $(printf 'ashimhq/ashim@sha256:%s ' *)
+
+      - name: Create GHCR manifest (rocm)
+        if: steps.check.outputs.has_rocm == 'true'
+        working-directory: /tmp/digests/rocm
+        env:
+          META_JSON: ${{ steps.meta-rocm.outputs.json }}
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io/")) | "-t " + .) | join(" ")' <<< "$META_JSON") \
             $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,8 @@ jobs:
           - platform: linux/amd64
             gpu: cuda
             runner: ubuntu-latest
+            nvidia_visible_devices: all
+            nvidia_driver_capabilities: compute,utility
           - platform: linux/amd64
             gpu: rocm
             runner: ubuntu-latest
@@ -128,7 +130,10 @@ jobs:
           file: docker/Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: GPU_BACKEND=${{ matrix.gpu }}
+          build-args: |
+            GPU_BACKEND=${{ matrix.gpu }}
+            NVIDIA_VISIBLE_DEVICES_VAL=${{ matrix.nvidia_visible_devices || '' }}
+            NVIDIA_DRIVER_CAPABILITIES_VAL=${{ matrix.nvidia_driver_capabilities || '' }}
           outputs: type=image,"name=ashimhq/ashim,ghcr.io/${{ github.repository }}",push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:cache-${{ env.PLATFORM_PAIR }}
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:cache-${{ env.PLATFORM_PAIR }},mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [1.16.0](https://github.com/wheetazlab/ashim/compare/v1.15.9...v1.16.0) (2026-04-18)
+
+
+### Bug Fixes
+
+* **ci:** make GHCR login optional so forks without GHCR_TOKEN secret can still build ([f2cd39f](https://github.com/wheetazlab/ashim/commit/f2cd39f8c4c0973d776529930fda7715aafbc3c3))
+* **ci:** remove conditional cache logic, simplify GHCR login ([2afea3b](https://github.com/wheetazlab/ashim/commit/2afea3bd219df9fb7f7a63d0e8a732e7cf4aadcd))
+* **ci:** replace GHCR_TOKEN with built-in GITHUB_TOKEN for GHCR auth ([53e69b8](https://github.com/wheetazlab/ashim/commit/53e69b8861b6ff78e723630b09027b757c9138a1))
+
+
+### Features
+
+* multi-GPU support, lazy model downloads, and Helm chart ([246c3d3](https://github.com/wheetazlab/ashim/commit/246c3d3c73fa29753e61181e1f30a0b631d67c5d)), closes [#pages](https://github.com/wheetazlab/ashim/issues/pages) [#pages](https://github.com/wheetazlab/ashim/issues/pages)
+
 ## [1.15.8](https://github.com/ashim-hq/ashim/compare/v1.15.7...v1.15.8) (2026-04-17)
 
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,28 @@ Open http://localhost:1349 in your browser.
 <summary><sub>Have an NVIDIA GPU? Click here for GPU acceleration.</sub></summary>
 <br>
 
-Add `--gpus all` for GPU-accelerated background removal, upscaling, and OCR:
+Use the `latest-cuda` tag for GPU-accelerated background removal, upscaling, and OCR:
 
 ```bash
-docker run -d --name ashim -p 1349:1349 --gpus all -v ashim-data:/data ghcr.io/ashim-hq/ashim:latest
+docker run -d --name ashim -p 1349:1349 --gpus all \
+  -v ashim-data:/data ghcr.io/ashim-hq/ashim:latest-cuda
 ```
 
-> Requires an NVIDIA GPU and [Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). Falls back to CPU if no GPU is found. See [Docker Tags](https://ashim-hq.github.io/ashim/guide/docker-tags) for benchmarks and Docker Compose examples.
+> Requires an NVIDIA GPU and [Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). If the NVIDIA Container Runtime is your default Docker runtime, `--gpus all` is optional. See [Docker Tags](https://ashim-hq.github.io/ashim/guide/docker-tags) for benchmarks and Docker Compose examples.
+
+</details>
+
+<details>
+<summary><sub>Have an AMD GPU? Click here for GPU acceleration.</sub></summary>
+<br>
+
+Use the `latest-rocm` tag with device passthrough:
+
+```bash
+docker run -d --name ashim -p 1349:1349 \
+  --device=/dev/kfd --device=/dev/dri \
+  -v ashim-data:/data ghcr.io/ashim-hq/ashim:latest-rocm
+```
 
 </details>
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ashim/api",
-  "version": "1.15.9",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/docs/guide/docker-tags.md
+++ b/apps/docs/guide/docker-tags.md
@@ -1,6 +1,12 @@
 # Docker Image
 
-ashim ships as a single Docker image that works on all platforms.
+ashim ships three image tags, each optimised for a different hardware target.
+
+| Tag | Platform | GPU |
+|---|---|---|
+| `latest` | amd64 + arm64 | CPU only |
+| `latest-cuda` | amd64 | NVIDIA (CUDA wheels baked in) |
+| `latest-rocm` | amd64 | AMD (ROCm wheels baked in) |
 
 ## Quick start
 
@@ -12,13 +18,31 @@ The app is available at `http://localhost:1349`.
 
 ## GPU acceleration
 
-The image includes CUDA support on amd64. If you have an NVIDIA GPU with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed, add `--gpus all`:
+### NVIDIA
+
+Pull `latest-cuda`. It has CUDA wheels baked in and sets `NVIDIA_VISIBLE_DEVICES=all` + `NVIDIA_DRIVER_CAPABILITIES=compute,utility` in the image env layer.
+
+If the [NVIDIA Container Runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) is configured as your **default** Docker runtime, GPUs are injected automatically — no flag needed:
 
 ```bash
-docker run -d --name ashim --gpus all -p 1349:1349 -v ashim-data:/data ashimhq/ashim:latest
+docker run -d --name ashim -p 1349:1349 -v ashim-data:/data ashimhq/ashim:latest-cuda
 ```
 
-The image auto-detects your GPU at runtime. Without `--gpus all`, it runs on CPU. Same image either way.
+Otherwise pass `--gpus all` explicitly:
+
+```bash
+docker run -d --name ashim --gpus all -p 1349:1349 -v ashim-data:/data ashimhq/ashim:latest-cuda
+```
+
+### AMD
+
+Pull `latest-rocm`. ROCm requires device passthrough — this is always needed regardless of runtime configuration:
+
+```bash
+docker run -d --name ashim \
+  --device=/dev/kfd --device=/dev/dri \
+  -p 1349:1349 -v ashim-data:/data ashimhq/ashim:latest-rocm
+```
 
 ### Benchmarks
 
@@ -75,49 +99,90 @@ volumes:
   ashim-workspace:
 ```
 
-For GPU acceleration via Docker Compose, add the deploy section:
+For NVIDIA GPU acceleration via Docker Compose, use `latest-cuda` and add the deploy section (if the NVIDIA Container Runtime is not configured as your default runtime):
 
 ```yaml
 services:
   ashim:
-    image: ashimhq/ashim:latest
+    image: ashimhq/ashim:latest-cuda
     ports:
       - "1349:1349"
     volumes:
       - ashim-data:/data
       - ashim-workspace:/tmp/workspace
+      - ashim-models:/opt/models
     deploy:
       resources:
         reservations:
           devices:
             - driver: nvidia
-              count: 1
+              count: all
               capabilities: [gpu]
     restart: unless-stopped
 
 volumes:
   ashim-data:
   ashim-workspace:
+  ashim-models:
+```
+
+For AMD GPU acceleration, use `latest-rocm` with device passthrough:
+
+```yaml
+services:
+  ashim:
+    image: ashimhq/ashim:latest-rocm
+    ports:
+      - "1349:1349"
+    volumes:
+      - ashim-data:/data
+      - ashim-workspace:/tmp/workspace
+      - ashim-models:/opt/models
+    devices:
+      - /dev/kfd:/dev/kfd
+      - /dev/dri:/dev/dri
+    restart: unless-stopped
+
+volumes:
+  ashim-data:
+  ashim-workspace:
+  ashim-models:
 ```
 
 ## Version pinning
 
 | Tag | Description |
 |-----|------------|
-| `latest` | Latest release |
-| `1.11.0` | Exact version |
-| `1.11` | Latest patch in 1.11.x |
-| `1` | Latest minor in 1.x |
+| `latest` | Latest release (CPU, multi-arch) |
+| `latest-cuda` | Latest release (NVIDIA CUDA, amd64) |
+| `latest-rocm` | Latest release (AMD ROCm, amd64) |
+| `1.16.0` | Exact version (CPU) |
+| `1.16.0-cuda` | Exact version (NVIDIA) |
+| `1.16.0-rocm` | Exact version (AMD) |
 
 ## Platforms
 
-| Architecture | GPU support | Notes |
+| Tag | Architecture | GPU |
 |---|---|---|
-| linux/amd64 | NVIDIA CUDA | Full GPU acceleration for AI tools |
-| linux/arm64 | CPU only | Raspberry Pi 4/5, Apple Silicon via Docker Desktop |
+| `latest` | amd64 + arm64 | CPU only |
+| `latest-cuda` | amd64 | NVIDIA CUDA |
+| `latest-rocm` | amd64 | AMD ROCm |
 
-## Migration from previous tags
+ARM64 (Raspberry Pi 4/5, Apple Silicon) always uses `latest` — CUDA and ROCm wheels have no aarch64 builds.
 
-If you were using the `:cuda` tag, switch to `:latest` and keep `--gpus all`. Same GPU support, unified image.
+## Model downloads
 
-Your data and settings are preserved in the volumes.
+AI models are **not** baked into the image. On first container start, models are downloaded into the `/opt/models` volume (about 400 MB). Subsequent starts are instant.
+
+Mount a named volume to persist models across container updates:
+
+```bash
+docker run -d --name ashim -p 1349:1349 \
+  -v ashim-data:/data \
+  -v ashim-models:/opt/models \
+  ashimhq/ashim:latest
+```
+
+## Migration from v1.15 and earlier
+
+Previous releases used `nvidia/cuda` as the base image and included `--gpus all` with the `latest` tag. As of v1.16, `latest` is CPU-only. Switch to `latest-cuda` for NVIDIA GPU acceleration. Your data and settings in volumes are unaffected.

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -26,13 +26,24 @@ Both registries publish the same image on every release.
 You will be asked to change your password on first login.
 
 ::: tip NVIDIA GPU acceleration
-Add `--gpus all` for GPU-accelerated background removal, upscaling, OCR, face enhancement, and restoration:
+Use the `latest-cuda` tag for GPU-accelerated background removal, upscaling, OCR, face enhancement, and restoration:
 
 ```bash
-docker run -d --name ashim -p 1349:1349 --gpus all -v ashim-data:/data ashimhq/ashim:latest
+docker run -d --name ashim -p 1349:1349 --gpus all \
+  -v ashim-data:/data ashimhq/ashim:latest-cuda
 ```
 
-Requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). Falls back to CPU automatically. See [Docker Tags](/guide/docker-tags) for benchmarks.
+Requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). If the NVIDIA Container Runtime is your default Docker runtime, `--gpus all` is optional. See [Docker Tags](/guide/docker-tags) for benchmarks.
+:::
+
+::: tip AMD GPU acceleration
+Use the `latest-rocm` tag with device passthrough:
+
+```bash
+docker run -d --name ashim -p 1349:1349 \
+  --device=/dev/kfd --device=/dev/dri \
+  -v ashim-data:/data ashimhq/ashim:latest-rocm
+```
 :::
 
 ## Docker Compose

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ashim/docs",
-  "version": "1.15.9",
+  "version": "1.16.0",
   "private": true,
   "scripts": {
     "docs:dev": "vitepress dev .",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ashim/web",
-  "version": "1.15.9",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/charts/ashim/Chart.yaml
+++ b/charts/ashim/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: ashim
+description: >
+  Self-hosted image processing application with ML-powered features including
+  background removal, inpainting, upscaling, face enhancement, colorization,
+  and OCR. GPU acceleration available via -cuda (NVIDIA) and -rocm (AMD) image tags.
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - image-processing
+  - ai
+  - ml
+  - self-hosted
+home: https://github.com/ashim-hq/ashim
+sources:
+  - https://github.com/ashim-hq/ashim
+maintainers:
+  - name: ashim-hq
+    url: https://github.com/ashim-hq

--- a/charts/ashim/templates/NOTES.txt
+++ b/charts/ashim/templates/NOTES.txt
@@ -1,0 +1,20 @@
+ashim has been deployed!
+
+Access the UI:
+{{- if .Values.ingress.enabled }}
+  http{{ if .Values.ingress.tls }}s{{ end }}://{{ (index .Values.ingress.hosts 0).host }}
+{{- else }}
+  kubectl port-forward svc/{{ include "ashim.fullname" . }} 1349:1349 -n {{ include "ashim.namespace" . }}
+  Then open: http://localhost:1349
+{{- end }}
+
+Default credentials: {{ .Values.env.DEFAULT_USERNAME }} / {{ .Values.env.DEFAULT_PASSWORD }}
+Change via: --set env.DEFAULT_USERNAME=... --set env.DEFAULT_PASSWORD=...
+
+ML models (~6 GB) will download on first container start into the persistent volume.
+This happens once and is skipped on all subsequent restarts.
+
+For GPU acceleration:
+  NVIDIA:  --set image.tag=latest-cuda
+  AMD:     --set image.tag=latest-rocm
+  (also configure nodeSelector/tolerations to target GPU nodes)

--- a/charts/ashim/templates/_helpers.tpl
+++ b/charts/ashim/templates/_helpers.tpl
@@ -1,0 +1,76 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ashim.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncate at 63 chars because some Kubernetes name fields are limited to this (by DNS).
+*/}}
+{{- define "ashim.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label.
+*/}}
+{{- define "ashim.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "ashim.labels" -}}
+helm.sh/chart: {{ include "ashim.chart" . }}
+{{ include "ashim.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "ashim.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ashim.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Resolve the namespace for all resources.
+Precedence: namespaceOverride → Release.Namespace
+*/}}
+{{- define "ashim.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the full image reference.
+*/}}
+{{- define "ashim.image" -}}
+{{- $registry := .Values.image.registry }}
+{{- $repository := .Values.image.repository }}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- if $registry }}
+{{- printf "%s/%s:%s" $registry $repository $tag }}
+{{- else }}
+{{- printf "%s:%s" $repository $tag }}
+{{- end }}
+{{- end }}

--- a/charts/ashim/templates/deployment.yaml
+++ b/charts/ashim/templates/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ashim.fullname" . }}
+  namespace: {{ include "ashim.namespace" . }}
+  labels:
+    {{- include "ashim.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "ashim.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ashim.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: ashim
+          image: {{ include "ashim.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 1349
+              protocol: TCP
+          env:
+            {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: models
+              mountPath: /opt/models
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 1349
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 1349
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "ashim.fullname" . }}-data
+        - name: models
+          persistentVolumeClaim:
+            claimName: {{ include "ashim.fullname" . }}-models
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ashim/templates/ingress.yaml
+++ b/charts/ashim/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ashim.fullname" . }}
+  namespace: {{ include "ashim.namespace" . }}
+  labels:
+    {{- include "ashim.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "ashim.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/ashim/templates/pvc.yaml
+++ b/charts/ashim/templates/pvc.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ashim.fullname" . }}-data
+  namespace: {{ include "ashim.namespace" . }}
+  labels:
+    {{- include "ashim.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size }}
+  {{- if .Values.persistence.data.storageClass }}
+  storageClassName: {{ .Values.persistence.data.storageClass }}
+  {{- end }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ashim.fullname" . }}-models
+  namespace: {{ include "ashim.namespace" . }}
+  labels:
+    {{- include "ashim.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.models.size }}
+  {{- if .Values.persistence.models.storageClass }}
+  storageClassName: {{ .Values.persistence.models.storageClass }}
+  {{- end }}

--- a/charts/ashim/templates/service.yaml
+++ b/charts/ashim/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ashim.fullname" . }}
+  namespace: {{ include "ashim.namespace" . }}
+  labels:
+    {{- include "ashim.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "ashim.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: 1349
+      protocol: TCP

--- a/charts/ashim/values.yaml
+++ b/charts/ashim/values.yaml
@@ -1,0 +1,91 @@
+# Override the chart name used in resource names and labels.
+nameOverride: ""
+# Override the fully qualified app name used in resource names.
+fullnameOverride: ""
+
+# -------------------------------------------------------------------
+# Image settings
+# -------------------------------------------------------------------
+image:
+  registry: ghcr.io
+  repository: ashim-hq/ashim
+  # tag defaults to the chart's appVersion when left empty.
+  # Use "latest-cuda" for NVIDIA GPU or "latest-rocm" for AMD GPU.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# -------------------------------------------------------------------
+# Namespace
+# -------------------------------------------------------------------
+namespaceOverride: ""
+
+# -------------------------------------------------------------------
+# Service
+# -------------------------------------------------------------------
+service:
+  type: ClusterIP
+  port: 1349
+
+# -------------------------------------------------------------------
+# Ingress
+# -------------------------------------------------------------------
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: ashim.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# -------------------------------------------------------------------
+# Persistent storage
+# -------------------------------------------------------------------
+# Both PVCs are always created — models (~6 GB) must persist across restarts.
+persistence:
+  models:
+    size: 10Gi
+    # storageClass: "" uses the cluster default. Set explicitly if needed.
+    storageClass: ""
+  data:
+    size: 5Gi
+    storageClass: ""
+
+# -------------------------------------------------------------------
+# Application environment
+# -------------------------------------------------------------------
+env:
+  AUTH_ENABLED: "true"
+  DEFAULT_USERNAME: "admin"
+  DEFAULT_PASSWORD: "admin"
+  LOG_LEVEL: "info"
+  MAX_UPLOAD_SIZE_MB: "100"
+  CONCURRENT_JOBS: "3"
+  MAX_MEGAPIXELS: "100"
+  RATE_LIMIT_PER_MIN: "100"
+  FILE_MAX_AGE_HOURS: "24"
+  CLEANUP_INTERVAL_MINUTES: "30"
+
+# -------------------------------------------------------------------
+# Resource requests/limits
+# -------------------------------------------------------------------
+resources: {}
+# For GPU nodes, add nodeSelector and tolerations matching your node labels:
+# nodeSelector:
+#   nvidia.com/gpu: "true"
+# tolerations:
+#   - key: nvidia.com/gpu
+#     operator: Exists
+#     effect: NoSchedule
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+podAnnotations: {}
+podLabels: {}
+podSecurityContext: {}
+securityContext: {}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1
 # ============================================
 # ashim - Unified Production Dockerfile
-# Single image: GPU auto-detected on amd64, CPU on arm64
+# Tags: latest (cpu, amd64+arm64)  |  latest-cuda (NVIDIA)  |  latest-rocm (AMD)
+# Build arg GPU_BACKEND=cpu|cuda|rocm controls GPU acceleration package set.
+# Models are NOT baked in by default — downloaded on first container start.
 # ============================================
 
 # ============================================
@@ -108,9 +110,12 @@ RUN set -e; \
 # Stage 3: Platform-specific base images
 # ============================================
 FROM node:22-bookworm AS base-linux-arm64
-FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04 AS base-linux-amd64
+# amd64 uses a plain Ubuntu base for all variants (cpu/cuda/rocm).
+# GPU libs are injected at runtime by the NVIDIA Container Toolkit or ROCm
+# device plugin — no CUDA/ROCm base image required.
+FROM ubuntu:24.04 AS base-linux-amd64
 
-# Node.js donor: provides Node binaries for the CUDA amd64 image without
+# Node.js donor: provides Node binaries for the amd64 image without
 # relying on NodeSource apt repos or Ubuntu mirrors (which are flaky on CI).
 FROM node:22-bookworm AS node-bins
 
@@ -122,7 +127,12 @@ ARG TARGETARCH
 FROM base-${TARGETOS}-${TARGETARCH} AS production
 
 ARG TARGETARCH
-# Set to "true" to skip model downloads (for CI builds that just test the image structure)
+# GPU acceleration backend: cpu (default) | cuda (NVIDIA) | rocm (AMD)
+ARG GPU_BACKEND=cpu
+# Set to "true" to bake models into the image at build time (large image, instant start).
+# Default false: models download on first container start into a persistent volume.
+ARG BAKE_MODELS=false
+# Set to "true" in CI to skip model operations entirely (just test image structure).
 ARG SKIP_MODEL_DOWNLOADS=false
 
 # Pin corepack's cache to a system-wide path so all users share the same pnpm
@@ -173,28 +183,35 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         numpy==1.26.4 \
         opencv-python-headless==4.10.0.84
 
-# Platform-conditional ONNX runtime
+# GPU-backend-conditional ONNX runtime
 RUN --mount=type=cache,target=/root/.cache/pip \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-    /opt/venv/bin/pip install onnxruntime-gpu==1.20.1 \
-; else \
-    /opt/venv/bin/pip install onnxruntime==1.20.1 \
-; fi
+    if [ "$GPU_BACKEND" = "cuda" ]; then \
+        /opt/venv/bin/pip install onnxruntime-gpu==1.20.1; \
+    elif [ "$GPU_BACKEND" = "rocm" ]; then \
+        /opt/venv/bin/pip install onnxruntime-rocm==1.20.0; \
+    else \
+        /opt/venv/bin/pip install onnxruntime==1.20.1; \
+    fi
 
-# Python venv - Layer 2: Tool packages (change occasionally, ~2 GB)
+# GPU-backend-conditional tool packages (~2 GB)
 RUN --mount=type=cache,target=/root/.cache/pip \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-    /opt/venv/bin/pip install rembg==2.0.62 && \
-    /opt/venv/bin/pip install realesrgan==0.3.0 \
-        --extra-index-url https://download.pytorch.org/whl/cu126 && \
-    /opt/venv/bin/pip install paddlepaddle-gpu>=3.2.1 \
-        --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu126/ && \
-    /opt/venv/bin/pip install "paddleocr[doc-parser]>=3.4.0,<3.5.0" \
-; else \
-    /opt/venv/bin/pip install "rembg[cpu]==2.0.62" && \
-    /opt/venv/bin/pip install realesrgan==0.3.0 && \
-    /opt/venv/bin/pip install paddlepaddle==3.0.0 "paddleocr[doc-parser]>=3.4.0,<3.5.0" \
-; fi
+    if [ "$GPU_BACKEND" = "cuda" ]; then \
+        /opt/venv/bin/pip install rembg==2.0.62 && \
+        /opt/venv/bin/pip install realesrgan==0.3.0 \
+            --extra-index-url https://download.pytorch.org/whl/cu126 && \
+        /opt/venv/bin/pip install "paddlepaddle-gpu>=3.2.1" \
+            --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu126/ && \
+        /opt/venv/bin/pip install "paddleocr[doc-parser]>=3.4.0,<3.5.0"; \
+    elif [ "$GPU_BACKEND" = "rocm" ]; then \
+        /opt/venv/bin/pip install rembg==2.0.62 && \
+        /opt/venv/bin/pip install realesrgan==0.3.0 \
+            --extra-index-url https://download.pytorch.org/whl/rocm6.3 && \
+        /opt/venv/bin/pip install paddlepaddle==3.0.0 "paddleocr[doc-parser]>=3.4.0,<3.5.0"; \
+    else \
+        /opt/venv/bin/pip install "rembg[cpu]==2.0.62" && \
+        /opt/venv/bin/pip install realesrgan==0.3.0 && \
+        /opt/venv/bin/pip install paddlepaddle==3.0.0 "paddleocr[doc-parser]>=3.4.0,<3.5.0"; \
+    fi
 
 # mediapipe 0.10.21 only has amd64 wheels; arm64 maxes out at 0.10.18
 RUN --mount=type=cache,target=/root/.cache/pip \
@@ -212,17 +229,16 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 RUN --mount=type=cache,target=/root/.cache/pip \
     /opt/venv/bin/pip install numpy==1.26.4
 
-# Re-align NCCL to match torch's requirement.  paddlepaddle-gpu pins an older
-# nvidia-nccl-cu12 which silently downgrades the version installed by torch,
-# causing "undefined symbol: ncclCommShrink" at import time.  NCCL is ABI-
-# backwards-compatible, so the newer version satisfies both packages.
+# Re-align NCCL to match torch's requirement (CUDA only). paddlepaddle-gpu pins
+# an older nvidia-nccl-cu12 which silently downgrades the version installed by
+# torch, causing "undefined symbol: ncclCommShrink" at import time.
 RUN --mount=type=cache,target=/root/.cache/pip \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-    /opt/venv/bin/pip install $(/opt/venv/bin/python3 -c \
-        "from importlib.metadata import requires; \
-         print([r.split(';')[0].strip() for r in requires('torch') \
-                if 'nccl' in r][0])") \
-    ; fi
+    if [ "$GPU_BACKEND" = "cuda" ]; then \
+        /opt/venv/bin/pip install $(/opt/venv/bin/python3 -c \
+            "from importlib.metadata import requires; \
+             print([r.split(';')[0].strip() for r in requires('torch') \
+                    if 'nccl' in r][0])"); \
+    fi
 
 # Pin rembg model storage to a fixed path so models downloaded at build time
 # (as root) are found at runtime (as the non-root ashim user, home=/app).
@@ -235,12 +251,17 @@ ENV U2NET_HOME=/opt/models/rembg
 # pre-download in this case; models download on first use at runtime instead.
 # In CI (SKIP_MODEL_DOWNLOADS=true), skip downloads — the image structure is
 # what matters for the build test; models are verified in integration tests.
-COPY docker/download_models.py /tmp/download_models.py
+# Keep download script in the image — used here when BAKE_MODELS=true and
+# by entrypoint.sh on first container start when BAKE_MODELS=false (default).
+COPY docker/download_models.py /opt/ashim/download_models.py
 RUN if [ "$SKIP_MODEL_DOWNLOADS" = "true" ]; then \
         echo "Skipping model downloads (CI build)"; \
+    elif [ "$BAKE_MODELS" = "true" ]; then \
+        CUDA_VISIBLE_DEVICES="" /opt/venv/bin/python3 /opt/ashim/download_models.py && \
+        touch /opt/models/.complete; \
     else \
-        CUDA_VISIBLE_DEVICES="" /opt/venv/bin/python3 /tmp/download_models.py; \
-    fi && rm -f /tmp/download_models.py && \
+        echo "BAKE_MODELS=false: models will download on first container start."; \
+    fi && \
     # Symlink PaddleX model dir into both possible HOME locations so models are
     # found regardless of whether HOME=/root (build/root context) or HOME=/app
     # (runtime ashim user via gosu). Without this PaddleX re-downloads on every

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -134,6 +134,14 @@ ARG GPU_BACKEND=cpu
 ARG BAKE_MODELS=false
 # Set to "true" in CI to skip model operations entirely (just test image structure).
 ARG SKIP_MODEL_DOWNLOADS=false
+# NVIDIA Container Toolkit: when these env vars are present in the image and the
+# NVIDIA Container Runtime is configured as the default Docker runtime on the host,
+# GPUs are made available automatically without --gpus on the docker run command.
+# Only set for latest-cuda builds via build-arg; empty string on cpu/rocm images.
+ARG NVIDIA_VISIBLE_DEVICES_VAL=""
+ARG NVIDIA_DRIVER_CAPABILITIES_VAL=""
+ENV NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES_VAL}
+ENV NVIDIA_DRIVER_CAPABILITIES=${NVIDIA_DRIVER_CAPABILITIES_VAL}
 
 # Pin corepack's cache to a system-wide path so all users share the same pnpm
 # binary without downloading it on each container start.
@@ -332,10 +340,6 @@ ENV PORT=1349 \
     MAX_MEGAPIXELS=100 \
     RATE_LIMIT_PER_MIN=100 \
     LOG_LEVEL=debug
-
-# NVIDIA Container Toolkit env vars (harmless on non-GPU systems)
-ENV NVIDIA_VISIBLE_DEVICES=all \
-    NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
 # Suppress noisy ML library output in docker logs
 ENV PYTHONWARNINGS=default \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - ashim-data:/data
       - ashim-workspace:/tmp/workspace
+      - ashim-models:/opt/models
     environment:
       - AUTH_ENABLED=true
       - DEFAULT_USERNAME=admin
@@ -24,3 +25,4 @@ services:
 volumes:
   ashim-data:
   ashim-workspace:
+  ashim-models:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,19 @@
+# GPU USAGE:
+#
+# CPU (default):
+#   image: ashimhq/ashim:latest
+#   No extra flags needed.
+#
+# NVIDIA GPU:
+#   image: ashimhq/ashim:latest-cuda
+#   If NVIDIA Container Runtime is your default Docker runtime, GPUs are
+#   available automatically (the image sets NVIDIA_VISIBLE_DEVICES=all).
+#   Otherwise add:  deploy: (see commented block below) or run with --gpus all
+#
+# AMD GPU:
+#   image: ashimhq/ashim:latest-rocm
+#   Always requires device passthrough — add the deploy block below.
+
 services:
   ashim:
     build:
@@ -16,6 +32,18 @@ services:
       - DEFAULT_USERNAME=admin
       - DEFAULT_PASSWORD=admin
     restart: unless-stopped
+    # Uncomment for NVIDIA GPU (if not using nvidia-container-runtime as default):
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+    # Uncomment for AMD GPU (always required):
+    # devices:
+    #   - /dev/kfd:/dev/kfd
+    #   - /dev/dri:/dev/dri
     logging:
       driver: json-file
       options:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,13 +7,35 @@ export AUTH_ENABLED="${AUTH_ENABLED:-true}"
 export DEFAULT_USERNAME="${DEFAULT_USERNAME:-admin}"
 export DEFAULT_PASSWORD="${DEFAULT_PASSWORD:-admin}"
 
+# Download ML models on first container start when BAKE_MODELS=false (default).
+# When BAKE_MODELS=true was used at build time, /opt/models/.complete already
+# exists and this block is skipped. Models are written to the /opt/models
+# persistent volume so they survive restarts without re-downloading.
+_download_models() {
+  if [ ! -f /opt/models/.complete ]; then
+    echo "=== First run: downloading ML models to /opt/models (~6 GB, may take several minutes) ==="
+    CUDA_VISIBLE_DEVICES="" /opt/venv/bin/python3 /opt/ashim/download_models.py
+    touch /opt/models/.complete
+    echo "=== Model download complete ==="
+  fi
+}
+
 # Fix ownership of mounted volumes so the non-root ashim user can write.
 # This runs as root, fixes permissions, then drops to ashim via gosu.
 if [ "$(id -u)" = "0" ]; then
-  chown -R ashim:ashim /data /tmp/workspace 2>&1 || \
+  chown -R ashim:ashim /data /tmp/workspace /opt/models 2>&1 || \
     echo "WARNING: Could not fix volume permissions. Use named volumes (not Windows bind mounts) to avoid this. See docs for details." >&2
+  gosu ashim sh -c '
+    if [ ! -f /opt/models/.complete ]; then
+      echo "=== First run: downloading ML models to /opt/models (~6 GB, may take several minutes) ==="
+      CUDA_VISIBLE_DEVICES="" /opt/venv/bin/python3 /opt/ashim/download_models.py
+      touch /opt/models/.complete
+      echo "=== Model download complete ==="
+    fi
+  '
   exec gosu ashim "$@"
 fi
 
 # Already running as ashim (e.g. Kubernetes runAsUser)
+_download_models
 exec "$@"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ashim",
-  "version": "1.15.9",
+  "version": "1.16.0",
   "private": true,
   "packageManager": "pnpm@9.15.4",
   "scripts": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ashim/ai",
-  "version": "1.15.9",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/image-engine/package.json
+++ b/packages/image-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ashim/image-engine",
-  "version": "1.15.9",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ashim/shared",
-  "version": "1.15.9",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1180,7 +1180,7 @@ export const PRINT_LAYOUTS: PrintLayout[] = [
   { id: "none", label: "None", width: 0, height: 0 },
 ];
 
-export const APP_VERSION = "1.15.9";
+export const APP_VERSION = "1.16.0";
 
 /**
  * Tool IDs that require the Python sidecar (AI/ML tools).


### PR DESCRIPTION
## Summary

Fixes #77, #74 — the 29 GB image that breaks CI and prevents `latest` from being updated.

---

## Root Cause

**Issue #77, #74: image size 29 GB, `latest` tag never updated**

The problem has two compounding parts:

**1. Base image bloat (~20 GB)**
`nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04` ships the full CUDA runtime, cuDNN libraries, and all NVIDIA toolkit dependencies. This alone consumes ~20 GB of disk before a single line of application code is installed. GitHub-hosted `ubuntu-latest` runners have ~30 GB of usable disk after the pre-installed toolchain — leaving almost no headroom.

**2. Models baked in at build time (~5–6 GB)**
The original Dockerfile ran `download_models.py` during the image build, embedding ONNX and other model weights directly into the image layer. Combined with the CUDA base, the final image reached ~29 GB.

**3. The cascade failure**
When the amd64 build exhausts disk space mid-layer, `docker build` fails silently with a no-space error. The build job is marked failed, but because the manifest job only runs when *all* build matrix jobs succeed, it is skipped. The `latest` tag on both GHCR and Docker Hub is never updated — so users pulling `latest` get an increasingly stale image with no error or warning.

**4. Why the arm64 build appeared fine**
The arm64 variant used a plain `ubuntu` base (no CUDA — CUDA has no arm64/aarch64 support in this image family), so it was small enough to build successfully. This masked the problem: `latest` was technically being published from the arm64 manifest only, but amd64 users silently received the wrong architecture or a pull error depending on their client.

---

## Changes

#### Docker image (`docker/Dockerfile`)
- Base changed from `nvidia/cuda` → `ubuntu:24.04` for all builds
- New `GPU_BACKEND=cpu|cuda|rocm` build arg controls which GPU pip wheels are installed
- New `BAKE_MODELS=false` build arg — models are **not** baked in by default
- ONNX runtime variant selected per backend (`onnxruntime` / `onnxruntime-gpu` / `onnxruntime-rocm`)
- Torch, PaddlePaddle, rembg all gated on `GPU_BACKEND`
- NCCL symlink fix only applied for `cuda` backend
- `download_models.py` kept permanently at `/opt/ashim/download_models.py`
- `latest-cuda` image bakes `NVIDIA_VISIBLE_DEVICES=all` + `NVIDIA_DRIVER_CAPABILITIES=compute,utility` via build-args so an NVIDIA runtime-enabled host injects GPU automatically (see GPU usage below)

#### First-run model download (`docker/entrypoint.sh`)
- On first container start, if `/opt/models/.complete` sentinel is absent, models are downloaded via `download_models.py` (runs as `ashim` user via gosu)
- Sentinel written after successful download; subsequent starts skip the download

#### docker-compose (`docker/docker-compose.yml`)
- Added `ashim-models:/opt/models` named volume for persistent model storage
- Added commented GPU override examples for NVIDIA and AMD

#### Release pipeline (`.github/workflows/release.yml`)
- Matrix expanded to 4 entries: `linux/amd64+cpu`, `linux/arm64+cpu`, `linux/amd64+cuda`, `linux/amd64+rocm`
- Three separate manifest groups: `latest` (cpu, multi-arch), `latest-cuda` (NVIDIA, amd64), `latest-rocm` (AMD, amd64)
- Manifest job now runs if *any* build succeeds (not all) — `latest` is always published as long as both cpu builds pass
- `GPU_BACKEND` build arg passed per matrix entry; NVIDIA env vars passed as build-args for the cuda entry only

#### CI (`.github/workflows/ci.yml`)
- Switched from `GHCR_TOKEN` secret → built-in `GITHUB_TOKEN` with `packages: write`
- Simplified registry cache (no conditional expressions)

#### Helm chart (`charts/ashim/`)
- New chart for Kubernetes deployment
- PVCs always created: `models` (10Gi), `data` (5Gi)
- Ingress disabled by default; GPU tolerations/nodeSelector configurable
- Published via GitHub Pages with `.github/workflows/chart-release.yml`

#### Documentation (`README.md`, `apps/docs/`)
- `README.md`: GPU quick start now shows `latest-cuda` + `--gpus all` for NVIDIA; adds AMD collapse section with `latest-rocm` + `--device` flags
- `apps/docs/guide/getting-started.md`: GPU tip updated to `latest-cuda`; AMD tip added for `latest-rocm`
- `apps/docs/guide/docker-tags.md`: rewritten to document the new 3-tag structure — new intro table, NVIDIA/AMD sections with correct commands, Docker Compose examples for all three variants (`latest`, `latest-cuda` with deploy section, `latest-rocm` with devices section), corrected platforms table (ARM64 always `latest`), versioned tag examples (`1.16.0-cuda` etc.), model download volume guidance, corrected migration note

---

## Image tags after this change

| Tag | Platform | GPU |
|---|---|---|
| `latest` | amd64 + arm64 | CPU only |
| `latest-cuda` | amd64 | NVIDIA (CUDA wheels baked in) |
| `latest-rocm` | amd64 | AMD (ROCm wheels baked in) |

---

## GPU usage

#### NVIDIA

The `latest-cuda` image bakes `NVIDIA_VISIBLE_DEVICES=all` and `NVIDIA_DRIVER_CAPABILITIES=compute,utility` into its env layer. When the [NVIDIA Container Runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) is configured as the **default** Docker runtime on the host, these env vars trigger automatic GPU injection — no `--gpus all` flag needed:

```bash
docker run -p 1349:1349 -v ashim-models:/opt/models ghcr.io/ashim-hq/ashim:latest-cuda
```

If the NVIDIA runtime is *not* the default runtime, add `--gpus all` explicitly:

```bash
docker run --gpus all -p 1349:1349 -v ashim-models:/opt/models ghcr.io/ashim-hq/ashim:latest-cuda
```

#### AMD

ROCm has no equivalent auto-injection mechanism. Device passthrough is always required:

```bash
docker run \
  --device=/dev/kfd --device=/dev/dri \
  -p 1349:1349 -v ashim-models:/opt/models \
  ghcr.io/ashim-hq/ashim:latest-rocm
```

---

## Breaking changes

`latest` no longer includes CUDA. Users who previously ran `docker run --gpus all ... ashimhq/ashim:latest` for GPU acceleration should switch to `latest-cuda`. CPU users and ARM64 users are unaffected.