### PR TITLE
fix: show modality starting points in landing command center

### DIFF
--- a/apps/landing/src/components/ToolGrid.astro
+++ b/apps/landing/src/components/ToolGrid.astro
@@ -567,17 +567,20 @@ const safeDefaultToolIdsJson = JSON.stringify(defaultToolIds).replace(/</g, "\\u
     }
 
     function renderDefault(): void {
-      const defaultTools = tools.filter(
-        (tool) => defaultToolIdSet.has(tool.id) && matchesActiveModality(tool),
-      );
-      const fallbackTools =
-        defaultTools.length > 0 ? defaultTools : tools.filter(matchesActiveModality).slice(0, 12);
+      const matchingTools = tools.filter(matchesActiveModality);
+      const defaultTools =
+        activeModality === "all"
+          ? tools.filter((tool) => defaultToolIdSet.has(tool.id))
+          : matchingTools.slice(0, 12);
       const modalityName = modalityLabels.get(activeModality) ?? "All";
 
       titleNode.textContent =
         activeModality === "all" ? "Suggested starting points" : `${modalityName} starting points`;
-      countNode.textContent = `${fallbackTools.length} curated tools`;
-      resultContainer.innerHTML = fallbackTools.map((tool) => renderCard(tool)).join("");
+      countNode.textContent =
+        activeModality === "all"
+          ? `${defaultTools.length} curated tools`
+          : `${defaultTools.length} of ${matchingTools.length} tools`;
+      resultContainer.innerHTML = defaultTools.map((tool) => renderCard(tool)).join("");
       resultContainer.classList.remove("hidden");
       hideEmptyState();
       setRequestLinks("");

--- a/tests/e2e-landing/homepage.spec.ts
+++ b/tests/e2e-landing/homepage.spec.ts
@@ -80,6 +80,19 @@ test.describe("Landing Homepage", () => {
     expect(requestHref).toContain("title=Tool+request%3A+convert+figma+file+to+layered+psd");
   });
 
+  test("tool command center shows multiple starting points for a selected modality", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: /Video 57/ }).click();
+
+    const results = page.locator("#tool-command-results");
+    await expect(page.getByText("Video starting points")).toBeVisible();
+    await expect(page.getByText(/12 of 57 tools/)).toBeVisible();
+    await expect(results.getByRole("link", { name: /Convert Video/ })).toBeVisible();
+    await expect(results.getByRole("link", { name: /Compress Video/ })).toBeVisible();
+    await expect(results.getByRole("link", { name: /Trim Video/ })).toBeVisible();
+  });
+
   test("enterprise section renders eyebrow and feature cards", async ({ page }) => {
     await expect(page.getByText("Built for enterprise deployment.")).toBeVisible();
     await expect(page.getByText("Enterprise-grade security")).toBeVisible();


### PR DESCRIPTION
## Summary
- Fix empty-query modality filters in the landing command center so selected modalities show the first 12 matching tools instead of only the cross-modality curated overlap.
- Keep the All state as the curated cross-modality starting set.
- Add a landing e2e regression test for the Video filter showing multiple starting points.

## Test Plan
- pnpm --filter @snapotter/landing typecheck
- pnpm exec biome check apps/landing/src/components/ToolGrid.astro tests/e2e-landing/homepage.spec.ts
- pnpm playwright test --config playwright.landing.config.ts tests/e2e-landing/homepage.spec.ts
- pnpm --filter @snapotter/landing build

## Regression
- The new test failed before the fix because Video showed only `Compress Video` and `1 curated tools`.
- The same test now passes and verifies `Convert Video`, `Compress Video`, and `Trim Video` with `12 of 57 tools`.