### PR TITLE
fix(docker): copy patches/ before pnpm install so cold builds succeed

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,6 +46,10 @@ COPY packages/media-engine/package.json packages/media-engine/tsconfig.json ./pa
 COPY packages/doc-engine/package.json packages/doc-engine/tsconfig.json ./packages/doc-engine/
 COPY packages/ai/package.json packages/ai/tsconfig.json ./packages/ai/
 
+# pnpm patchedDependencies (package.json) needs the patch files present before
+# install, or `pnpm install` aborts with ENOENT on the patch.
+COPY patches/ ./patches/
+
 # Install ALL dependencies (dev + prod needed for building)
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store/v3 \
     pnpm install --frozen-lockfile
@@ -306,6 +310,10 @@ COPY packages/image-engine/package.json packages/image-engine/tsconfig.json ./pa
 COPY packages/media-engine/package.json packages/media-engine/tsconfig.json ./packages/media-engine/
 COPY packages/doc-engine/package.json packages/doc-engine/tsconfig.json ./packages/doc-engine/
 COPY packages/ai/package.json packages/ai/tsconfig.json ./packages/ai/
+
+# pnpm patchedDependencies (package.json) needs the patch files present before
+# install, or `pnpm install` aborts with ENOENT on the patch.
+COPY patches/ ./patches/
 
 # Install production dependencies (tsx is now in prod deps)
 # Skip the root prepare script (husky is a devDep, not available in prod)


### PR DESCRIPTION
## Summary

Cold Docker builds (`docker build` / `docker compose build` on a runner without a warm pnpm-store layer cache) fail with:

```
ENOENT: no such file or directory, open '/app/patches/gray-matter@4.0.3.patch'
```

`package.json` declares a `patchedDependencies` entry for `gray-matter@4.0.3`, so `pnpm install` needs `patches/` present — but neither the **builder** stage nor the **production** stage COPYs `patches/` before running `pnpm install`. The published image only built because that layer happened to be cached; any cache miss (fresh CI, `docker compose build`, local first build) hits this.

## Fix

Add `COPY patches/ ./patches/` ahead of both `pnpm install` invocations (builder + production). 8 lines, no behavior change beyond making the install resolve patches.

## Test Plan

- [x] Reproduced the failure on a cold build (both stages)
- [x] With the fix, a clean `docker build -f docker/Dockerfile .` completes end to end and the resulting image boots + serves
- [x] Independent of #299 (different Dockerfile regions; no overlap)

Found while verifying #299; filed separately to keep that PR scoped to the storage-permissions fix.