### PR TITLE
fix(deps): close js-yaml DoS alert + document rembg non-reachability

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,12 +110,14 @@
       "@babel/core": ">=7.29.6",
       "@opentelemetry/core": ">=2.8.0",
       "js-yaml": ">=4.2.0",
-      "gray-matter>js-yaml": "^3.14.1",
       "qs": ">=6.15.2",
       "uuid": ">=11.1.1",
       "yaml": ">=2.8.3",
       "dompurify": ">=3.4.11",
       "nanoid@4": ">=5.0.9"
+    },
+    "patchedDependencies": {
+      "gray-matter@4.0.3": "patches/gray-matter@4.0.3.patch"
     }
   },
   "dependencies": {

--- a/packages/ai/python/requirements-gpu.txt
+++ b/packages/ai/python/requirements-gpu.txt
@@ -1,3 +1,10 @@
+# rembg is pinned to 2.0.69. The patched 2.0.75 (GHSA: server SSRF/CORS +
+# custom-model path traversal) pulls numpy>=2.3, scipy>=1.16 and
+# scikit-image>=0.26 -- a numpy 2.x closure that is incompatible with this
+# numpy==1.26.4-locked stack (realesrgan 0.3.0 and codeformer-pip 0.0.4 break
+# on numpy 2.x). Both advisories are unreachable here: rembg is used purely as
+# a library (we never run `rembg s`), and new_session() only ever receives
+# allowlisted model names (remove_bg.py ALLOWED_MODELS), never user paths.
 rembg==2.0.69
 realesrgan==0.3.0
 paddleocr==2.9.1

--- a/packages/ai/python/requirements.txt
+++ b/packages/ai/python/requirements.txt
@@ -1,3 +1,10 @@
+# rembg is pinned to 2.0.69. The patched 2.0.75 (GHSA: server SSRF/CORS +
+# custom-model path traversal) pulls numpy>=2.3, scipy>=1.16 and
+# scikit-image>=0.26 -- a numpy 2.x closure that is incompatible with this
+# numpy==1.26.4-locked stack (realesrgan 0.3.0 and codeformer-pip 0.0.4 break
+# on numpy 2.x). Both advisories are unreachable here: rembg is used purely as
+# a library (we never run `rembg s`), and new_session() only ever receives
+# allowlisted model names (remove_bg.py ALLOWED_MODELS), never user paths.
 rembg[cpu]==2.0.69
 realesrgan==0.3.0
 paddleocr[doc-parser]>=3.4.0,<3.5.0

--- a/patches/gray-matter@4.0.3.patch
+++ b/patches/gray-matter@4.0.3.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/engines.js b/lib/engines.js
+index 38f993db06cf364191ac635a6590c2d29303297d..1dfec8d9527653ad9ccfaacfa59732246fdb1e32 100644
+--- a/lib/engines.js
++++ b/lib/engines.js
+@@ -13,8 +13,8 @@ const engines = exports = module.exports;
+  */
+ 
+ engines.yaml = {
+-  parse: yaml.safeLoad.bind(yaml),
+-  stringify: yaml.safeDump.bind(yaml)
++  parse: yaml.load.bind(yaml),
++  stringify: yaml.dump.bind(yaml)
+ };
+ 
+ /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,12 +24,16 @@ overrides:
   '@babel/core': '>=7.29.6'
   '@opentelemetry/core': '>=2.8.0'
   js-yaml: '>=4.2.0'
-  gray-matter>js-yaml: ^3.14.1
   qs: '>=6.15.2'
   uuid: '>=11.1.1'
   yaml: '>=2.8.3'
   dompurify: '>=3.4.11'
   nanoid@4: '>=5.0.9'
+
+patchedDependencies:
+  gray-matter@4.0.3:
+    hash: vkz7jnrv727ytpnfp5cox2adfu
+    path: patches/gray-matter@4.0.3.patch
 
 importers:
 
@@ -3999,9 +4003,6 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -4920,11 +4921,6 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -5595,10 +5591,6 @@ packages:
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -7366,9 +7358,6 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
-
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   ssh-remote-port-forward@1.0.4:
     resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
@@ -11580,7 +11569,7 @@ snapshots:
   '@sugarat/theme-shared@0.0.7':
     dependencies:
       cross-spawn: 7.0.6
-      gray-matter: 4.0.3
+      gray-matter: 4.0.3(patch_hash=vkz7jnrv727ytpnfp5cox2adfu)
 
   '@swc/helpers@0.5.23':
     dependencies:
@@ -12392,10 +12381,6 @@ snapshots:
       - react-native-b4a
 
   arg@5.0.2: {}
-
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -13277,8 +13262,6 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  esprima@4.0.1: {}
-
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -13674,9 +13657,9 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  gray-matter@4.0.3:
+  gray-matter@4.0.3(patch_hash=vkz7jnrv727ytpnfp5cox2adfu):
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -14062,11 +14045,6 @@ snapshots:
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.2.0:
     dependencies:
@@ -16061,8 +16039,6 @@ snapshots:
 
   split2@4.2.0: {}
 
-  sprintf-js@1.0.3: {}
-
   ssh-remote-port-forward@1.0.4:
     dependencies:
       '@types/ssh2': 0.5.52
@@ -16712,7 +16688,7 @@ snapshots:
 
   vitepress-plugin-llms@1.13.1:
     dependencies:
-      gray-matter: 4.0.3
+      gray-matter: 4.0.3(patch_hash=vkz7jnrv727ytpnfp5cox2adfu)
       markdown-it: 14.2.0
       markdown-title: 1.0.2
       mdast-util-from-markdown: 2.0.3


### PR DESCRIPTION
Resolves the 5 open Dependabot alerts properly (1 fixed at the root, 4 dismissed as unreachable with rationale).

## js-yaml 3.14.2 (alert #29, quadratic-complexity DoS) — fixed

`js-yaml@3.14.2` lingered only because a scoped pnpm override `"gray-matter>js-yaml": "^3.14.1"` exempted gray-matter from the global `js-yaml>=4.2.0` override. gray-matter (a build-time-only transitive dep of the docs site via `vitepress-plugin-llms` / `@sugarat/theme-shared`) is pinned to js-yaml 3.x because it calls the removed `yaml.safeLoad` / `yaml.safeDump` APIs.

- Removed the exemption so gray-matter resolves the patched `js-yaml@4.2.0`.
- Added a pnpm patch (`patches/gray-matter@4.0.3.patch`) renaming `safeLoad`→`load`, `safeDump`→`dump` (the 4.x equivalents; `load` is safe by default).
- **`js-yaml@3.x` is now gone from the lockfile** — alert #29 auto-closes on merge.

Verified: gray-matter parse+stringify smoke passes on 4.2.0; full VitePress docs build green (177 pages, llms plugin parses every tool's frontmatter with no error).

## rembg 2.0.69 (alerts #4/#5/#11/#12) — dismissed as `not_used`

Both advisories (server SSRF/CORS, custom-model path traversal) are **unreachable** in this codebase:
- rembg is used purely as a library; we never run the `rembg s` server.
- `new_session()` only receives allowlisted model names (`remove_bg.py` `ALLOWED_MODELS`), never user-controlled paths.

The patched 2.0.75 pulls a numpy 2.x closure (`numpy>=2.3`, `scipy>=1.16`, `scikit-image>=0.26`) that breaks the `numpy==1.26.4`-locked stack (realesrgan 0.3.0, codeformer-pip 0.0.4). Pinned to 2.0.69 with the rationale documented in both requirements files; the 4 alerts are dismissed `not_used`.

## Test plan
- [x] `js-yaml@3.x` absent from `pnpm-lock.yaml`
- [x] gray-matter functional smoke (parse + stringify) on js-yaml 4.2.0
- [x] VitePress docs build green
- [x] Biome clean on staged files