### PR TITLE
test(integration): accept 202 async for DNG in format-matrix smoke tests

### DIFF
--- a/tests/integration/generated/format-matrix-comprehensive.test.ts
+++ b/tests/integration/generated/format-matrix-comprehensive.test.ts
@@ -189,7 +189,7 @@ const CORE_FORMATS = PRIMARY_FORMATS.filter(
   (f) => !f.needsCliDecoder && !f.needsHeifDecoder && !f.mayFailValidation,
 );
 
-const ACCEPTABLE_FALLBACK_CODES = [200, 400, 422];
+const ACCEPTABLE_FALLBACK_CODES = [200, 202, 400, 422];
 
 function needsFallback(fmt: FormatDef): boolean {
   return fmt.needsCliDecoder || fmt.needsHeifDecoder || fmt.mayFailValidation;
@@ -699,7 +699,7 @@ describe("Image enhancement across all 16 primary formats", () => {
           });
 
           if (needsFallback(fmt)) {
-            expect([200, 400, 422]).toContain(res.statusCode);
+            expect([200, 202, 400, 422]).toContain(res.statusCode);
           } else {
             expect(res.statusCode).toBe(200);
           }
@@ -922,7 +922,7 @@ describe("No-crash matrix: 16 formats x 12 tools", () => {
             expect(typeof body).toBe("object");
 
             // If error, verify clean error shape
-            if (res.statusCode !== 200) {
+            if (res.statusCode >= 400) {
               expect(body.error).toBeDefined();
               expect(typeof body.error).toBe("string");
               expect(body.error.length).toBeGreaterThan(0);
@@ -1031,7 +1031,7 @@ describe("Exotic format error shape verification", () => {
           if (!res) return;
 
           expect(res.statusCode).not.toBe(500);
-          expect([200, 400, 422]).toContain(res.statusCode);
+          expect([200, 202, 400, 422]).toContain(res.statusCode);
 
           // Response must be valid JSON (not HTML, not raw text)
           let body: Record<string, unknown>;
@@ -1043,7 +1043,7 @@ describe("Exotic format error shape verification", () => {
             );
           }
 
-          if (res.statusCode !== 200) {
+          if (res.statusCode >= 400) {
             expect(body.error).toBeDefined();
             expect(typeof body.error).toBe("string");
             // Error message should not contain raw stack trace indicators
@@ -1093,10 +1093,10 @@ describe("HEIC/HEIF graceful handling", () => {
             expect(res.statusCode).not.toBe(500);
 
             // Accept success (200) or clean error (400/422)
-            expect([200, 400, 422]).toContain(res.statusCode);
+            expect([200, 202, 400, 422]).toContain(res.statusCode);
 
             const body = JSON.parse(res.body);
-            if (res.statusCode !== 200) {
+            if (res.statusCode >= 400) {
               expect(body.error).toBeDefined();
               expect(typeof body.error).toBe("string");
             }
@@ -1188,7 +1188,7 @@ describe("SVG through raster tools", () => {
 
       // SVG should either be rasterized and processed (200) or cleanly rejected
       expect(res.statusCode).not.toBe(500);
-      expect([200, 400, 422]).toContain(res.statusCode);
+      expect([200, 202, 400, 422]).toContain(res.statusCode);
 
       const body = JSON.parse(res.body);
       if (res.statusCode === 200) {
@@ -1234,10 +1234,10 @@ describe("ICO (multi-size format) through tools", () => {
 
       // ICO requires CLI decoder; accept success or clean error
       expect(res.statusCode).not.toBe(500);
-      expect([200, 400, 422]).toContain(res.statusCode);
+      expect([200, 202, 400, 422]).toContain(res.statusCode);
 
       const body = JSON.parse(res.body);
-      if (res.statusCode !== 200) {
+      if (res.statusCode >= 400) {
         expect(body.error).toBeDefined();
         expect(typeof body.error).toBe("string");
       }

--- a/tests/integration/generated/format-matrix-exotic.test.ts
+++ b/tests/integration/generated/format-matrix-exotic.test.ts
@@ -308,7 +308,9 @@ describe("Exotic format output conversion matrix", () => {
             // Verify output URL contains correct extension
             const ext = outFmt === "jpg" ? ".jpg" : `.${outFmt}`;
             expect(body.downloadUrl).toContain(ext);
-          } else {
+          } else if (res.statusCode >= 400) {
+            // 202 (accepted, async) has no sync body to verify; only error
+            // codes carry a JSON error.
             const body = JSON.parse(res.body);
             expect(body.error).toBeDefined();
             expect(typeof body.error).toBe("string");

--- a/tests/integration/generated/format-matrix-exotic.test.ts
+++ b/tests/integration/generated/format-matrix-exotic.test.ts
@@ -70,7 +70,7 @@ const ALL_OUTPUT_FORMATS = ["jpg", "png", "webp", "avif", "tiff", "gif"];
 const EXTENDED_OUTPUT_FORMATS = ["heic", "jxl", "bmp", "ico", "jp2", "qoi"];
 
 /** Acceptable status codes for exotic formats that may lack decoders */
-const ACCEPTABLE_CODES = [200, 400, 422];
+const ACCEPTABLE_CODES = [200, 202, 400, 422];
 
 // ---------------------------------------------------------------------------
 // Shared state
@@ -131,7 +131,7 @@ function assertNoServerCrash(statusCode: number) {
 function assertSuccessOrCleanError(res: { statusCode: number; body: string }) {
   assertNoServerCrash(res.statusCode);
   const body = JSON.parse(res.body);
-  if (res.statusCode !== 200) {
+  if (res.statusCode >= 400) {
     expect(body.error).toBeDefined();
     expect(typeof body.error).toBe("string");
     expect(body.error.length).toBeGreaterThan(0);
@@ -363,7 +363,7 @@ describe("Core format to extended output format matrix", () => {
         });
 
         // Extended encoders may not be available
-        expect([200, 400, 422]).toContain(res.statusCode);
+        expect([200, 202, 400, 422]).toContain(res.statusCode);
 
         if (res.statusCode === 200) {
           const body = JSON.parse(res.body);

--- a/tests/integration/generated/format-matrix-expanded.test.ts
+++ b/tests/integration/generated/format-matrix-expanded.test.ts
@@ -280,7 +280,9 @@ describe("Color-blindness simulation cross-format", () => {
           expect(typeof body.downloadUrl).toBe("string");
           expect(body.processedSize).toBeGreaterThan(0);
           expect(body.originalSize).toBeGreaterThan(0);
-        } else {
+        } else if (res.statusCode >= 400) {
+          // 202 (accepted, async) has no sync body to verify; only error
+          // codes carry a JSON error.
           const body = JSON.parse(res.body);
           expect(body.error).toBeDefined();
           expect(typeof body.error).toBe("string");
@@ -348,7 +350,9 @@ describe("Beautify cross-format", () => {
           expect(typeof body.downloadUrl).toBe("string");
           expect(body.processedSize).toBeGreaterThan(0);
           expect(body.originalSize).toBeGreaterThan(0);
-        } else {
+        } else if (res.statusCode >= 400) {
+          // 202 (accepted, async) has no sync body to verify; only error
+          // codes carry a JSON error.
           const body = JSON.parse(res.body);
           expect(body.error).toBeDefined();
           expect(typeof body.error).toBe("string");

--- a/tests/integration/generated/format-matrix-expanded.test.ts
+++ b/tests/integration/generated/format-matrix-expanded.test.ts
@@ -204,7 +204,7 @@ const EXOTIC_FORMATS = FORMAT_SAMPLES.filter(
 );
 
 /** Status codes we accept for formats that may lack decoder support */
-const ACCEPTABLE_FALLBACK_CODES = [200, 400, 422];
+const ACCEPTABLE_FALLBACK_CODES = [200, 202, 400, 422];
 
 function needsFallback(fmt: FormatSample): boolean {
   return fmt.needsCliDecoder || fmt.needsHeifDecoder || fmt.mayFailValidation;
@@ -407,7 +407,7 @@ describe("Edit-metadata cross-format", () => {
             expect(ACCEPTABLE_FALLBACK_CODES).toContain(res.statusCode);
           } else {
             // edit-metadata may also fail with 422 if ExifTool is not installed
-            expect([200, 400, 422]).toContain(res.statusCode);
+            expect([200, 202, 400, 422]).toContain(res.statusCode);
           }
 
           if (res.statusCode === 200) {
@@ -458,7 +458,7 @@ describe("Edit-metadata cross-format", () => {
 
           // Inspect uses ExifTool, which may not be installed; accept clean errors
           expect(res.statusCode).not.toBe(500);
-          expect([200, 400, 422]).toContain(res.statusCode);
+          expect([200, 202, 400, 422]).toContain(res.statusCode);
 
           const body = JSON.parse(res.body);
           if (res.statusCode === 200) {
@@ -618,7 +618,7 @@ describe("Split cross-format", () => {
 
         // Must not crash. Accept 200 (ZIP streamed) or 422 (clean error)
         expect(res.statusCode).not.toBe(500);
-        expect([200, 400, 422]).toContain(res.statusCode);
+        expect([200, 202, 400, 422]).toContain(res.statusCode);
       },
       perTestTimeout,
     );
@@ -1104,7 +1104,7 @@ describe("Compose cross-format", () => {
           });
 
           expect(res.statusCode).not.toBe(500);
-          expect([200, 400, 422]).toContain(res.statusCode);
+          expect([200, 202, 400, 422]).toContain(res.statusCode);
         },
         perTestTimeout,
       );
@@ -1204,7 +1204,7 @@ describe("Compare cross-format", () => {
         });
 
         expect(res.statusCode).not.toBe(500);
-        expect([200, 400, 422]).toContain(res.statusCode);
+        expect([200, 202, 400, 422]).toContain(res.statusCode);
       },
       perTestTimeout,
     );
@@ -1319,7 +1319,7 @@ describe("Collage cross-format", () => {
         });
 
         expect(res.statusCode).not.toBe(500);
-        expect([200, 400, 422]).toContain(res.statusCode);
+        expect([200, 202, 400, 422]).toContain(res.statusCode);
       },
       perTestTimeout,
     );
@@ -1433,7 +1433,7 @@ describe("Stitch cross-format", () => {
         });
 
         expect(res.statusCode).not.toBe(500);
-        expect([200, 400, 422]).toContain(res.statusCode);
+        expect([200, 202, 400, 422]).toContain(res.statusCode);
       },
       perTestTimeout,
     );
@@ -1494,7 +1494,7 @@ describe("Transparency-fixer cross-format", () => {
         } else if (res.statusCode === 202) {
           expect(body.jobId).toBeDefined();
           expect(body.async).toBe(true);
-        } else if (res.statusCode !== 200) {
+        } else if (res.statusCode >= 400) {
           expect(body.error).toBeDefined();
           expect(typeof body.error).toBe("string");
         }
@@ -1869,7 +1869,7 @@ describe("Find-duplicates cross-format", () => {
         });
 
         expect(res.statusCode).not.toBe(500);
-        expect([200, 400, 422]).toContain(res.statusCode);
+        expect([200, 202, 400, 422]).toContain(res.statusCode);
       },
       perTestTimeout,
     );

--- a/tests/integration/generated/format-matrix.test.ts
+++ b/tests/integration/generated/format-matrix.test.ts
@@ -419,7 +419,7 @@ const TOOLS: ToolDef[] = [
 // ---------------------------------------------------------------------------
 
 /** Status codes we accept for formats that may lack decoder support */
-const ACCEPTABLE_FALLBACK_CODES = [200, 400, 422];
+const ACCEPTABLE_FALLBACK_CODES = [200, 202, 400, 422];
 
 function needsFallback(fmt: FormatSample): boolean {
   return fmt.needsCliDecoder || fmt.needsHeifDecoder || fmt.mayFailValidation;
@@ -606,7 +606,7 @@ describe("Cross-format matrix", () => {
             // If the API returned an error, verify it is a clean JSON error
             // (not a raw crash / stack trace / HTML error page)
             // ------------------------------------------------------------------
-            if (res.statusCode !== 200) {
+            if (res.statusCode >= 400) {
               const body = JSON.parse(res.body);
               expect(body.error).toBeDefined();
               expect(typeof body.error).toBe("string");
@@ -653,7 +653,7 @@ describe("Multipage TIFF handling", () => {
       });
 
       // Multipage TIFF should either succeed or return a clean error
-      expect([200, 400, 422]).toContain(res.statusCode);
+      expect([200, 202, 400, 422]).toContain(res.statusCode);
 
       if (res.statusCode === 200) {
         const body = JSON.parse(res.body);
@@ -781,11 +781,11 @@ describe("Exotic format error resilience", () => {
         // Must not crash (500) — either succeed or return a clean error
         if (isAsyncFallback(res)) return;
         expect(res.statusCode).not.toBe(500);
-        expect([200, 400, 422]).toContain(res.statusCode);
+        expect([200, 202, 400, 422]).toContain(res.statusCode);
 
         // Response must always be valid JSON
         const body = JSON.parse(res.body);
-        if (res.statusCode !== 200) {
+        if (res.statusCode >= 400) {
           expect(body.error).toBeDefined();
           expect(typeof body.error).toBe("string");
           expect(body.error.length).toBeGreaterThan(0);
@@ -867,10 +867,10 @@ describe("Image enhancement analysis across formats", () => {
       });
 
       expect(res.statusCode).not.toBe(500);
-      expect([200, 400, 422]).toContain(res.statusCode);
+      expect([200, 202, 400, 422]).toContain(res.statusCode);
 
       const body = JSON.parse(res.body);
-      if (res.statusCode !== 200) {
+      if (res.statusCode >= 400) {
         expect(body.error).toBeDefined();
         expect(typeof body.error).toBe("string");
       }
@@ -1344,7 +1344,7 @@ describe("Image-to-PDF cross-format matrix", () => {
         body: payload,
       });
 
-      expect([200, 400, 422]).toContain(res.statusCode);
+      expect([200, 202, 400, 422]).toContain(res.statusCode);
 
       if (res.statusCode === 200) {
         const body = JSON.parse(res.body);
@@ -1394,10 +1394,10 @@ describe("Image-to-PDF cross-format matrix", () => {
         if (isAsyncFallback(res)) return;
         if (isAsyncFallback(res)) return;
         expect(res.statusCode).not.toBe(500);
-        expect([200, 400, 422]).toContain(res.statusCode);
+        expect([200, 202, 400, 422]).toContain(res.statusCode);
 
         const body = JSON.parse(res.body);
-        if (res.statusCode !== 200) {
+        if (res.statusCode >= 400) {
           expect(body.error).toBeDefined();
           expect(typeof body.error).toBe("string");
           expect(body.error.length).toBeGreaterThan(0);
@@ -1453,10 +1453,10 @@ describe("Watermark-image exotic format error resilience", () => {
         });
 
         expect(res.statusCode).not.toBe(500);
-        expect([200, 400, 422]).toContain(res.statusCode);
+        expect([200, 202, 400, 422]).toContain(res.statusCode);
 
         const body = JSON.parse(res.body);
-        if (res.statusCode !== 200) {
+        if (res.statusCode >= 400) {
           expect(body.error).toBeDefined();
           expect(typeof body.error).toBe("string");
           expect(body.error.length).toBeGreaterThan(0);
@@ -1505,10 +1505,10 @@ describe("Watermark-image exotic format error resilience", () => {
 
         if (isAsyncFallback(res)) return;
         expect(res.statusCode).not.toBe(500);
-        expect([200, 400, 422]).toContain(res.statusCode);
+        expect([200, 202, 400, 422]).toContain(res.statusCode);
 
         const body = JSON.parse(res.body);
-        if (res.statusCode !== 200) {
+        if (res.statusCode >= 400) {
           expect(body.error).toBeDefined();
           expect(typeof body.error).toBe("string");
           expect(body.error.length).toBeGreaterThan(0);


### PR DESCRIPTION
Follow-up to #290 (which is currently failing Integration shard 4/4 on `main`).

## Why

#290 made DNG decode at full resolution (3474×2314) instead of the old 1024px embedded preview. For expensive operations (AVIF encode, image-enhancement), processing an 8 MP image exceeds the **8s sync window** on CI runners, so the API correctly returns **202 Accepted** and runs the job async (by design, per CLAUDE.md sync-window behavior).

The format-matrix smoke tests only allowed `[200, 400, 422]` and required a clean error body on any non-200, so the 202 made two tests fail:
- `format-matrix-exotic > DNG input -> avif`
- `format-matrix-comprehensive > DNG + image-enhancement: clean JSON error`

Which operations cross the sync boundary is timing-dependent (fast Mac → 200, slower CI → 202), so the robust fix is to make these "no-crash / clean-response" checks 202-tolerant.

## Changes (test-only)

- Add `202` to `ACCEPTABLE_CODES` / `ACCEPTABLE_FALLBACK_CODES` and inline status allowlists across the 4 DNG-bearing matrix files.
- Change `if (statusCode !== 200)` error-body assertions to `>= 400`, so an error body is required only for true error codes (200 and 202 are both clean non-error responses).
- `ACCEPTABLE_AI_CODES` already included 202; `new-formats.test.ts` doesn't test DNG, so neither was touched.

## Verification (local, against Postgres + Redis)

| Run | Result |
|---|---|
| DNG matrix tests, normal sync window | 68 passed, 0 failed |
| DNG matrix tests, `SYNC_WAIT_MS=1` (forces 202 — the CI condition) | 68 passed, 0 failed |
| `pnpm typecheck` / Biome on changed files | green |

The forced-202 run directly exercises the path that failed on CI.
