### PR TITLE
fix: adopt sharp 0.35.2+ by centralizing the FormatEnum key type

### DIFF
--- a/apps/api/src/lib/output-format.ts
+++ b/apps/api/src/lib/output-format.ts
@@ -1,6 +1,5 @@
-import sharp, { type FormatEnum } from "sharp";
-
-export type SharpFormat = Extract<keyof FormatEnum, string> | "avif";
+import type { SharpFormat } from "@snapotter/image-engine";
+import sharp from "sharp";
 
 export interface OutputFormat {
   format: SharpFormat;

--- a/apps/api/src/routes/tools/split.ts
+++ b/apps/api/src/routes/tools/split.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { extname } from "node:path";
+import type { SharpFormat } from "@snapotter/image-engine";
 import archiver from "archiver";
 import type { FastifyInstance } from "fastify";
-import sharp, { type FormatEnum } from "sharp";
+import sharp from "sharp";
 import { z } from "zod";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { getSecurityHeaders } from "../../lib/csp.js";
@@ -23,8 +24,6 @@ const settingsSchema = z.object({
   outputFormat: z.enum(["original", "png", "jpg", "webp", "avif", "jxl"]).default("original"),
   quality: z.number().min(1).max(100).default(90),
 });
-
-type SharpFormat = Extract<keyof FormatEnum, string> | "avif";
 
 function resolveOutputFormat(
   outputFormat: string,

--- a/packages/image-engine/src/types.ts
+++ b/packages/image-engine/src/types.ts
@@ -1,7 +1,7 @@
-import type { ChannelStats, FormatEnum, Metadata, Sharp as SharpInstance } from "sharp";
+import type { ChannelStats, Metadata, Sharp as SharpInstance } from "sharp";
 
 export type Sharp = SharpInstance;
-export type SharpFormat = Extract<keyof FormatEnum, string> | "avif";
+export type SharpFormat = Extract<Parameters<Sharp["toFormat"]>[0], string>;
 export type SharpChannelStats = ChannelStats;
 export type SharpMetadata = Metadata;
 

--- a/packages/image-engine/tests/operations.test.ts
+++ b/packages/image-engine/tests/operations.test.ts
@@ -16,12 +16,41 @@ import { rotate } from "../src/operations/rotate.js";
 import { saturation } from "../src/operations/saturation.js";
 import { sepia } from "../src/operations/sepia.js";
 import { stripMetadata } from "../src/operations/strip-metadata.js";
+import type { OutputFormat, Sharp, SharpFormat } from "../src/types.js";
 import { getImageInfo } from "../src/utils/metadata.js";
 import { extToMime, formatToExt, formatToMime, mimeToExt } from "../src/utils/mime.js";
 
 // Generate a 100x100 red PNG buffer for testing
 let testBuffer: Buffer;
-let testImage: () => sharp.Sharp;
+let testImage: () => Sharp;
+
+const SHARP_FORMAT_CASES = [
+  { sharpFormat: "webp", operationFormat: "webp", expectedFormat: "webp" },
+  { sharpFormat: "avif", operationFormat: "avif", expectedFormat: "avif" },
+  { sharpFormat: "png", operationFormat: "png", expectedFormat: "png" },
+  { sharpFormat: "jpeg", operationFormat: "jpg", expectedFormat: "jpeg" },
+] as const satisfies ReadonlyArray<{
+  sharpFormat: SharpFormat;
+  operationFormat: OutputFormat;
+  expectedFormat: string;
+}>;
+
+function tinyTestImage(): Sharp {
+  return sharp({
+    create: {
+      width: 4,
+      height: 4,
+      channels: 3,
+      background: { r: 255, g: 0, b: 0 },
+    },
+  });
+}
+
+async function expectOutputFormat(buffer: Buffer, expectedFormat: string): Promise<void> {
+  const meta = await sharp(buffer).metadata();
+  const format = meta.format === "heif" ? "avif" : meta.format;
+  expect(format).toBe(expectedFormat);
+}
 
 beforeAll(async () => {
   testBuffer = await sharp({
@@ -209,6 +238,26 @@ describe("compress", () => {
     const buf = await result.toBuffer();
     // Should be reasonably close to target (within 50% tolerance for small images)
     expect(buf.length).toBeLessThan(largeBuffer.length);
+  });
+});
+
+describe("sharp format compatibility", () => {
+  it.each(SHARP_FORMAT_CASES)("convert accepts $sharpFormat", async ({
+    operationFormat,
+    expectedFormat,
+  }) => {
+    const result = await convert(tinyTestImage(), { format: operationFormat });
+    const buf = await result.toBuffer();
+    await expectOutputFormat(buf, expectedFormat);
+  });
+
+  it.each(SHARP_FORMAT_CASES)("compress accepts $sharpFormat", async ({
+    operationFormat,
+    expectedFormat,
+  }) => {
+    const result = await compress(tinyTestImage(), { quality: 80, format: operationFormat });
+    const buf = await result.toBuffer();
+    await expectOutputFormat(buf, expectedFormat);
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

Adopts `sharp` 0.35.2+ in `@snapotter/image-engine` by replacing the broken `keyof sharp.FormatEnum` namespace-as-type pattern with a single centralized `SharpFormat` alias derived from sharp's own `toFormat()` signature. This unblocks the held dependency bump.

Part of #325

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New translation or i18n update
- [ ] Documentation update
- [ ] Test improvement
- [ ] Refactor (no functional change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/snapotter-hq/snapotter/blob/main/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://github.com/snapotter-hq/snapotter/blob/main/CLA.md) (the bot will prompt you if not)
- [x] My changes follow the project's code style (Biome passes)
- [x] I have added or updated tests for my changes
- [x] All existing tests pass locally (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] My PR is focused on a single concern (under 400 lines of change)
- [x] I have not modified CI, release, or linter configuration files

## Details

Sharp 0.35.2+ changed its bundled TypeScript types so that the namespace-as-type pattern stops working: `keyof sharp.FormatEnum` is no longer assignable to `toFormat()`'s parameter, and `sharp.ChannelStats` / `sharp.Metadata` / `sharp.Sharp` fail with `TS2503` once the namespace import is type-only. Dependabot held sharp at `0.35.1` to avoid this break.

This change:

- Bumps `sharp` to `^0.35.2` in `packages/image-engine/package.json` (0.35.2 is the latest published patch and the first release with the new types).
- Adds one centralized, exported alias in `packages/image-engine/src/types.ts`: `export type SharpFormat = Extract<Parameters<Sharp["toFormat"]>[0], string>;`, and re-exports `Sharp`, `ChannelStats`, and `Metadata` via direct named imports instead of the namespace.
- Replaces every `keyof sharp.FormatEnum` usage in `engine.ts`, `compress.ts`, and `convert.ts` with `SharpFormat`, and drops the redundant `as` casts on `toFormat()`.
- Reuses the same alias in the two API consumers (`apps/api/src/lib/output-format.ts`, `apps/api/src/routes/tools/split.ts`) by importing `SharpFormat` from `@snapotter/image-engine` instead of redefining a local `keyof sharp.FormatEnum | "avif"`.

No runtime behavior changes: the format keys passed to `toFormat()` are identical; only the type derivation changed.

## Testing

- `pnpm --filter @snapotter/image-engine typecheck` - passes
- `pnpm --filter @snapotter/api typecheck` - passes
- `pnpm --filter @snapotter/image-engine test` - 49 tests pass, including new parametrized convert/compress cases asserting `webp`, `avif`, `png`, and `jpeg` keys still round-trip
- `pnpm --filter @snapotter/image-engine lint` (Biome) - passes

## Screenshots (if applicable)

Not applicable - this is a type-level dependency adoption with no UI change.