### PR TITLE
fix(media): preserve source sample rate after loudnorm

### DIFF
--- a/apps/api/src/lib/media-tool.ts
+++ b/apps/api/src/lib/media-tool.ts
@@ -162,7 +162,11 @@ export async function runFfmpegWithProgress(
 export async function runMediaTool(
   ctx: ToolProcessCtxV2,
   outName: string,
-  argsFor: (inPath: string, outPath: string, info: { durationS: number | null }) => string[],
+  argsFor: (
+    inPath: string,
+    outPath: string,
+    info: { durationS: number | null; audioSampleRate: number | null },
+  ) => string[],
   opts: { timeoutMs?: number } = {},
 ): Promise<MediaRunResult> {
   const dir = join(ctx.scratchDir, "media");
@@ -173,7 +177,10 @@ export async function runMediaTool(
   const outPath = join(dir, outName);
   await runFfmpegWithProgress(
     ctx,
-    argsFor(inPath, outPath, { durationS: info.durationS }),
+    argsFor(inPath, outPath, {
+      durationS: info.durationS,
+      audioSampleRate: info.streams.find((s) => s.type === "audio")?.sampleRate ?? null,
+    }),
     info.durationS,
     opts,
   );

--- a/apps/api/src/routes/tools/normalize-audio.ts
+++ b/apps/api/src/routes/tools/normalize-audio.ts
@@ -19,8 +19,18 @@ export function registerNormalizeAudio(app: FastifyInstance) {
       const base = ctx.inputs[0].filename.replace(/\.[^.]+$/, "");
       const outName = `${base}_normalized${out.ext}`;
 
-      const { outPath } = await runMediaTool(ctx, outName, (inPath, outPath) => {
-        return ["-i", inPath, "-af", "loudnorm=I=-16:TP=-1.5:LRA=11", ...out.encodeArgs, outPath];
+      const { outPath } = await runMediaTool(ctx, outName, (inPath, outPath, info) => {
+        // loudnorm runs internally at 192 kHz and emits at 192 kHz unless we
+        // resample back, so restore the source rate to avoid inflating the file.
+        const sr = info.audioSampleRate ?? 44100;
+        return [
+          "-i",
+          inPath,
+          "-af",
+          `loudnorm=I=-16:TP=-1.5:LRA=11,aresample=${sr}`,
+          ...out.encodeArgs,
+          outPath,
+        ];
       });
       return { scratchPath: outPath, filename: outName, contentType: out.contentType };
     },

--- a/apps/api/src/routes/tools/video-loudnorm.ts
+++ b/apps/api/src/routes/tools/video-loudnorm.ts
@@ -35,11 +35,15 @@ export function registerVideoLoudnorm(app: FastifyInstance) {
 
       const outPath = join(ctx.scratchDir, "media", outName);
 
+      // loudnorm runs internally at 192 kHz and emits at 192 kHz unless we
+      // resample back, so restore the source rate to avoid inflating the audio.
+      const sr = info.streams.find((s) => s.type === "audio")?.sampleRate ?? 48000;
+
       const args = [
         "-i",
         inPath,
         "-af",
-        "loudnorm=I=-16:TP=-1.5:LRA=11",
+        `loudnorm=I=-16:TP=-1.5:LRA=11,aresample=${sr}`,
         "-c:v",
         "copy",
         ...audioEncodeArgsForContainer(origExt),


### PR DESCRIPTION
## Problem
`normalize-audio` and `video-loudnorm` emitted **192 kHz** audio regardless of the input sample rate, inflating output roughly 4.3x (a 44.1 kHz / 2.6 MB clip became 192 kHz / 11.5 MB).

## Root cause
ffmpeg's `loudnorm` filter runs internally at 192 kHz and emits at 192 kHz unless the chain resamples back. Both tools ran `loudnorm=I=-16:TP=-1.5:LRA=11` with no trailing `aresample`.

## Fix
Append `,aresample=<source rate>` after `loudnorm`. `runMediaTool` now exposes the input audio sample rate to its args callback so `normalize-audio` recovers the source rate; `video-loudnorm` reads it from its existing probe. Loudness normalization is unchanged.

## Verification
Drove all 17 audio tools end-to-end through a fresh Docker stack (real UI via Playwright) + ffprobe analysis:
- normalize-audio: 192000 -> 44100 Hz, 11.5 MB -> 2.65 MB; loudness still normalized (mean -17.1 / max -11.5 dB).
- video-loudnorm: audio 192000 -> 44100 Hz; video stream copied intact; loudness normalized.
- Full 17-tool regression run: all pass; every other output byte-identical (the `runMediaTool` change is purely additive).

## Notes
Stacked on `fix/qa-codec-eraser-and-pdf-rename` because the fix builds on the media-tool changes there (not yet in main). Retarget to `main` once that branch lands.