### PR TITLE
docs: update privacy and analytics disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 - **REST API:** Every tool available via API with API key auth. Interactive docs at `/api/docs`
 - **Self-hosted stack:** SnapOtter + Postgres 17 + Redis 8, run together with one `docker compose up`. No external SaaS dependencies
 - **Multi-arch:** Runs on AMD64 and ARM64 (Intel, Apple Silicon, Raspberry Pi)
-- **Privacy first:** Your files never leave your network. SnapOtter asks once whether you'd like to share anonymous product analytics (which tools are used, errors encountered, never file data). Change anytime in Settings, or set `ANALYTICS_ENABLED=false` to disable completely
+- **Privacy first:** Your files never leave your network. No file data, personal information, or IP addresses are ever sent anywhere. Analytics can be disabled by rebuilding with `--build-arg SNAPOTTER_ANALYTICS=off` ([details](https://docs.snapotter.com/guide/deployment.html#analytics))
 
 ## Quick Start
 

--- a/apps/docs/guide/deployment.md
+++ b/apps/docs/guide/deployment.md
@@ -525,10 +525,35 @@ Semantic-release determines the version from commit history. The `latest` Docker
 
 ## Analytics
 
-The official SnapOtter Docker image includes anonymous usage analytics (PostHog) and crash reporting (Sentry) to help improve the software. No IP addresses, personal identifiers, or file contents are collected.
+SnapOtter uses anonymous analytics to improve reliability and prioritize features. No file contents, file names, personal information, or IP addresses are ever sent.
 
-To disable analytics, build from source with the analytics flag off:
+### What is recorded
+
+- Tool usage patterns (e.g. which tools are used most, success/failure rates)
+- Error reports and performance metrics (stack traces with file paths redacted)
+- App version and browser type
+
+Analytics is powered by [PostHog](https://posthog.com) (usage) and [Sentry](https://sentry.io) (errors).
+
+### Disabling analytics
+
+You can disable analytics at any time by cloning the repository and rebuilding:
 
 ```bash
-docker compose build --build-arg SNAPOTTER_ANALYTICS=off
+git clone https://github.com/snapotter-hq/SnapOtter.git
+cd SnapOtter
+docker compose -f docker/docker-compose.yml build --build-arg SNAPOTTER_ANALYTICS=off
+docker compose -f docker/docker-compose.yml up -d
+```
+
+Or add the build arg to your existing `docker-compose.yml`:
+
+```yaml
+services:
+  snapotter:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        SNAPOTTER_ANALYTICS: "off"
 ```

--- a/apps/landing/src/pages/privacy.astro
+++ b/apps/landing/src/pages/privacy.astro
@@ -34,7 +34,7 @@ const breadcrumbJsonLd = {
     <div class="mx-auto max-w-3xl">
       <div class="reveal text-center">
         <h1 class="font-display text-4xl font-bold tracking-tight md:text-5xl">Privacy Policy</h1>
-        <p class="mt-6 text-lg text-muted">Last updated: May 18, 2026</p>
+        <p class="mt-6 text-lg text-muted">Last updated: June 24, 2026</p>
       </div>
 
       <div class="mt-16 space-y-12 text-sm leading-relaxed text-muted">
@@ -77,22 +77,24 @@ const breadcrumbJsonLd = {
           <h2 class="text-lg font-semibold text-foreground">Self-Hosted Software</h2>
           <ul class="mt-3 list-disc space-y-2 pl-5">
             <li>All file processing happens entirely on your server.</li>
-            <li>No data is sent to SnapOtter or any third party.</li>
-            <li>There is no telemetry by default.</li>
+            <li>Your files are never sent anywhere.</li>
+            <li>No personal data, file contents, file names, or IP addresses leave your network.</li>
           </ul>
         </section>
 
         <section class="reveal">
-          <h2 class="text-lg font-semibold text-foreground">Optional Analytics</h2>
+          <h2 class="text-lg font-semibold text-foreground">Analytics</h2>
           <ul class="mt-3 list-disc space-y-2 pl-5">
-            <li>Analytics is disabled by default.</li>
             <li>
-              When enabled, it collects anonymous usage data (feature usage, error logs) to
-              help improve the software.
+              SnapOtter uses anonymous analytics to improve reliability and prioritize
+              features. Only tool usage patterns and error reports (without file data) are
+              recorded.
             </li>
-            <li>No personal data, image content, or file names are collected.</li>
-            <li>You can disable analytics at any time in settings.</li>
-            <li>Analytics data is processed by PostHog.</li>
+            <li>Analytics is powered by PostHog and Sentry.</li>
+            <li>
+              You can disable analytics at any time by rebuilding with
+              <code class="text-xs">--build-arg SNAPOTTER_ANALYTICS=off</code>.
+            </li>
           </ul>
         </section>
 

--- a/apps/web/src/pages/privacy-policy-page.tsx
+++ b/apps/web/src/pages/privacy-policy-page.tsx
@@ -16,7 +16,7 @@ export function PrivacyPolicyPage() {
         </Link>
 
         <h1 className="text-3xl font-bold mb-2">{t.common.privacyPolicy}</h1>
-        <p className="text-sm text-muted-foreground mb-8">Last updated: April 22, 2026</p>
+        <p className="text-sm text-muted-foreground mb-8">Last updated: June 24, 2026</p>
 
         <div className="space-y-6 text-sm leading-relaxed text-muted-foreground">
           <section>
@@ -41,22 +41,16 @@ export function PrivacyPolicyPage() {
           <section>
             <h2 className="text-lg font-semibold text-foreground mb-2">Product Analytics</h2>
             <p>
-              SnapOtter includes optional, anonymous product analytics. When you choose to
-              participate, the following is collected:
+              SnapOtter uses anonymous analytics to improve reliability and prioritize features.
             </p>
+            <p className="mt-2 font-medium">What is never sent:</p>
             <ul className="list-disc ps-5 mt-2 space-y-1">
-              <li>Which tools you use (e.g., "crop tool used")</li>
-              <li>Error reports without file data</li>
-              <li>App version and performance metrics</li>
-            </ul>
-            <p className="mt-2 font-medium">What is never collected:</p>
-            <ul className="list-disc ps-5 mt-2 space-y-1">
-              <li>Your images, PDFs, and files</li>
-              <li>File names and contents</li>
-              <li>Any personal information or IP addresses</li>
+              <li>Your images, PDFs, videos, or any file contents</li>
+              <li>File names or file paths</li>
+              <li>Personal information or IP addresses</li>
             </ul>
             <p className="mt-2">
-              Analytics data is sent to{" "}
+              Analytics is powered by{" "}
               <a
                 href="https://posthog.com"
                 className="text-primary hover:underline"
@@ -65,7 +59,7 @@ export function PrivacyPolicyPage() {
               >
                 PostHog
               </a>{" "}
-              (usage analytics) and{" "}
+              and{" "}
               <a
                 href="https://sentry.io"
                 className="text-primary hover:underline"
@@ -73,18 +67,9 @@ export function PrivacyPolicyPage() {
                 rel="noopener noreferrer"
               >
                 Sentry
-              </a>{" "}
-              (error tracking) — both open-source projects.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">Your Choice</h2>
-            <p>
-              Each user is asked individually on first login whether to participate. You can change
-              your choice anytime in Settings. Server administrators can disable analytics entirely
-              by setting{" "}
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">ANALYTICS_ENABLED=false</code>.
+              </a>
+              . You can disable analytics at any time by rebuilding with the flag{" "}
+              <code className="text-xs bg-muted px-1 py-0.5 rounded">SNAPOTTER_ANALYTICS=off</code>.
             </p>
           </section>
 
@@ -101,10 +86,9 @@ export function PrivacyPolicyPage() {
           <section>
             <h2 className="text-lg font-semibold text-foreground mb-2">Third-Party Services</h2>
             <p>
-              All processing happens locally; your files are never sent anywhere. If you opt in to
-              product analytics, anonymous usage data is sent to PostHog and Sentry as described
-              above. AI-powered features run locally using bundled models. No other external
-              services are contacted.
+              All processing happens locally; your files are never sent anywhere. Anonymous usage
+              analytics are powered by PostHog and Sentry as described above. AI-powered features
+              run locally using bundled models. No other external services are contacted.
             </p>
           </section>
 


### PR DESCRIPTION
## Summary

- Update README, in-app privacy page, landing privacy page, and deployment docs for the new build-time analytics model (PR #336)
- Remove references to opt-in consent flow, Settings toggle, and `ANALYTICS_ENABLED` env var
- Document the `SNAPOTTER_ANALYTICS=off` build arg with full rebuild instructions
- Tone: matter-of-fact about privacy (files never leave, no PII), with clear disable path

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] Visual review of privacy pages (landing + in-app)