### PR TITLE
ci: harden testcontainers against Docker Hub registry flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ concurrency:
 permissions:
   contents: read
 
+# Testcontainers' ryuk reaper is redundant here (tests/global-setup.ts explicitly
+# stops its containers and CI runners are ephemeral), and its image pull from Docker
+# Hub is a recurring flake source (HTTP 500 on registry-1.docker.io). Disable it so a
+# registry hiccup pulling ryuk cannot fail the suite.
+env:
+  TESTCONTAINERS_RYUK_DISABLED: "true"
+
 jobs:
   lint:
     name: Lint
@@ -50,7 +57,7 @@ jobs:
   test-unit:
     name: Unit Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -58,6 +65,17 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends libheif-examples libheif-plugin-x265 libheif-plugin-libde265 libimage-exiftool-perl libraw-bin imagemagick ghostscript libjxl-tools libopenjp2-tools
 
       - uses: ./.github/actions/setup
+      - name: Pre-pull testcontainer images (retry transient Docker Hub errors)
+        run: |
+          for img in postgres:17-alpine redis:8-alpine; do
+            ok=
+            for attempt in 1 2 3 4 5; do
+              if docker pull "$img"; then ok=1; break; fi
+              echo "::warning::docker pull $img failed (attempt $attempt/5); retrying in $((attempt * 5))s"
+              sleep "$((attempt * 5))"
+            done
+            [ -n "$ok" ] || { echo "::error::could not pull $img after 5 attempts"; exit 1; }
+          done
       - run: pnpm vitest run tests/unit/ --reporter=verbose
 
   test-integration:
@@ -90,6 +108,17 @@ jobs:
           fi
 
       - uses: ./.github/actions/setup
+      - name: Pre-pull testcontainer images (retry transient Docker Hub errors)
+        run: |
+          for img in postgres:17-alpine redis:8-alpine; do
+            ok=
+            for attempt in 1 2 3 4 5; do
+              if docker pull "$img"; then ok=1; break; fi
+              echo "::warning::docker pull $img failed (attempt $attempt/5); retrying in $((attempt * 5))s"
+              sleep "$((attempt * 5))"
+            done
+            [ -n "$ok" ] || { echo "::error::could not pull $img after 5 attempts"; exit 1; }
+          done
       - run: pnpm vitest run tests/integration/ --reporter=verbose --shard=${{ matrix.shard }}/4
 
   test-e2e-smoke:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,9 @@ permissions:
 
 env:
   SYSTEM_DEPS: libheif-examples libheif-plugin-x265 libheif-plugin-libde265 libimage-exiftool-perl libraw-bin imagemagick ghostscript libjxl-tools libopenjp2-tools ffmpeg qpdf
+  # See ci.yml: ryuk's Docker Hub pull is a recurring flake source; disable the reaper
+  # (tests/global-setup.ts stops its containers explicitly; runners are ephemeral).
+  TESTCONTAINERS_RYUK_DISABLED: "true"
 
 jobs:
   e2e-full:
@@ -253,6 +256,17 @@ jobs:
             sudo sed -i 's/<policy domain="coder" rights="none" pattern="PS"/<policy domain="coder" rights="read" pattern="PS"/' "$POLICY_FILE"
           fi
       - uses: ./.github/actions/setup
+      - name: Pre-pull testcontainer images (retry transient Docker Hub errors)
+        run: |
+          for img in postgres:17-alpine redis:8-alpine; do
+            ok=
+            for attempt in 1 2 3 4 5; do
+              if docker pull "$img"; then ok=1; break; fi
+              echo "::warning::docker pull $img failed (attempt $attempt/5); retrying in $((attempt * 5))s"
+              sleep "$((attempt * 5))"
+            done
+            [ -n "$ok" ] || { echo "::error::could not pull $img after 5 attempts"; exit 1; }
+          done
       - name: Run integration suite with full matrix and fuzz enabled
         run: pnpm vitest run tests/integration/ --reporter=verbose
         env:


### PR DESCRIPTION
## Problem

#320's post-merge `main` CI failed when testcontainers pulled its `ryuk` reaper image and Docker Hub returned HTTP 500:

```
Error: (HTTP code 500) server error - Head "https://registry-1.docker.io/v2/testcontainers/ryuk/manifests/0.14.0"
```

This is a transient external-registry flake, not a code issue, but it can recur on any testcontainers run (`tests/unit/` and `tests/integration/`) and silently fail the suite ("No test files found" is the collateral symptom). A re-run fixed that instance, but the exposure remains repo-wide.

## Fix

- **Disable the ryuk reaper** (`TESTCONTAINERS_RYUK_DISABLED: "true"`, top-level env in both `ci.yml` and `nightly.yml`). It's redundant here: `tests/global-setup.ts` already calls `container.stop()` / `redisContainer.stop()` in `teardown()`, and CI runners are ephemeral. Removing it eliminates the exact image pull that flaked.
- **Pre-pull `postgres:17-alpine` + `redis:8-alpine` with retry** in the testcontainers jobs (`test-unit`, `test-integration`, nightly `extended-matrix`) so a transient 500 on those pulls is retried (5 attempts, linear backoff) rather than fatal.
- Bumped `test-unit` timeout 5 -> 8 min to absorb retry backoff.

## Verification

- Both workflow files parse as valid YAML.
- The pre-pull retry loop was dry-run locally (pulls succeed, exits 0; fails loudly only after 5 genuine failures).
- This PR's own CI exercises the changed `ci.yml`, so a green run is end-to-end confirmation.

No application code changes; CI workflow only.