### PR TITLE
Expand landing alternatives comparisons

### DIFF
--- a/apps/landing/src/data/alternatives.ts
+++ b/apps/landing/src/data/alternatives.ts
@@ -1,7 +1,7 @@
 // SEO comparison pages: "open-source alternative to <X>" content.
 // Each entry renders a static page at /alternatives/<slug> plus a card on the hub.
-// Keep competitor claims general and defensible; the differentiator is self-hosting
-// plus breadth across all five modalities, not point-by-point feature parity.
+// Keep competitor claims sourced, dated, and framed around deployment model,
+// data control, and workflow fit instead of brittle point-by-point parity.
 
 export interface ComparisonRow {
   feature: string;
@@ -14,6 +14,11 @@ export interface ComparisonRow {
 export interface AltFaq {
   q: string;
   a: string;
+}
+
+export interface AlternativeSource {
+  label: string;
+  url: string;
 }
 
 export interface Alternative {
@@ -34,51 +39,71 @@ export interface Alternative {
   breadth: string;
   /** true when the competitor is itself open-source / self-hostable (shifts framing to breadth) */
   competitorOpenSource: boolean;
+  /** YYYY-MM-DD date when public vendor pages were last checked */
+  lastReviewed: string;
+  /** Public pages used to substantiate the comparison */
+  sources: AlternativeSource[];
   rows: ComparisonRow[];
   faqs: AltFaq[];
 }
 
-const cloudRows = (category: string, pricing: string, beyond: string): ComparisonRow[] => [
+const REVIEW_DATE = "2026-07-01";
+
+interface HostedRowsOptions {
+  category: string;
+  competitorCoverage: string;
+  pricing: string;
+  fileHandling?: string;
+  automation?: string;
+}
+
+const hostedRows = ({
+  category,
+  competitorCoverage,
+  pricing,
+  fileHandling = "Files are uploaded to a vendor-hosted service for processing",
+  automation = "Browser workflow or vendor-managed API, depending on product",
+}: HostedRowsOptions): ComparisonRow[] => [
   {
-    feature: "Where your files go",
-    snapotter: "Your own server",
-    competitor: "Their cloud",
+    feature: "Deployment model",
+    snapotter: "Self-hosted on your server",
+    competitor: "Hosted web service",
     snapotterWins: true,
   },
   {
-    feature: "Pricing",
-    snapotter: "Free, open source (AGPLv3)",
+    feature: "File processing location",
+    snapotter: "Your infrastructure",
+    competitor: fileHandling,
+    snapotterWins: true,
+  },
+  {
+    feature: "Cost control",
+    snapotter: "Free AGPLv3; limits are your hardware",
     competitor: pricing,
     snapotterWins: true,
   },
   {
-    feature: "File-size limits",
-    snapotter: "Bounded by your hardware",
-    competitor: "Capped by plan",
-    snapotterWins: true,
-  },
-  {
-    feature: "Works offline / air-gapped",
-    snapotter: "Yes",
-    competitor: "No, needs their servers",
+    feature: "Offline / air-gapped use",
+    snapotter: "Supported when deployed inside your network",
+    competitor: "Designed for browser-based online use",
     snapotterWins: true,
   },
   {
     feature: `Beyond ${category}`,
     snapotter: "Image, video, audio, PDF, and files",
-    competitor: beyond,
+    competitor: competitorCoverage,
     snapotterWins: true,
   },
   {
-    feature: "Open source",
-    snapotter: "Yes, AGPLv3",
-    competitor: "No",
+    feature: "Source and auditability",
+    snapotter: "Source available under AGPLv3",
+    competitor: "Vendor-operated service; source availability is not the product model",
     snapotterWins: true,
   },
   {
-    feature: "REST API and pipelines",
-    snapotter: "Built in, self-hosted",
-    competitor: "API on paid plans",
+    feature: "Automation",
+    snapotter: "REST API and pipelines in your deployment",
+    competitor: automation,
     snapotterWins: true,
   },
 ];
@@ -91,25 +116,34 @@ export const ALTERNATIVES: Alternative[] = [
     pageTitle: "The Open-Source, Self-Hosted Alternative to Smallpdf",
     h1: "The open-source, self-hosted alternative to Smallpdf",
     metaDescription:
-      "Smallpdf uploads your documents to its servers. SnapOtter runs the same PDF tools on yours. 29 PDF tools plus 212 more for image, video, audio, and files. Open source, AGPLv3.",
+      "Smallpdf is a hosted PDF toolkit. SnapOtter runs PDF merge, split, compress, convert, OCR, and more on your own server, with 200+ extra tools across five file types.",
     intro:
-      "Smallpdf is a cloud PDF suite, so every file you touch goes up to its servers. SnapOtter runs the same kinds of tools on hardware you own, and the file never leaves it.",
+      "Smallpdf is a polished hosted PDF suite. SnapOtter is the self-hosted alternative for teams that want PDF tools to run on infrastructure they control, without sending sensitive documents to a third-party PDF service.",
     breadth:
-      "Smallpdf does PDFs. SnapOtter ships 29 PDF tools (merge, split, compress, convert, redact, OCR, and more) and another 212 across image, video, audio, and files, so one stack covers what you'd otherwise spread across several accounts.",
+      "Smallpdf is focused on PDFs, which is exactly what many people need. SnapOtter covers that lane with merge, split, compress, convert, redact, OCR, and more, then adds image, video, audio, and file workflows in the same deployment.",
     competitorOpenSource: false,
-    rows: cloudRows("PDFs", "Subscription, free tier with daily limits", "PDF only"),
+    lastReviewed: REVIEW_DATE,
+    sources: [
+      { label: "Smallpdf tools", url: "https://smallpdf.com/pdf-tools" },
+      { label: "Smallpdf pricing", url: "https://smallpdf.com/pricing" },
+    ],
+    rows: hostedRows({
+      category: "PDFs",
+      competitorCoverage: "PDF workflow suite",
+      pricing: "Free and paid plans with plan-specific features",
+    }),
     faqs: [
       {
         q: "Is there a free, self-hosted alternative to Smallpdf?",
-        a: "Yes. SnapOtter is open source under AGPLv3 and runs on your own server with Docker. It covers merge, split, compress, convert, protect, redact, watermark, page numbers, and OCR, with no per-file fees.",
+        a: "Yes. SnapOtter is open source under AGPLv3 and runs on your own server with Docker. It covers merge, split, compress, convert, protect, redact, watermark, page numbers, and OCR, with no per-file fee from SnapOtter.",
       },
       {
         q: "Do my documents get uploaded anywhere?",
-        a: "No. SnapOtter processes files on the machine you run it on. Nothing is sent to a third-party PDF service, which is the whole point of self-hosting it.",
+        a: "SnapOtter processes files on the machine you run it on. If you deploy it inside your own network, files stay inside that deployment instead of going to a third-party PDF service.",
       },
       {
-        q: "Does it do more than PDFs?",
-        a: "Yes. Beyond its PDF tools, SnapOtter handles image, video, audio, and file tasks too, 200+ tools in one stack.",
+        q: "Does SnapOtter do more than PDFs?",
+        a: "Yes. Beyond PDF tools, SnapOtter handles image, video, audio, and file tasks too, so one deployment can cover several day-to-day file workflows.",
       },
     ],
   },
@@ -120,21 +154,30 @@ export const ALTERNATIVES: Alternative[] = [
     pageTitle: "The Open-Source, Self-Hosted Alternative to iLovePDF",
     h1: "The open-source, self-hosted alternative to iLovePDF",
     metaDescription:
-      "iLovePDF processes your files in the cloud. SnapOtter runs PDF merge, split, compress, convert, and OCR on your own server. 200+ tools across five file types. Open source, AGPLv3.",
+      "iLovePDF is an online PDF service. SnapOtter gives teams self-hosted PDF tools plus image, video, audio, and file workflows in one open-source stack.",
     intro:
-      "iLovePDF is a hosted PDF service, which means your documents are uploaded to process them. SnapOtter gives you the same toolset to run yourself, with the file staying on your server.",
+      "iLovePDF is a hosted PDF service for fast browser-based document work. SnapOtter is the self-hosted alternative when you want the same kind of PDF workflow to run on your own server.",
     breadth:
-      "iLovePDF stays inside PDFs. SnapOtter pairs 29 PDF tools with image, video, audio, and file tools, so the same deployment handles a contract, a screen recording, and a podcast edit.",
+      "iLovePDF is strong for online PDF tasks. SnapOtter pairs PDF tools with image, video, audio, and file tools, so the same deployment handles a contract, a screen recording, and a podcast edit.",
     competitorOpenSource: false,
-    rows: cloudRows("PDFs", "Subscription, free tier with limits", "PDF only"),
+    lastReviewed: REVIEW_DATE,
+    sources: [
+      { label: "iLovePDF tools", url: "https://www.ilovepdf.com/" },
+      { label: "iLovePDF pricing", url: "https://www.ilovepdf.com/pricing" },
+    ],
+    rows: hostedRows({
+      category: "PDFs",
+      competitorCoverage: "PDF workflow suite",
+      pricing: "Free and premium plans with plan-specific features",
+    }),
     faqs: [
       {
         q: "What's a self-hosted alternative to iLovePDF?",
-        a: "SnapOtter. It's open source (AGPLv3), deploys with Docker, and gives you merge, split, compress, convert, protect, OCR, and the rest on your own hardware.",
+        a: "SnapOtter. It is open source under AGPLv3, deploys with Docker, and gives you merge, split, compress, convert, protect, OCR, and related PDF workflows on your own hardware.",
       },
       {
         q: "Is SnapOtter free?",
-        a: "The full open-source edition is free forever. A paid enterprise tier adds SSO, audit logging, and similar controls, but every file tool is in the free edition.",
+        a: "The open-source edition is free. A paid enterprise tier adds controls like SSO and audit logging, but the file tools live in the open-source stack.",
       },
     ],
   },
@@ -145,21 +188,27 @@ export const ALTERNATIVES: Alternative[] = [
     pageTitle: "The Open-Source, Self-Hosted Alternative to TinyPNG",
     h1: "The open-source, self-hosted alternative to TinyPNG",
     metaDescription:
-      "TinyPNG compresses images in the cloud with a monthly quota. SnapOtter compresses PNG, JPEG, WebP, and AVIF on your own server, with no quota and no upload. Open source, AGPLv3.",
+      "TinyPNG compresses images online and through Tinify's API. SnapOtter compresses and converts images on your own server, with broader file workflows in one stack.",
     intro:
-      "TinyPNG is a cloud image compressor with a monthly free quota and an upload step. SnapOtter compresses images on your own hardware, with no quota and nothing leaving your network.",
+      "TinyPNG is a focused online image compressor. SnapOtter is the self-hosted alternative for teams that want compression, conversion, resize, metadata, and other image work to run locally.",
     breadth:
-      "TinyPNG compresses images. SnapOtter compresses across PNG, JPEG, WebP, and AVIF, and then keeps going: resize, crop, convert between 14 output formats, watermark, plus 60+ other image tools and full video, audio, PDF, and file support.",
+      "TinyPNG is excellent when the job is image compression. SnapOtter compresses PNG, JPEG, WebP, and AVIF, then keeps going with resize, crop, conversion, watermarking, metadata tools, video, audio, PDF, and file workflows.",
     competitorOpenSource: false,
-    rows: cloudRows("image compression", "Monthly free quota, then paid", "Image compression only"),
+    lastReviewed: REVIEW_DATE,
+    sources: [{ label: "TinyPNG / Tinify", url: "https://tinypng.com/" }],
+    rows: hostedRows({
+      category: "image compression",
+      competitorCoverage: "Image compression and Tinify API workflows",
+      pricing: "Free web use and paid/developer API options",
+    }),
     faqs: [
       {
-        q: "Is there a self-hosted TinyPNG alternative with no quota?",
-        a: "Yes. SnapOtter runs image compression locally, so the only limit is your hardware. There's no per-month cap and no API key to a third party.",
+        q: "Is there a self-hosted TinyPNG alternative?",
+        a: "Yes. SnapOtter runs image compression locally, so the practical limit is your deployment hardware rather than a third-party image service quota.",
       },
       {
-        q: "Which formats can it compress?",
-        a: "PNG, JPEG, WebP, and AVIF, with conversion between formats. SnapOtter reads 55+ input formats including 23 camera RAW formats.",
+        q: "Which formats can SnapOtter compress?",
+        a: "PNG, JPEG, WebP, and AVIF, with conversion between formats. SnapOtter also reads many input formats, including camera RAW formats.",
       },
     ],
   },
@@ -170,21 +219,261 @@ export const ALTERNATIVES: Alternative[] = [
     pageTitle: "The Open-Source, Self-Hosted Alternative to CloudConvert",
     h1: "The open-source, self-hosted alternative to CloudConvert",
     metaDescription:
-      "CloudConvert converts files in the cloud, billed per conversion. SnapOtter converts image, video, audio, PDF, and data formats on your own server. Open source, AGPLv3, no upload.",
+      "CloudConvert is a hosted conversion platform with an API. SnapOtter converts image, video, audio, PDF, and data files on your own server with open-source pipelines.",
     intro:
-      "CloudConvert is a hosted converter, so files are uploaded and conversions are metered. SnapOtter converts across every modality on hardware you own, with no metering and no upload.",
+      "CloudConvert is a mature hosted converter and API. SnapOtter is the self-hosted alternative when conversion should happen inside your own infrastructure, with pipelines you control.",
     breadth:
-      "CloudConvert converts. SnapOtter converts too, across image, video, audio, PDF, and data formats, and then adds compression, editing, OCR, transcription, and pipelines, so conversion is one of 241 things it does.",
+      "CloudConvert is broad and API-friendly for conversion. SnapOtter converts across image, video, audio, PDF, and data formats, then adds compression, editing, OCR, transcription, and local pipelines.",
     competitorOpenSource: false,
-    rows: cloudRows("file conversion", "Pay per conversion / minutes", "Conversion only"),
+    lastReviewed: REVIEW_DATE,
+    sources: [
+      { label: "CloudConvert product", url: "https://cloudconvert.com/" },
+      { label: "CloudConvert pricing", url: "https://cloudconvert.com/pricing" },
+    ],
+    rows: hostedRows({
+      category: "file conversion",
+      competitorCoverage: "Hosted conversion across many file categories",
+      pricing: "Usage-based and plan-based cloud pricing",
+      automation: "Hosted API and browser workflows",
+    }),
     faqs: [
       {
         q: "Can I self-host a CloudConvert alternative?",
-        a: "Yes. SnapOtter is open source and runs on Docker. It converts image, video, audio, PDF, and data formats locally, with no per-conversion billing.",
+        a: "Yes. SnapOtter is open source and runs on Docker. It converts image, video, audio, PDF, and data formats locally, with no per-conversion billing from SnapOtter.",
       },
       {
-        q: "Does it convert video and audio too?",
-        a: "Yes. SnapOtter uses FFmpeg under the hood for video and audio, alongside Sharp for images and qpdf and LibreOffice for documents.",
+        q: "Does SnapOtter convert video and audio too?",
+        a: "Yes. SnapOtter uses FFmpeg under the hood for video and audio, alongside Sharp for images and qpdf, LibreOffice, and related tools for documents.",
+      },
+    ],
+  },
+  {
+    slug: "tinywow",
+    competitor: "TinyWow",
+    category: "Hosted online toolbox",
+    pageTitle: "The Open-Source, Self-Hosted Alternative to TinyWow",
+    h1: "The open-source, self-hosted alternative to TinyWow",
+    metaDescription:
+      "TinyWow is a broad hosted toolbox for PDF, image, video, AI writing, and file tasks. SnapOtter is the self-hosted alternative for private file workflows.",
+    intro:
+      "TinyWow is a broad hosted toolbox for quick PDF, image, video, AI writing, and file tasks. SnapOtter is the self-hosted alternative for teams that want everyday file utilities on infrastructure they control.",
+    breadth:
+      "TinyWow is convenient when you want a quick browser tool and do not want to install anything. SnapOtter is built for the other side of that tradeoff: private deployments, internal workflows, repeatable pipelines, and local file processing across image, video, audio, PDF, and files.",
+    competitorOpenSource: false,
+    lastReviewed: REVIEW_DATE,
+    sources: [
+      { label: "TinyWow tools", url: "https://tinywow.com/tools" },
+      { label: "TinyWow support plans", url: "https://tinywow.com/support-tinywow" },
+      { label: "TinyWow file deletion policy", url: "https://tinywow.com/your-data" },
+    ],
+    rows: [
+      {
+        feature: "Deployment model",
+        snapotter: "Self-hosted on your server",
+        competitor: "Hosted online toolbox",
+        snapotterWins: true,
+      },
+      {
+        feature: "File processing location",
+        snapotter: "Your infrastructure",
+        competitor: "Uploads to TinyWow servers; TinyWow says files are deleted after 1 hour",
+        snapotterWins: true,
+      },
+      {
+        feature: "Tool coverage",
+        snapotter: "Image, video, audio, PDF, and files",
+        competitor: "PDF, image, video, AI writing, and file utilities",
+        snapotterWins: false,
+      },
+      {
+        feature: "Cost control",
+        snapotter: "Free AGPLv3; limits are your hardware",
+        competitor: "Free tools plus paid supporter/content plans",
+        snapotterWins: true,
+      },
+      {
+        feature: "Offline / air-gapped use",
+        snapotter: "Supported when deployed inside your network",
+        competitor: "Designed for browser-based online use",
+        snapotterWins: true,
+      },
+      {
+        feature: "Source and auditability",
+        snapotter: "Source available under AGPLv3",
+        competitor: "Vendor-operated service; source availability is not the product model",
+        snapotterWins: true,
+      },
+      {
+        feature: "Automation",
+        snapotter: "REST API and pipelines in your deployment",
+        competitor: "Primarily quick web-tool workflows",
+        snapotterWins: true,
+      },
+    ],
+    faqs: [
+      {
+        q: "Is SnapOtter a TinyWow clone?",
+        a: "No. TinyWow is a broad hosted web toolbox. SnapOtter is a self-hosted file-processing suite for teams that want private deployment, source visibility, APIs, and pipelines.",
+      },
+      {
+        q: "Should I use TinyWow or SnapOtter?",
+        a: "Use TinyWow for quick one-off browser tasks where hosted processing is acceptable. Use SnapOtter when files are sensitive, workflows repeat, or your organization needs processing to happen on infrastructure it controls.",
+      },
+      {
+        q: "Does SnapOtter replace TinyWow's AI writing tools?",
+        a: "Not directly. SnapOtter focuses on file manipulation: images, video, audio, PDFs, documents, archives, and data files. It is a better fit when the file-processing layer matters more than writing templates.",
+      },
+    ],
+  },
+  {
+    slug: "adobe-acrobat-online",
+    competitor: "Adobe Acrobat online",
+    category: "PDF tools",
+    pageTitle: "The Open-Source, Self-Hosted Alternative to Adobe Acrobat Online",
+    h1: "The open-source, self-hosted alternative to Adobe Acrobat online",
+    metaDescription:
+      "Adobe Acrobat online is a hosted PDF toolset from Adobe. SnapOtter gives teams self-hosted PDF tools and broader file workflows with open-source deployment.",
+    intro:
+      "Adobe Acrobat online is a polished hosted PDF workflow from the company behind PDF. SnapOtter is the self-hosted alternative for teams that need PDF work to stay on their own infrastructure.",
+    breadth:
+      "Adobe Acrobat online is strong for PDF editing, signing, conversion, and Acrobat subscriptions. SnapOtter is not trying to replace the entire Adobe ecosystem; it gives teams self-hosted PDF tools plus image, video, audio, and file workflows in one open-source stack.",
+    competitorOpenSource: false,
+    lastReviewed: REVIEW_DATE,
+    sources: [
+      { label: "Adobe Acrobat online", url: "https://www.adobe.com/acrobat/online.html" },
+      { label: "Adobe Acrobat pricing", url: "https://www.adobe.com/acrobat/pricing.html" },
+      {
+        label: "Adobe online PDF editor",
+        url: "https://www.adobe.com/acrobat/online/pdf-editor.html",
+      },
+    ],
+    rows: hostedRows({
+      category: "PDFs",
+      competitorCoverage: "PDF, e-signature, AI, and Acrobat account workflows",
+      pricing: "Free online tools, trials, and paid Acrobat plans",
+      fileHandling: "Adobe says online editor files are handled by Adobe servers",
+    }),
+    faqs: [
+      {
+        q: "Is SnapOtter a replacement for Adobe Acrobat Pro?",
+        a: "Not for every Acrobat workflow. SnapOtter is best when you need self-hosted PDF processing, conversion, OCR, compression, page operations, and automation. Acrobat remains a deep desktop and cloud document platform.",
+      },
+      {
+        q: "Why choose SnapOtter over Adobe Acrobat online?",
+        a: "Choose SnapOtter when deployment control, source visibility, air-gapped use, or repeatable file pipelines matter more than Adobe account features and the wider Acrobat ecosystem.",
+      },
+    ],
+  },
+  {
+    slug: "freeconvert",
+    competitor: "FreeConvert",
+    category: "File conversion",
+    pageTitle: "The Open-Source, Self-Hosted Alternative to FreeConvert",
+    h1: "The open-source, self-hosted alternative to FreeConvert",
+    metaDescription:
+      "FreeConvert converts and compresses files online. SnapOtter is the self-hosted alternative for image, video, audio, PDF, and file conversion on your own server.",
+    intro:
+      "FreeConvert is a broad hosted converter for browser-based file conversion and compression. SnapOtter is the self-hosted alternative when you want those file operations to run inside your own deployment.",
+    breadth:
+      "FreeConvert is useful for quick online conversions across many categories. SnapOtter covers conversion too, then adds local image tools, video/audio workflows, PDFs, archives, data tools, APIs, and pipelines.",
+    competitorOpenSource: false,
+    lastReviewed: REVIEW_DATE,
+    sources: [
+      { label: "FreeConvert product", url: "https://www.freeconvert.com/" },
+      { label: "FreeConvert pricing", url: "https://www.freeconvert.com/pricing" },
+    ],
+    rows: hostedRows({
+      category: "file conversion",
+      competitorCoverage: "Online conversion and compression across many formats",
+      pricing: "Free web tier plus paid plans for larger or higher-priority workloads",
+      fileHandling:
+        "Files are uploaded to FreeConvert; FreeConvert says converted files are automatically deleted after a few hours",
+    }),
+    faqs: [
+      {
+        q: "Can SnapOtter replace FreeConvert?",
+        a: "For many image, video, audio, PDF, archive, and data conversions, yes. SnapOtter is strongest when you want the converter deployed privately instead of using a hosted web service.",
+      },
+      {
+        q: "Does SnapOtter support large files?",
+        a: "SnapOtter's practical limits come from your server, storage, memory, and configured runtime limits. That makes it a better fit when you want to tune capacity yourself.",
+      },
+    ],
+  },
+  {
+    slug: "convertio",
+    competitor: "Convertio",
+    category: "File conversion",
+    pageTitle: "The Open-Source, Self-Hosted Alternative to Convertio",
+    h1: "The open-source, self-hosted alternative to Convertio",
+    metaDescription:
+      "Convertio is a cloud file converter with browser tools and an API. SnapOtter is the self-hosted alternative for private conversion workflows and local pipelines.",
+    intro:
+      "Convertio is a cloud converter for browser-based file conversion across many formats. SnapOtter is the self-hosted alternative when you want conversion jobs to stay inside your own infrastructure.",
+    breadth:
+      "Convertio is convenient for quick conversions and developer API use. SnapOtter keeps conversion local and adds broader file processing: compression, editing, OCR, transcription, PDF operations, and repeatable pipelines.",
+    competitorOpenSource: false,
+    lastReviewed: REVIEW_DATE,
+    sources: [
+      { label: "Convertio product", url: "https://convertio.co/" },
+      {
+        label: "Convertio free-tier limits",
+        url: "https://support.convertio.co/hc/en-us/articles/360004386774-Free-tier-limit-for-file-conversions",
+      },
+    ],
+    rows: hostedRows({
+      category: "file conversion",
+      competitorCoverage: "Cloud conversion across 300+ formats and API workflows",
+      pricing: "Free tier with file and credit limits plus premium plans",
+      fileHandling:
+        "Cloud conversion; Convertio says uploaded files are deleted instantly and converted files after 24 hours",
+      automation: "Hosted conversion API and browser workflows",
+    }),
+    faqs: [
+      {
+        q: "What is a self-hosted Convertio alternative?",
+        a: "SnapOtter gives you a Docker-deployable converter and file-processing suite. Instead of sending files to a cloud converter, your server runs the conversion pipeline.",
+      },
+      {
+        q: "Does SnapOtter have an API?",
+        a: "Yes. SnapOtter includes REST APIs and pipeline support so teams can automate file workflows inside their own environment.",
+      },
+    ],
+  },
+  {
+    slug: "online-convert",
+    competitor: "Online-Convert",
+    category: "File conversion",
+    pageTitle: "The Open-Source, Self-Hosted Alternative to Online-Convert",
+    h1: "The open-source, self-hosted alternative to Online-Convert",
+    metaDescription:
+      "Online-Convert converts video, image, audio, document, ebook, and archive files online. SnapOtter is the self-hosted alternative for private file workflows.",
+    intro:
+      "Online-Convert is a long-running hosted converter for many file categories. SnapOtter is the self-hosted alternative for teams that want conversion and processing to happen on their own server.",
+    breadth:
+      "Online-Convert covers many conversion categories and has an API ecosystem through API2Convert. SnapOtter is built for private deployments where conversion, compression, PDF work, audio/video processing, and local AI tools sit in one stack.",
+    competitorOpenSource: false,
+    lastReviewed: REVIEW_DATE,
+    sources: [
+      { label: "Online-Convert product", url: "https://www.online-convert.com/" },
+      { label: "Online-Convert pricing", url: "https://www.online-convert.com/pricing" },
+      { label: "API2Convert", url: "https://www.api2convert.com/" },
+    ],
+    rows: hostedRows({
+      category: "file conversion",
+      competitorCoverage: "Online converters for media, documents, ebooks, and archives",
+      pricing: "Free trial, credit packages, subscriptions, and enterprise options",
+      fileHandling: "Browser uploads to Online-Convert/API2Convert cloud services",
+      automation: "Hosted API2Convert API and browser workflows",
+    }),
+    faqs: [
+      {
+        q: "Why choose SnapOtter over Online-Convert?",
+        a: "Choose SnapOtter when privacy, internal deployment, open-source code, or air-gapped file processing matters. Choose Online-Convert when you prefer a hosted converter with no server to maintain.",
+      },
+      {
+        q: "Does SnapOtter cover more than conversion?",
+        a: "Yes. SnapOtter includes conversion, compression, editing, OCR, transcription, PDF operations, metadata tools, archives, data tools, and pipelines.",
       },
     ],
   },
@@ -195,54 +484,29 @@ export const ALTERNATIVES: Alternative[] = [
     pageTitle: "The Open-Source, Self-Hosted Alternative to Otter.ai",
     h1: "The open-source, self-hosted alternative to Otter.ai",
     metaDescription:
-      "Otter.ai transcribes audio in the cloud. SnapOtter transcribes on your own CPU or NVIDIA CUDA GPU with local Whisper models. No upload, no per-minute fees. Open source, AGPLv3.",
+      "Otter.ai transcribes meetings in the cloud. SnapOtter runs speech-to-text on your own CPU or NVIDIA CUDA GPU with local Whisper models and no audio upload.",
     intro:
-      "Otter.ai uploads your recordings to transcribe them in the cloud. SnapOtter runs speech-to-text on your own hardware with local models, so sensitive recordings never leave your network.",
+      "Otter.ai is a hosted meeting transcription platform. SnapOtter is the self-hosted alternative when you want transcription to run on your own CPU or NVIDIA CUDA GPU with local models.",
     breadth:
-      "Otter.ai transcribes. SnapOtter transcribes locally and also handles the rest of an audio workflow (trim, normalize, noise reduction, format conversion) plus video subtitles, image, PDF, and file tools.",
+      "Otter.ai is built around meetings, notes, and collaboration. SnapOtter focuses on local speech-to-text plus the rest of an audio workflow: trim, normalize, noise reduction, format conversion, video subtitles, image, PDF, and file tools.",
     competitorOpenSource: false,
-    rows: [
-      {
-        feature: "Where your audio goes",
-        snapotter: "Your own server",
-        competitor: "Their cloud",
-        snapotterWins: true,
-      },
-      {
-        feature: "Pricing",
-        snapotter: "Free, open source (AGPLv3)",
-        competitor: "Subscription, per-minute limits",
-        snapotterWins: true,
-      },
-      {
-        feature: "Transcription engine",
-        snapotter: "Local Whisper models, on your hardware",
-        competitor: "Cloud service",
-        snapotterWins: true,
-      },
-      {
-        feature: "Works offline / air-gapped",
-        snapotter: "Yes",
-        competitor: "No",
-        snapotterWins: true,
-      },
-      {
-        feature: "Beyond transcription",
-        snapotter: "Audio editing, video, image, PDF, files",
-        competitor: "Notes and transcription",
-        snapotterWins: true,
-      },
-      {
-        feature: "Open source",
-        snapotter: "Yes, AGPLv3",
-        competitor: "No",
-        snapotterWins: true,
-      },
+    lastReviewed: REVIEW_DATE,
+    sources: [
+      { label: "Otter.ai product", url: "https://otter.ai/" },
+      { label: "Otter.ai pricing", url: "https://otter.ai/pricing" },
+      { label: "Otter.ai free plan", url: "https://otter.ai/start-for-free" },
     ],
+    rows: hostedRows({
+      category: "transcription",
+      competitorCoverage: "Meeting notes, AI summaries, collaboration, and transcription",
+      pricing: "Free and paid plans with minute/import limits by plan",
+      fileHandling: "Audio and meeting content is processed by the hosted Otter.ai service",
+      automation: "Hosted app integrations and meeting workflows",
+    }),
     faqs: [
       {
         q: "Is there a self-hosted Otter.ai alternative?",
-        a: "Yes. SnapOtter runs transcription locally with Whisper models on your own CPU or NVIDIA CUDA GPU. No audio is uploaded to a third party.",
+        a: "Yes. SnapOtter runs transcription locally with Whisper models on your own CPU or NVIDIA CUDA GPU. It is better suited to private audio and video files than meeting-agent collaboration.",
       },
       {
         q: "Do I need a GPU?",
@@ -257,12 +521,17 @@ export const ALTERNATIVES: Alternative[] = [
     pageTitle: "SnapOtter vs Stirling-PDF: Self-Hosted File Tools Compared",
     h1: "SnapOtter vs Stirling-PDF",
     metaDescription:
-      "Stirling-PDF is a great self-hosted PDF toolkit. SnapOtter covers PDFs too, plus image, video, audio, and file tools in one stack. Both open source. Here's how they compare.",
+      "Stirling-PDF is a strong self-hosted PDF toolkit. SnapOtter covers PDFs too, plus image, video, audio, and file tools in one stack. Both are open source.",
     intro:
-      "Stirling-PDF and SnapOtter are both self-hosted and open source, so files stay on your server either way. The difference is scope: Stirling-PDF focuses on PDFs, SnapOtter spans all five file types.",
+      "Stirling-PDF and SnapOtter are both self-hosted and open source, so files stay on your server either way. The difference is scope: Stirling-PDF focuses on PDFs, while SnapOtter spans all five file types.",
     breadth:
       "If you only ever touch PDFs, Stirling-PDF is excellent and worth a look. If you also resize images, convert video, transcribe audio, or batch files, SnapOtter handles all of it in one deployment instead of running several tools side by side.",
     competitorOpenSource: true,
+    lastReviewed: REVIEW_DATE,
+    sources: [
+      { label: "Stirling-PDF GitHub", url: "https://github.com/Stirling-Tools/stirling-pdf" },
+      { label: "Stirling-PDF docs", url: "https://docs.stirlingpdf.com/" },
+    ],
     rows: [
       {
         feature: "Self-hosted",
@@ -277,33 +546,33 @@ export const ALTERNATIVES: Alternative[] = [
         snapotterWins: false,
       },
       {
-        feature: "Modalities covered",
-        snapotter: "Image, video, audio, PDF, files",
-        competitor: "PDF only",
+        feature: "Primary focus",
+        snapotter: "Full file workflow across five types",
+        competitor: "PDF workflows",
         snapotterWins: true,
       },
       {
         feature: "Tool count",
         snapotter: "241",
-        competitor: "50+ PDF tools",
+        competitor: "60+ PDF operations",
         snapotterWins: true,
       },
       {
         feature: "Local AI (OCR, transcription, upscaling)",
-        snapotter: "Yes, on-demand bundles",
-        competitor: "OCR",
+        snapotter: "OCR, transcription, upscaling, and more",
+        competitor: "PDF-oriented OCR workflows",
         snapotterWins: true,
       },
       {
         feature: "Layer-based image editor",
         snapotter: "Yes",
-        competitor: "No",
+        competitor: "Not its focus",
         snapotterWins: true,
       },
       {
         feature: "Pipelines and batch processing",
         snapotter: "Yes",
-        competitor: "Pipelines",
+        competitor: "PDF automation workflows",
         snapotterWins: false,
       },
     ],
@@ -314,7 +583,7 @@ export const ALTERNATIVES: Alternative[] = [
       },
       {
         q: "Are both free and open source?",
-        a: "Yes. Both are open source and self-hostable. SnapOtter is AGPLv3 and adds an optional paid enterprise tier for SSO and audit features.",
+        a: "Both projects are open source and self-hostable. SnapOtter is AGPLv3 and adds an optional paid enterprise tier for SSO, audit logging, and similar controls.",
       },
     ],
   },
@@ -325,12 +594,14 @@ export const ALTERNATIVES: Alternative[] = [
     pageTitle: "SnapOtter vs ConvertX: Self-Hosted File Tools Compared",
     h1: "SnapOtter vs ConvertX",
     metaDescription:
-      "ConvertX is a self-hosted file converter for 1000+ formats. SnapOtter converts too, and adds editing, compression, OCR, and transcription across five modalities. Both open source.",
+      "ConvertX is a self-hosted file converter for 1000+ formats. SnapOtter converts too, and adds editing, compression, OCR, and transcription across five modalities.",
     intro:
       "ConvertX and SnapOtter are both self-hosted and open source. ConvertX is built around format conversion; SnapOtter does conversion plus the rest of a file workflow.",
     breadth:
-      "ConvertX is a focused converter and handles a huge list of formats. SnapOtter converts as well, then adds compression, editing, redaction, OCR, transcription, and pipelines, so it's a fit when conversion is one step among many.",
+      "ConvertX is a focused converter and handles a huge list of formats. SnapOtter converts as well, then adds compression, editing, redaction, OCR, transcription, and pipelines, so it fits when conversion is one step among many.",
     competitorOpenSource: true,
+    lastReviewed: REVIEW_DATE,
+    sources: [{ label: "ConvertX GitHub", url: "https://github.com/c4illin/ConvertX" }],
     rows: [
       {
         feature: "Self-hosted",
@@ -353,25 +624,25 @@ export const ALTERNATIVES: Alternative[] = [
       {
         feature: "Beyond conversion",
         snapotter: "Compress, edit, redact, OCR, transcribe",
-        competitor: "Conversion",
+        competitor: "Conversion-centered workflow",
         snapotterWins: true,
       },
       {
         feature: "Tool count",
         snapotter: "241",
-        competitor: "Conversion-focused",
-        snapotterWins: true,
+        competitor: "1000+ conversion formats",
+        snapotterWins: false,
       },
       {
         feature: "Local AI tools",
-        snapotter: "OCR, transcription, upscaling, more",
-        competitor: "No",
+        snapotter: "OCR, transcription, upscaling, and more",
+        competitor: "Not a primary focus",
         snapotterWins: true,
       },
       {
         feature: "Layer-based image editor",
         snapotter: "Yes",
-        competitor: "No",
+        competitor: "Not a primary focus",
         snapotterWins: true,
       },
     ],

--- a/apps/landing/src/pages/alternatives/[slug].astro
+++ b/apps/landing/src/pages/alternatives/[slug].astro
@@ -17,6 +17,12 @@ export function getStaticPaths() {
 const { alt } = Astro.props;
 const canonical = `https://snapotter.com/alternatives/${alt.slug}`;
 const others = ALTERNATIVES.filter((a) => a.slug !== alt.slug);
+const reviewedOn = new Intl.DateTimeFormat("en-US", {
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+  timeZone: "UTC",
+}).format(new Date(`${alt.lastReviewed}T00:00:00Z`));
 
 const breadcrumbJsonLd = {
   "@context": "https://schema.org",
@@ -143,9 +149,28 @@ const allJsonLd = [breadcrumbJsonLd, ...(faqJsonLd ? [faqJsonLd] : [])];
             </table>
           </div>
           <p class="mt-4 text-xs text-muted">
-            Comparison reflects the open-source editions and publicly documented plans. Vendor
-            features change; check current docs before deciding.
+            Last reviewed {reviewedOn}. Comparison uses publicly available vendor pages and focuses
+            on deployment model, file location, auditability, and workflow fit. Vendor features and
+            plans change; check current docs before deciding. SnapOtter is not affiliated with
+            {alt.competitor}.
           </p>
+          <div class="mt-5">
+            <p class="text-xs font-semibold uppercase tracking-wide text-muted">Sources reviewed</p>
+            <ul class="mt-2 flex flex-wrap gap-x-4 gap-y-2 text-xs">
+              {alt.sources.map((source) => (
+                <li>
+                  <a
+                    href={source.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-primary transition-colors hover:text-primary-dark"
+                  >
+                    {source.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       </div>
     </section>

--- a/apps/landing/src/pages/alternatives/index.astro
+++ b/apps/landing/src/pages/alternatives/index.astro
@@ -30,11 +30,19 @@ const itemListJsonLd = {
 };
 
 const allJsonLd = [breadcrumbJsonLd, itemListJsonLd];
+
+const formatReviewDate = (date: string) =>
+  new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T00:00:00Z`));
 ---
 
 <Base
   title="Open-Source, Self-Hosted Alternatives to Cloud File Tools | SnapOtter"
-  description="Open-source, self-hosted alternatives to Smallpdf, iLovePDF, TinyPNG, CloudConvert, and Otter.ai. One stack for image, video, audio, PDF, and files, on infrastructure you own."
+  description="Open-source, self-hosted alternatives to TinyWow, Smallpdf, Adobe Acrobat online, FreeConvert, Convertio, CloudConvert, Otter.ai, and more. One stack for image, video, audio, PDF, and files."
   canonical={canonical}
 >
   <Fragment slot="head">
@@ -51,9 +59,9 @@ const allJsonLd = [breadcrumbJsonLd, itemListJsonLd];
           Open-source alternatives to cloud file tools
         </h1>
         <p class="mx-auto mt-5 max-w-2xl text-lg leading-relaxed text-muted md:text-xl">
-          Most file tools upload your work to someone else's server. SnapOtter runs the same kinds of
-          tools on yours: 241 of them across image, video, audio, PDF, and files, in one self-hosted
-          stack.
+          Most online file tools upload your work to someone else's server. SnapOtter runs the same
+          kinds of tools on yours: 241 of them across image, video, audio, PDF, and files, in one
+          self-hosted stack.
         </p>
       </div>
     </section>
@@ -73,6 +81,7 @@ const allJsonLd = [breadcrumbJsonLd, itemListJsonLd];
                 : `The alternative to ${alt.competitor}`}
             </span>
             <span class="mt-2 text-sm leading-relaxed text-muted">{alt.intro}</span>
+            <span class="mt-4 text-xs text-muted">Reviewed {formatReviewDate(alt.lastReviewed)}</span>
             <span class="mt-auto inline-flex items-center gap-1 pt-5 text-sm font-medium text-primary transition-all group-hover:gap-2">
               Compare
               <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -81,6 +90,39 @@ const allJsonLd = [breadcrumbJsonLd, itemListJsonLd];
             </span>
           </a>
         ))}
+      </div>
+    </section>
+
+    <!-- Methodology -->
+    <section class="border-t border-border py-16">
+      <div class="mx-auto max-w-4xl px-6">
+        <div class="reveal">
+          <h2 class="font-display text-2xl font-bold tracking-tight md:text-3xl">
+            Comparisons that age gracefully
+          </h2>
+          <div class="mt-6 grid gap-6 sm:grid-cols-3">
+            <div>
+              <h3 class="text-sm font-semibold">Dated reviews</h3>
+              <p class="mt-2 text-sm leading-relaxed text-muted">
+                Every comparison page shows when the vendor pages were last checked, so stale
+                claims are easier to spot.
+              </p>
+            </div>
+            <div>
+              <h3 class="text-sm font-semibold">Public sources</h3>
+              <p class="mt-2 text-sm leading-relaxed text-muted">
+                Source links sit next to the comparison instead of being buried in a private note.
+              </p>
+            </div>
+            <div>
+              <h3 class="text-sm font-semibold">Stable criteria</h3>
+              <p class="mt-2 text-sm leading-relaxed text-muted">
+                The core comparison is deployment model, file location, auditability, and workflow
+                fit, not fragile point-in-time feature trivia.
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
 
@@ -102,8 +144,8 @@ const allJsonLd = [breadcrumbJsonLd, itemListJsonLd];
             <div>
               <h3 class="text-sm font-semibold">No quotas or per-file fees</h3>
               <p class="mt-2 text-sm leading-relaxed text-muted">
-                The only limit is your machine. No monthly cap, no per-conversion billing, no
-                watermarks on the free output.
+                The only limit is your machine and your configuration. No third-party
+                per-conversion billing for internal jobs.
               </p>
             </div>
             <div>

--- a/tests/unit/landing/alternatives.test.ts
+++ b/tests/unit/landing/alternatives.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { ALTERNATIVES } from "../../../apps/landing/src/data/alternatives.js";
+
+const addedCompetitors = [
+  "tinywow",
+  "adobe-acrobat-online",
+  "freeconvert",
+  "convertio",
+  "online-convert",
+];
+
+describe("landing alternatives data", () => {
+  it("includes the expanded hosted-tool competitors", () => {
+    const slugs = ALTERNATIVES.map((alternative) => alternative.slug);
+
+    expect(slugs).toEqual(expect.arrayContaining(addedCompetitors));
+  });
+
+  it("keeps every comparison reviewable with dates and sources", () => {
+    for (const alternative of ALTERNATIVES) {
+      expect(alternative.lastReviewed).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(alternative.sources.length).toBeGreaterThanOrEqual(1);
+      expect(alternative.sources.every((source) => source.url.startsWith("https://"))).toBe(true);
+    }
+  });
+
+  it("frames TinyWow as a broad hosted toolbox, not a narrow single-tool product", () => {
+    const tinywow = ALTERNATIVES.find((alternative) => alternative.slug === "tinywow");
+
+    expect(tinywow?.category).toBe("Hosted online toolbox");
+    expect(tinywow?.intro).toContain("broad hosted toolbox");
+    expect(tinywow?.rows.some((row) => row.competitor.includes("PDF, image, video"))).toBe(true);
+  });
+
+  it("avoids brittle absolute negatives for hosted competitors", () => {
+    const hostedAlternatives = ALTERNATIVES.filter(
+      (alternative) => !alternative.competitorOpenSource,
+    );
+
+    for (const alternative of hostedAlternatives) {
+      const competitorCells = alternative.rows.map((row) => row.competitor);
+
+      expect(competitorCells).not.toContain("No");
+      expect(competitorCells).not.toContain("PDF only");
+      expect(competitorCells).not.toContain("Conversion only");
+      expect(competitorCells).not.toContain("Image compression only");
+      expect(competitorCells).not.toContain("API on paid plans");
+      expect(competitorCells).not.toContain("Capped by plan");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add TinyWow, Adobe Acrobat online, FreeConvert, Convertio, and Online-Convert alternatives pages.
- Add dated review/source metadata and source links so comparisons are easier to refresh safely.
- Rework hosted-tool comparison rows around stable criteria like deployment model, file location, auditability, and workflow fit.
- Add unit coverage for required review/source metadata and less brittle hosted competitor rows.

## Test Plan
- [x] pnpm --filter @snapotter/landing lint
- [x] pnpm --filter @snapotter/landing typecheck
- [x] pnpm vitest run --config vitest.config.ts tests/unit/landing/alternatives.test.ts tests/unit/landing/tool-search.test.ts tests/unit/landing/stats.test.ts
- [x] pnpm --filter @snapotter/landing build