### PR TITLE
fix(ci): deploy landing from dist, not the stale Next.js out path

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -26,7 +26,7 @@ jobs:
         run: pnpm --filter @snapotter/landing build
 
       - name: Deploy to Cloudflare Pages
-        run: npx wrangler pages deploy apps/landing/out --project-name snapotter-landing --branch main --commit-dirty=true
+        run: npx wrangler pages deploy apps/landing/dist --project-name snapotter-landing --branch main --commit-dirty=true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
The Deploy Landing workflow ran `wrangler pages deploy apps/landing/out`, but the Astro build outputs to `dist` (`out` is a leftover from the pre-Astro Next.js setup). Every landing deploy has failed with ENOENT since the Astro migration. Point the deploy at `apps/landing/dist`.