### PR TITLE
ci: manage Docker Hub short description via the sync workflow

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,7 +1,8 @@
 name: Sync Docker Hub description
 
-# Publishes DOCKERHUB.md as the snapotter/snapotter repository overview on Docker Hub
-# when it changes on main (or on manual dispatch). Secret DOCKER_HUB_README holds the
+# Publishes DOCKERHUB.md as the snapotter/snapotter repository overview (and sets the
+# short description) on Docker Hub when it changes on main (or on manual dispatch).
+# Secret DOCKER_HUB_README holds the
 # Docker Hub account password; DOCKERHUB_USERNAME already exists (used by release.yml).
 
 on:
@@ -28,3 +29,4 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_README }}
           repository: snapotter/snapotter
           readme-filepath: ./DOCKERHUB.md
+          short-description: "Self-hosted file toolkit. 200+ tools for Image, Video, Audio, PDF, and Files. Open source."


### PR DESCRIPTION
The auto-sync workflow only set the full overview, leaving the Docker Hub short description stuck at '150+ tools'. This adds a `short-description` input so it stays at '200+ tools' (90 chars, under Docker Hub's 100-char limit) and is managed declaratively going forward. Applied by dispatching the workflow after merge.