### PR TITLE
docs: sync API and documentation coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,14 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install system dependencies (image formats + doc-engine qpdf/pandoc/LibreOffice)
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends libheif-examples libheif-plugin-x265 libheif-plugin-libde265 libimage-exiftool-perl libraw-bin imagemagick ghostscript libjxl-tools libopenjp2-tools qpdf pandoc libreoffice-calc libreoffice-impress libreoffice-writer
+      - name: Install system dependencies (image formats + doc-engine qpdf/LibreOffice)
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends libheif-examples libheif-plugin-x265 libheif-plugin-libde265 libimage-exiftool-perl libraw-bin imagemagick ghostscript libjxl-tools libopenjp2-tools qpdf libreoffice-calc libreoffice-impress libreoffice-writer
+
+      - name: Install Pandoc 3.10 (sandboxed DOCX/EPUB)
+        run: |
+          curl -fsSL https://github.com/jgm/pandoc/releases/download/3.10/pandoc-3.10-1-amd64.deb -o /tmp/pandoc.deb
+          sudo apt-get install -y --no-install-recommends /tmp/pandoc.deb
+          pandoc --version
 
       - name: Install pdfcpu (doc-engine PDF layout binary; matches docker/Dockerfile v0.13.0)
         run: |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 > [!NOTE]
-> **SnapOtter v2.0.0 is coming soon.** The current Docker image (`latest`) is v1.x and includes image tools only. v2.0 adds 200+ tools across image, video, audio, documents, and files. We're fixing a last-minute issue with local AI installs before publishing the new image. Stay tuned!
+> **SnapOtter v2.0.0** is the current monorepo version, with 200+ tools across image, video, audio, PDF, and files. For published image channels and GPU variants, see the Docker Tags guide.
 
 <p align="center">
   <a href="https://hub.docker.com/r/snapotter/snapotter"><img src="https://img.shields.io/docker/v/snapotter/snapotter?label=Docker%20Hub&logo=docker" alt="Docker Hub"></a>
@@ -33,7 +33,7 @@ Stirling-PDF stops at PDFs. ConvertX stops at conversions. SnapOtter runs all fi
   - **Image (105):** resize, crop, compress, convert, watermark, color adjust, beautify screenshots, generate memes, vectorize, GIF tools, find duplicates, passport photos, plus dedicated format converters (JPG to PNG, HEIC to JPG, WebP to PNG, image to PDF, and more). Supports 55+ input formats (including 23 camera RAW formats) and 14 output formats
   - **Video (57):** convert, compress, trim, resize, crop, merge, video-to-GIF, extract audio, stabilize, change FPS, burn/extract subtitles, plus dedicated converters (MOV to MP4, MKV to MP4, MP4 to MP3, and more)
   - **Audio (27):** convert, trim, normalize, volume, fade, pitch shift, silence removal, noise reduction, merge/split, waveform, plus dedicated converters (M4A to MP3, AAC to MP3, OGG to WAV, and more)
-  - **Documents / PDF (28):** merge, split, compress, convert (Word/Excel/PowerPoint/EPUB), protect/unlock, redact, watermark, page numbers, OCR, plus PDF to JPG/PNG/TIFF
+  - **PDF (29):** merge, split, compress, convert, protect/unlock, redact, sign, watermark, page numbers, OCR, plus PDF to JPG/PNG/TIFF
   - **Files (23):** CSV/JSON/XML/YAML conversion, CSV merge/split, Excel to CSV, chart maker, ZIP create/extract
 - **Image editor:** Layer-based editor with brushes, shapes, adjustments, filters, curves, and keyboard shortcuts. Runs in your browser, processes on your hardware
 - **Local AI:** Remove backgrounds, upscale images, restore and colorize old photos, erase objects, blur faces, enhance faces, extract text (OCR from images and PDFs), transcribe audio, auto-generate video subtitles, expand canvas, and fix transparency. All on your hardware, no internet required

--- a/apps/api/src/openapi.yaml
+++ b/apps/api/src/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: SnapOtter API
-  version: 1.17.1
+  version: 2.0.0
   description: |
     REST API for SnapOtter, a self-hosted file processing suite with 200+ tools across image, video, audio, document, and data.
 
@@ -3809,8 +3809,7 @@ paths:
                   bitDepth:
                     type: string
                   density:
-                    type: integer
-                    nullable: true
+                    type: [integer, "null"]
                   hasAlpha:
                     type: boolean
                   fileSize:
@@ -3820,8 +3819,7 @@ paths:
                   isProgressive:
                     type: boolean
                   orientation:
-                    type: integer
-                    nullable: true
+                    type: [integer, "null"]
                   hasProfile:
                     type: boolean
                   hasIcc:
@@ -3982,11 +3980,9 @@ paths:
                                 x: { type: number }
                                 y: { type: number }
                   annotatedUrl:
-                    type: string
-                    nullable: true
+                    type: [string, "null"]
                   previewUrl:
-                    type: string
-                    nullable: true
+                    type: [string, "null"]
         "400":
           description: Invalid input
           content:
@@ -4070,8 +4066,7 @@ paths:
                               isBest:
                                 type: boolean
                               thumbnail:
-                                type: string
-                                nullable: true
+                                type: [string, "null"]
                   uniqueImages:
                     type: integer
                   spaceSaveable:
@@ -5186,8 +5181,7 @@ paths:
                       version:
                         type: integer
                       parentId:
-                        type: string
-                        nullable: true
+                        type: [string, "null"]
                       toolChain:
                         type: array
                         items:
@@ -5343,8 +5337,7 @@ paths:
                         downloadUrl:
                           type: string
                         previewUrl:
-                          type: string
-                          nullable: true
+                          type: [string, "null"]
                         error:
                           type: string
                           description: Present only when success is false
@@ -5501,9 +5494,8 @@ paths:
                         items:
                           type: string
                   expiresAt:
-                    type: string
+                    type: [string, "null"]
                     format: date-time
-                    nullable: true
 
   /api/auth/change-password:
     post:
@@ -5861,14 +5853,12 @@ paths:
                   name:
                     type: string
                   permissions:
-                    type: array
+                    type: [array, "null"]
                     items:
                       type: string
-                    nullable: true
                   expiresAt:
-                    type: string
+                    type: [string, "null"]
                     format: date-time
-                    nullable: true
                   createdAt:
                     type: string
                     format: date-time
@@ -5909,21 +5899,18 @@ paths:
                         name:
                           type: string
                         permissions:
-                          type: array
+                          type: [array, "null"]
                           items:
                             type: string
-                          nullable: true
                         createdAt:
                           type: string
                           format: date-time
                         lastUsedAt:
-                          type: string
+                          type: [string, "null"]
                           format: date-time
-                          nullable: true
                         expiresAt:
-                          type: string
+                          type: [string, "null"]
                           format: date-time
-                          nullable: true
         "401":
           description: Authentication required
           content:
@@ -6465,8 +6452,7 @@ paths:
                           type: string
                           enum: [installed, not_installed, installing, error]
                         installedVersion:
-                          type: string
-                          nullable: true
+                          type: [string, "null"]
                         estimatedSize:
                           type: string
                         enablesTools:
@@ -6474,16 +6460,14 @@ paths:
                           items:
                             type: string
                         progress:
-                          type: object
-                          nullable: true
+                          type: [object, "null"]
                           properties:
                             percent:
                               type: number
                             stage:
                               type: string
                         error:
-                          type: string
-                          nullable: true
+                          type: [string, "null"]
         "401":
           description: Authentication required
           content:
@@ -6692,27 +6676,21 @@ paths:
                         id:
                           type: string
                         actorId:
-                          type: string
-                          nullable: true
+                          type: [string, "null"]
                         actorUsername:
                           type: string
                         action:
                           type: string
                         targetType:
-                          type: string
-                          nullable: true
+                          type: [string, "null"]
                         targetId:
-                          type: string
-                          nullable: true
+                          type: [string, "null"]
                         details:
-                          type: object
-                          nullable: true
+                          type: [object, "null"]
                         ipAddress:
-                          type: string
-                          nullable: true
+                          type: [string, "null"]
                         requestId:
-                          type: string
-                          nullable: true
+                          type: [string, "null"]
                         createdAt:
                           type: string
                           format: date-time
