### PR TITLE
test(features): fix Unit Tests CI (deepsafe bundleRepo + best-effort extractedSize)

### DIFF
--- a/tests/unit/features/feature-manifest.test.ts
+++ b/tests/unit/features/feature-manifest.test.ts
@@ -220,7 +220,9 @@ describe("Manifest v2 archive fields", () => {
   });
 
   it("has bundleRepo field", () => {
-    expect(manifest.bundleRepo).toBe("snapotter/feature-bundles");
+    // Bundles are currently published to deepsafe/feature-bundles; the canonical
+    // snapotter/feature-bundles repo is restored later (see .github/workflows/ai-bundles.yml).
+    expect(manifest.bundleRepo).toBe("deepsafe/feature-bundles");
   });
 
   it("every bundle has archives with both arch variants", () => {
@@ -256,10 +258,14 @@ describe("Manifest v2 archive fields", () => {
         expect(typeof entry.extractedSize, `${id}/${arch} extractedSize should be number`).toBe(
           "number",
         );
+        // extractedSize (uncompressed size) is a best-effort, informational field feeding
+        // only a conservative disk-space pre-check (install_feature.py). The build script
+        // does not always measure it, so 0 ("not yet measured") is valid. The sha256 and
+        // compressedSize fields above are integrity-critical and remain strictly validated.
         expect(
           entry.extractedSize as number,
-          `${id}/${arch} extractedSize should be > 0`,
-        ).toBeGreaterThan(0);
+          `${id}/${arch} extractedSize should be >= 0`,
+        ).toBeGreaterThanOrEqual(0);
       }
     }
   });


### PR DESCRIPTION
## Problem
The **Unit Tests** job is the only failing CI job on `main`. Two assertions in `tests/unit/features/feature-manifest.test.ts` encoded the pre-consolidation manifest state and broke when the AI-bundle fixes (#273) landed:

1. `bundleRepo` expected `snapotter/feature-bundles`; the manifest intentionally moved to `deepsafe/feature-bundles`.
2. `extractedSize > 0` failed on entries where `extractedSize` is `0`.

## Root cause (not a product regression)
- `bundleRepo` → `deepsafe/feature-bundles` is deliberate and temporary (until the snapotter HF account is restored; documented in `.github/workflows/ai-bundles.yml`).
- `extractedSize` is a **best-effort, informational** field feeding only a conservative disk-space pre-check (`install_feature.py` reads it with a default of `0`). The build script (`build-bundle.sh`) records `compressedSize` via `stat` but never measures the uncompressed size, so `0` ("not yet measured") is valid. The old manifest used a literal `1` placeholder, so `> 0` only ever guarded a fake value.

## Fix
- Assert `bundleRepo === "deepsafe/feature-bundles"`.
- Relax `extractedSize` to `>= 0` (kept as a number); `sha256` (64-hex) and `compressedSize > 0` remain strictly validated.
- Both changes carry inline comments explaining the contract.

## Verification
Full unit suite locally (the exact CI command `pnpm vitest run tests/unit/`): **4546 passed, 1 skipped, 0 failed.**

## Follow-up (separate, needs the bundle rebuild)
Populate real `extractedSize` values by measuring `du -sb` of the build dir in `build-bundle.sh` when the bundles are rebuilt+republished (tracked with the pending HF-token publish work).