### PR TITLE
fix(tools): honest content-type for edit-metadata pass-through

### DIFF
--- a/apps/api/src/routes/tools/edit-metadata.ts
+++ b/apps/api/src/routes/tools/edit-metadata.ts
@@ -45,6 +45,10 @@ const settingsSchema = z.object({
 
 type Settings = z.infer<typeof settingsSchema>;
 
+// edit-metadata writes tags in place and streams the ORIGINAL bytes back, so
+// the download's content-type must match the real format, not a default. A
+// previous fallback to image/jpeg made a BMP/PSD/PPM download claim to be a
+// JPEG. Map every format validateImageBuffer can report.
 const MIME_BY_FORMAT: Record<string, string> = {
   jpeg: "image/jpeg",
   png: "image/png",
@@ -53,6 +57,26 @@ const MIME_BY_FORMAT: Record<string, string> = {
   tiff: "image/tiff",
   gif: "image/gif",
   heif: "image/heif",
+  bmp: "image/bmp",
+  svg: "image/svg+xml",
+  ico: "image/x-icon",
+  cur: "image/x-icon",
+  psd: "image/vnd.adobe.photoshop",
+  jxl: "image/jxl",
+  jp2: "image/jp2",
+  qoi: "image/qoi",
+  dds: "image/vnd.ms-dds",
+  exr: "image/x-exr",
+  dpx: "image/x-dpx",
+  fits: "image/fits",
+  eps: "application/postscript",
+  pbm: "image/x-portable-bitmap",
+  pgm: "image/x-portable-graymap",
+  ppm: "image/x-portable-pixmap",
+  pfm: "image/x-portable-floatmap",
+  tga: "image/x-tga",
+  cr3: "image/x-canon-cr3",
+  raw: "image/x-dcraw",
 };
 
 const BROWSER_PREVIEWABLE = new Set([

--- a/tests/integration/generated/format-matrix-generated.test.ts
+++ b/tests/integration/generated/format-matrix-generated.test.ts
@@ -43,13 +43,19 @@ const fixtureFiles = process.env.FULL_MATRIX
 
 const ALLOWED_STATUSES = new Set([200, 202, 400, 413, 415, 422, 501]);
 
-/** Content types whose payloads are not raster images (skip pixel decode). */
-const NON_RASTER_OUTPUT = new Set([
-  "application/pdf",
-  "application/json",
-  "application/zip",
-  "image/svg+xml",
-  "text/plain",
+/**
+ * Raster content types this libvips/Sharp build is guaranteed to decode. Used
+ * to decide whether a 200 image response should be pixel-verified. Anything
+ * else (PDF, JSON, ZIP, SVG, or a niche raster like BMP/PSD streamed back
+ * untouched) carries an honest content-type we don't attempt to decode.
+ */
+const SHARP_DECODABLE_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+  "image/tiff",
+  "image/avif",
 ]);
 
 describe("tool x format matrix (generated)", () => {
@@ -134,19 +140,14 @@ describe("tool x format matrix (generated)", () => {
             headers: { authorization: `Bearer ${adminToken}` },
           });
           expect(dl.statusCode, `${toolId} x ${fixture}: download failed`).toBe(200);
-          const outType = dl.headers["content-type"]?.toString() ?? "";
-          const isRaster =
-            !NON_RASTER_OUTPUT.has(outType.split(";")[0]) && outType.startsWith("image/");
-          const sharpDecodable =
-            isRaster &&
-            ![
-              "image/heic",
-              "image/heif",
-              "image/x-icon",
-              "image/qoi",
-              "image/x-portable-pixmap",
-              "image/x-tga",
-            ].includes(outType.split(";")[0]);
+          const outType = (dl.headers["content-type"]?.toString() ?? "").split(";")[0];
+          // Allowlist of raster types this libvips build is guaranteed to
+          // decode. An allowlist (vs the old denylist) is robust to tools that
+          // legitimately stream back niche formats untouched (e.g. edit-metadata
+          // writing tags in place on a BMP/PSD): those carry an honest
+          // content-type we simply don't pixel-verify, rather than being
+          // misread as a corrupt JPEG.
+          const sharpDecodable = SHARP_DECODABLE_TYPES.has(outType);
           if (sharpDecodable) {
             // The processed output must actually decode; a corrupt "success" is a bug.
             const meta = await sharp(dl.rawPayload).metadata();


### PR DESCRIPTION
## Problem

The nightly **Extended Matrix + Fuzz** job failed on:

```
FAIL tests/integration/generated/format-matrix-generated.test.ts
  > edit-metadata handles every input format cleanly
  Error: Input buffer contains unsupported image format  (Sharp.metadata)
```

`edit-metadata` writes EXIF tags in place via ExifTool and streams the **original** bytes back (no re-encode). The download content-type was derived from a small `MIME_BY_FORMAT` map that only covered jpeg/png/webp/avif/tiff/gif/heif, defaulting everything else to `image/jpeg`. So editing the metadata of a BMP/PSD/PPM returned bytes of the real format under a lying `image/jpeg` header. The matrix test then tried to Sharp-decode the "JPEG" and threw.

## Fix

1. **Product correctness** (`edit-metadata.ts`): map every format `validateImageBuffer` can report to its real MIME type, so the download header matches the bytes.
2. **Test robustness** (`format-matrix-generated.test.ts`): replace the fragile denylist of "types Sharp can't decode" with an allowlist of the raster types this libvips build is guaranteed to decode (jpeg/png/webp/gif/tiff/avif). Niche formats streamed back untouched now carry an honest content-type that we simply don't pixel-verify, instead of being misread as a corrupt JPEG.

## Verification

Ran the **full** matrix locally with `FULL_MATRIX=1` (157 tools × 34 input formats): exit 0, all green. The previously-failing `edit-metadata` case passes.