### PR TITLE
fix(normalize-audio): preserve source sample rate after loudnorm

### DIFF
--- a/apps/api/src/lib/media-tool.ts
+++ b/apps/api/src/lib/media-tool.ts
@@ -128,7 +128,11 @@ export async function runFfmpegWithProgress(
 export async function runMediaTool(
   ctx: ToolProcessCtxV2,
   outName: string,
-  argsFor: (inPath: string, outPath: string, info: { durationS: number | null }) => string[],
+  argsFor: (
+    inPath: string,
+    outPath: string,
+    info: { durationS: number | null; audioSampleRate: number | null },
+  ) => string[],
   opts: { timeoutMs?: number } = {},
 ): Promise<MediaRunResult> {
   const dir = join(ctx.scratchDir, "media");
@@ -139,7 +143,10 @@ export async function runMediaTool(
   const outPath = join(dir, outName);
   await runFfmpegWithProgress(
     ctx,
-    argsFor(inPath, outPath, { durationS: info.durationS }),
+    argsFor(inPath, outPath, {
+      durationS: info.durationS,
+      audioSampleRate: info.streams.find((s) => s.type === "audio")?.sampleRate ?? null,
+    }),
     info.durationS,
     opts,
   );

--- a/apps/api/src/routes/tools/normalize-audio.ts
+++ b/apps/api/src/routes/tools/normalize-audio.ts
@@ -19,8 +19,18 @@ export function registerNormalizeAudio(app: FastifyInstance) {
       const base = ctx.inputs[0].filename.replace(/\.[^.]+$/, "");
       const outName = `${base}_normalized${out.ext}`;
 
-      const { outPath } = await runMediaTool(ctx, outName, (inPath, outPath) => {
-        return ["-i", inPath, "-af", "loudnorm=I=-16:TP=-1.5:LRA=11", ...out.encodeArgs, outPath];
+      const { outPath } = await runMediaTool(ctx, outName, (inPath, outPath, info) => {
+        // loudnorm runs internally at 192 kHz and emits at 192 kHz unless we
+        // resample back, so restore the source rate to avoid inflating the file.
+        const sr = info.audioSampleRate ?? 44100;
+        return [
+          "-i",
+          inPath,
+          "-af",
+          `loudnorm=I=-16:TP=-1.5:LRA=11,aresample=${sr}`,
+          ...out.encodeArgs,
+          outPath,
+        ];
       });
       return { scratchPath: outPath, filename: outName, contentType: out.contentType };
     },


### PR DESCRIPTION
## Problem
`normalize-audio` emitted **192 kHz** output regardless of the input rate (a 44.1 kHz / 2.6 MB clip became 192 kHz / 11.5 MB). ffmpeg's `loudnorm` filter runs internally at 192 kHz and emits at 192 kHz unless the chain resamples back.

## Fix
Append `,aresample=<source rate>` after `loudnorm`. `runMediaTool` now exposes the input audio sample rate to its args callback so `normalize-audio` recovers the source rate. Loudness normalization is unchanged.

## Verification
Verified end-to-end on a fresh Docker build (identical change was tested in the combined branch): 192000 → 44100 Hz, file 11.5 MB → 2.65 MB, loudness still normalized (mean -17.1 / max -11.5 dB); also held inside batch.

## Note
This is the audio half of the loudnorm fix, extracted to target `main` directly. The `video-loudnorm` half (a video tool) depends on the codec feature-branch and rides to main with that stack (#243).