### PR TITLE
chore: docs retention wording, demo analytics mock cleanup, gitignore fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ tests/benchmark/bench-limits-results-mac.jsonl
 scripts/setup-cloudflare-email.sh
 apps/videos
 remotion/
-demo
+/demo
 pentest-results/
 # Stryker mutation testing
 .stryker-tmp/

--- a/apps/demo/src/mock-api.ts
+++ b/apps/demo/src/mock-api.ts
@@ -88,14 +88,12 @@ const STATE_KEY = "snapotter-demo-state";
 
 function loadState(): {
   passwordChanged: boolean;
-  analyticsEnabled: boolean | null;
-  analyticsConsentShownAt: number | null;
 } {
   try {
     const raw = localStorage.getItem(STATE_KEY);
     if (raw) return JSON.parse(raw);
   } catch {}
-  return { passwordChanged: false, analyticsEnabled: null, analyticsConsentShownAt: null };
+  return { passwordChanged: false };
 }
 
 function saveState(patch: Partial<ReturnType<typeof loadState>>) {
@@ -134,9 +132,6 @@ function matchRoute(url: string, method: string): Response | null {
         role: "admin",
         permissions: PERMISSIONS,
         mustChangePassword: !state.passwordChanged,
-        analyticsEnabled: state.analyticsEnabled,
-        analyticsConsentShownAt: state.analyticsConsentShownAt,
-        analyticsConsentRemindAt: null,
         loginMethod: "local",
         hasLocalPassword: true,
       },
@@ -177,11 +172,6 @@ function matchRoute(url: string, method: string): Response | null {
       sampleRate: 0,
       instanceId: "demo-instance",
     });
-  }
-
-  if (path === "/api/v1/user/analytics" && method === "PUT") {
-    saveState({ analyticsEnabled: true, analyticsConsentShownAt: Date.now() });
-    return json({ ok: true });
   }
 
   if (path.startsWith("/api/v1/tools/") && method === "POST") {

--- a/apps/docs/guide/configuration.md
+++ b/apps/docs/guide/configuration.md
@@ -59,7 +59,7 @@ All configuration is done through environment variables. Every variable has a se
 
 | Variable | Default | Description |
 |---|---|---|
-| `FILE_MAX_AGE_HOURS` | `72` | How long temporary files are kept before automatic deletion. |
+| `FILE_MAX_AGE_HOURS` | `72` | How long unsaved processing results (raw uploads and tool outputs) are kept before automatic deletion. Files you explicitly save to the Files library are not affected and persist until you delete them. |
 | `CLEANUP_INTERVAL_MINUTES` | `60` | How often the cleanup job runs. |
 
 ### Appearance

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -134,6 +134,8 @@ Pipelines have unlimited steps by default.
 
 Every file you process can be saved to your **Files** library. SnapOtter tracks the full version history so you can trace every processing step from the original upload to the final output.
 
+Saving is explicit: results you save to the library are kept until you delete them, while results you process and leave unsaved are cleared automatically after 72 hours (configurable via `FILE_MAX_AGE_HOURS`).
+
 ### REST API & API Keys
 
 Every tool is accessible via HTTP:


### PR DESCRIPTION
Three small housekeeping changes, finishing the analytics-removal cleanup and an adjacent gitignore bug found along the way.

## 1. docs: file-retention wording (`apps/docs`)
Clarify that `FILE_MAX_AGE_HOURS` only affects **unsaved** processing results (raw uploads and tool outputs); files saved to the Files library persist until the user deletes them. Updated the configuration table and the getting-started Files section.

## 2. chore(demo): remove dead per-user analytics from the mock API (`apps/demo`)
#336 deleted the per-user analytics consent system (DB columns, the `PUT /api/v1/user/analytics` endpoint, and the consent UI). The demo mock still simulated it: a PUT handler, `analyticsEnabled` / `analyticsConsentShownAt` state fields, and analytics fields on the session user. The real API no longer returns those and apps/web no longer reads them, so they're removed. The `GET /api/v1/config/analytics` mock stays (that endpoint still exists). Demo build verified.

## 3. fix(gitignore): anchor the `demo` ignore to root
A bare `demo` pattern matched any directory named `demo`, including the tracked `apps/demo` workspace, so new files under it were silently ignored (and lint-staged choked re-adding it during commit 2 above). The intended target, a root `demo/`, no longer exists. Anchored to `/demo`. Build artifacts under `apps/demo` stay ignored via the global `dist/` and `.turbo/` rules (verified: zero unexpected files surface).

## Verification
`pnpm --filter @snapotter/demo build` passes. Biome clean. `git add apps/demo/...` no longer warns. The docs changes are content-only.