### PR TITLE
fix: repair URL import (DNS-pinned fetch on Node 22 + non-image modalities)

### DIFF
--- a/apps/api/src/lib/ssrf.ts
+++ b/apps/api/src/lib/ssrf.ts
@@ -108,13 +108,26 @@ export const URL_FETCH_CONCURRENCY = 4;
  * (private) IP between our SSRF validation and the actual connection.
  */
 function createPinnedAgent(resolvedIp: string, protocol: string): http.Agent | https.Agent {
+  const family = resolvedIp.includes(":") ? 6 : 4;
+  // Node's lookup contract: when called with { all: true } the callback must
+  // return the address(es) as an array. Node 22 invokes the agent's custom
+  // lookup this way, so a single-arg callback passes `undefined` as the
+  // address and every fetch fails with "Invalid IP address: undefined".
+  // Honor both forms while still pinning to the SSRF-validated public IP.
   const pinnedLookup: (
     hostname: string,
-    options: object,
-    callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
-  ) => void = (_hostname, _options, callback) => {
-    const family = resolvedIp.includes(":") ? 6 : 4;
-    callback(null, resolvedIp, family);
+    options: { all?: boolean },
+    callback: (
+      err: NodeJS.ErrnoException | null,
+      address: string | Array<{ address: string; family: number }>,
+      family?: number,
+    ) => void,
+  ) => void = (_hostname, options, callback) => {
+    if (options?.all) {
+      callback(null, [{ address: resolvedIp, family }]);
+    } else {
+      callback(null, resolvedIp, family);
+    }
   };
 
   if (protocol === "https:") {

--- a/apps/api/src/routes/fetch-urls.ts
+++ b/apps/api/src/routes/fetch-urls.ts
@@ -80,8 +80,8 @@ interface SuccessResult {
   filename: string;
   contentType: string;
   size: number;
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
   downloadUrl: string;
   previewUrl: string | null;
 }
@@ -236,21 +236,25 @@ async function fetchSingleUrl(
     const rawFilename = filenameFromUrl(url);
     const filename = getUniqueName(sanitizeFilename(rawFilename), usedFilenames);
 
-    // Validate as an image
-    const validation = await validateImageBuffer(buffer, filename);
-    if (!validation.valid) {
-      return { success: false, url, error: validation.reason };
-    }
+    // Try image validation; non-image media (audio/video/document/data) is
+    // accepted and typed from the HTTP response so URL import works for every
+    // modality. The consuming tool runs modality-specific validation at
+    // process time, and SSRF + size limits still bound what can be fetched.
+    const validation = await validateImageBuffer(buffer, filename).catch(() => null);
 
     // Save to object storage uploads prefix (raw fetched files)
     await putObject(`uploads/${jobId}/${filename}`, buffer);
 
-    const contentType = FORMAT_TO_MIME[validation.format] ?? "application/octet-stream";
+    const responseContentType = response.headers.get("content-type")?.split(";")[0]?.trim();
+    const contentType = validation?.valid
+      ? (FORMAT_TO_MIME[validation.format] ?? "application/octet-stream")
+      : responseContentType || "application/octet-stream";
     const downloadUrl = `/api/v1/download/${jobId}/${encodeURIComponent(filename)}`;
 
-    // Generate preview for non-browser formats
+    // Generate a webp preview only for non-browser-native image formats.
+    // Non-image media has no image preview; the UI shows a modality icon.
     let previewUrl: string | null = null;
-    if (!BROWSER_PREVIEWABLE.has(contentType)) {
+    if (validation?.valid && !BROWSER_PREVIEWABLE.has(contentType)) {
       try {
         const previewBuffer = await sharp(buffer).webp({ quality: 80 }).toBuffer();
         const previewFilename = `preview-${filename.replace(/\.[^.]+$/, "")}.webp`;
@@ -267,8 +271,8 @@ async function fetchSingleUrl(
       filename,
       contentType,
       size: buffer.length,
-      width: validation.width,
-      height: validation.height,
+      width: validation?.valid ? validation.width : undefined,
+      height: validation?.valid ? validation.height : undefined,
       downloadUrl,
       previewUrl,
     };


### PR DESCRIPTION
The "Paste file URL" import was broken in two ways. Found while QA-testing audio tools.

## Bug 1 — URL import fully broken on Node 22 (`ssrf.ts`)
`createPinnedAgent`'s custom DNS `lookup` (the anti-DNS-rebinding pin) always called back in single-address form. Node 22 invokes the agent lookup with `{ all: true }`, so the address arrived as `undefined` and **every** URL fetch failed with `Invalid IP address: undefined` — for all file types. Confirmed in-container: plain HTTPS works (200), the pinned agent fails, and honoring `options.all` returns 200.

**Fix:** return the pinned IP as an array when `{ all: true }` is requested. The connection is still pinned to the SSRF-validated public IP — no DNS-rebinding regression.

## Bug 2 — image-only validation (`fetch-urls.ts`)
Even once fetched, every file was validated as an image (+ Sharp preview), so audio/video/document URL imports were rejected. **Fix:** try image validation, accept non-image media (typed from the HTTP `content-type`), skip the image preview for non-images (the UI shows a modality icon). SSRF + size limits unchanged; image import (with dimensions + preview) is unchanged.

## Verification
Fresh Docker stack (Node 22), real fetch over HTTPS:
- `tiny.mp3` -> `audio/mpeg`, imported file is valid mp3 (ffprobe: 1.04s)
- `media-30s.wav` -> `audio/wav` (2.6 MB, intact)
- `test-200x150.png` -> `image/png`, 200x150 (no regression)

Independent of the other audio-QA PRs.