### PR TITLE
fix(lint): green apps/api lint (format tool-factory + json-xml)

### DIFF
--- a/apps/api/src/routes/tool-factory.ts
+++ b/apps/api/src/routes/tool-factory.ts
@@ -80,9 +80,7 @@ export interface ToolRouteConfig<T> {
    * and validated settings; throw InputValidationError to reject with its
    * statusCode (default 400) before any job is enqueued (vs a worker 422).
    */
-  preValidate?: (ctx: {
-    inputs: { filename: string; buffer: Buffer }[];
-  }) => Promise<void> | void;
+  preValidate?: (ctx: { inputs: { filename: string; buffer: Buffer }[] }) => Promise<void> | void;
   /**
    * Per-position input kind overrides for mixed-input tools (e.g. video +
    * subtitle). Input i validates with kind inputKinds[Math.min(i, len-1)].
@@ -121,9 +119,7 @@ export interface AnyToolRouteConfig {
   toolId: string;
   maxInputs?: number;
   minInputs?: number;
-  preValidate?: (ctx: {
-    inputs: { filename: string; buffer: Buffer }[];
-  }) => Promise<void> | void;
+  preValidate?: (ctx: { inputs: { filename: string; buffer: Buffer }[] }) => Promise<void> | void;
   inputKinds?: ("video" | "audio" | "image" | "subtitle")[];
   settingsSchema: z.ZodType<unknown, z.ZodTypeDef, unknown>;
   process: (
@@ -589,8 +585,7 @@ export function createToolRoute<T>(app: FastifyInstance, config: ToolRouteConfig
             category: TOOLS.find((t) => t.id === config.toolId)?.category ?? "unknown",
             is_ai_tool: getBundleForTool(config.toolId) !== null,
             error_code: err instanceof Error ? err.constructor.name : "UnknownError",
-            error_message:
-              err instanceof Error ? err.message.slice(0, 200) : "Processing failed",
+            error_message: err instanceof Error ? err.message.slice(0, 200) : "Processing failed",
           });
           return reply.status(422).send({
             error: "Processing failed",

--- a/apps/api/src/routes/tools/json-xml.ts
+++ b/apps/api/src/routes/tools/json-xml.ts
@@ -49,8 +49,7 @@ export function registerJsonXml(app: FastifyInstance) {
       }
       // Wrap in a root element when the top level is an array or has multiple
       // keys, so the XML is well-formed with a single root.
-      const wrapped =
-        Array.isArray(data) || Object.keys(data).length !== 1 ? { root: data } : data;
+      const wrapped = Array.isArray(data) || Object.keys(data).length !== 1 ? { root: data } : data;
       const builder = new XMLBuilder({ format: settings.pretty, ignoreAttributes: false });
       const xml = builder.build(wrapped) as string;
       return {


### PR DESCRIPTION
Format-only follow-up to #251. Collapses the `error_message` line that #251 introduced, plus the pre-existing `preValidate` blocks and the `json-xml` wrapped assignment that were already failing `apps/api` lint on main. `biome check src/` now exits 0 for apps/api. No logic change.