### PR TITLE
fix: settings dialog and settings API correctness bugs

### DIFF
--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -104,6 +104,15 @@ export async function settingsRoutes(app: FastifyInstance): Promise<void> {
         });
       }
 
+      // A redacted secret comes back from GET as the literal mask, so a client that
+      // reads settings, edits one field, and saves the whole object echoes the mask
+      // back. Treat the mask as "leave this secret unchanged" instead of encrypting
+      // and persisting "********", which would destroy the real secret (e.g. the OIDC
+      // client secret or SIEM webhook auth, neither of which is read-only).
+      if (REDACTED_KEYS.has(key) && strValue === "********") {
+        continue;
+      }
+
       if (READONLY_KEYS.has(key)) {
         return reply.status(400).send({
           error: `Setting "${key}" cannot be modified via the API`,

--- a/apps/web/src/components/settings/settings-dialog.tsx
+++ b/apps/web/src/components/settings/settings-dialog.tsx
@@ -122,7 +122,12 @@ function useNavItems() {
         icon: Sparkles,
         requiredPermission: "settings:write",
       },
-      { id: "tools", label: t.settings.nav.tools, icon: Wrench },
+      {
+        id: "tools",
+        label: t.settings.nav.tools,
+        icon: Wrench,
+        requiredPermission: "settings:write",
+      },
       { id: "about", label: t.settings.nav.about, icon: Info },
     ],
     [t],
@@ -1295,13 +1300,18 @@ function generatePassword(): string {
   const upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
   const lower = "abcdefghijklmnopqrstuvwxyz";
   const digits = "0123456789";
-  const all = upper + lower + digits;
+  // The server policy can require a special character (passwordRequireSpecial), so
+  // always include one alongside an upper, lower, and digit; otherwise Generate can
+  // produce a password the server rejects. These specials all satisfy its check.
+  const special = "!@#$%^&*()-_=+";
+  const all = upper + lower + digits + special;
   const required = [
     upper[secureRandom(upper.length)],
     lower[secureRandom(lower.length)],
     digits[secureRandom(digits.length)],
+    special[secureRandom(special.length)],
   ];
-  const rest = Array.from({ length: 13 }, () => all[secureRandom(all.length)]);
+  const rest = Array.from({ length: 12 }, () => all[secureRandom(all.length)]);
   const chars = [...required, ...rest];
   for (let i = chars.length - 1; i > 0; i--) {
     const j = secureRandom(i + 1);
@@ -1996,6 +2006,7 @@ function ApiKeysSection() {
   const [showScoping, setShowScoping] = useState(false);
   const [scopedPerms, setScopedPerms] = useState<string[]>([]);
   const [expiresAt, setExpiresAt] = useState("");
+  const [error, setError] = useState<string | null>(null);
   const { permissions } = useAuth();
 
   const loadKeys = useCallback(async () => {
@@ -2016,6 +2027,7 @@ function ApiKeysSection() {
   const generateKey = useCallback(async () => {
     setGenerating(true);
     setNewKey(null);
+    setError(null);
     try {
       const payload: Record<string, unknown> = { name: keyName || "default" };
       if (showScoping && scopedPerms.length > 0) {
@@ -2032,11 +2044,11 @@ function ApiKeysSection() {
       setExpiresAt("");
       await loadKeys();
     } catch {
-      // Silently fail
+      setError(t.common.somethingWentWrong);
     } finally {
       setGenerating(false);
     }
-  }, [keyName, showScoping, scopedPerms, expiresAt, loadKeys]);
+  }, [keyName, showScoping, scopedPerms, expiresAt, loadKeys, t]);
 
   const copyKey = useCallback(async (key: string) => {
     const ok = await copyToClipboard(key);
@@ -2049,14 +2061,15 @@ function ApiKeysSection() {
   const deleteKey = useCallback(
     async (id: number) => {
       if (!confirm(t.settings.apiKeys.deleteConfirm)) return;
+      setError(null);
       try {
         await apiDelete(`/v1/api-keys/${id}`);
         await loadKeys();
       } catch {
-        // Silently fail
+        setError(t.common.somethingWentWrong);
       }
     },
-    [loadKeys],
+    [loadKeys, t],
   );
 
   if (loading) {
@@ -2098,6 +2111,12 @@ function ApiKeysSection() {
           {t.settings.apiKeys.generateButton}
         </button>
       </div>
+
+      {error && (
+        <div className="px-4 py-3 rounded-lg border border-red-500/30 bg-red-500/10 text-sm text-red-700 dark:text-red-400">
+          {error}
+        </div>
+      )}
 
       {/* Permission scoping */}
       <div className="space-y-2">
@@ -3286,6 +3305,7 @@ function ToolsSection() {
   const [saving, setSaving] = useState(false);
   const [search, setSearch] = useState("");
   const [showRestartBanner, setShowRestartBanner] = useState(false);
+  const [saveFailed, setSaveFailed] = useState(false);
 
   useEffect(() => {
     apiGet<{ settings: Record<string, string> }>("/v1/settings")
@@ -3325,11 +3345,12 @@ function ToolsSection() {
 
   const handleSave = useCallback(async () => {
     setSaving(true);
+    setSaveFailed(false);
     try {
       await apiPut("/v1/settings", { disabledTools: JSON.stringify(disabledTools) });
       setShowRestartBanner(true);
     } catch {
-      /* handle error */
+      setSaveFailed(true);
     } finally {
       setSaving(false);
     }
@@ -3424,6 +3445,12 @@ function ToolsSection() {
       {loadFailed && (
         <div className="px-4 py-3 rounded-lg border border-red-500/30 bg-red-500/10 text-sm text-red-700 dark:text-red-400">
           {t.settings.tools.loadFailedError}
+        </div>
+      )}
+
+      {saveFailed && (
+        <div className="px-4 py-3 rounded-lg border border-red-500/30 bg-red-500/10 text-sm text-red-700 dark:text-red-400">
+          {t.common.somethingWentWrong}
         </div>
       )}
 

--- a/apps/web/src/components/settings/settings-dialog.tsx
+++ b/apps/web/src/components/settings/settings-dialog.tsx
@@ -521,6 +521,19 @@ function GeneralSection() {
 
 /* ────────────────────── System ────────────────────── */
 
+// PUT /v1/settings rejects server-managed read-only keys (instance_id, cookie_secret)
+// with 400 READONLY_SETTING, and GET returns redacted secrets as the literal "********"
+// (cookie_secret, oidc_client_secret, siem_webhook_auth). Echoing either back breaks the
+// save or overwrites a real secret with the mask, so strip both before any bulk save.
+const READONLY_SETTING_KEYS = new Set(["instance_id", "cookie_secret"]);
+function writableSettings(settings: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(settings).filter(
+      ([key, value]) => !READONLY_SETTING_KEYS.has(key) && value !== "********",
+    ),
+  );
+}
+
 function SystemSection() {
   const { t } = useTranslation();
   const [settings, setSettings] = useState<Record<string, string>>({});
@@ -553,17 +566,7 @@ function SystemSection() {
     setSaving(true);
     setSaveMsg(null);
     try {
-      // GET returns read-only keys (instance_id, cookie_secret) and shows redacted
-      // secrets as the literal "********". Echoing those back fails with 400
-      // READONLY_SETTING or would overwrite a real secret with the mask, so send
-      // only the keys this section can actually change.
-      const READONLY_KEYS = new Set(["instance_id", "cookie_secret"]);
-      const writable = Object.fromEntries(
-        Object.entries(settings).filter(
-          ([key, value]) => !READONLY_KEYS.has(key) && value !== "********",
-        ),
-      );
-      await apiPut("/v1/settings", writable);
+      await apiPut("/v1/settings", writableSettings(settings));
       if (settings.analyticsEnabled === "false") {
         const { optOut } = await import("@/lib/analytics");
         optOut();
@@ -1032,7 +1035,7 @@ function AdminSecuritySettings() {
     setSaving(true);
     setSaveMsg(null);
     try {
-      await apiPut("/v1/settings", settings);
+      await apiPut("/v1/settings", writableSettings(settings));
       setSaveMsg(t.settings.security.securitySettingsSaved);
     } catch {
       setSaveMsg(t.settings.security.securitySettingsFailed);

--- a/tests/integration/platform/api.test.ts
+++ b/tests/integration/platform/api.test.ts
@@ -1394,6 +1394,33 @@ describe("Settings", () => {
       expect(body.value).toBe("testValue");
     });
 
+    it("treats a redacted secret mask as a no-op instead of overwriting the secret", async () => {
+      // Store a real secret; GET then redacts it to the literal mask.
+      await app.inject({
+        method: "PUT",
+        url: "/api/v1/settings",
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { oidc_client_secret: "real-oidc-secret-xyz" },
+      });
+      const getRes = await app.inject({
+        method: "GET",
+        url: "/api/v1/settings/oidc_client_secret",
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+      expect(JSON.parse(getRes.body).value).toBe("********");
+
+      // A client echoing the mask back must not overwrite the stored secret, so only
+      // the other key is written (updatedCount counts actual writes).
+      const putRes = await app.inject({
+        method: "PUT",
+        url: "/api/v1/settings",
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { oidc_client_secret: "********", theme: "dark" },
+      });
+      expect(putRes.statusCode).toBe(200);
+      expect(JSON.parse(putRes.body).updatedCount).toBe(1);
+    });
+
     it("non-admin cannot save settings", async () => {
       // Create a regular user
       await app.inject({


### PR DESCRIPTION
Follow-up to the settings work. Fixes a cluster of correctness bugs in the admin settings dialog and the settings API, found by extending the same analysis that caught the AdminSecuritySettings save bug. Typecheck, lint, and the Settings integration suite (plus a new regression test) are green.

## Fixes

1. **AdminSecuritySettings save always failed.** `handleSave` POSTed the whole `/v1/settings` object back, including read-only keys (`instance_id`, `cookie_secret`, rejected with 400 READONLY_SETTING) and redacted secrets shown as `********`. Extracted a shared `writableSettings()` helper (one source of truth for the filter) used in both SystemSection and AdminSecuritySettings.

2. **Server destroyed OIDC/SIEM secrets on a settings round trip (highest impact).** `oidc_client_secret` and `siem_webhook_auth` come back from GET as the `********` mask but, unlike `cookie_secret`, are not read-only. Any client that read settings and saved them back encrypted and persisted the literal mask, wiping the real secret and breaking SSO / SIEM auth. The PUT handler now treats the mask on a redacted key as leave-unchanged (skips it). New integration test guards this.

3. **Tools admin panel was not permission-gated.** The Tools nav item lacked the `requiredPermission: "settings:write"` its admin-config siblings declare, so a non-admin saw a panel whose Save 403s.

4. **Three silent failures now surface.** ToolsSection save, and ApiKeysSection generate and delete, swallowed errors, so a failed save or a key that was not actually revoked looked like success. They now show an error.

5. **Generated passwords could be rejected.** `generatePassword` produced alphanumeric-only passwords, so with `passwordRequireSpecial` enabled the server rejected them. It now always includes a special character.

## Known follow-ups (intentionally not in this PR)

- Cleared numeric settings inputs show their default via `|| "100"` but hold `""`, which can persist as `""` and read back as `NaN`. Needs per-field coalescing on save; deferred because naively dropping empty values would also block intentionally clearing a field.
- The settings PUT write loop is not transactional, so a mid-loop DB error leaves a partial write and skips the audit entry. Low severity; worth wrapping in a transaction on its own.
- The change-password form hardcodes a client minimum of 8 while the server enforces a configurable `passwordMinLength`. The server still rejects with a clear message, so this is a pre-validation nicety.

## Test plan

- [x] `pnpm --filter @snapotter/web typecheck` and `--filter @snapotter/api typecheck`: pass
- [x] `pnpm exec biome check` on changed files: warnings only (pre-existing), no errors
- [x] Settings integration suite incl. the new mask no-op regression test: 13 passed
- [ ] CI: full integration + e2e (this PR)