### PR TITLE
test: clear the sync-wait floor in the format matrix per-case timeout

### DIFF
--- a/tests/integration/generated/format-matrix-multimodal.test.ts
+++ b/tests/integration/generated/format-matrix-multimodal.test.ts
@@ -177,6 +177,10 @@ describe("multi-modality tool x format matrix", () => {
 
     describe(toolId, () => {
       for (const fixture of effectiveFixtures) {
+        // 60s per-case timeout clears the 30s SYNC_WAIT_MS test floor (per-fork-env.ts):
+        // under load a contended docs/media job can ride the full sync-wait window and
+        // return a valid 202 (which this matrix accepts), so the timeout must sit above
+        // that floor or a slow-but-valid job is wrongly flagged as a hang.
         it(`${fixture.filename} -> clean status`, async () => {
           const content = readFileSync(join(fixture.dir, fixture.filename));
           const settings = defaultSettingsFor(toolId);
@@ -281,7 +285,7 @@ describe("multi-modality tool x format matrix", () => {
               `${toolId} x ${fixture.filename}: 501 without error/code`,
             ).toBeDefined();
           }
-        }, 30_000);
+        }, 60_000);
       }
     });
   }


### PR DESCRIPTION
## What

Raise the per-case timeout in `format-matrix-multimodal.test.ts` from 30s to 60s.

## Why

The matrix gives each tool case a 30s timeout, the same value as the `SYNC_WAIT_MS` floor that integration tests apply (`tests/setup/per-fork-env.ts` floors it to 30s). Under parallel forks a contended docs/media job can hold its single worker long enough to ride the full sync-wait window and return a valid `202` async envelope, which the matrix already treats as a pass (it is in `ALLOWED_STATUSES`). The equal 30s case timeout fires at the same instant, so Vitest reports `Test timed out in 30000ms` instead.

`extract-pages` on `tiny.pdf` sits right on that boundary:
- CI run #380: timed out (over 30s), went red
- CI run #379: passed at 28628ms, green by about 1.4s

Lifting the case timeout above the sync-wait floor lets the valid `202` fallback surface instead of racing the timeout.

## Notes

- Test-robustness change only; no product code touched.
- The pandoc `--sandbox` failures that also reddened #380 are already fixed on `main` (the upstream pandoc `.deb` install in #379). I independently verified that fix is sound: the jgm `.deb` embeds its data files, so `pandoc --sandbox` produces docx/epub correctly. This PR closes the one remaining latent flake.
