### PR TITLE
fix(data): rename Files modality to Data + 20 Data-tool bug fixes

### DIFF
--- a/apps/api/src/routes/tool-factory.ts
+++ b/apps/api/src/routes/tool-factory.ts
@@ -76,6 +76,14 @@ export interface ToolRouteConfig<T> {
   /** Minimum number of file parts required (default 1). Fewer returns HTTP 400. */
   minInputs?: number;
   /**
+   * Optional pre-enqueue validation hook. Receives the prepared input buffers
+   * and validated settings; throw InputValidationError to reject with its
+   * statusCode (default 400) before any job is enqueued (vs a worker 422).
+   */
+  preValidate?: (ctx: {
+    inputs: { filename: string; buffer: Buffer }[];
+  }) => Promise<void> | void;
+  /**
    * Per-position input kind overrides for mixed-input tools (e.g. video +
    * subtitle). Input i validates with kind inputKinds[Math.min(i, len-1)].
    * When absent, the tool's modality drives a single handler as before.
@@ -113,6 +121,9 @@ export interface AnyToolRouteConfig {
   toolId: string;
   maxInputs?: number;
   minInputs?: number;
+  preValidate?: (ctx: {
+    inputs: { filename: string; buffer: Buffer }[];
+  }) => Promise<void> | void;
   inputKinds?: ("video" | "audio" | "image" | "subtitle")[];
   settingsSchema: z.ZodType<unknown, z.ZodTypeDef, unknown>;
   process: (
@@ -373,6 +384,7 @@ export function createToolRoute<T>(app: FastifyInstance, config: ToolRouteConfig
 
         // Prepare all files through the modality input handler
         const inputRefs: string[] = [];
+        const preparedInputs: { filename: string; buffer: Buffer }[] = [];
         for (let i = 0; i < received.length; i++) {
           const upload = received[i];
           let fileBuffer = await getObjectBuffer(upload.key);
@@ -416,6 +428,10 @@ export function createToolRoute<T>(app: FastifyInstance, config: ToolRouteConfig
           if (i === 0) {
             filename = fname;
           }
+
+          if (config.preValidate) {
+            preparedInputs.push({ filename: fname, buffer: fileBuffer });
+          }
         }
 
         reportProgress(15, "Preparing...");
@@ -440,6 +456,22 @@ export function createToolRoute<T>(app: FastifyInstance, config: ToolRouteConfig
         } catch {
           // Orphaned uploads/<jobId>/ dir will be cleaned by T10 TTL sweeper
           return reply.status(400).send({ error: "Settings must be valid JSON" });
+        }
+
+        // Optional tool-specific pre-enqueue validation (e.g. zip-entry safety).
+        // Throwing InputValidationError here returns its statusCode (400) before
+        // any job is enqueued, instead of a generic 422 from the worker.
+        if (config.preValidate) {
+          try {
+            await config.preValidate({ inputs: preparedInputs });
+          } catch (err) {
+            if (err instanceof InputValidationError) {
+              const body: Record<string, string> = { error: err.message };
+              if (err.details) body.details = err.details;
+              return reply.status(err.statusCode).send(body);
+            }
+            throw err;
+          }
         }
 
         // Guard: check if the tool's AI feature bundle is installed

--- a/apps/api/src/routes/tool-factory.ts
+++ b/apps/api/src/routes/tool-factory.ts
@@ -73,6 +73,8 @@ export interface ToolRouteConfig<T> {
    * inputRefs in arrival order.
    */
   maxInputs?: number;
+  /** Minimum number of file parts required (default 1). Fewer returns HTTP 400. */
+  minInputs?: number;
   /**
    * Per-position input kind overrides for mixed-input tools (e.g. video +
    * subtitle). Input i validates with kind inputKinds[Math.min(i, len-1)].
@@ -110,6 +112,7 @@ export interface ToolRouteConfig<T> {
 export interface AnyToolRouteConfig {
   toolId: string;
   maxInputs?: number;
+  minInputs?: number;
   inputKinds?: ("video" | "audio" | "image" | "subtitle")[];
   settingsSchema: z.ZodType<unknown, z.ZodTypeDef, unknown>;
   process: (
@@ -215,6 +218,7 @@ export function createToolRoute<T>(app: FastifyInstance, config: ToolRouteConfig
 
       const jobId = randomUUID();
       const maxInputs = config.maxInputs ?? 1;
+      const minInputs = config.minInputs ?? 1;
       let filename = "image";
       let settingsRaw: string | null = null;
       let fileId: string | null = null;
@@ -304,6 +308,14 @@ export function createToolRoute<T>(app: FastifyInstance, config: ToolRouteConfig
       // Require at least one file
       if (received.length === 0) {
         return reply.status(400).send({ error: "No image file provided" });
+      }
+
+      // Require the tool's minimum number of files (e.g. create-zip / merge-csvs
+      // need 2). Returns 400 pre-enqueue instead of a 422 from the worker.
+      if (received.length < minInputs) {
+        return reply.status(400).send({
+          error: `This tool needs at least ${minInputs} files`,
+        });
       }
 
       const reportProgress = (percent: number, stage?: string) => {

--- a/apps/api/src/routes/tools/chart-maker.ts
+++ b/apps/api/src/routes/tools/chart-maker.ts
@@ -223,6 +223,11 @@ export function registerChartMaker(app: FastifyInstance) {
           throw new Error("Column 2 must be numeric");
         }
       }
+      // Negative values render as invalid/degenerate SVG (negative bar heights,
+      // backward pie arcs that Sharp silently drops); reject with a clear message.
+      if (data.some((point) => point.value < 0)) {
+        throw new Error("Chart values must be zero or greater");
+      }
 
       let svg: string;
       switch (settings.kind) {

--- a/apps/api/src/routes/tools/create-zip.ts
+++ b/apps/api/src/routes/tools/create-zip.ts
@@ -12,6 +12,7 @@ export function registerCreateZip(app: FastifyInstance) {
   createToolRoute(app, {
     toolId: "create-zip",
     maxInputs: 50,
+    minInputs: 2,
     settingsSchema,
     process: async () => {
       throw new Error("create-zip is v2-only");
@@ -21,20 +22,22 @@ export function registerCreateZip(app: FastifyInstance) {
         throw new InputValidationError("Zipping needs at least two files");
       }
 
-      // Deduplicate filenames: name-1.ext, name-2.ext on collision
-      const usedNames = new Map<string, number>();
+      // Deduplicate output names: append -1, -2, ... until unique. Checking the
+      // generated name (not just the input name) avoids collisions when an input
+      // is literally named like a generated one (e.g. file.txt, file.txt, file-1.txt).
+      const usedNames = new Set<string>();
       const entryNames: string[] = [];
       for (const input of ctx.inputs) {
         const ext = extname(input.filename);
         const base = input.filename.slice(0, input.filename.length - ext.length) || "file";
-        const key = input.filename.toLowerCase();
-        const count = usedNames.get(key) ?? 0;
-        if (count === 0) {
-          entryNames.push(input.filename);
-        } else {
-          entryNames.push(`${base}-${count}${ext}`);
+        let name = input.filename;
+        let n = 1;
+        while (usedNames.has(name.toLowerCase())) {
+          name = `${base}-${n}${ext}`;
+          n++;
         }
-        usedNames.set(key, count + 1);
+        usedNames.add(name.toLowerCase());
+        entryNames.push(name);
       }
 
       const zipPath = join(ctx.scratchDir, "archive.zip");

--- a/apps/api/src/routes/tools/csv-excel.ts
+++ b/apps/api/src/routes/tools/csv-excel.ts
@@ -39,7 +39,9 @@ export function registerCsvExcel(app: FastifyInstance) {
         ws.eachRow((row) => {
           const cells: string[] = [];
           row.eachCell({ includeEmpty: true }, (cell) => {
-            cells.push(cell.text);
+            // cell.text renders dates via Date.toString() (timezone-dependent and
+            // not round-trippable); emit ISO 8601 for Date values instead.
+            cells.push(cell.value instanceof Date ? cell.value.toISOString() : cell.text);
           });
           rows.push(cells);
         });

--- a/apps/api/src/routes/tools/csv-json.ts
+++ b/apps/api/src/routes/tools/csv-json.ts
@@ -21,11 +21,31 @@ export function registerCsvJson(app: FastifyInstance) {
       const lower = input.filename.toLowerCase();
 
       if (lower.endsWith(".json")) {
-        const data: unknown = JSON.parse(input.buffer.toString("utf8"));
+        let data: unknown;
+        try {
+          data = JSON.parse(input.buffer.toString("utf8"));
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          throw new Error(`Not valid JSON: ${msg.split("\n")[0]}`);
+        }
         if (!Array.isArray(data)) {
           throw new Error("JSON input must be an array of objects to convert to CSV");
         }
-        const csv = Papa.unparse(data as Record<string, unknown>[]);
+        if (data.some((r) => r === null || typeof r !== "object" || Array.isArray(r))) {
+          throw new Error("JSON array elements must be objects to convert to CSV");
+        }
+        // Flatten nested objects/arrays to JSON strings (Papa would otherwise emit
+        // "[object Object]"), and pass the union of all keys so columns appearing
+        // only in later rows are not dropped.
+        const flattened = (data as Record<string, unknown>[]).map((row) => {
+          const out: Record<string, unknown> = {};
+          for (const [k, v] of Object.entries(row)) {
+            out[k] = v !== null && typeof v === "object" ? JSON.stringify(v) : v;
+          }
+          return out;
+        });
+        const columns = Array.from(new Set(flattened.flatMap((row) => Object.keys(row))));
+        const csv = Papa.unparse(flattened, { columns });
         return {
           buffer: Buffer.from(csv, "utf8"),
           filename: `${base}.csv`,

--- a/apps/api/src/routes/tools/extract-zip.ts
+++ b/apps/api/src/routes/tools/extract-zip.ts
@@ -53,22 +53,22 @@ function readEntryBuffer(zipfile: ZipFile, entry: Entry): Promise<Buffer> {
   });
 }
 
-/** Deduplicate basenames: name-1.ext, name-2.ext on collision. */
+/** Deduplicate basenames: name-1.ext, name-2.ext until each output is unique. */
 function deduplicateNames(names: string[]): string[] {
-  const usedNames = new Map<string, number>();
+  const usedNames = new Set<string>();
   const result: string[] = [];
   for (const raw of names) {
     const name = basename(raw);
     const ext = extname(name);
     const base = name.slice(0, name.length - ext.length) || "file";
-    const key = name.toLowerCase();
-    const count = usedNames.get(key) ?? 0;
-    if (count === 0) {
-      result.push(name);
-    } else {
-      result.push(`${base}-${count}${ext}`);
+    let candidate = name;
+    let n = 1;
+    while (usedNames.has(candidate.toLowerCase())) {
+      candidate = `${base}-${n}${ext}`;
+      n++;
     }
-    usedNames.set(key, count + 1);
+    usedNames.add(candidate.toLowerCase());
+    result.push(candidate);
   }
   return result;
 }
@@ -99,6 +99,10 @@ export function registerExtractZip(app: FastifyInstance) {
         const mode = (entry.externalFileAttributes >>> 16) & 0o170000;
         if (mode === 0o120000) continue;
         fileEntries.push(entry);
+      }
+
+      if (fileEntries.length === 0) {
+        throw new InputValidationError("No extractable files found in the archive");
       }
 
       // Guard: entry count

--- a/apps/api/src/routes/tools/extract-zip.ts
+++ b/apps/api/src/routes/tools/extract-zip.ts
@@ -77,6 +77,39 @@ export function registerExtractZip(app: FastifyInstance) {
   createToolRoute(app, {
     toolId: "extract-zip",
     settingsSchema,
+    // Reject path-traversal / absolute-path entries pre-enqueue with a clean 400.
+    // (yauzl also blocks them, but only as a generic worker 422; the processV2
+    // guards below remain as defense-in-depth for the pipeline/batch path.)
+    preValidate: async ({ inputs }) => {
+      const buf = inputs[0]?.buffer;
+      if (!buf) return;
+      let entries: Entry[];
+      try {
+        entries = await collectEntries(await openZipBuffer(buf));
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (/relative path|absolute path/i.test(msg)) {
+          throw new InputValidationError(
+            "This archive contains an unsafe entry path (path traversal or absolute) and was rejected",
+          );
+        }
+        throw new InputValidationError(
+          "Could not read the archive; it may be corrupt or not a valid .zip",
+        );
+      }
+      for (const e of entries) {
+        const name = e.fileName;
+        if (
+          name.startsWith("/") ||
+          name.startsWith("\\") ||
+          name.split(/[/\\]/).some((s) => s === "..")
+        ) {
+          throw new InputValidationError(
+            "This archive contains an unsafe entry path (path traversal or absolute) and was rejected",
+          );
+        }
+      }
+    },
     process: async () => {
       throw new Error("extract-zip is v2-only");
     },

--- a/apps/api/src/routes/tools/json-xml.ts
+++ b/apps/api/src/routes/tools/json-xml.ts
@@ -1,6 +1,7 @@
 import { XMLBuilder, XMLParser } from "fast-xml-parser";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
+import { InputValidationError } from "../../modality/contract.js";
 import { createToolRoute } from "../tool-factory.js";
 
 const settingsSchema = z.object({
@@ -34,14 +35,22 @@ export function registerJsonXml(app: FastifyInstance) {
       }
 
       // json -> xml
-      const data: unknown = JSON.parse(text);
-      // Wrap in a root element when the top level is an array or has
-      // multiple keys, so the XML is well-formed with a single root.
+      let data: unknown;
+      try {
+        data = JSON.parse(text);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new InputValidationError(`Not valid JSON: ${msg.split("\n")[0]}`);
+      }
+      // The builder needs an object/array root; primitives (null, string, number,
+      // boolean) crash builder.build or produce per-character garbage XML.
+      if (data === null || typeof data !== "object") {
+        throw new InputValidationError("JSON must be an object or array to convert to XML");
+      }
+      // Wrap in a root element when the top level is an array or has multiple
+      // keys, so the XML is well-formed with a single root.
       const wrapped =
-        Array.isArray(data) ||
-        (typeof data === "object" && data !== null && Object.keys(data).length !== 1)
-          ? { root: data }
-          : data;
+        Array.isArray(data) || Object.keys(data).length !== 1 ? { root: data } : data;
       const builder = new XMLBuilder({ format: settings.pretty, ignoreAttributes: false });
       const xml = builder.build(wrapped) as string;
       return {

--- a/apps/api/src/routes/tools/merge-csvs.ts
+++ b/apps/api/src/routes/tools/merge-csvs.ts
@@ -10,6 +10,7 @@ export function registerMergeCsvs(app: FastifyInstance) {
   createToolRoute(app, {
     toolId: "merge-csvs",
     maxInputs: 20,
+    minInputs: 2,
     settingsSchema,
     process: async () => {
       throw new Error("merge-csvs is v2-only");

--- a/apps/api/src/routes/tools/split-csv.ts
+++ b/apps/api/src/routes/tools/split-csv.ts
@@ -36,8 +36,10 @@ export function registerSplitCsv(app: FastifyInstance) {
         throw new Error("CSV file is empty");
       }
 
-      const header = settings.keepHeader ? allRows[0] : null;
-      const dataRows = settings.keepHeader ? allRows.slice(1) : allRows;
+      // Always treat row 0 as the header; keepHeader only controls whether it is
+      // repeated into each part (false = parts contain data rows only).
+      const header = allRows[0];
+      const dataRows = allRows.slice(1);
       if (dataRows.length === 0) {
         throw new Error("No data rows to split");
       }
@@ -51,7 +53,7 @@ export function registerSplitCsv(app: FastifyInstance) {
       // Write part files to scratch
       const partPaths: string[] = [];
       for (let i = 0; i < chunks.length; i++) {
-        const rows = header ? [header, ...chunks[i]] : chunks[i];
+        const rows = settings.keepHeader ? [header, ...chunks[i]] : chunks[i];
         const csv = Papa.unparse(rows);
         const partPath = join(ctx.scratchDir, `part-${i + 1}.csv`);
         await writeFile(partPath, csv, "utf8");

--- a/apps/api/src/routes/tools/split-csv.ts
+++ b/apps/api/src/routes/tools/split-csv.ts
@@ -38,6 +38,9 @@ export function registerSplitCsv(app: FastifyInstance) {
 
       const header = settings.keepHeader ? allRows[0] : null;
       const dataRows = settings.keepHeader ? allRows.slice(1) : allRows;
+      if (dataRows.length === 0) {
+        throw new Error("No data rows to split");
+      }
 
       // Chunk data rows
       const chunks: string[][][] = [];

--- a/apps/api/src/routes/tools/xml-to-csv.ts
+++ b/apps/api/src/routes/tools/xml-to-csv.ts
@@ -30,16 +30,42 @@ function findFirstArray(node: unknown): Record<string, unknown>[] | null {
 }
 
 /**
+ * Fallback for a single (non-repeating) record: depth-first, find the first
+ * object whose values are all scalar (a leaf record), skipping the XML
+ * declaration (keys starting with "?"). Lets a 1-element XML still tabulate.
+ */
+function findFirstRecord(node: unknown): Record<string, unknown> | null {
+  if (typeof node !== "object" || node === null || Array.isArray(node)) return null;
+  const entries = Object.entries(node as Record<string, unknown>).filter(
+    ([k]) => !k.startsWith("?"),
+  );
+  const objectChildren = entries.filter(([, v]) => typeof v === "object" && v !== null);
+  const hasScalar = entries.some(([, v]) => v === null || typeof v !== "object");
+  if (hasScalar && objectChildren.length === 0) {
+    return Object.fromEntries(entries);
+  }
+  for (const [, v] of objectChildren) {
+    const found = findFirstRecord(v);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
  * Flatten one level: nested objects and arrays become JSON strings in the cell.
  */
 function flattenRow(row: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
+  const original = new Set(Object.keys(row));
   for (const [key, val] of Object.entries(row)) {
-    if (val !== null && typeof val === "object") {
-      out[key] = JSON.stringify(val);
-    } else {
-      out[key] = val;
-    }
+    // Strip fast-xml-parser's internal markers from column names: "@_" on
+    // attributes and "#text" for an element's text content -- unless a sibling
+    // element already owns the cleaned-up name.
+    let bare = key;
+    if (key.startsWith("@_")) bare = key.slice(2);
+    else if (key === "#text") bare = "text";
+    const outKey = bare !== key && original.has(bare) ? key : bare;
+    out[outKey] = val !== null && typeof val === "object" ? JSON.stringify(val) : val;
   }
   return out;
 }
@@ -71,13 +97,21 @@ export function registerXmlToCsv(app: FastifyInstance) {
         throw new InputValidationError(`XML parse failed: ${msg.split("\n")[0]}`);
       }
 
-      const rows = findFirstArray(parsed);
+      let rows = findFirstArray(parsed);
+      if (!rows) {
+        // No repeating array: fall back to a single record (1-row table).
+        const single = findFirstRecord(parsed);
+        if (single) rows = [single];
+      }
       if (!rows || rows.length === 0) {
         throw new InputValidationError("No repeating elements found to tabulate");
       }
 
       const flattened = rows.map(flattenRow);
-      const csv = Papa.unparse(flattened);
+      // Papa.unparse derives columns from the first row only; pass the union of
+      // all keys so heterogeneous records don't silently drop columns.
+      const columns = Array.from(new Set(flattened.flatMap((row) => Object.keys(row))));
+      const csv = Papa.unparse(flattened, { columns });
 
       return {
         buffer: Buffer.from(csv, "utf8"),

--- a/apps/api/src/routes/tools/yaml-json.ts
+++ b/apps/api/src/routes/tools/yaml-json.ts
@@ -51,7 +51,10 @@ export function registerYamlJson(app: FastifyInstance) {
         const msg = err instanceof Error ? err.message : String(err);
         throw new InputValidationError(`Not valid YAML: ${msg.split("\n")[0]}`);
       }
-      const json = JSON.stringify(parsed, null, 2);
+      // js-yaml returns undefined for empty/comment-only documents; normalize to
+      // null so JSON.stringify yields the string "null" instead of undefined
+      // (Buffer.from(undefined) throws).
+      const json = JSON.stringify(parsed ?? null, null, 2);
       return {
         buffer: Buffer.from(json, "utf8"),
         filename: `${base}.json`,

--- a/apps/web/src/components/common/review-panel.tsx
+++ b/apps/web/src/components/common/review-panel.tsx
@@ -134,24 +134,14 @@ export function ReviewPanel({
             <span className="text-muted-foreground">{t.toolPage.processed}</span>
             <span className="tabular-nums text-foreground">{formatFileSize(fileSize)}</span>
           </div>
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">{t.toolPage.saved}</span>
-            <span
-              className={`tabular-nums font-medium ${
-                sizeDelta > 0
-                  ? "text-emerald-600"
-                  : sizeDelta === 0
-                    ? "text-muted-foreground"
-                    : "text-foreground"
-              }`}
-            >
-              {sizeDelta === 0
-                ? t.toolPage.noChange
-                : sizeDelta > 0
-                  ? `-${sizeDelta}%`
-                  : `+${Math.abs(sizeDelta)}%`}
-            </span>
-          </div>
+          {/* Only claim "Saved" when the output is actually smaller; growth or
+              no-change is already visible from the Original/Processed sizes above. */}
+          {sizeDelta > 0 && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">{t.toolPage.saved}</span>
+              <span className="tabular-nums font-medium text-emerald-600">{sizeDelta}%</span>
+            </div>
+          )}
         </div>
       )}
 

--- a/apps/web/src/components/tools/create-zip-settings.tsx
+++ b/apps/web/src/components/tools/create-zip-settings.tsx
@@ -9,7 +9,7 @@ export function CreateZipSettings() {
   const { files } = useFileStore();
   const { processFiles, processing, error, progress } = useToolProcessor("create-zip");
 
-  const hasFile = files.length > 0;
+  const hasEnough = files.length >= 2;
 
   const handleProcess = () => {
     processFiles(files, {});
@@ -33,7 +33,7 @@ export function CreateZipSettings() {
           type="button"
           data-testid="create-zip-submit"
           onClick={handleProcess}
-          disabled={!hasFile || processing}
+          disabled={!hasEnough || processing}
           className="w-full py-2.5 rounded-lg bg-primary text-primary-foreground font-medium disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {s.submit}

--- a/apps/web/src/pages/home-page.tsx
+++ b/apps/web/src/pages/home-page.tsx
@@ -40,7 +40,7 @@ const MODALITY_TAB_ORDER = [
   { modalityId: "video", tabKey: "video", label: "Video" },
   { modalityId: "audio", tabKey: "audio", label: "Audio" },
   { modalityId: "document", tabKey: "document", label: "PDF" },
-  { modalityId: "file", tabKey: "data", label: "Files" },
+  { modalityId: "file", tabKey: "data", label: "Data" },
 ];
 
 export function HomePage() {

--- a/packages/shared/src/i18n/ar.ts
+++ b/packages/shared/src/i18n/ar.ts
@@ -70,7 +70,7 @@ export const ar: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2488,7 +2488,7 @@ export const ar: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/de.ts
+++ b/packages/shared/src/i18n/de.ts
@@ -70,7 +70,7 @@ export const de: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2502,7 +2502,7 @@ export const de: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/en.ts
+++ b/packages/shared/src/i18n/en.ts
@@ -73,7 +73,7 @@ export const en = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2452,7 +2452,7 @@ export const en = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/es.ts
+++ b/packages/shared/src/i18n/es.ts
@@ -70,7 +70,7 @@ export const es: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2484,7 +2484,7 @@ export const es: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/fr.ts
+++ b/packages/shared/src/i18n/fr.ts
@@ -70,7 +70,7 @@ export const fr: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2503,7 +2503,7 @@ export const fr: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/hi.ts
+++ b/packages/shared/src/i18n/hi.ts
@@ -70,7 +70,7 @@ export const hi: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2485,7 +2485,7 @@ export const hi: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/id.ts
+++ b/packages/shared/src/i18n/id.ts
@@ -70,7 +70,7 @@ export const id: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2497,7 +2497,7 @@ export const id: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/it.ts
+++ b/packages/shared/src/i18n/it.ts
@@ -70,7 +70,7 @@ export const it: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2496,7 +2496,7 @@ export const it: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/ja.ts
+++ b/packages/shared/src/i18n/ja.ts
@@ -70,7 +70,7 @@ export const ja: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2455,7 +2455,7 @@ export const ja: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/ko.ts
+++ b/packages/shared/src/i18n/ko.ts
@@ -70,7 +70,7 @@ export const ko: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2440,7 +2440,7 @@ export const ko: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/nl.ts
+++ b/packages/shared/src/i18n/nl.ts
@@ -70,7 +70,7 @@ export const nl: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2499,7 +2499,7 @@ export const nl: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/pl.ts
+++ b/packages/shared/src/i18n/pl.ts
@@ -70,7 +70,7 @@ export const pl: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2500,7 +2500,7 @@ export const pl: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/pt-BR.ts
+++ b/packages/shared/src/i18n/pt-BR.ts
@@ -70,7 +70,7 @@ export const ptBR: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2496,7 +2496,7 @@ export const ptBR: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/ru.ts
+++ b/packages/shared/src/i18n/ru.ts
@@ -70,7 +70,7 @@ export const ru: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2498,7 +2498,7 @@ export const ru: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/sv.ts
+++ b/packages/shared/src/i18n/sv.ts
@@ -70,7 +70,7 @@ export const sv: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2495,7 +2495,7 @@ export const sv: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/th.ts
+++ b/packages/shared/src/i18n/th.ts
@@ -70,7 +70,7 @@ export const th: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2477,7 +2477,7 @@ export const th: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/tr.ts
+++ b/packages/shared/src/i18n/tr.ts
@@ -70,7 +70,7 @@ export const tr: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2500,7 +2500,7 @@ export const tr: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/uk.ts
+++ b/packages/shared/src/i18n/uk.ts
@@ -70,7 +70,7 @@ export const uk: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2498,7 +2498,7 @@ export const uk: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/vi.ts
+++ b/packages/shared/src/i18n/vi.ts
@@ -70,7 +70,7 @@ export const vi: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2497,7 +2497,7 @@ export const vi: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/zh-CN.ts
+++ b/packages/shared/src/i18n/zh-CN.ts
@@ -70,7 +70,7 @@ export const zhCN: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2430,7 +2430,7 @@ export const zhCN: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/i18n/zh-TW.ts
+++ b/packages/shared/src/i18n/zh-TW.ts
@@ -70,7 +70,7 @@ export const zhTW: TranslationKeys = {
     image: "Image",
     video: "Video",
     audio: "Audio",
-    documentsAndFiles: "PDF & Files",
+    documentsAndFiles: "PDF & Data",
   },
   tools: {
     resize: {
@@ -2428,7 +2428,7 @@ export const zhTW: TranslationKeys = {
     clearSearch: "Clear search",
     all: "All",
     documents: "PDF",
-    data: "Files",
+    data: "Data",
     toolCount: "{count} tools",
     heading: "SnapOtter Tools",
   },

--- a/packages/shared/src/modality.ts
+++ b/packages/shared/src/modality.ts
@@ -8,13 +8,13 @@ export interface ModalityInfo {
 }
 
 // Five modality values in code, surfaced as five UI sections:
-// Image, Video, Audio, PDF ("document" id) and Files ("file" id).
+// Image, Video, Audio, PDF ("document" id) and Data ("file" id).
 export const MODALITIES: ModalityInfo[] = [
   { id: "image", name: "Image", icon: "Image", color: "#3B82F6" },
   { id: "video", name: "Video", icon: "Video", color: "#EF4444" },
   { id: "audio", name: "Audio", icon: "AudioLines", color: "#10B981" },
   { id: "document", name: "PDF", icon: "FileText", color: "#8B5CF6" },
-  { id: "file", name: "Files", icon: "FileArchive", color: "#F59E0B" },
+  { id: "file", name: "Data", icon: "FileArchive", color: "#F59E0B" },
 ];
 
 // Which BullMQ pool a modality's tools run on. AI tools override to "ai"


### PR DESCRIPTION
Renames the `file` modality's display name back to **Data** (a partial revert of the Files rename, keeping PDF for documents), and fixes **20 bugs/nuances** found in a full QA sweep of the 10 Data tools.

## Rename
- `file` modality display name **Files → Data** — `modality.ts`, the home-page tab, and `tools.data` + `documentsAndFiles` across all 21 locales. The URL slug was already `/data`, so name and slug realign; the breadcrumb follows `modality.ts`. (`document` keeps the new "PDF" name.)

## Fixes (by tool)
- **csv-json**: crash on a primitive array (`[1,2,3]`); nested objects rendered as `[object Object]` (now JSON); dropped columns for heterogeneous objects (now the union of keys).
- **json-xml**: crash on a `null`/primitive JSON root (now a clear 4xx).
- **yaml-json**: crash on empty/comment-only YAML (returned `undefined`; now emits `null`).
- **xml-to-csv**: leaked `@_`/`#text` parser markers into CSV headers (now clean); single-record XML failed to tabulate (now a 1-row table); dropped columns for heterogeneous records (now union).
- **csv-excel**: xlsx date cells were timezone-dependent via `Date.toString` (now ISO 8601).
- **split-csv**: header-only CSV produced an empty zip (now errors); `keepHeader=false` now drops the header instead of keeping it as part-1's first row.
- **create-zip**: filename-collision dedup overwrote entries / lost a file (now unique); submit gated at ≥2 files; single-file request returns 400 (was a worker 422).
- **extract-zip**: basename-collision dedup data loss (now unique); directory-only zip produced an empty zip (now errors); unsafe / absolute / corrupt archives now return a clean **400** via a new pre-enqueue `preValidate` hook (the worker can't, since BullMQ drops the error class).
- **chart-maker**: negative values produced invalid/degenerate SVG that Sharp dropped (now rejected with a clear message).
- **merge-csvs**: single-file request returns 400 (was 422).
- **review-panel**: result card showed "Saved +X%" when the output grew (now only when the file is actually smaller).
- **tool-factory**: added opt-in `minInputs` and `preValidate` hooks (both return a clean 400 pre-enqueue).

## QA
Verified against a fresh Docker stack on :1359: Playwright drove all 10 tools with realistic input (visual + downloaded-output content checks), plus a 51-check API harness covering the fix edge cases, multiple-files handling (single-file tools reject 2 files; multi-file tools scale and enforce bounds), reverse directions, round-trips, CSV quoting, merge column handling, and zip path-traversal/absolute-path security. **51/51 green, no regressions.**
