### PR TITLE
fix(nightly): qpdf in test image, NUL-byte settings hardening, AI sub-path exclude

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -338,7 +338,7 @@ jobs:
             --url http://localhost:13490 \
             --checks not_a_server_error \
             --include-path-regex "^/api/v1/(tools|health|info)" \
-            --exclude-path-regex "/(remove-background|upscale|blur-faces|erase-object|ocr|ocr-pdf|colorize|enhance-faces|noise-removal|smart-crop|red-eye-removal|restore-photo|passport-photo|transparency-fixer|ai-canvas-expand|transcribe-audio|auto-subtitles|background-replace|blur-background)$" \
+            --exclude-path-regex "/(remove-background|upscale|blur-faces|erase-object|ocr|ocr-pdf|colorize|enhance-faces|noise-removal|smart-crop|red-eye-removal|restore-photo|passport-photo|transparency-fixer|ai-canvas-expand|transcribe-audio|auto-subtitles|background-replace|blur-background)(/[a-z-]+)?$" \
             --max-examples 25 \
             --report junit \
             --report-dir st-report

--- a/apps/api/src/jobs/enqueue.ts
+++ b/apps/api/src/jobs/enqueue.ts
@@ -18,6 +18,23 @@ import { POOLS, type Pool, queueName, type ToolJobData, type ToolJobResult } fro
 
 const queueEventsMap = new Map<Pool, QueueEvents>();
 
+/**
+ * Recursively strip NUL (U+0000) bytes from a value. Postgres rejects NUL in
+ * text/jsonb ("invalid byte sequence for encoding UTF8: 0x00"), so a tool whose
+ * settings contain a NUL (e.g. a fuzzed string field) would 500 on the jobs
+ * insert. NUL is never meaningful in tool settings, so drop it.
+ */
+function stripNulBytes<T>(value: T): T {
+  if (typeof value === "string") return value.replace(/\0/g, "") as T;
+  if (Array.isArray(value)) return value.map(stripNulBytes) as T;
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = stripNulBytes(v);
+    return out as T;
+  }
+  return value;
+}
+
 function getQueueEvents(pool: Pool): QueueEvents {
   let qe = queueEventsMap.get(pool);
   if (!qe) {
@@ -110,7 +127,7 @@ export async function enqueueToolJob(data: ToolJobData): Promise<Job<ToolJobData
     type: data.kind,
     status: "queued",
     inputRefs: data.inputRefs,
-    settings: (data.dbSettings ?? data.settings) as Record<string, unknown>,
+    settings: stripNulBytes((data.dbSettings ?? data.settings) as Record<string, unknown>),
   });
 
   // Fire-and-forget: compute deleteAfter from team retention override

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libraw-dev \
     libjxl-tools \
     ghostscript \
+    qpdf \
     && if apt-cache show libx265-199 >/dev/null 2>&1; then \
          apt-get install -y --no-install-recommends libx265-199; \
        elif apt-cache show libx265-209 >/dev/null 2>&1; then \


### PR DESCRIPTION
Third round. The earlier fixes unblocked the next layer of nightly failures, each now root-caused:

- **Docker E2E**: the `patches/` fix (#346) let the image build finish, so the suite finally *runs* — and fails with `spawnSync qpdf ENOENT`. `Dockerfile.test` installs imagemagick/ghostscript/exiftool but never **qpdf** (needed by the PDF tools + fixture-integrity). Added.
- **NUL-byte 500 (real bug)**: Schemathesis found that a settings string containing `U+0000` reaches the `jobs.settings` jsonb insert and Postgres rejects it (`invalid byte sequence for encoding UTF8: 0x00`), 500ing html-to-image. Strip NUL bytes from settings before the insert. (api typecheck passes.)
- **Schemathesis AI sub-paths**: the #346 exclude only matched the tool id at the path *end*, so `/passport-photo/analyze` still got fuzzed → 501. Regex now allows an optional sub-path.

## Verified
api typecheck clean; YAML valid; biome clean. The Docker/Schemathesis fixes are container/CI-only, confirmed by the next nightly.

## Honest status
This nightly is a multi-layer onion — each fix reveals the next. Measured deltas across rounds: Coverage now green; Extended Matrix 8→1; Schemathesis loads + 169→151 ops (AI excluded), down to the 2 NUL-byte 5xx this PR fixes; Docker build fixed → now qpdf. Remaining after this: a `pipeline-multimodal` doc-pool test (likely qpdf-related, should clear), the last Extended-Matrix timeout, and the e2e jobs (route sweep #347 needs nightly confirmation).