@@ -12162,3 +12140,4940 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UnauthorizedError"
+
+  # Generated catalog and docs parity paths. Keep in sync with packages/shared/src/constants.ts.
+  /api/v1/tools/image/passport-photo:
+    post:
+      operationId: passportPhotoTool
+      tags: [Tools]
+      summary: "Passport Photo"
+      description: |
+        Guidance endpoint for the two-phase passport photo flow. Use
+        `/api/v1/tools/image/passport-photo/analyze` to analyze an image,
+        then `/api/v1/tools/image/passport-photo/generate` to create the final
+        passport photo. This base route returns a 400 guidance error when the
+        required feature bundles are installed, or 501 when they are missing.
+      security:
+        - bearerAuth: []
+      responses:
+        "400":
+          description: Use the analyze or generate endpoint
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "501":
+          description: Feature not installed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeatureNotInstalledError"
+
+  /api/v1/tools/pdf/sign-pdf:
+    post:
+      operationId: signPdfTool
+      tags: [Tools]
+      summary: Sign PDF
+      description: Stamp one or more signature PNG images onto a PDF using normalized page placements.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file, placements, sig0]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: PDF file to sign
+                sig0:
+                  type: string
+                  format: binary
+                  description: First signature image. Additional signatures use sig1, sig2, and so on.
+                placements:
+                  type: string
+                  description: JSON array of placement objects with sig, page, x, y, w, and h. Coordinates are page fractions with top-left origin.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+                fileId:
+                  type: string
+                  description: Optional file library ID to save the signed result as a new version
+      responses:
+        "200":
+          description: Signed PDF
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/jpg-to-png:
+    post:
+      operationId: jpgToPngTool
+      tags: [Tools]
+      summary: "JPG to PNG"
+      description: |
+        Convert JPG to PNG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "JPG to PNG input file (.jpg, .jpeg)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated JPG to PNG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/png-to-jpg:
+    post:
+      operationId: pngToJpgTool
+      tags: [Tools]
+      summary: "PNG to JPG"
+      description: |
+        Convert PNG to JPG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PNG to JPG input file (.png)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PNG to JPG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/jpg-to-webp:
+    post:
+      operationId: jpgToWebpTool
+      tags: [Tools]
+      summary: "JPG to WebP"
+      description: |
+        Convert JPG to WebP
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "JPG to WebP input file (.jpg, .jpeg)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated JPG to WebP converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/png-to-webp:
+    post:
+      operationId: pngToWebpTool
+      tags: [Tools]
+      summary: "PNG to WebP"
+      description: |
+        Convert PNG to WebP
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PNG to WebP input file (.png)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PNG to WebP converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/webp-to-jpg:
+    post:
+      operationId: webpToJpgTool
+      tags: [Tools]
+      summary: "WebP to JPG"
+      description: |
+        Convert WebP to JPG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "WebP to JPG input file (.webp)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated WebP to JPG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/webp-to-png:
+    post:
+      operationId: webpToPngTool
+      tags: [Tools]
+      summary: "WebP to PNG"
+      description: |
+        Convert WebP to PNG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "WebP to PNG input file (.webp)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated WebP to PNG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/jpg-to-avif:
+    post:
+      operationId: jpgToAvifTool
+      tags: [Tools]
+      summary: "JPG to AVIF"
+      description: |
+        Convert JPG to AVIF
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "JPG to AVIF input file (.jpg, .jpeg)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated JPG to AVIF converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/png-to-avif:
+    post:
+      operationId: pngToAvifTool
+      tags: [Tools]
+      summary: "PNG to AVIF"
+      description: |
+        Convert PNG to AVIF
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PNG to AVIF input file (.png)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PNG to AVIF converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/webp-to-avif:
+    post:
+      operationId: webpToAvifTool
+      tags: [Tools]
+      summary: "WebP to AVIF"
+      description: |
+        Convert WebP to AVIF
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "WebP to AVIF input file (.webp)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated WebP to AVIF converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/heic-to-jpg:
+    post:
+      operationId: heicToJpgTool
+      tags: [Tools]
+      summary: "HEIC to JPG"
+      description: |
+        Convert HEIC to JPG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "HEIC to JPG input file (.heic, .heif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated HEIC to JPG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/heic-to-png:
+    post:
+      operationId: heicToPngTool
+      tags: [Tools]
+      summary: "HEIC to PNG"
+      description: |
+        Convert HEIC to PNG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "HEIC to PNG input file (.heic, .heif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated HEIC to PNG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/heic-to-avif:
+    post:
+      operationId: heicToAvifTool
+      tags: [Tools]
+      summary: "HEIC to AVIF"
+      description: |
+        Convert HEIC to AVIF
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "HEIC to AVIF input file (.heic, .heif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated HEIC to AVIF converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/jpg-to-gif:
+    post:
+      operationId: jpgToGifTool
+      tags: [Tools]
+      summary: "JPG to GIF"
+      description: |
+        Convert JPG to GIF
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "JPG to GIF input file (.jpg, .jpeg)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated JPG to GIF converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/png-to-gif:
+    post:
+      operationId: pngToGifTool
+      tags: [Tools]
+      summary: "PNG to GIF"
+      description: |
+        Convert PNG to GIF
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PNG to GIF input file (.png)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PNG to GIF converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/gif-to-jpg:
+    post:
+      operationId: gifToJpgTool
+      tags: [Tools]
+      summary: "GIF to JPG"
+      description: |
+        Convert GIF to JPG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "GIF to JPG input file (.gif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated GIF to JPG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/gif-to-png:
+    post:
+      operationId: gifToPngTool
+      tags: [Tools]
+      summary: "GIF to PNG"
+      description: |
+        Convert GIF to PNG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "GIF to PNG input file (.gif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated GIF to PNG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/webp-to-gif:
+    post:
+      operationId: webpToGifTool
+      tags: [Tools]
+      summary: "WebP to GIF"
+      description: |
+        Convert WebP to GIF
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "WebP to GIF input file (.webp)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated WebP to GIF converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/jpg-to-tiff:
+    post:
+      operationId: jpgToTiffTool
+      tags: [Tools]
+      summary: "JPG to TIFF"
+      description: |
+        Convert JPG to TIFF
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "JPG to TIFF input file (.jpg, .jpeg)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated JPG to TIFF converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/png-to-tiff:
+    post:
+      operationId: pngToTiffTool
+      tags: [Tools]
+      summary: "PNG to TIFF"
+      description: |
+        Convert PNG to TIFF
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PNG to TIFF input file (.png)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PNG to TIFF converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/tiff-to-jpg:
+    post:
+      operationId: tiffToJpgTool
+      tags: [Tools]
+      summary: "TIFF to JPG"
+      description: |
+        Convert TIFF to JPG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "TIFF to JPG input file (.tiff, .tif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated TIFF to JPG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/tiff-to-png:
+    post:
+      operationId: tiffToPngTool
+      tags: [Tools]
+      summary: "TIFF to PNG"
+      description: |
+        Convert TIFF to PNG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "TIFF to PNG input file (.tiff, .tif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated TIFF to PNG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/psd-to-jpg:
+    post:
+      operationId: psdToJpgTool
+      tags: [Tools]
+      summary: "PSD to JPG"
+      description: |
+        Convert PSD to JPG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PSD to JPG input file (.psd)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PSD to JPG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/psd-to-png:
+    post:
+      operationId: psdToPngTool
+      tags: [Tools]
+      summary: "PSD to PNG"
+      description: |
+        Convert PSD to PNG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PSD to PNG input file (.psd)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PSD to PNG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/png-to-eps:
+    post:
+      operationId: pngToEpsTool
+      tags: [Tools]
+      summary: "PNG to EPS"
+      description: |
+        Convert PNG to EPS
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PNG to EPS input file (.png)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PNG to EPS converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/jpg-to-eps:
+    post:
+      operationId: jpgToEpsTool
+      tags: [Tools]
+      summary: "JPG to EPS"
+      description: |
+        Convert JPG to EPS
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "JPG to EPS input file (.jpg, .jpeg)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated JPG to EPS converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/eps-to-png:
+    post:
+      operationId: epsToPngTool
+      tags: [Tools]
+      summary: "EPS to PNG"
+      description: |
+        Convert EPS to PNG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "EPS to PNG input file (.eps)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated EPS to PNG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/eps-to-jpg:
+    post:
+      operationId: epsToJpgTool
+      tags: [Tools]
+      summary: "EPS to JPG"
+      description: |
+        Convert EPS to JPG
+        This is a dedicated conversion preset endpoint backed by `convert`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "EPS to JPG input file (.eps)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated EPS to JPG converter using the convert pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/png-to-svg:
+    post:
+      operationId: pngToSvgTool
+      tags: [Tools]
+      summary: "PNG to SVG"
+      description: |
+        Convert PNG to SVG
+        This is a dedicated conversion preset endpoint backed by `vectorize`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PNG to SVG input file (.png)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PNG to SVG converter using the vectorize pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/jpg-to-svg:
+    post:
+      operationId: jpgToSvgTool
+      tags: [Tools]
+      summary: "JPG to SVG"
+      description: |
+        Convert JPG to SVG
+        This is a dedicated conversion preset endpoint backed by `vectorize`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "JPG to SVG input file (.jpg, .jpeg)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated JPG to SVG converter using the vectorize pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/tiff-to-svg:
+    post:
+      operationId: tiffToSvgTool
+      tags: [Tools]
+      summary: "TIFF to SVG"
+      description: |
+        Convert TIFF to SVG
+        This is a dedicated conversion preset endpoint backed by `vectorize`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "TIFF to SVG input file (.tiff, .tif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated TIFF to SVG converter using the vectorize pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/psd-to-svg:
+    post:
+      operationId: psdToSvgTool
+      tags: [Tools]
+      summary: "PSD to SVG"
+      description: |
+        Convert PSD to SVG
+        This is a dedicated conversion preset endpoint backed by `vectorize`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PSD to SVG input file (.psd)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PSD to SVG converter using the vectorize pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/eps-to-svg:
+    post:
+      operationId: epsToSvgTool
+      tags: [Tools]
+      summary: "EPS to SVG"
+      description: |
+        Convert EPS to SVG
+        This is a dedicated conversion preset endpoint backed by `vectorize`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "EPS to SVG input file (.eps)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated EPS to SVG converter using the vectorize pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/svg-to-png:
+    post:
+      operationId: svgToPngTool
+      tags: [Tools]
+      summary: "SVG to PNG"
+      description: |
+        Convert SVG to PNG
+        This is a dedicated conversion preset endpoint backed by `svg-to-raster`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "SVG to PNG input file (.svg, .svgz)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated SVG to PNG converter using the svg-to-raster pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/svg-to-jpg:
+    post:
+      operationId: svgToJpgTool
+      tags: [Tools]
+      summary: "SVG to JPG"
+      description: |
+        Convert SVG to JPG
+        This is a dedicated conversion preset endpoint backed by `svg-to-raster`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "SVG to JPG input file (.svg, .svgz)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated SVG to JPG converter using the svg-to-raster pipeline.
+                    Optional settings: quality (number 1-100). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/jpg-to-pdf:
+    post:
+      operationId: jpgToPdfTool
+      tags: [Tools]
+      summary: "JPG to PDF"
+      description: |
+        Convert JPG to PDF
+        This is a dedicated conversion preset endpoint backed by `image-to-pdf`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                  description: "JPG to PDF input files (.jpg, .jpeg)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated JPG to PDF converter using the image-to-pdf pipeline.
+                    Optional settings: pageSize (A4, Letter, A3, A5), orientation (portrait or landscape), margin, targetSize, and collate.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/png-to-pdf:
+    post:
+      operationId: pngToPdfTool
+      tags: [Tools]
+      summary: "PNG to PDF"
+      description: |
+        Convert PNG to PDF
+        This is a dedicated conversion preset endpoint backed by `image-to-pdf`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                  description: "PNG to PDF input files (.png)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PNG to PDF converter using the image-to-pdf pipeline.
+                    Optional settings: pageSize (A4, Letter, A3, A5), orientation (portrait or landscape), margin, targetSize, and collate.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/heic-to-pdf:
+    post:
+      operationId: heicToPdfTool
+      tags: [Tools]
+      summary: "HEIC to PDF"
+      description: |
+        Convert HEIC to PDF
+        This is a dedicated conversion preset endpoint backed by `image-to-pdf`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                  description: "HEIC to PDF input files (.heic, .heif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated HEIC to PDF converter using the image-to-pdf pipeline.
+                    Optional settings: pageSize (A4, Letter, A3, A5), orientation (portrait or landscape), margin, targetSize, and collate.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/tiff-to-pdf:
+    post:
+      operationId: tiffToPdfTool
+      tags: [Tools]
+      summary: "TIFF to PDF"
+      description: |
+        Convert TIFF to PDF
+        This is a dedicated conversion preset endpoint backed by `image-to-pdf`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                  description: "TIFF to PDF input files (.tiff, .tif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated TIFF to PDF converter using the image-to-pdf pipeline.
+                    Optional settings: pageSize (A4, Letter, A3, A5), orientation (portrait or landscape), margin, targetSize, and collate.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/webp-to-pdf:
+    post:
+      operationId: webpToPdfTool
+      tags: [Tools]
+      summary: "WebP to PDF"
+      description: |
+        Convert WebP to PDF
+        This is a dedicated conversion preset endpoint backed by `image-to-pdf`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                  description: "WebP to PDF input files (.webp)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated WebP to PDF converter using the image-to-pdf pipeline.
+                    Optional settings: pageSize (A4, Letter, A3, A5), orientation (portrait or landscape), margin, targetSize, and collate.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/gif-to-pdf:
+    post:
+      operationId: gifToPdfTool
+      tags: [Tools]
+      summary: "GIF to PDF"
+      description: |
+        Convert GIF to PDF
+        This is a dedicated conversion preset endpoint backed by `image-to-pdf`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                  description: "GIF to PDF input files (.gif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated GIF to PDF converter using the image-to-pdf pipeline.
+                    Optional settings: pageSize (A4, Letter, A3, A5), orientation (portrait or landscape), margin, targetSize, and collate.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/image/eps-to-pdf:
+    post:
+      operationId: epsToPdfTool
+      tags: [Tools]
+      summary: "EPS to PDF"
+      description: |
+        Convert EPS to PDF
+        This is a dedicated conversion preset endpoint backed by `image-to-pdf`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                  description: "EPS to PDF input files (.eps)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated EPS to PDF converter using the image-to-pdf pipeline.
+                    Optional settings: pageSize (A4, Letter, A3, A5), orientation (portrait or landscape), margin, targetSize, and collate.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/pdf/pdf-to-jpg:
+    post:
+      operationId: pdfToJpgTool
+      tags: [Tools]
+      summary: "PDF to JPG"
+      description: |
+        Convert PDF to JPG
+        This is a dedicated conversion preset endpoint backed by `pdf-to-image`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PDF to JPG input file (.pdf)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PDF to JPG converter using the pdf-to-image pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/pdf/pdf-to-png:
+    post:
+      operationId: pdfToPngTool
+      tags: [Tools]
+      summary: "PDF to PNG"
+      description: |
+        Convert PDF to PNG
+        This is a dedicated conversion preset endpoint backed by `pdf-to-image`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PDF to PNG input file (.pdf)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PDF to PNG converter using the pdf-to-image pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/pdf/pdf-to-tiff:
+    post:
+      operationId: pdfToTiffTool
+      tags: [Tools]
+      summary: "PDF to TIFF"
+      description: |
+        Convert PDF to TIFF
+        This is a dedicated conversion preset endpoint backed by `pdf-to-image`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "PDF to TIFF input file (.pdf)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated PDF to TIFF converter using the pdf-to-image pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mov-to-mp4:
+    post:
+      operationId: movToMp4Tool
+      tags: [Tools]
+      summary: "MOV to MP4"
+      description: |
+        Convert MOV to MP4
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MOV to MP4 input file (.mov)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MOV to MP4 converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/webm-to-mp4:
+    post:
+      operationId: webmToMp4Tool
+      tags: [Tools]
+      summary: "WEBM to MP4"
+      description: |
+        Convert WEBM to MP4
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "WEBM to MP4 input file (.webm)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated WEBM to MP4 converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mkv-to-mp4:
+    post:
+      operationId: mkvToMp4Tool
+      tags: [Tools]
+      summary: "MKV to MP4"
+      description: |
+        Convert MKV to MP4
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MKV to MP4 input file (.mkv)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MKV to MP4 converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/avi-to-mp4:
+    post:
+      operationId: aviToMp4Tool
+      tags: [Tools]
+      summary: "AVI to MP4"
+      description: |
+        Convert AVI to MP4
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "AVI to MP4 input file (.avi)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated AVI to MP4 converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mp4-to-mov:
+    post:
+      operationId: mp4ToMovTool
+      tags: [Tools]
+      summary: "MP4 to MOV"
+      description: |
+        Convert MP4 to MOV
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MP4 to MOV input file (.mp4)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MP4 to MOV converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mp4-to-webm:
+    post:
+      operationId: mp4ToWebmTool
+      tags: [Tools]
+      summary: "MP4 to WEBM"
+      description: |
+        Convert MP4 to WEBM
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MP4 to WEBM input file (.mp4)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MP4 to WEBM converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/webm-to-mov:
+    post:
+      operationId: webmToMovTool
+      tags: [Tools]
+      summary: "WEBM to MOV"
+      description: |
+        Convert WEBM to MOV
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "WEBM to MOV input file (.webm)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated WEBM to MOV converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mkv-to-mov:
+    post:
+      operationId: mkvToMovTool
+      tags: [Tools]
+      summary: "MKV to MOV"
+      description: |
+        Convert MKV to MOV
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MKV to MOV input file (.mkv)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MKV to MOV converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/avi-to-mov:
+    post:
+      operationId: aviToMovTool
+      tags: [Tools]
+      summary: "AVI to MOV"
+      description: |
+        Convert AVI to MOV
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "AVI to MOV input file (.avi)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated AVI to MOV converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mp4-to-avi:
+    post:
+      operationId: mp4ToAviTool
+      tags: [Tools]
+      summary: "MP4 to AVI"
+      description: |
+        Convert MP4 to AVI
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MP4 to AVI input file (.mp4)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MP4 to AVI converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mov-to-avi:
+    post:
+      operationId: movToAviTool
+      tags: [Tools]
+      summary: "MOV to AVI"
+      description: |
+        Convert MOV to AVI
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MOV to AVI input file (.mov)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MOV to AVI converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mkv-to-avi:
+    post:
+      operationId: mkvToAviTool
+      tags: [Tools]
+      summary: "MKV to AVI"
+      description: |
+        Convert MKV to AVI
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MKV to AVI input file (.mkv)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MKV to AVI converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/avi-to-mkv:
+    post:
+      operationId: aviToMkvTool
+      tags: [Tools]
+      summary: "AVI to MKV"
+      description: |
+        Convert AVI to MKV
+        This is a dedicated conversion preset endpoint backed by `convert-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "AVI to MKV input file (.avi)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated AVI to MKV converter using the convert-video pipeline.
+                    Optional settings: quality (high, balanced, small). The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mp4-to-gif:
+    post:
+      operationId: mp4ToGifTool
+      tags: [Tools]
+      summary: "MP4 to GIF"
+      description: |
+        Convert MP4 to GIF
+        This is a dedicated conversion preset endpoint backed by `video-to-gif`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MP4 to GIF input file (.mp4)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MP4 to GIF converter using the video-to-gif pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mov-to-gif:
+    post:
+      operationId: movToGifTool
+      tags: [Tools]
+      summary: "MOV to GIF"
+      description: |
+        Convert MOV to GIF
+        This is a dedicated conversion preset endpoint backed by `video-to-gif`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MOV to GIF input file (.mov)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MOV to GIF converter using the video-to-gif pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mkv-to-gif:
+    post:
+      operationId: mkvToGifTool
+      tags: [Tools]
+      summary: "MKV to GIF"
+      description: |
+        Convert MKV to GIF
+        This is a dedicated conversion preset endpoint backed by `video-to-gif`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MKV to GIF input file (.mkv)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MKV to GIF converter using the video-to-gif pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/avi-to-gif:
+    post:
+      operationId: aviToGifTool
+      tags: [Tools]
+      summary: "AVI to GIF"
+      description: |
+        Convert AVI to GIF
+        This is a dedicated conversion preset endpoint backed by `video-to-gif`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "AVI to GIF input file (.avi)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated AVI to GIF converter using the video-to-gif pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/gif-to-mp4:
+    post:
+      operationId: gifToMp4Tool
+      tags: [Tools]
+      summary: "GIF to MP4"
+      description: |
+        Convert GIF to MP4
+        This is a dedicated conversion preset endpoint backed by `gif-to-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "GIF to MP4 input file (.gif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated GIF to MP4 converter using the gif-to-video pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/gif-to-webm:
+    post:
+      operationId: gifToWebmTool
+      tags: [Tools]
+      summary: "GIF to WEBM"
+      description: |
+        Convert GIF to WEBM
+        This is a dedicated conversion preset endpoint backed by `gif-to-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "GIF to WEBM input file (.gif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated GIF to WEBM converter using the gif-to-video pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/gif-to-mov:
+    post:
+      operationId: gifToMovTool
+      tags: [Tools]
+      summary: "GIF to MOV"
+      description: |
+        Convert GIF to MOV
+        This is a dedicated conversion preset endpoint backed by `gif-to-video`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "GIF to MOV input file (.gif)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated GIF to MOV converter using the gif-to-video pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mp4-to-mp3:
+    post:
+      operationId: mp4ToMp3Tool
+      tags: [Tools]
+      summary: "MP4 to MP3"
+      description: |
+        Convert MP4 to MP3
+        This is a dedicated conversion preset endpoint backed by `extract-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MP4 to MP3 input file (.mp4)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MP4 to MP3 converter using the extract-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mov-to-mp3:
+    post:
+      operationId: movToMp3Tool
+      tags: [Tools]
+      summary: "MOV to MP3"
+      description: |
+        Convert MOV to MP3
+        This is a dedicated conversion preset endpoint backed by `extract-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MOV to MP3 input file (.mov)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MOV to MP3 converter using the extract-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mkv-to-mp3:
+    post:
+      operationId: mkvToMp3Tool
+      tags: [Tools]
+      summary: "MKV to MP3"
+      description: |
+        Convert MKV to MP3
+        This is a dedicated conversion preset endpoint backed by `extract-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MKV to MP3 input file (.mkv)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MKV to MP3 converter using the extract-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/webm-to-mp3:
+    post:
+      operationId: webmToMp3Tool
+      tags: [Tools]
+      summary: "WEBM to MP3"
+      description: |
+        Convert WEBM to MP3
+        This is a dedicated conversion preset endpoint backed by `extract-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "WEBM to MP3 input file (.webm)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated WEBM to MP3 converter using the extract-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/avi-to-mp3:
+    post:
+      operationId: aviToMp3Tool
+      tags: [Tools]
+      summary: "AVI to MP3"
+      description: |
+        Convert AVI to MP3
+        This is a dedicated conversion preset endpoint backed by `extract-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "AVI to MP3 input file (.avi)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated AVI to MP3 converter using the extract-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mp4-to-wav:
+    post:
+      operationId: mp4ToWavTool
+      tags: [Tools]
+      summary: "MP4 to WAV"
+      description: |
+        Convert MP4 to WAV
+        This is a dedicated conversion preset endpoint backed by `extract-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MP4 to WAV input file (.mp4)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MP4 to WAV converter using the extract-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mov-to-wav:
+    post:
+      operationId: movToWavTool
+      tags: [Tools]
+      summary: "MOV to WAV"
+      description: |
+        Convert MOV to WAV
+        This is a dedicated conversion preset endpoint backed by `extract-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MOV to WAV input file (.mov)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MOV to WAV converter using the extract-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/video/mp4-to-ogg:
+    post:
+      operationId: mp4ToOggTool
+      tags: [Tools]
+      summary: "MP4 to OGG"
+      description: |
+        Convert MP4 to OGG
+        This is a dedicated conversion preset endpoint backed by `extract-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MP4 to OGG input file (.mp4)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MP4 to OGG converter using the extract-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/audio/m4a-to-mp3:
+    post:
+      operationId: m4aToMp3Tool
+      tags: [Tools]
+      summary: "M4A to MP3"
+      description: |
+        Convert M4A to MP3
+        This is a dedicated conversion preset endpoint backed by `convert-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "M4A to MP3 input file (.m4a)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated M4A to MP3 converter using the convert-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/audio/m4a-to-wav:
+    post:
+      operationId: m4aToWavTool
+      tags: [Tools]
+      summary: "M4A to WAV"
+      description: |
+        Convert M4A to WAV
+        This is a dedicated conversion preset endpoint backed by `convert-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "M4A to WAV input file (.m4a)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated M4A to WAV converter using the convert-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/audio/aac-to-mp3:
+    post:
+      operationId: aacToMp3Tool
+      tags: [Tools]
+      summary: "AAC to MP3"
+      description: |
+        Convert AAC to MP3
+        This is a dedicated conversion preset endpoint backed by `convert-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "AAC to MP3 input file (.aac)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated AAC to MP3 converter using the convert-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/audio/aac-to-wav:
+    post:
+      operationId: aacToWavTool
+      tags: [Tools]
+      summary: "AAC to WAV"
+      description: |
+        Convert AAC to WAV
+        This is a dedicated conversion preset endpoint backed by `convert-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "AAC to WAV input file (.aac)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated AAC to WAV converter using the convert-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/audio/aac-to-flac:
+    post:
+      operationId: aacToFlacTool
+      tags: [Tools]
+      summary: "AAC to FLAC"
+      description: |
+        Convert AAC to FLAC
+        This is a dedicated conversion preset endpoint backed by `convert-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "AAC to FLAC input file (.aac)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated AAC to FLAC converter using the convert-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/audio/ogg-to-mp3:
+    post:
+      operationId: oggToMp3Tool
+      tags: [Tools]
+      summary: "OGG to MP3"
+      description: |
+        Convert OGG to MP3
+        This is a dedicated conversion preset endpoint backed by `convert-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "OGG to MP3 input file (.ogg)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated OGG to MP3 converter using the convert-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/audio/ogg-to-wav:
+    post:
+      operationId: oggToWavTool
+      tags: [Tools]
+      summary: "OGG to WAV"
+      description: |
+        Convert OGG to WAV
+        This is a dedicated conversion preset endpoint backed by `convert-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "OGG to WAV input file (.ogg)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated OGG to WAV converter using the convert-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/audio/wav-to-mp3:
+    post:
+      operationId: wavToMp3Tool
+      tags: [Tools]
+      summary: "WAV to MP3"
+      description: |
+        Convert WAV to MP3
+        This is a dedicated conversion preset endpoint backed by `convert-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "WAV to MP3 input file (.wav)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated WAV to MP3 converter using the convert-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/audio/mp3-to-wav:
+    post:
+      operationId: mp3ToWavTool
+      tags: [Tools]
+      summary: "MP3 to WAV"
+      description: |
+        Convert MP3 to WAV
+        This is a dedicated conversion preset endpoint backed by `convert-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "MP3 to WAV input file (.mp3)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated MP3 to WAV converter using the convert-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/audio/flac-to-mp3:
+    post:
+      operationId: flacToMp3Tool
+      tags: [Tools]
+      summary: "FLAC to MP3"
+      description: |
+        Convert FLAC to MP3
+        This is a dedicated conversion preset endpoint backed by `convert-audio`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "FLAC to MP3 input file (.flac)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated FLAC to MP3 converter using the convert-audio pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "200":
+          description: Processed file
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/tools/files/excel-to-csv:
+    post:
+      operationId: excelToCsvTool
+      tags: [Tools]
+      summary: "Excel to CSV"
+      description: |
+        Convert Excel to CSV
+        This is a dedicated conversion preset endpoint backed by `convert-spreadsheet`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: "Excel to CSV input file (.xlsx, .xls)"
+                settings:
+                  type: string
+                  description: |
+                    Dedicated Excel to CSV converter using the convert-spreadsheet pipeline.
+                    The output format is locked by the endpoint.
+                clientJobId:
+                  type: string
+                  description: Client-provided job ID for SSE progress tracking
+      responses:
+        "202":
+          description: Accepted for async processing. Track progress via SSE at /api/v1/jobs/{jobId}/progress.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  async:
+                    type: boolean
+                    example: true
+        "400":
+          description: Invalid input or settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "422":
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /llms.txt:
+    get:
+      operationId: getLlmsTxt
+      tags: [System]
+      summary: LLM summary
+      description: LLM-friendly plain-text API summary generated from the OpenAPI spec.
+      security: []
+      responses:
+        "200":
+          description: Plain-text LLM summary
+          content:
+            text/plain:
+              schema:
+                type: string
+  /llms-full.txt:
+    get:
+      operationId: getLlmsFullTxt
+      tags: [System]
+      summary: Full LLM API docs
+      description: Complete plain-text API documentation generated from the OpenAPI spec.
+      security: []
+      responses:
+        "200":
+          description: Full plain-text API docs
+          content:
+            text/plain:
+              schema:
+                type: string
+  /api/v1/openapi.yaml:
+    get:
+      operationId: getOpenApiYaml
+      tags: [System]
+      summary: OpenAPI YAML
+      description: Machine-readable OpenAPI 3.1 specification for this SnapOtter instance.
+      security: []
+      responses:
+        "200":
+          description: OpenAPI YAML document
+          content:
+            text/yaml:
+              schema:
+                type: string
+  /api/v1/tools/popular:
+    get:
+      operationId: getPopularTools
+      tags: [Tools]
+      summary: Popular tools
+      description: Return up to 12 popular tool IDs, falling back to a curated default list when usage data is sparse.
+      security: []
+      responses:
+        "200":
+          description: Popular tool IDs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tools:
+                    type: array
+                    items:
+                      type: string

