### PR TITLE
fix(nightly): de-flake matrix timeouts + exclude browser tool from fuzz

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -338,7 +338,7 @@ jobs:
             --url http://localhost:13490 \
             --checks not_a_server_error \
             --include-path-regex "^/api/v1/(tools|health|info)" \
-            --exclude-path-regex "/(remove-background|upscale|blur-faces|erase-object|ocr|ocr-pdf|colorize|enhance-faces|noise-removal|smart-crop|red-eye-removal|restore-photo|passport-photo|transparency-fixer|ai-canvas-expand|transcribe-audio|auto-subtitles|background-replace|blur-background)(/[a-z-]+)?$" \
+            --exclude-path-regex "/(remove-background|upscale|html-to-image|blur-faces|erase-object|ocr|ocr-pdf|colorize|enhance-faces|noise-removal|smart-crop|red-eye-removal|restore-photo|passport-photo|transparency-fixer|ai-canvas-expand|transcribe-audio|auto-subtitles|background-replace|blur-background)(/[a-z-]+)?$" \
             --max-examples 25 \
             --report junit \
             --report-dir st-report

--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -11,7 +11,7 @@ jobs:
   update-baselines:
     name: Regenerate linux visual baselines
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     # The e2e webServer (playwright.config.ts) creates an isolated database via
     # tests/e2e-pg-create-db.cjs, so it needs Postgres + Redis on localhost.
     # Without these services the webServer fails with "failed to create database".

--- a/tests/integration/generated/format-matrix-comprehensive.test.ts
+++ b/tests/integration/generated/format-matrix-comprehensive.test.ts
@@ -955,7 +955,7 @@ describe("Extended conversion targets (core formats)", () => {
         if (fmt.name.toLowerCase() === target.format) continue;
         if (fmt.name === "AVIF" && target.format === "avif") continue;
 
-        const testTimeout = target.format === "avif" || target.format === "gif" ? 120_000 : 30_000;
+        const testTimeout = target.format === "avif" || target.format === "gif" ? 120_000 : 120_000;
         it(`${fmt.name} -> ${target.format}`, { timeout: testTimeout }, async () => {
           const res = await callTool("convert", fmt, { format: target.format });
           if (!res) return;

--- a/tests/integration/generated/format-matrix-expanded.test.ts
+++ b/tests/integration/generated/format-matrix-expanded.test.ts
@@ -859,7 +859,7 @@ describe("SVG-to-raster", () => {
   const SVG_OUTPUT_FORMATS = ["png", "jpg", "webp", "avif"] as const;
 
   for (const outFmt of SVG_OUTPUT_FORMATS) {
-    const testTimeout = outFmt === "avif" ? 120_000 : 30_000;
+    const testTimeout = outFmt === "avif" ? 120_000 : 120_000;
     it(`converts SVG to ${outFmt}`, { timeout: testTimeout }, async () => {
       const fixturePath = fixtures.image.formats("svg");
       if (!existsSync(fixturePath)) return;

--- a/tests/integration/generated/format-matrix.test.ts
+++ b/tests/integration/generated/format-matrix.test.ts
@@ -704,7 +704,7 @@ describe("Cross-format conversion matrix", () => {
       if (inputLower === outFmt) continue;
       if (inputLower === "jpeg" && outFmt === "jpg") continue;
 
-      const testTimeout = outFmt === "avif" ? 120_000 : 60_000;
+      const testTimeout = outFmt === "avif" ? 120_000 : 120_000;
       it(`${fmt.name} -> ${outFmt}`, { timeout: testTimeout }, async () => {
         const fixturePath = join(fixtureDir.formats, fmt.file);
         if (!existsSync(fixturePath)) return;

--- a/tests/integration/generated/new-formats.test.ts
+++ b/tests/integration/generated/new-formats.test.ts
@@ -185,7 +185,7 @@ describe("New format support", () => {
       for (const outFmt of OUTPUTS) {
         const inLower = input.name.toLowerCase();
         if (inLower === outFmt || (inLower === "jpeg" && outFmt === "jpg")) continue;
-        const testTimeout = outFmt === "avif" ? 120_000 : 60_000;
+        const testTimeout = outFmt === "avif" ? 120_000 : 120_000;
         it(`converts ${input.name} to ${outFmt}`, { timeout: testTimeout }, async () => {
           const fileBuffer = readFileSync(join(fixtureDir.formats, input.file));
           const { body, contentType } = createMultipartPayload([


### PR DESCRIPTION
Systematic round attacking failure classes. Matrix conversion tests' hardcoded 30s/60s timeouts -> 120s (de-flakes Coverage + Extended Matrix). html-to-image excluded from Schemathesis (503 without a browser, like the AI 501s). Baseline regen 60->120 min. Verified: biome + YAML clean; nightly confirms.