### PR TITLE
fix: post-2.0 audit bug fixes (404 route, worker logging, outpaint gate, pandoc path)

### DIFF
--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -824,7 +824,7 @@ export function startWorkers(): void {
     });
 
     worker.on("error", (err) => {
-      console.error(`Worker error [${pool}]:`, err);
+      logger.error({ err, pool }, "Worker error");
     });
 
     workers.push(worker);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -32,6 +32,9 @@ const EditorPage = lazy(() =>
   import("./pages/editor-page").then((m) => ({ default: m.EditorPage })),
 );
 const ToolPage = lazy(() => import("./pages/tool-page").then((m) => ({ default: m.ToolPage })));
+const NotFoundPage = lazy(() =>
+  import("./pages/not-found-page").then((m) => ({ default: m.NotFoundPage })),
+);
 
 class ErrorBoundary extends Component<
   { children: ReactNode },
@@ -239,6 +242,7 @@ export function App() {
                   <Route path="/editor" element={<EditorPage />} />
                   <Route path="/:modality/:toolId" element={<ToolPage />} />
                   <Route path="/" element={<HomePage />} />
+                  <Route path="*" element={<NotFoundPage />} />
                 </Routes>
               </Suspense>
             </AuthGuard>

--- a/packages/ai/python/dispatcher.py
+++ b/packages/ai/python/dispatcher.py
@@ -112,6 +112,7 @@ TOOL_BUNDLE_MAP = {
     "face_landmarks": "face-detection",
     "red_eye_removal": "face-detection",
     "inpaint": "object-eraser-colorize",
+    "outpaint": "object-eraser-colorize",
     "colorize": "object-eraser-colorize",
     "upscale": "upscale-enhance",
     "enhance_faces": "upscale-enhance",

--- a/packages/doc-engine/src/pandoc.ts
+++ b/packages/doc-engine/src/pandoc.ts
@@ -1,11 +1,16 @@
 import { spawn, spawnSync } from "node:child_process";
 
+/** Resolve the pandoc binary, honoring PANDOC_PATH for parity with the other doc-engine wrappers. */
+function pandocBin(): string {
+  return process.env.PANDOC_PATH || "pandoc";
+}
+
 let cachedAvailable: boolean | null = null;
 
 /** True when a pandoc binary is on PATH (gates local tests; the image installs it). */
 export function pandocAvailable(): boolean {
   if (cachedAvailable !== null) return cachedAvailable;
-  const r = spawnSync("pandoc", ["--version"], { stdio: "ignore" });
+  const r = spawnSync(pandocBin(), ["--version"], { stdio: "ignore" });
   cachedAvailable = r.status === 0;
   return cachedAvailable;
 }
@@ -15,7 +20,7 @@ let cachedSelfContainedArgs: string[] | null = null;
 
 function selfContainedArgs(): string[] {
   if (cachedSelfContainedArgs !== null) return cachedSelfContainedArgs;
-  const r = spawnSync("pandoc", ["--version"], {
+  const r = spawnSync(pandocBin(), ["--version"], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],
   });
@@ -55,7 +60,7 @@ export function runPandoc(
     args.push(...opts.extraArgs);
   }
   return new Promise<void>((resolvePromise, reject) => {
-    const child = spawn("pandoc", args, { stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(pandocBin(), args, { stdio: ["ignore", "pipe", "pipe"] });
     let err = "";
     let settled = false;
     const timer = setTimeout(() => {


### PR DESCRIPTION
## Summary

Four small, independent bug fixes surfaced while auditing the codebase for the 2.0.0 release. Each was checked against source before changing.

| Area | Fix | Why |
|------|-----|-----|
| web (`App.tsx`) | Add a catch-all `*` route rendering `NotFoundPage` | The page existed but was never routed; unknown URLs rendered a blank screen. The route sits below `/:modality/:toolId`, so valid tool routes are unaffected. |
| api (`jobs/worker.ts`) | `logger.error({ err, pool })` instead of `console.error` | Non-system pool worker errors bypassed structured logging (no JSON, no trace correlation). |
| ai (`python/dispatcher.py`) | Add `"outpaint": "object-eraser-colorize"` to `TOOL_BUNDLE_MAP` | `outpaint` was the only ML script with no Python-side bundle gate; the API already gates `ai-canvas-expand`, this aligns the sidecar. |
| doc-engine (`pandoc.ts`) | Resolve pandoc via `PANDOC_PATH` | Parity with the `qpdf` / `ghostscript` / `libreoffice` / `pdfcpu` wrappers, which all honor an env override. |

## Verification

- `pnpm typecheck` 9/9, `biome check` clean, husky pre-commit passed locally.
- On CI, the checks that exercise these files pass: **Lint, Typecheck, CodeQL, Analyze (js/py)**.

## Merge context (please read before merging)

`main` is currently **red on CI for reasons unrelated to this PR**:
1. A `numpy==1.26.4` vs `rembg` dependency conflict in `packages/ai/python/requirements.txt` (fails Python Dependency Audit and cascades into AI-dependent integration tests).
2. In-flight "modality-aware error" test alignment (unit/integration tests for `dropzone`, `tool-factory-route`, `edge-cases`, `fetch-urls`, `image-enhancement`, `format-matrix`, etc.).

This branch is cut from `main`, so it inherits that red. **None of the failing tests touch the files in this PR.** The same jobs fail on `main`'s own latest CI run, so compare against that baseline. Recommend merging only after `main` is green (rebase then), or after confirming the failing checks match `main`'s baseline.

This is a `fix:` commit, so semantic-release will cut a patch version on merge.

Split from the original combined audit PR (now closed); the dead-code cleanup is in a separate `chore:` PR so it can be reviewed independently.
