### PR TITLE
feat(landing): auto-refresh live GitHub stars and image-pull stats

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - "apps/landing/**"
+  # Daily rebuild so the build-time GitHub stars / Docker Hub pull-count fetches
+  # refresh even when no landing files changed.
+  schedule:
+    - cron: "0 7 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -24,6 +28,10 @@ jobs:
 
       - name: Build Landing Page
         run: pnpm --filter @snapotter/landing build
+        env:
+          # Authenticated GitHub API (5,000 req/hr) so the build-time star-count
+          # fetch isn't rate-limited on shared runner IPs (60 req/hr unauth).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Cloudflare Pages
         run: npx wrangler pages deploy apps/landing/dist --project-name snapotter-landing --branch main --commit-dirty=true

--- a/apps/landing/src/components/Navbar.astro
+++ b/apps/landing/src/components/Navbar.astro
@@ -1,20 +1,8 @@
 ---
-let starCount = "";
-try {
-  const res = await fetch("https://api.github.com/repos/snapotter-hq/snapotter", {
-    headers: { "User-Agent": "SnapOtter-Landing" },
-  });
-  if (res.ok) {
-    const data = await res.json();
-    const count = data.stargazers_count;
-    if (typeof count === "number") {
-      starCount =
-        count >= 1000
-          ? `${(count / 1000) % 1 === 0 ? (count / 1000).toFixed(0) : (count / 1000).toFixed(1)}k`
-          : count.toString();
-    }
-  }
-} catch {}
+import { formatCompact, getStarCount } from "@/lib/stats";
+
+// Fetched at build time; refreshed by the scheduled landing rebuild.
+const starCount = formatCompact(await getStarCount());
 
 const links = [
   { label: "Features", href: "/#features" },
@@ -56,7 +44,7 @@ const links = [
       >
         <svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         <svg class="h-3.5 w-3.5 text-primary" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-        <span id="gh-stars" class="text-xs">{starCount || "1.6k"}</span>
+        <span id="gh-stars" class="text-xs">{starCount}</span>
       </a>
       <a
         href="https://demo.snapotter.com"

--- a/apps/landing/src/components/TrustSignals.astro
+++ b/apps/landing/src/components/TrustSignals.astro
@@ -1,43 +1,9 @@
 ---
-function formatNumber(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1).replace(/\.0$/, "")}k`;
-  return n.toString();
-}
+import { formatCompact, getImagePulls, getStarCount } from "@/lib/stats";
 
-let starCount = 0;
-try {
-  const res = await fetch("https://api.github.com/repos/snapotter-hq/snapotter", {
-    headers: { Accept: "application/vnd.github.v3+json" },
-  });
-  if (res.ok) {
-    const data = await res.json();
-    starCount = data.stargazers_count ?? 0;
-  }
-} catch {
-  starCount = 0;
-}
-
-// Docker Hub pull count (public API, refreshed at build time)
-let dockerHubPulls = 0;
-try {
-  const res = await fetch("https://hub.docker.com/v2/repositories/snapotter/snapotter/");
-  if (res.ok) {
-    const data = await res.json();
-    dockerHubPulls = data.pull_count ?? 0;
-  }
-} catch {
-  dockerHubPulls = 0;
-}
-
-// GHCR (ghcr.io) has no public pull-count API, so this is a manual figure (update as it grows).
-const GHCR_PULLS = 28_800;
-const dockerForTotal = dockerHubPulls > 0 ? dockerHubPulls : 89_100;
-const totalPulls = dockerForTotal + GHCR_PULLS;
-const pullsDisplay =
-  totalPulls >= 1_000_000
-    ? `${Math.floor(totalPulls / 100_000) / 10}M+`
-    : `${Math.floor(totalPulls / 100_000) * 100}K+`;
+// Fetched at build time; refreshed by the scheduled landing rebuild.
+const starCount = await getStarCount();
+const { display: pullsDisplay } = await getImagePulls();
 
 const stats = [
   {
@@ -46,7 +12,7 @@ const stats = [
     sublabel: "Across 5 file modalities",
   },
   {
-    value: starCount > 0 ? formatNumber(starCount) : "1.6k",
+    value: formatCompact(starCount),
     label: "GitHub Stars",
     sublabel: "Open-source & growing",
   },

--- a/apps/landing/src/lib/stats.ts
+++ b/apps/landing/src/lib/stats.ts
@@ -1,0 +1,81 @@
+// Shared, build-time stats for the landing page (GitHub stars + image pulls).
+// The landing site ships zero client JS, so these are fetched in Astro
+// frontmatter at build time and refreshed by a scheduled rebuild. Both
+// fetchers degrade to a maintained constant if the upstream API is unreachable
+// (or rate-limited), so a build never ships an empty number.
+
+// ghcr.io exposes no public pull-count API, so the GitHub Container Registry
+// portion is a manually maintained estimate. Update it as it grows.
+const GHCR_ESTIMATE = 36_000;
+
+// Fallbacks used when an upstream fetch fails. Keep roughly current so a
+// degraded build still shows a believable figure.
+const STAR_FALLBACK = 1720;
+const DOCKER_FALLBACK = 104_000;
+
+const GITHUB_REPO = "snapotter-hq/SnapOtter";
+const DOCKERHUB_REPO = "snapotter/snapotter";
+
+/** Compact integer formatting: 1720 -> "1.7k", 2_300_000 -> "2.3M". */
+export function formatCompact(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1).replace(/\.0$/, "")}k`;
+  return n.toString();
+}
+
+/**
+ * Image-pull formatting, rounded DOWN so the figure stays conservative:
+ * nearest 10K below 1M (140_801 -> "140K+"), nearest 0.1M at/above 1M
+ * (1_250_000 -> "1.2M+").
+ */
+export function formatPulls(total: number): string {
+  if (total >= 1_000_000) return `${Math.floor(total / 100_000) / 10}M+`;
+  return `${Math.floor(total / 10_000) * 10}K+`;
+}
+
+/**
+ * GitHub star count, fetched at build time. Sends an Authorization header when
+ * GITHUB_TOKEN is set (CI), lifting the unauthenticated 60 req/hr limit that
+ * otherwise pins the count to the fallback. Returns STAR_FALLBACK on failure.
+ */
+export async function getStarCount(): Promise<number> {
+  try {
+    const token = process.env.GITHUB_TOKEN;
+    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "SnapOtter-Landing",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (typeof data.stargazers_count === "number") return data.stargazers_count;
+    }
+  } catch {
+    // Network/JSON failure: fall through to the fallback below.
+  }
+  return STAR_FALLBACK;
+}
+
+/**
+ * Total image pulls = live Docker Hub pull_count + the GHCR estimate.
+ * Returns the raw total and a display string. Docker Hub degrades to
+ * DOCKER_FALLBACK if the API is unreachable.
+ */
+export async function getImagePulls(): Promise<{ total: number; display: string }> {
+  let dockerPulls = DOCKER_FALLBACK;
+  try {
+    const res = await fetch(`https://hub.docker.com/v2/repositories/${DOCKERHUB_REPO}/`);
+    if (res.ok) {
+      const data = await res.json();
+      if (typeof data.pull_count === "number" && data.pull_count > 0) {
+        dockerPulls = data.pull_count;
+      }
+    }
+  } catch {
+    // Network/JSON failure: keep the Docker fallback.
+  }
+  const total = dockerPulls + GHCR_ESTIMATE;
+  return { total, display: formatPulls(total) };
+}