--- a/apps/api/src/routes/docs.ts
+++ b/apps/api/src/routes/docs.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import scalarPlugin from "@scalar/fastify-api-reference";
+import { SECTIONS, TOOLS, toolSection } from "@snapotter/shared";
 import type { FastifyInstance } from "fastify";
 import yaml from "js-yaml";
 
@@ -59,9 +60,20 @@ function generateLlmsTxt(spec: OpenAPISpec): string {
   }
 
   lines.push("");
+  lines.push("## Tools");
+  for (const section of SECTIONS) {
+    const tools = TOOLS.filter((tool) => toolSection(tool) === section.id);
+    lines.push(`- ${section.name} (${tools.length} tools)`);
+    for (const tool of tools) {
+      const mode = tool.executionHint === "long" ? "async" : "sync";
+      lines.push(`  - ${tool.name} - ${tool.description} (${tool.id}, ${mode})`);
+    }
+  }
+
+  lines.push("");
   lines.push("## Authentication");
-  lines.push("- Session token via `POST /api/auth/login` → `Authorization: Bearer <token>`");
-  lines.push("- API key (prefixed `si_`) → `Authorization: Bearer si_...`");
+  lines.push("- Session token via `POST /api/auth/login` -> `Authorization: Bearer <token>`");
+  lines.push("- API key (prefixed `si_`) -> `Authorization: Bearer si_...`");
 
   return lines.join("\n");
 }

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -135,6 +135,7 @@ export default defineConfig({
       {
         text: "Tools",
         items: [
+          { text: "Conversion Presets", link: "/tools/conversion-presets" },
           {
             text: "Image",
             collapsed: false,
@@ -325,6 +326,7 @@ export default defineConfig({
               { text: "PDF Page Numbers", link: "/tools/pdf/pdf-page-numbers" },
               { text: "Flatten PDF", link: "/tools/pdf/flatten-pdf" },
               { text: "Redact PDF", link: "/tools/pdf/redact-pdf" },
+              { text: "Sign PDF", link: "/tools/pdf/sign-pdf" },
               { text: "PDF to Text", link: "/tools/pdf/pdf-to-text" },
               { text: "PDF to Word", link: "/tools/pdf/pdf-to-word" },
               { text: "PDF Metadata", link: "/tools/pdf/pdf-metadata" },

--- a/apps/docs/api/rest.md
+++ b/apps/docs/api/rest.md
@@ -110,6 +110,14 @@ curl -X POST http://localhost:1349/api/v1/tools/<section>/<toolId>/batch \
 
 ## Tools Reference
 
+### Conversion Presets
+
+The shared catalog includes 83 dedicated conversion preset endpoints such as `jpg-to-png`, `mov-to-mp4`, `m4a-to-mp3`, `pdf-to-jpg`, and `excel-to-csv`. Presets are first-class tool routes:
+
+`POST /api/v1/tools/<section>/<presetId>`
+
+Each preset locks the output format and delegates to a base tool such as `convert`, `convert-video`, `extract-audio`, `convert-audio`, `image-to-pdf`, `pdf-to-image`, `svg-to-raster`, or `convert-spreadsheet`. See [Conversion Presets](/tools/conversion-presets) for the complete route table and optional settings.
+
 ### Essentials
 
 | Tool ID | Name | Key settings |
@@ -161,7 +169,7 @@ All AI tools run on your hardware (CPU or NVIDIA GPU). No internet required.
 | `noise-removal` | Noise Removal | Tiered denoising | `tier` (quick/balanced/quality/maximum), `strength`, `detailPreservation`, `colorNoise`, `format`, `quality` |
 | `red-eye-removal` | Red Eye Removal | Face landmark + color analysis | `sensitivity`, `strength` |
 | `restore-photo` | Photo Restoration | Multi-step pipeline | `mode` (auto/light/heavy), `scratchRemoval`, `faceEnhancement`, `fidelity`, `denoise`, `denoiseStrength`, `colorize` |
-| `passport-photo` | Passport Photo | MediaPipe landmarks | `country` (37 countries), `printLayout` (4x6/A4/none), `backgroundColor` |
+| `passport-photo` | Passport Photo | MediaPipe landmarks | Two-phase flow. Analyze uses multipart `file`; generate uses JSON with `countryCode`, `bgColor`, `printLayout` (none/4x6/a4), landmarks, image dimensions |
 | `content-aware-resize` | Content-Aware Resize | Seam carving (caire) | `width`, `height`, `protectFaces`, `blurRadius`, `sobelThreshold`, `square` |
 | `transparency-fixer` | PNG Transparency Fixer | BiRefNet HR-matting | `defringe` (0-100), `outputFormat` (png/webp) |
 | `background-replace` | Background Replace | rembg (BiRefNet) | `backgroundType` (color/gradient), `color` (hex), `gradientColor1`, `gradientColor2`, `gradientAngle`, `feather` (0-20), `format` (png/webp) |
@@ -297,6 +305,7 @@ All AI tools run on your hardware (CPU or NVIDIA GPU). No internet required.
 | `pdf-page-numbers` | PDF Page Numbers | `position` (bl/bc/br/tl/tc/tr), `fontSize` |
 | `flatten-pdf` | Flatten PDF | - (bakes forms and annotations) |
 | `redact-pdf` | Redact PDF | `terms` (string[]), `caseSensitive` (bool) |
+| `sign-pdf` | Sign PDF | Custom multipart route with PDF `file`, signature files `sig0`, `sig1`, and `placements` JSON array |
 | `pdf-to-text` | PDF to Text | - |
 | `pdf-to-word` | PDF to Word | - |
 | `pdf-metadata` | PDF Metadata | `title`, `author`, `subject`, `keywords` |
@@ -373,6 +382,7 @@ Some tools expose additional endpoints beyond the standard `POST /api/v1/tools/<
 
 | Method | Path | Description |
 |--------|------|-------------|
+| `GET` | `/api/v1/tools/popular` | Return popular tool IDs, falling back to a curated default list when usage data is sparse |
 | `POST` | `/api/v1/tools/image/remove-background/effects` | Apply background effects (color/gradient/blur/shadow) without re-running AI. Uses cached mask from initial removal. |
 | `POST` | `/api/v1/tools/image/edit-metadata/inspect` | Read existing EXIF/IPTC/XMP metadata from an image |
 | `POST` | `/api/v1/tools/image/strip-metadata/inspect` | Inspect metadata fields before stripping |
@@ -464,6 +474,7 @@ Persistent file storage with version history.
 | `GET` | `/api/v1/files/:id/download` | Download file |
 | `GET` | `/api/v1/files/:id/thumbnail` | Get 300px JPEG thumbnail |
 | `DELETE` | `/api/v1/files` | Bulk delete files and their version chains (body: `{ ids: [...] }`) |
+| `POST` | `/api/v1/fetch-urls` | Fetch remote URLs into the workspace for URL-based imports |
 | `POST` | `/api/v1/preview` | Generate a browser-compatible WebP preview (for HEIC/HEIF/RAW formats) |
 | `GET` | `/api/v1/download/:jobId/:filename` | Download a processed file from a workspace |
 

--- a/apps/docs/public/_redirects
+++ b/apps/docs/public/_redirects
@@ -208,6 +208,8 @@
 /tools/red-eye-removal.html /tools/image/red-eye-removal 301
 /tools/redact-pdf /tools/pdf/redact-pdf 301
 /tools/redact-pdf.html /tools/pdf/redact-pdf 301
+/tools/sign-pdf /tools/pdf/sign-pdf 301
+/tools/sign-pdf.html /tools/pdf/sign-pdf 301
 /tools/remove-background /tools/image/remove-background 301
 /tools/remove-background.html /tools/image/remove-background 301
 /tools/remove-pages /tools/pdf/remove-pages 301

--- a/apps/docs/tools/conversion-presets.md
+++ b/apps/docs/tools/conversion-presets.md
@@ -1,0 +1,127 @@
+---
+description: Dedicated conversion preset endpoints generated from the SnapOtter tool catalog.
+---
+
+# Conversion Presets
+
+SnapOtter exposes 83 dedicated conversion preset endpoints in addition to the base converter tools. Each preset locks the output format and delegates to its base processing pipeline, so the behavior, validation, and output contract match the base tool listed below.
+
+## API Endpoint Pattern
+
+`POST /api/v1/tools/<section>/<presetId>`
+
+Send `multipart/form-data` with a `file` part and optional `settings` JSON string. Fast presets return `200` with a `downloadUrl`; long-running presets return `202` and progress streams from `/api/v1/jobs/<jobId>/progress`.
+
+## Image Presets
+
+| Preset ID | Converts | Route | Base tool | Accepted inputs | Optional settings |
+|-----------|----------|-------|-----------|-----------------|-------------------|
+| `jpg-to-png` | JPG to PNG | `/api/v1/tools/image/jpg-to-png` | `convert` | `.jpg`, `.jpeg` | quality |
+| `png-to-jpg` | PNG to JPG | `/api/v1/tools/image/png-to-jpg` | `convert` | `.png` | quality |
+| `jpg-to-webp` | JPG to WebP | `/api/v1/tools/image/jpg-to-webp` | `convert` | `.jpg`, `.jpeg` | quality |
+| `png-to-webp` | PNG to WebP | `/api/v1/tools/image/png-to-webp` | `convert` | `.png` | quality |
+| `webp-to-jpg` | WebP to JPG | `/api/v1/tools/image/webp-to-jpg` | `convert` | `.webp` | quality |
+| `webp-to-png` | WebP to PNG | `/api/v1/tools/image/webp-to-png` | `convert` | `.webp` | quality |
+| `jpg-to-avif` | JPG to AVIF | `/api/v1/tools/image/jpg-to-avif` | `convert` | `.jpg`, `.jpeg` | quality |
+| `png-to-avif` | PNG to AVIF | `/api/v1/tools/image/png-to-avif` | `convert` | `.png` | quality |
+| `webp-to-avif` | WebP to AVIF | `/api/v1/tools/image/webp-to-avif` | `convert` | `.webp` | quality |
+| `heic-to-jpg` | HEIC to JPG | `/api/v1/tools/image/heic-to-jpg` | `convert` | `.heic`, `.heif` | quality |
+| `heic-to-png` | HEIC to PNG | `/api/v1/tools/image/heic-to-png` | `convert` | `.heic`, `.heif` | quality |
+| `heic-to-avif` | HEIC to AVIF | `/api/v1/tools/image/heic-to-avif` | `convert` | `.heic`, `.heif` | quality |
+| `jpg-to-gif` | JPG to GIF | `/api/v1/tools/image/jpg-to-gif` | `convert` | `.jpg`, `.jpeg` | quality |
+| `png-to-gif` | PNG to GIF | `/api/v1/tools/image/png-to-gif` | `convert` | `.png` | quality |
+| `gif-to-jpg` | GIF to JPG | `/api/v1/tools/image/gif-to-jpg` | `convert` | `.gif` | quality |
+| `gif-to-png` | GIF to PNG | `/api/v1/tools/image/gif-to-png` | `convert` | `.gif` | quality |
+| `webp-to-gif` | WebP to GIF | `/api/v1/tools/image/webp-to-gif` | `convert` | `.webp` | quality |
+| `jpg-to-tiff` | JPG to TIFF | `/api/v1/tools/image/jpg-to-tiff` | `convert` | `.jpg`, `.jpeg` | quality |
+| `png-to-tiff` | PNG to TIFF | `/api/v1/tools/image/png-to-tiff` | `convert` | `.png` | quality |
+| `tiff-to-jpg` | TIFF to JPG | `/api/v1/tools/image/tiff-to-jpg` | `convert` | `.tiff`, `.tif` | quality |
+| `tiff-to-png` | TIFF to PNG | `/api/v1/tools/image/tiff-to-png` | `convert` | `.tiff`, `.tif` | quality |
+| `psd-to-jpg` | PSD to JPG | `/api/v1/tools/image/psd-to-jpg` | `convert` | `.psd` | quality |
+| `psd-to-png` | PSD to PNG | `/api/v1/tools/image/psd-to-png` | `convert` | `.psd` | quality |
+| `png-to-eps` | PNG to EPS | `/api/v1/tools/image/png-to-eps` | `convert` | `.png` | quality |
+| `jpg-to-eps` | JPG to EPS | `/api/v1/tools/image/jpg-to-eps` | `convert` | `.jpg`, `.jpeg` | quality |
+| `eps-to-png` | EPS to PNG | `/api/v1/tools/image/eps-to-png` | `convert` | `.eps` | quality |
+| `eps-to-jpg` | EPS to JPG | `/api/v1/tools/image/eps-to-jpg` | `convert` | `.eps` | quality |
+| `png-to-svg` | PNG to SVG | `/api/v1/tools/image/png-to-svg` | `vectorize` | `.png` | none |
+| `jpg-to-svg` | JPG to SVG | `/api/v1/tools/image/jpg-to-svg` | `vectorize` | `.jpg`, `.jpeg` | none |
+| `tiff-to-svg` | TIFF to SVG | `/api/v1/tools/image/tiff-to-svg` | `vectorize` | `.tiff`, `.tif` | none |
+| `psd-to-svg` | PSD to SVG | `/api/v1/tools/image/psd-to-svg` | `vectorize` | `.psd` | none |
+| `eps-to-svg` | EPS to SVG | `/api/v1/tools/image/eps-to-svg` | `vectorize` | `.eps` | none |
+| `svg-to-png` | SVG to PNG | `/api/v1/tools/image/svg-to-png` | `svg-to-raster` | `.svg`, `.svgz` | quality, width, height, dpi, backgroundColor |
+| `svg-to-jpg` | SVG to JPG | `/api/v1/tools/image/svg-to-jpg` | `svg-to-raster` | `.svg`, `.svgz` | quality, width, height, dpi, backgroundColor |
+| `jpg-to-pdf` | JPG to PDF | `/api/v1/tools/image/jpg-to-pdf` | `image-to-pdf` | `.jpg`, `.jpeg` | pageSize, orientation, margin, targetSize, collate |
+| `png-to-pdf` | PNG to PDF | `/api/v1/tools/image/png-to-pdf` | `image-to-pdf` | `.png` | pageSize, orientation, margin, targetSize, collate |
+| `heic-to-pdf` | HEIC to PDF | `/api/v1/tools/image/heic-to-pdf` | `image-to-pdf` | `.heic`, `.heif` | pageSize, orientation, margin, targetSize, collate |
+| `tiff-to-pdf` | TIFF to PDF | `/api/v1/tools/image/tiff-to-pdf` | `image-to-pdf` | `.tiff`, `.tif` | pageSize, orientation, margin, targetSize, collate |
+| `webp-to-pdf` | WebP to PDF | `/api/v1/tools/image/webp-to-pdf` | `image-to-pdf` | `.webp` | pageSize, orientation, margin, targetSize, collate |
+| `gif-to-pdf` | GIF to PDF | `/api/v1/tools/image/gif-to-pdf` | `image-to-pdf` | `.gif` | pageSize, orientation, margin, targetSize, collate |
+| `eps-to-pdf` | EPS to PDF | `/api/v1/tools/image/eps-to-pdf` | `image-to-pdf` | `.eps` | pageSize, orientation, margin, targetSize, collate |
+
+## Video Presets
+
+| Preset ID | Converts | Route | Base tool | Accepted inputs | Optional settings |
+|-----------|----------|-------|-----------|-----------------|-------------------|
+| `mov-to-mp4` | MOV to MP4 | `/api/v1/tools/video/mov-to-mp4` | `convert-video` | `.mov` | quality |
+| `webm-to-mp4` | WEBM to MP4 | `/api/v1/tools/video/webm-to-mp4` | `convert-video` | `.webm` | quality |
+| `mkv-to-mp4` | MKV to MP4 | `/api/v1/tools/video/mkv-to-mp4` | `convert-video` | `.mkv` | quality |
+| `avi-to-mp4` | AVI to MP4 | `/api/v1/tools/video/avi-to-mp4` | `convert-video` | `.avi` | quality |
+| `mp4-to-mov` | MP4 to MOV | `/api/v1/tools/video/mp4-to-mov` | `convert-video` | `.mp4` | quality |
+| `mp4-to-webm` | MP4 to WEBM | `/api/v1/tools/video/mp4-to-webm` | `convert-video` | `.mp4` | quality |
+| `webm-to-mov` | WEBM to MOV | `/api/v1/tools/video/webm-to-mov` | `convert-video` | `.webm` | quality |
+| `mkv-to-mov` | MKV to MOV | `/api/v1/tools/video/mkv-to-mov` | `convert-video` | `.mkv` | quality |
+| `avi-to-mov` | AVI to MOV | `/api/v1/tools/video/avi-to-mov` | `convert-video` | `.avi` | quality |
+| `mp4-to-avi` | MP4 to AVI | `/api/v1/tools/video/mp4-to-avi` | `convert-video` | `.mp4` | quality |
+| `mov-to-avi` | MOV to AVI | `/api/v1/tools/video/mov-to-avi` | `convert-video` | `.mov` | quality |
+| `mkv-to-avi` | MKV to AVI | `/api/v1/tools/video/mkv-to-avi` | `convert-video` | `.mkv` | quality |
+| `avi-to-mkv` | AVI to MKV | `/api/v1/tools/video/avi-to-mkv` | `convert-video` | `.avi` | quality |
+| `mp4-to-gif` | MP4 to GIF | `/api/v1/tools/video/mp4-to-gif` | `video-to-gif` | `.mp4` | fps, width, startS, durationS |
+| `mov-to-gif` | MOV to GIF | `/api/v1/tools/video/mov-to-gif` | `video-to-gif` | `.mov` | fps, width, startS, durationS |
+| `mkv-to-gif` | MKV to GIF | `/api/v1/tools/video/mkv-to-gif` | `video-to-gif` | `.mkv` | fps, width, startS, durationS |
+| `avi-to-gif` | AVI to GIF | `/api/v1/tools/video/avi-to-gif` | `video-to-gif` | `.avi` | fps, width, startS, durationS |
+| `gif-to-mp4` | GIF to MP4 | `/api/v1/tools/video/gif-to-mp4` | `gif-to-video` | `.gif` | none |
+| `gif-to-webm` | GIF to WEBM | `/api/v1/tools/video/gif-to-webm` | `gif-to-video` | `.gif` | none |
+| `gif-to-mov` | GIF to MOV | `/api/v1/tools/video/gif-to-mov` | `gif-to-video` | `.gif` | none |
+| `mp4-to-mp3` | MP4 to MP3 | `/api/v1/tools/video/mp4-to-mp3` | `extract-audio` | `.mp4` | none |
+| `mov-to-mp3` | MOV to MP3 | `/api/v1/tools/video/mov-to-mp3` | `extract-audio` | `.mov` | none |
+| `mkv-to-mp3` | MKV to MP3 | `/api/v1/tools/video/mkv-to-mp3` | `extract-audio` | `.mkv` | none |
+| `webm-to-mp3` | WEBM to MP3 | `/api/v1/tools/video/webm-to-mp3` | `extract-audio` | `.webm` | none |
+| `avi-to-mp3` | AVI to MP3 | `/api/v1/tools/video/avi-to-mp3` | `extract-audio` | `.avi` | none |
+| `mp4-to-wav` | MP4 to WAV | `/api/v1/tools/video/mp4-to-wav` | `extract-audio` | `.mp4` | none |
+| `mov-to-wav` | MOV to WAV | `/api/v1/tools/video/mov-to-wav` | `extract-audio` | `.mov` | none |
+| `mp4-to-ogg` | MP4 to OGG | `/api/v1/tools/video/mp4-to-ogg` | `extract-audio` | `.mp4` | none |
+
+## Audio Presets
+
+| Preset ID | Converts | Route | Base tool | Accepted inputs | Optional settings |
+|-----------|----------|-------|-----------|-----------------|-------------------|
+| `m4a-to-mp3` | M4A to MP3 | `/api/v1/tools/audio/m4a-to-mp3` | `convert-audio` | `.m4a` | none |
+| `m4a-to-wav` | M4A to WAV | `/api/v1/tools/audio/m4a-to-wav` | `convert-audio` | `.m4a` | none |
+| `aac-to-mp3` | AAC to MP3 | `/api/v1/tools/audio/aac-to-mp3` | `convert-audio` | `.aac` | none |
+| `aac-to-wav` | AAC to WAV | `/api/v1/tools/audio/aac-to-wav` | `convert-audio` | `.aac` | none |
+| `aac-to-flac` | AAC to FLAC | `/api/v1/tools/audio/aac-to-flac` | `convert-audio` | `.aac` | none |
+| `ogg-to-mp3` | OGG to MP3 | `/api/v1/tools/audio/ogg-to-mp3` | `convert-audio` | `.ogg` | none |
+| `ogg-to-wav` | OGG to WAV | `/api/v1/tools/audio/ogg-to-wav` | `convert-audio` | `.ogg` | none |
+| `wav-to-mp3` | WAV to MP3 | `/api/v1/tools/audio/wav-to-mp3` | `convert-audio` | `.wav` | none |
+| `mp3-to-wav` | MP3 to WAV | `/api/v1/tools/audio/mp3-to-wav` | `convert-audio` | `.mp3` | none |
+| `flac-to-mp3` | FLAC to MP3 | `/api/v1/tools/audio/flac-to-mp3` | `convert-audio` | `.flac` | none |
+
+## PDF Presets
+
+| Preset ID | Converts | Route | Base tool | Accepted inputs | Optional settings |
+|-----------|----------|-------|-----------|-----------------|-------------------|
+| `pdf-to-jpg` | PDF to JPG | `/api/v1/tools/pdf/pdf-to-jpg` | `pdf-to-image` | `.pdf` | dpi, quality, colorMode, pages |
+| `pdf-to-png` | PDF to PNG | `/api/v1/tools/pdf/pdf-to-png` | `pdf-to-image` | `.pdf` | dpi, quality, colorMode, pages |
+| `pdf-to-tiff` | PDF to TIFF | `/api/v1/tools/pdf/pdf-to-tiff` | `pdf-to-image` | `.pdf` | dpi, quality, colorMode, pages |
+
+## Files Presets
+
+| Preset ID | Converts | Route | Base tool | Accepted inputs | Optional settings |
+|-----------|----------|-------|-----------|-----------------|-------------------|
+| `excel-to-csv` | Excel to CSV | `/api/v1/tools/files/excel-to-csv` | `convert-spreadsheet` | `.xlsx`, `.xls` | none |
+
+## Notes
+
+- Presets are first-class API endpoints and are also valid in batch requests where their base route supports batch processing.
+- Presets that use video conversion can return `202 Accepted`; connect to the job progress SSE endpoint before downloading the result.
+- For advanced options not exposed by a preset, call the base converter tool directly and set the output format in `settings`.

--- a/apps/docs/tools/image/passport-photo.md
+++ b/apps/docs/tools/image/passport-photo.md
@@ -10,7 +10,7 @@ AI-powered passport and ID photo generator. Two-phase workflow: analyze (face de
 
 This tool uses a two-phase flow with separate endpoints for analysis and generation.
 
-**Model bundle:** `background-removal` (4-5 GB)
+**Model bundles:** `background-removal` and `face-detection`
 
 ---
 
@@ -88,7 +88,7 @@ Crops, resizes, and optionally tiles the photo onto a print sheet. Uses cached i
 | countryCode | string | Yes | - | Country code for passport spec (e.g., `US`, `GB`, `IN`) |
 | documentType | string | No | `"passport"` | Document type (from country spec) |
 | bgColor | string | No | `"#FFFFFF"` | Background color hex |
-| printLayout | string | No | `"none"` | Print paper layout: `none`, `4x6`, `a4`, `letter` |
+| printLayout | string | No | `"none"` | Print paper layout: `none`, `4x6`, `a4` |
 | maxFileSizeKb | number | No | `0` | Max file size constraint in KB (0 = no limit) |
 | dpi | number | No | `300` | Output DPI (72-1200) |
 | customWidthMm | number | No | - | Custom photo width in mm (overrides country spec) |
@@ -161,10 +161,10 @@ Returns guidance to use the correct sub-endpoint.
 
 ## Notes
 
-- Requires the `background-removal` model bundle to be installed (4-5 GB).
+- Requires the `background-removal` and `face-detection` model bundles to be installed.
 - Phase 1 runs AI (face landmarks + background removal) and caches results. Phase 2 is pure Sharp image manipulation (fast, no AI needed).
 - Landmarks are returned as normalized coordinates (0-1 range relative to image dimensions).
 - The `preview` field in the analyze response is a base64-encoded PNG (max 800px wide) for fast display.
 - Country specs include document dimensions, head height ratios, and eye-line positioning based on official passport photo requirements.
-- The `printLayout` option generates a tiled sheet on standard paper sizes (4x6", A4, Letter) with 2mm gutters between photos.
+- The `printLayout` option generates a tiled sheet on 4x6" or A4 paper with 2mm gutters between photos.
 - When `maxFileSizeKb` is set, the output is iteratively compressed to fit within the size limit.

--- a/apps/docs/tools/pdf/sign-pdf.md
+++ b/apps/docs/tools/pdf/sign-pdf.md
@@ -1,0 +1,76 @@
+---
+description: Stamp uploaded signature images onto a PDF using normalized page placements.
+---
+
+# Sign PDF
+
+Stamp one or more uploaded signature PNG images onto any page of a PDF. This route uses a custom multipart contract because it needs the PDF, one or more signature images, and placement coordinates.
+
+## API Endpoint
+
+`POST /api/v1/tools/pdf/sign-pdf`
+
+Accepts multipart form data. The PDF is sent as `file`; signatures are sent as `sig0`, `sig1`, and so on; placements are sent in a `placements` JSON field.
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| file | file | Yes | - | PDF file to sign |
+| sig0 | file | Yes | - | First signature image. Additional images use `sig1`, `sig2`, and so on |
+| placements | JSON string | Yes | - | Array of placement objects: `{ "sig": 0, "page": 0, "x": 0.2, "y": 0.7, "w": 0.25, "h": 0.08 }` |
+| clientJobId | string | No | - | Optional UUID for progress tracking via SSE |
+| fileId | string | No | - | Optional file library ID to save the signed result as a new version |
+
+## Placement Coordinates
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sig | integer | Signature image index. `0` maps to `sig0` |
+| page | integer | Zero-based PDF page index |
+| x | number | Left position as a page fraction |
+| y | number | Top position as a page fraction |
+| w | number | Signature width as a page fraction |
+| h | number | Signature height as a page fraction |
+
+Coordinates use a top-left origin. Values may bleed slightly beyond the page edge; the PDF renderer clips the final stamp to the page.
+
+## Example Request
+
+```bash
+curl -X POST http://localhost:1349/api/v1/tools/pdf/sign-pdf \
+  -H "Authorization: Bearer si_your-api-key" \
+  -F "file=@contract.pdf" \
+  -F "sig0=@signature.png" \
+  -F 'placements=[{"sig":0,"page":0,"x":0.64,"y":0.82,"w":0.22,"h":0.08}]'
+```
+
+## Example Response
+
+```json
+{
+  "jobId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "downloadUrl": "/api/v1/download/a1b2c3d4-e5f6-7890-abcd-ef1234567890/contract_signed.pdf",
+  "previewUrl": "/api/v1/download/a1b2c3d4-e5f6-7890-abcd-ef1234567890/preview.png",
+  "originalSize": 245000,
+  "processedSize": 249000
+}
+```
+
+If the request cannot finish inside the synchronous wait window, the API returns:
+
+```json
+{
+  "jobId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "async": true
+}
+```
+
+Connect to `/api/v1/jobs/<jobId>/progress` and download the result when the job completes.
+
+## Notes
+
+- Accepted PDF input format: `.pdf`.
+- Signature images must be valid image files, typically PNG with transparency.
+- Up to 100 signature images and 100 placements are accepted.
+- `sign-pdf` is a custom route and does not use the standard tool `settings` JSON field.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -204,9 +204,11 @@ FROM node:22-bookworm@sha256:c601a46abb4d2ab80a9dc3da208d50d1122642d53f17a101926
 # ============================================
 ARG TARGETOS
 ARG TARGETARCH
+ARG PANDOC_VERSION=3.10
 FROM base-${TARGETOS}-${TARGETARCH} AS production
 
 ARG TARGETARCH
+ARG PANDOC_VERSION
 
 # Pin corepack's cache to a system-wide path so all users share the same pnpm
 # binary without downloading it on each container start.
@@ -248,9 +250,8 @@ RUN for i in 1 2 3; do apt-get -o Acquire::Retries=3 update && break || sleep $(
     python3 python3-pip python3-venv python3-dev \
     tesseract-ocr tesseract-ocr-eng tesseract-ocr-deu tesseract-ocr-fra tesseract-ocr-spa \
     tesseract-ocr-chi-sim tesseract-ocr-jpn tesseract-ocr-kor \
-    # Document engine: qpdf + LibreOffice headless + pandoc + WeasyPrint runtime deps
+    # Document engine: qpdf + LibreOffice headless + WeasyPrint runtime deps
     # calibre deferred (5.2 GB ruling; pandoc covers epub/markdown families)
-    pandoc \
     qpdf \
     libpango-1.0-0 libpangocairo-1.0-0 libcairo2 libgdk-pixbuf-2.0-0 \
     fonts-dejavu-core \
@@ -272,6 +273,15 @@ RUN for i in 1 2 3; do apt-get -o Acquire::Retries=3 update && break || sleep $(
     && if apt-cache show libcublas-12-6 >/dev/null 2>&1; then \
          apt-get install -y --no-install-recommends libcublas-12-6; \
        fi \
+    && case "$TARGETARCH" in \
+         amd64) PANDOC_ARCH=amd64 ;; \
+         arm64) PANDOC_ARCH=arm64 ;; \
+         *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+       esac \
+    && curl -fsSL "https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-${PANDOC_ARCH}.deb" -o /tmp/pandoc.deb \
+    && apt-get install -y --no-install-recommends /tmp/pandoc.deb \
+    && rm -f /tmp/pandoc.deb \
+    && pandoc --version \
     && rm -rf /var/lib/apt/lists/*
 
 # Embedded-mode databases: PostgreSQL 17 (PGDG, to match the Compose postgres:17

--- a/llms.txt
+++ b/llms.txt
@@ -56,7 +56,7 @@ Transcribe Audio, Convert Audio, Trim Audio, Volume Adjust, Normalize Audio, Fad
 
 ### PDF
 
-PDF OCR, PDF to Image, Merge PDFs, Split PDF, Compress PDF, Rotate PDF, Extract Pages, Remove Pages, Organize PDF, Protect PDF, Unlock PDF, Repair PDF, Web-Optimize PDF, Grayscale PDF, PDF/A Convert, Crop PDF, N-up PDF, Booklet PDF, Watermark PDF, PDF Page Numbers, Flatten PDF, Redact PDF, PDF to Text, PDF to Word, PDF Metadata, PDF to JPG, PDF to PNG, PDF to TIFF.
+PDF OCR, PDF to Image, Merge PDFs, Split PDF, Compress PDF, Rotate PDF, Extract Pages, Remove Pages, Organize PDF, Protect PDF, Unlock PDF, Repair PDF, Web-Optimize PDF, Grayscale PDF, PDF/A Convert, Crop PDF, N-up PDF, Booklet PDF, Watermark PDF, PDF Page Numbers, Flatten PDF, Redact PDF, Sign PDF, PDF to Text, PDF to Word, PDF Metadata, PDF to JPG, PDF to PNG, PDF to TIFF.
 
 ### Files
 
@@ -69,10 +69,9 @@ Background removal (rembg), image upscaling 2x/4x (RealESRGAN), object eraser (L
 ## REST API
 
 Base URL: http://localhost:1349/api/v1
-Interactive docs: http://localhost:1349/api/docs (Swagger UI)
-Machine-readable spec: http://localhost:1349/api/docs/json (OpenAPI 3.1)
+Interactive docs: http://localhost:1349/api/docs (Scalar UI)
 OpenAPI YAML: http://localhost:1349/api/v1/openapi.yaml
-LLM-optimized spec: http://localhost:1349/llms.txt (generated from OpenAPI at runtime)
+Runtime LLM summary: http://localhost:1349/llms.txt
 Full plain-text API docs: http://localhost:1349/llms-full.txt
 
 Authentication methods:

--- a/tests/integration/platform/docs.test.ts
+++ b/tests/integration/platform/docs.test.ts
@@ -1,3 +1,4 @@
+import { apiToolPath, TOOLS } from "@snapotter/shared";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildTestApp, type TestApp } from "../test-server";
 
@@ -11,6 +12,10 @@ describe("API docs", () => {
   afterAll(async () => {
     await testApp.cleanup();
   });
+
+  function openApiPathSet(body: string): Set<string> {
+    return new Set([...body.matchAll(/^ {2}(\/[^:]+):/gm)].map((match) => match[1]));
+  }
 
   it("serves the OpenAPI spec as YAML", async () => {
     const res = await testApp.app.inject({
@@ -54,15 +59,43 @@ describe("API docs", () => {
     expect(res.headers["content-type"]).toContain("text/html");
   });
 
-  it("includes all tool endpoints in the spec", async () => {
+  it("includes every catalog tool endpoint in the spec", async () => {
     const res = await testApp.app.inject({
       method: "GET",
       url: "/api/v1/openapi.yaml",
     });
-    const body = res.body;
-    expect(body).toContain("/api/v1/tools/image/resize");
-    expect(body).toContain("/api/v1/tools/image/compress");
-    expect(body).toContain("/api/v1/tools/image/remove-background");
-    expect(body).toContain("/api/v1/tools/image/ocr");
+    const paths = openApiPathSet(res.body);
+    const missing = TOOLS.map((tool) => apiToolPath(tool.id)).filter((path) => !paths.has(path));
+
+    expect(missing, `OpenAPI missing tool paths: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("documents public docs metadata routes", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/openapi.yaml",
+    });
+    const paths = openApiPathSet(res.body);
+    const expectedPaths = [
+      "/llms.txt",
+      "/llms-full.txt",
+      "/api/v1/openapi.yaml",
+      "/api/v1/tools/popular",
+    ];
+    const missing = expectedPaths.filter((path) => !paths.has(path));
+
+    expect(missing, `OpenAPI missing docs metadata paths: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("serves an LLM summary with live catalog tools", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/llms.txt",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain("## Tools");
+    expect(res.body).toContain("- Image (105 tools)");
+    expect(res.body).toContain("Resize - Resize by pixels");
+    expect(res.body).toContain("Sign PDF -");
   });
 });


### PR DESCRIPTION
## Summary
- Expand OpenAPI coverage for all catalog tool paths, conversion presets, sign-pdf, passport-photo guidance, and docs metadata routes.
- Add live catalog tool listing to runtime llms.txt generation and update static README/llms/rest docs.
- Add VitePress pages for conversion presets and sign-pdf, with sidebar and redirect coverage.

## Test Plan
- pnpm vitest run --config vitest.config.ts tests/integration/platform/docs.test.ts
- pnpm vitest run --config vitest.config.ts tests/integration/generated/catalog-integrity.test.ts tests/integration/tool-route-drift.test.ts tests/unit/shared/api-tool-path.test.ts tests/unit/api/docs-route.test.ts
- parity script: 241 tools, 83 conversion presets, 0 missing OpenAPI paths, 0 missing docs pages
- node OpenAPI YAML parse: OpenAPI 3.1.0, 304 paths
- pnpm --package=@redocly/cli dlx redocly lint apps/api/src/openapi.yaml
- pnpm typecheck
- pnpm lint
- pnpm --filter @snapotter/docs docs:build
- git diff --check