### PR TITLE
chore: use "200+ tools" for the tool-count claim across public surfaces

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -2,7 +2,7 @@
 
 ![SnapOtter, a self-hosted file manipulation suite](https://raw.githubusercontent.com/snapotter-hq/SnapOtter/main/branding/social-preview.png)
 
-Open-source, self-hostable file manipulation suite. 240 tools across image, video, audio, documents, and files, plus a layer-based image editor and local AI. Everything runs on your own hardware, so your files never leave your network.
+Open-source, self-hostable file manipulation suite. 200+ tools across image, video, audio, documents, and files, plus a layer-based image editor and local AI. Everything runs on your own hardware, so your files never leave your network.
 
 [![License: AGPLv3](https://img.shields.io/badge/License-AGPLv3-blue)](https://github.com/snapotter-hq/SnapOtter/blob/main/LICENSE)
 [![Website](https://img.shields.io/badge/Website-snapotter.com-blue?logo=googlechrome&logoColor=white)](https://snapotter.com)
@@ -11,7 +11,7 @@ Open-source, self-hostable file manipulation suite. 240 tools across image, vide
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/hr3s7HPUsr)
 [![GitHub](https://img.shields.io/badge/GitHub-snapotter--hq%2FSnapOtter-181717?logo=github)](https://github.com/snapotter-hq/SnapOtter)
 
-> **SnapOtter v2.0.0 is coming soon.** The current `latest` image is v1.x and includes image tools only. v2.0 adds 240 tools across image, video, audio, documents, and files. We are fixing a last-minute issue with local AI installs before publishing the new image. Stay tuned.
+> **SnapOtter v2.0.0 is coming soon.** The current `latest` image is v1.x and includes image tools only. v2.0 adds 200+ tools across image, video, audio, documents, and files. We are fixing a last-minute issue with local AI installs before publishing the new image. Stay tuned.
 
 ## What is SnapOtter?
 
@@ -86,7 +86,7 @@ The same image runs on CPU or GPU. See [Docker Tags](https://docs.snapotter.com/
 
 ## Features
 
-- **240 tools across 5 modalities**
+- **200+ tools across 5 modalities**
   - **Image (105):** resize, crop, compress, convert, watermark, color adjust, beautify screenshots, generate memes, vectorize, GIF tools, find duplicates, passport photos, and more. Supports 55+ input formats (including 23 camera RAW formats) and 14 output formats.
   - **Video (57):** convert, compress, trim, resize, crop, merge, video-to-GIF, extract audio, stabilize, change FPS, burn or extract subtitles, and more.
   - **Audio (27):** convert, trim, normalize, volume, fade, pitch shift, silence removal, noise reduction, merge or split, waveform, and more.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 > [!NOTE]
-> **SnapOtter v2.0.0 is coming soon.** The current Docker image (`latest`) is v1.x and includes image tools only. v2.0 adds 240 tools across image, video, audio, documents, and files. We're fixing a last-minute issue with local AI installs before publishing the new image. Stay tuned!
+> **SnapOtter v2.0.0 is coming soon.** The current Docker image (`latest`) is v1.x and includes image tools only. v2.0 adds 200+ tools across image, video, audio, documents, and files. We're fixing a last-minute issue with local AI installs before publishing the new image. Stay tuned!
 
 <p align="center">
   <a href="https://hub.docker.com/r/snapotter/snapotter"><img src="https://img.shields.io/docker/v/snapotter/snapotter?label=Docker%20Hub&logo=docker" alt="Docker Hub"></a>
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <strong>Self-hosted file toolkit. 240 tools across image, video, audio, PDF, and files.</strong><br />
+  <strong>Self-hosted file toolkit. 200+ tools across image, video, audio, PDF, and files.</strong><br />
   The open-source alternative to Smallpdf, iLovePDF, TinyPNG, CloudConvert, and Otter.ai, in one stack you host yourself.
 </p>
 
@@ -29,7 +29,7 @@ Stirling-PDF stops at PDFs. ConvertX stops at conversions. SnapOtter runs all fi
 
 ## Key Features
 
-- **240 tools across 5 modalities:**
+- **200+ tools across 5 modalities:**
   - **Image (105):** resize, crop, compress, convert, watermark, color adjust, beautify screenshots, generate memes, vectorize, GIF tools, find duplicates, passport photos, plus dedicated format converters (JPG to PNG, HEIC to JPG, WebP to PNG, image to PDF, and more). Supports 55+ input formats (including 23 camera RAW formats) and 14 output formats
   - **Video (57):** convert, compress, trim, resize, crop, merge, video-to-GIF, extract audio, stabilize, change FPS, burn/extract subtitles, plus dedicated converters (MOV to MP4, MKV to MP4, MP4 to MP3, and more)
   - **Audio (27):** convert, trim, normalize, volume, fade, pitch shift, silence removal, noise reduction, merge/split, waveform, plus dedicated converters (M4A to MP3, AAC to MP3, OGG to WAV, and more)

--- a/apps/api/src/openapi.yaml
+++ b/apps/api/src/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: SnapOtter API
   version: 1.17.1
   description: |
-    REST API for SnapOtter, a self-hosted file processing suite with 240 tools across image, video, audio, document, and data.
+    REST API for SnapOtter, a self-hosted file processing suite with 200+ tools across image, video, audio, document, and data.
 
     ## Authentication
 

--- a/apps/api/src/routes/docs.ts
+++ b/apps/api/src/routes/docs.ts
@@ -39,7 +39,7 @@ function generateLlmsTxt(spec: OpenAPISpec): string {
   lines.push(`# ${spec.info.title}`);
   lines.push("");
   lines.push(
-    "> Self-hosted file processing API with 240 tools across image, video, audio, document, and data. Convert, compress, edit, transcribe, OCR, and more.",
+    "> Self-hosted file processing API with 200+ tools across image, video, audio, document, and data. Convert, compress, edit, transcribe, OCR, and more.",
   );
   lines.push("");
   lines.push("## Docs");

--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta property="og:title" content="SnapOtter Demo" />
-    <meta property="og:description" content="Try SnapOtter - open-source, self-hosted file processing. 240 tools, 100% local." />
+    <meta property="og:description" content="Try SnapOtter - open-source, self-hosted file processing. 200+ tools, 100% local." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://demo.snapotter.com" />
     <meta property="og:image" content="https://snapotter.com/og-image.png" />

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -6,7 +6,7 @@ import pkg from "../../../package.json";
 export default defineConfig({
   title: "SnapOtter",
   description:
-    "Documentation for SnapOtter - A Self-Hosted File Manipulation Suite. 240 tools for image, video, audio, PDF, and data processing. Local AI, pipelines, REST API.",
+    "Documentation for SnapOtter - A Self-Hosted File Manipulation Suite. 200+ tools for image, video, audio, PDF, and data processing. Local AI, pipelines, REST API.",
   base: "/",
   appearance: { initialValue: "light" },
   srcDir: ".",
@@ -86,7 +86,7 @@ export default defineConfig({
 `,
         customTemplateVariables: {
           description:
-            "SnapOtter is a self-hosted, open-source file processing platform with 240 tools across image, video, audio, PDF, and data. Includes AI/ML tools. Runs via Docker Compose with GPU auto-detection.",
+            "SnapOtter is a self-hosted, open-source file processing platform with 200+ tools across image, video, audio, PDF, and data. Includes AI/ML tools. Runs via Docker Compose with GPU auto-detection.",
           details:
             "Process images (resize, compress, convert, remove backgrounds, upscale, OCR), videos (trim, merge, subtitles), audio (normalize, transcribe, convert), PDFs (merge, split, watermark, redact), and data files (CSV, JSON, XML conversion) - without sending files to external services.",
         },

--- a/apps/docs/.vitepress/theme/DocsHome.vue
+++ b/apps/docs/.vitepress/theme/DocsHome.vue
@@ -45,7 +45,7 @@ function copyCommand() {
       <p class="eyebrow">Self-hosted · Open source · AGPLv3</p>
       <h1 class="hero-title">SnapOtter Documentation</h1>
       <p class="hero-sub">
-        <strong>Self-hosted file processing.</strong> 240 tools across image, video, audio, PDF &amp;
+        <strong>Self-hosted file processing.</strong> 200+ tools across image, video, audio, PDF &amp;
         files, all on your own hardware. Choose your path below, or get running in one command:
       </p>
       <div class="cmd" title="Click to copy" @click="copyCommand">
@@ -90,7 +90,7 @@ function copyCommand() {
     </section>
 
     <section class="mod">
-      <p class="mod-head"><strong>240 tools across 5 modalities</strong> <span>browse the full reference by type</span></p>
+      <p class="mod-head"><strong>200+ tools across 5 modalities</strong> <span>browse the full reference by type</span></p>
       <div class="chips">
         <a v-for="m in modalities" :key="m.href" class="chip" :href="m.href">
           <span class="chip-label">{{ m.label }}</span>

--- a/apps/docs/.vitepress/theme/search.css
+++ b/apps/docs/.vitepress/theme/search.css
@@ -45,7 +45,7 @@
 .algolia
   [command-dialog-wrapper]:has([command-input]:placeholder-shown)
   [command-empty=""]::after {
-  content: "Search 240 tools, guides, and the API reference";
+  content: "Search 200+ tools, guides, and the API reference";
   font-size: 14px;
   line-height: 1.4;
   color: var(--vp-c-text-2);

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -109,7 +109,7 @@ pnpm dev
 
 ## What You Can Do
 
-### File Processing (240 Tools)
+### File Processing (200+ Tools)
 
 | Modality | Count | Example Tools |
 |----------|-------|---------------|

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: SnapOtter Docs
-description: "Self-hosted file processing. 240 tools for image, video, audio, PDF, and files. Local AI, pipelines, REST API. Your files never leave your server."
+description: "Self-hosted file processing. 200+ tools for image, video, audio, PDF, and files. Local AI, pipelines, REST API. Your files never leave your server."
 sidebar: false
 ---
 

--- a/apps/landing/public/llms.txt
+++ b/apps/landing/public/llms.txt
@@ -1,6 +1,6 @@
 # SnapOtter
 
-> Open-source, self-hostable file processing suite with 240 tools across 5 modalities (image, video, audio, document, data). Single Docker container, no external services. Dual-licensed AGPLv3 / commercial.
+> Open-source, self-hostable file processing suite with 200+ tools across 5 modalities (image, video, audio, document, data). Single Docker container, no external services. Dual-licensed AGPLv3 / commercial.
 
 SnapOtter runs entirely on your own infrastructure. Files are processed locally with no data sent to external APIs. Deploy once with Docker and use it as much as you need. Supports GDPR, HIPAA, and CCPA compliance by architecture.
 
@@ -60,7 +60,7 @@ SAML SSO (Okta, Azure AD, Google Workspace, any OIDC), SCIM Provisioning, Multi-
 
 - Self-hosted: all processing on your infrastructure, no cloud dependency
 - Privacy-first: files never leave your network, air-gapped capable
-- 240 tools across 5 modalities (image, video, audio, document, data)
+- 200+ tools across 5 modalities (image, video, audio, document, data)
 - 15 local AI models, no external API calls
 - Batch processing with ZIP output
 - Pipeline automation: chain tools sequentially

--- a/apps/landing/src/data/alternatives.ts
+++ b/apps/landing/src/data/alternatives.ts
@@ -109,7 +109,7 @@ export const ALTERNATIVES: Alternative[] = [
       },
       {
         q: "Does it do more than PDFs?",
-        a: "Yes. Beyond its 28 PDF tools, SnapOtter handles image, video, audio, and file tasks too, 240 tools in one stack.",
+        a: "Yes. Beyond its PDF tools, SnapOtter handles image, video, audio, and file tasks too, 200+ tools in one stack.",
       },
     ],
   },
@@ -120,7 +120,7 @@ export const ALTERNATIVES: Alternative[] = [
     pageTitle: "The Open-Source, Self-Hosted Alternative to iLovePDF",
     h1: "The open-source, self-hosted alternative to iLovePDF",
     metaDescription:
-      "iLovePDF processes your files in the cloud. SnapOtter runs PDF merge, split, compress, convert, and OCR on your own server. 240 tools across five file types. Open source, AGPLv3.",
+      "iLovePDF processes your files in the cloud. SnapOtter runs PDF merge, split, compress, convert, and OCR on your own server. 200+ tools across five file types. Open source, AGPLv3.",
     intro:
       "iLovePDF is a hosted PDF service, which means your documents are uploaded to process them. SnapOtter gives you the same toolset to run yourself, with the file staying on your server.",
     breadth:

--- a/apps/landing/src/data/alternatives.ts
+++ b/apps/landing/src/data/alternatives.ts
@@ -91,11 +91,11 @@ export const ALTERNATIVES: Alternative[] = [
     pageTitle: "The Open-Source, Self-Hosted Alternative to Smallpdf",
     h1: "The open-source, self-hosted alternative to Smallpdf",
     metaDescription:
-      "Smallpdf uploads your documents to its servers. SnapOtter runs the same PDF tools on yours. 40 PDF tools plus 200 more for image, video, audio, and files. Open source, AGPLv3.",
+      "Smallpdf uploads your documents to its servers. SnapOtter runs the same PDF tools on yours. 28 PDF tools plus 212 more for image, video, audio, and files. Open source, AGPLv3.",
     intro:
       "Smallpdf is a cloud PDF suite, so every file you touch goes up to its servers. SnapOtter runs the same kinds of tools on hardware you own, and the file never leaves it.",
     breadth:
-      "Smallpdf does PDFs. SnapOtter ships 40 PDF tools (merge, split, compress, convert, redact, OCR, and more) and another 200 across image, video, audio, and files, so one stack covers what you'd otherwise spread across several accounts.",
+      "Smallpdf does PDFs. SnapOtter ships 28 PDF tools (merge, split, compress, convert, redact, OCR, and more) and another 212 across image, video, audio, and files, so one stack covers what you'd otherwise spread across several accounts.",
     competitorOpenSource: false,
     rows: cloudRows("PDFs", "Subscription, free tier with daily limits", "PDF only"),
     faqs: [
@@ -109,7 +109,7 @@ export const ALTERNATIVES: Alternative[] = [
       },
       {
         q: "Does it do more than PDFs?",
-        a: "Yes. Beyond its 40 PDF tools, SnapOtter handles image, video, audio, and file tasks too, 240 tools in one stack.",
+        a: "Yes. Beyond its 28 PDF tools, SnapOtter handles image, video, audio, and file tasks too, 240 tools in one stack.",
       },
     ],
   },
@@ -124,7 +124,7 @@ export const ALTERNATIVES: Alternative[] = [
     intro:
       "iLovePDF is a hosted PDF service, which means your documents are uploaded to process them. SnapOtter gives you the same toolset to run yourself, with the file staying on your server.",
     breadth:
-      "iLovePDF stays inside PDFs. SnapOtter pairs 40 PDF tools with image, video, audio, and file tools, so the same deployment handles a contract, a screen recording, and a podcast edit.",
+      "iLovePDF stays inside PDFs. SnapOtter pairs 28 PDF tools with image, video, audio, and file tools, so the same deployment handles a contract, a screen recording, and a podcast edit.",
     competitorOpenSource: false,
     rows: cloudRows("PDFs", "Subscription, free tier with limits", "PDF only"),
     faqs: [

--- a/apps/landing/src/pages/alternatives/[slug].astro
+++ b/apps/landing/src/pages/alternatives/[slug].astro
@@ -215,7 +215,7 @@ const allJsonLd = [breadcrumbJsonLd, ...(faqJsonLd ? [faqJsonLd] : [])];
             Run it on your own server
           </h2>
           <p class="mx-auto mt-4 max-w-lg text-muted">
-            240 tools across image, video, audio, PDF, and files. Open source, free forever, and your
+            200+ tools across image, video, audio, PDF, and files. Open source, free forever, and your
             files never leave your network.
           </p>
           <div class="mt-8 flex flex-wrap justify-center gap-4">

--- a/branding/README.md
+++ b/branding/README.md
@@ -2,7 +2,7 @@
 
 Press kit for use in blog posts, articles, reviews, and other publications about SnapOtter. Free to use when referencing SnapOtter.
 
-SnapOtter is an open-source, self-hosted file processing suite with 240 tools across image, video, audio, PDF, and file workflows.
+SnapOtter is an open-source, self-hosted file processing suite with 200+ tools across image, video, audio, PDF, and file workflows.
 
 ## Files
 
@@ -20,7 +20,7 @@ SnapOtter is an open-source, self-hosted file processing suite with 240 tools ac
 | `wordmark.svg` | Scalable | "SnapOtter" text mark (dark text) |
 | `wordmark-white.svg` | Scalable | "SnapOtter" text mark (white text, for dark backgrounds) |
 | `banner.svg` | Scalable | Wordmark + tagline banner on dark background |
-| `dashboard.gif` | Animated | Scrolling tour of all 240 tools across the five modalities (README hero) |
+| `dashboard.gif` | Animated | Scrolling tour of all 200+ tools across the five modalities (README hero) |
 
 ## Brand Colors
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snapotter",
   "version": "2.0.0",
   "private": true,
-  "description": "Self-hosted file processing suite with 240 tools across image, video, audio, document, and data, plus local AI. Runs as a Docker Compose stack with Postgres and Redis.",
+  "description": "Self-hosted file processing suite with 200+ tools across image, video, audio, document, and data, plus local AI. Runs as a Docker Compose stack with Postgres and Redis.",
   "homepage": "https://snapotter.com",
   "repository": {
     "type": "git",

--- a/packages/shared/src/i18n/en.ts
+++ b/packages/shared/src/i18n/en.ts
@@ -3334,7 +3334,7 @@ export const en = {
       heading: "About",
       appName: "SnapOtter",
       appDescription:
-        "A self-hosted, privacy-first file processing suite with 240 tools. Convert, compress, edit, transcribe, OCR, and automate image, video, audio, document, and data workflows without sending data to the cloud.",
+        "A self-hosted, privacy-first file processing suite with 200+ tools. Convert, compress, edit, transcribe, OCR, and automate image, video, audio, document, and data workflows without sending data to the cloud.",
       versionLabel: "Version:",
       linksHeading: "Links",
       githubLink: "GitHub Repository",
@@ -3393,7 +3393,7 @@ export const en = {
       "No limits. No hidden caps.",
       "Works fully offline.",
       "Unlimited batch processing.",
-      "240 tools.",
+      "200+ tools.",
       "16 AI models. Your hardware.",
       "Lightning fast. Built on Sharp.",
       "Air-gapped ready.",

--- a/packages/shared/src/i18n/nl.ts
+++ b/packages/shared/src/i18n/nl.ts
@@ -3393,7 +3393,7 @@ export const nl: TranslationKeys = {
       heading: "Over",
       appName: "SnapOtter",
       appDescription:
-        "Een zelf-gehoste, privacy-first bestandsverwerkingssuite met 240 tools. Converteren, comprimeren, bewerken, transcriberen, OCR en automatiseer je beeld-, video-, audio-, document- en dataworkflows zonder data naar de cloud te sturen.",
+        "Een zelf-gehoste, privacy-first bestandsverwerkingssuite met 200+ tools. Converteren, comprimeren, bewerken, transcriberen, OCR en automatiseer je beeld-, video-, audio-, document- en dataworkflows zonder data naar de cloud te sturen.",
       versionLabel: "Versie:",
       linksHeading: "Links",
       githubLink: "GitHub-repository",
@@ -3452,7 +3452,7 @@ export const nl: TranslationKeys = {
       "Geen limieten. Geen verborgen plafonds.",
       "Werkt volledig offline.",
       "Onbeperkte batchverwerking.",
-      "240 tools.",
+      "200+ tools.",
       "16 AI-modellen. Jouw hardware.",
       "Razendsnel. Gebouwd op Sharp.",
       "Geschikt voor air-gapped netwerken.",

--- a/tests/e2e-docs/homepage.spec.ts
+++ b/tests/e2e-docs/homepage.spec.ts
@@ -29,7 +29,7 @@ test.describe("docs homepage (Two Doors)", () => {
   });
 
   test("renders the modality strip with counts", async ({ page }) => {
-    await expect(page.getByText("240 tools across 5 modalities")).toBeVisible();
+    await expect(page.getByText("200+ tools across 5 modalities")).toBeVisible();
     await expect(page.getByRole("link", { name: /Image/ })).toBeVisible();
   });
 

--- a/tests/unit/api/docs-route.test.ts
+++ b/tests/unit/api/docs-route.test.ts
@@ -49,7 +49,7 @@ function generateLlmsTxt(spec: OpenAPISpec): string {
   lines.push(`# ${spec.info.title}`);
   lines.push("");
   lines.push(
-    "> Self-hosted file processing API with 240 tools across image, video, audio, document, and data. Convert, compress, edit, transcribe, OCR, and more.",
+    "> Self-hosted file processing API with 200+ tools across image, video, audio, document, and data. Convert, compress, edit, transcribe, OCR, and more.",
   );
   lines.push("");
   lines.push("## Docs");


### PR DESCRIPTION
Swaps the exact `240 tools` count (which drifts every time tools are added) for the stable `200+ tools` across all public surfaces: README, Docker Hub overview, landing pages, docs site (meta + homepage + search), API self-description, demo OG tag, llms.txt, package.json, branding readme, and the en/nl app strings.

Per-modality breakdown tables stay exact. The architecture doc's technical `240 tool routes` figure, an internal vitest comment, and a QA report line are intentionally left as-is. The two tests that assert the docs strings are updated to match.