--- a/tests/unit/landing/stats.test.ts
+++ b/tests/unit/landing/stats.test.ts
@@ -1,0 +1,42 @@
+import { formatCompact, formatPulls } from "@landing/lib/stats";
+import { describe, expect, it } from "vitest";
+
+describe("formatCompact", () => {
+  it("formats thousands with one decimal", () => {
+    expect(formatCompact(1720)).toBe("1.7k");
+  });
+
+  it("drops a trailing .0 on whole thousands", () => {
+    expect(formatCompact(1000)).toBe("1k");
+    expect(formatCompact(12_000)).toBe("12k");
+  });
+
+  it("leaves sub-thousand counts untouched", () => {
+    expect(formatCompact(999)).toBe("999");
+  });
+
+  it("formats millions with an M suffix", () => {
+    expect(formatCompact(1_000_000)).toBe("1M");
+    expect(formatCompact(2_300_000)).toBe("2.3M");
+  });
+});
+
+describe("formatPulls", () => {
+  it("rounds down to the nearest 10K below 1M", () => {
+    expect(formatPulls(140_801)).toBe("140K+");
+    expect(formatPulls(104_801)).toBe("100K+");
+  });
+
+  it("stays conservative just under a 10K boundary", () => {
+    expect(formatPulls(99_999)).toBe("90K+");
+  });
+
+  it("switches to millions at 1M", () => {
+    expect(formatPulls(1_000_000)).toBe("1M+");
+    expect(formatPulls(999_999)).toBe("990K+");
+  });
+
+  it("rounds millions down to one decimal", () => {
+    expect(formatPulls(1_250_000)).toBe("1.2M+");
+  });
+});


### PR DESCRIPTION
## What

Makes the landing page hero/navbar stats current and self-refreshing, and totals **both** Docker Hub and GHCR into the Image Pulls figure.

- **GitHub Stars** and **Image Pulls** are fetched at build time and refreshed automatically (daily), instead of freezing between landing edits.
- **Image Pulls = live Docker Hub `pull_count` + a maintained GHCR estimate.** `ghcr.io` exposes no public pull-count API (confirmed: the package and versions endpoints require auth and still return no download counts), so the GHCR portion is a constant you bump as it grows.

Renders **1.7k** stars (live: 1,720) and **140K+** pulls (104.8k Docker + 36k GHCR) today.

## Why it was stale

- The site only rebuilt on pushes touching `apps/landing/**` (no schedule), so build-time numbers froze.
- The GitHub stars fetch was unauthenticated, so it hit GitHub's 60 req/hr limit on shared CI runner IPs and fell back to a hardcoded "1.6k".

## Changes

- **New `apps/landing/src/lib/stats.ts`** — single source of truth (`getStarCount`, `getImagePulls`, pure `formatCompact`/`formatPulls`). Replaces fetch/format logic that was duplicated and divergent across two components.
- **`TrustSignals.astro` + `Navbar.astro`** — consume the lib (drops a redundant second GitHub API call per build).
- **`deploy-landing.yml`** — daily cron (`0 7 * * *`) so the build re-fetches with no code change, and `GITHUB_TOKEN` passed to the build for an authenticated (5,000 req/hr) GitHub API.

## Notes

- Stays **zero client JS** (the site's architecture principle): numbers refresh once per day, not per page-load. The daily refresh starts once this is on `main` (scheduled Actions run from the default branch); until then numbers update on any landing deploy.
- `GITHUB_TOKEN` is the Actions-provided token; no new secret to configure.
- To update GHCR, edit `GHCR_ESTIMATE` in `stats.ts` (currently `36000`).

## Test plan

- [x] `formatCompact` / `formatPulls` unit tests (8/8) - `tests/unit/landing/stats.test.ts`
- [x] `pnpm --filter @snapotter/landing build` - 170 pages, renders `1.7k` / `140K+`
- [x] `tsc --noEmit` (exit 0), `astro check` (0 errors), Biome (0 issues)
