### PR TITLE
fix(docker): patch OS + pip image CVEs, document accepted Trivy residuals

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -26,3 +26,25 @@ CVE-2026-24842
 CVE-2026-26960
 CVE-2026-29786
 CVE-2026-31802
+
+# pnpm 9.x core (2026 rescan) -- same build-time-tool rationale as above; every
+# one of these is fixed only in pnpm 10.x (10.0.0 / 10.28.1 / 10.28.2), a major
+# breaking migration tracked separately. pnpm runs only at install/start time.
+CVE-2024-47829
+CVE-2026-23888
+CVE-2026-23889
+CVE-2026-23890
+CVE-2026-24056
+CVE-2026-24131
+
+# golang.org/x/image bundled in the caire binary (content-aware seam-carving
+# resize, one tool). esimov/caire v1.5.0 is the latest release and still pins
+# golang.org/x/image v0.18.0; there is no upstream caire build with the fixed
+# x/image >=0.38.0. Re-evaluate when caire publishes a new release.
+CVE-2026-33809
+
+# brace-expansion: build-toolchain transitive of minimatch/glob. The patched
+# instance (5.0.6) is already present; the only flagged copy is the 2.x line
+# pulled by glob, whose fix is a major-version bump (5.0.5) the glob ecosystem
+# has not adopted. Not reachable from user input.
+CVE-2026-33750

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -195,7 +195,11 @@ RUN corepack enable && corepack prepare pnpm@9.15.4 --activate && \
 # System dependencies (all platforms)
 # Split into runtime deps and build deps to minimize final image size.
 # Retry apt-get update with backoff — Ubuntu mirrors can be flaky on CI runners
+# `apt-get upgrade` pulls security patches for base-image packages (e.g.
+# libgnutls30t64, libgcrypt20, liblzma5) that the pinned base digest ships at an
+# outdated patch level -- closes the Trivy OS-package CVEs on every rebuild.
 RUN for i in 1 2 3; do apt-get -o Acquire::Retries=3 update && break || sleep $((i * 15)); done && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
     tini \
     imagemagick \
@@ -269,7 +273,7 @@ RUN ldconfig
 # Uses pre-built manylinux wheels where available; gcc/g++ above covers the rest.
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m venv /opt/venv && \
-    /opt/venv/bin/pip install --upgrade "pip==25.1.1" && \
+    /opt/venv/bin/pip install --upgrade "pip==26.1.2" && \
     /opt/venv/bin/pip install wheel setuptools && \
     /opt/venv/bin/pip install \
         Pillow==12.2.0 \


### PR DESCRIPTION
Addresses the 32 Trivy container-image alerts. Splits cleanly into *genuinely fixed*, *accepted-and-documented*, and *already-resolved*.

## Genuinely fixed (every rebuild)
- **OS packages (~15 CVEs):** added `apt-get upgrade -y` to the production stage so the pinned base digest's outdated packages get Ubuntu security patches: `libgnutls30t64` 3.8.3-1.1ubuntu3.5 → ubuntu3.6 (13 CVEs), `libgcrypt20` → 1.10.3-2ubuntu0.1, `liblzma5` → ...ubuntu0.3.
- **pip (4 CVEs):** `pip==25.1.1` → `pip==26.1.2` (CVE-2025-8869, CVE-2026-1703, CVE-2026-3219, CVE-2026-6357).

## Accepted via `.trivyignore` (canonical, in-repo, reviewed)
- **6 pnpm 9.x build-tool CVEs** — fixed only in pnpm 10.x, a major breaking migration tracked separately; pnpm runs at install/start time only (same rationale as the existing pnpm entries in `.trivyignore`).
- **caire's bundled `golang.org/x/image`** — `esimov/caire` v1.5.0 is the latest release and still pins x/image v0.18.0; no upstream build with the fix exists.
- **brace-expansion 2.x ReDoS** — build-toolchain transitive of glob; the patched 5.0.6 already coexists in the tree; the fix is a major bump the glob ecosystem hasn't adopted; not reachable from user input.

## Already resolved in the current tree (clear on next scan, no change needed)
- `picomatch` → 4.0.4 (existing override), `ip-address` removed from the dependency graph. The stale alerts (4.0.3 / 9.0.5 / 10.1.0) are from the last image scan.

## Verification note
The Trivy job in `release.yml` `needs: [release, docker]`, and the docker build/publish job is intentionally gated `if: ${{ false }}`. So these cannot be re-scanned in CI **without enabling image publishing**, which is deliberately off. The image is not currently shipped, so none of these CVEs are in a released artifact. `docker build --check` passes on the modified Dockerfile.