### PR TITLE
fix(e2e): wait for post-login redirect before forcing navigation

### DIFF
--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -19,11 +19,11 @@ setup("authenticate", async ({ page }) => {
     timeout: 15_000,
   });
 
-  // Navigate to "/" and let any client-side redirect settle
-  // Use waitUntil: "domcontentloaded" to avoid racing with client-side redirects
-  await page.goto("/", { waitUntil: "domcontentloaded" });
-  // Wait for the URL to settle (app may redirect through auth guards)
+  // After login the app redirects to "/" on its own. Wait for that redirect to
+  // settle before forcing navigation, otherwise page.goto races the in-flight
+  // client-side redirect and aborts ("interrupted by another navigation").
   await page.waitForURL((url) => url.pathname === "/", { timeout: 30_000 }).catch(() => {});
+  await page.goto("/", { waitUntil: "domcontentloaded" });
   await page.waitForLoadState("load");
 
   // Fail fast on a misconfigured/stale e2e server. A correctly-configured e2e

--- a/tests/e2e/qa-auth.setup.ts
+++ b/tests/e2e/qa-auth.setup.ts
@@ -18,8 +18,11 @@ setup("authenticate for QA", async ({ page }) => {
     timeout: 15_000,
   });
 
-  await page.goto("/", { waitUntil: "domcontentloaded" });
+  // After login the app redirects to "/" on its own. Wait for that redirect to
+  // settle before forcing navigation, otherwise page.goto races the in-flight
+  // client-side redirect and aborts ("interrupted by another navigation").
   await page.waitForURL((url) => url.pathname === "/", { timeout: 15_000 }).catch(() => {});
+  await page.goto("/", { waitUntil: "domcontentloaded" });
   await page.waitForLoadState("load");
 
   await page.context().storageState({ path: authFile });


### PR DESCRIPTION
## Problem

After PR #340 merged, `main` CI went red on **E2E Mobile Smoke**: both `auth.setup.ts` and `qa-auth.setup.ts` failed with

> page.goto: Navigation to "http://localhost:2349/" is interrupted by another navigation to "http://localhost:2349/"

(16 dependent tests skipped). All other jobs were green, including the integration shards #340 fixed and the desktop E2E Smoke.

## Root cause

#340 removed the orphaned analytics-consent `PUT` from the auth setups. That call was an async HTTP round-trip that incidentally gave the app's own post-login client-side redirect (`/login` -> `/`) time to commit before the explicit `page.goto("/")`. With it gone, `page.goto("/")` fires while the app is mid-redirect, and Playwright aborts the navigation. The error itself ("another navigation to /") confirms the app auto-redirects. Desktop smoke passed on timing luck; mobile emulation is slower and consistently lost the race.

## Fix

Wait for the app's own redirect to settle (`waitForURL` to `/`) **before** the explicit `goto`, so the two no longer race. This is platform-timing-independent and keeps the explicit `goto` as a belt-and-suspenders force-to-home for any stale-server case (followed by the existing fail-fast guard).

## Verification

This is a timing-dependent failure (mobile emulation), so the authoritative check is CI's E2E Mobile Smoke job on this PR, which exercises both edited setup files. Biome clean.