### PR TITLE
feat(landing): warm up the contact CTAs

### DIFF
--- a/apps/landing/src/components/Navbar.astro
+++ b/apps/landing/src/components/Navbar.astro
@@ -11,7 +11,7 @@ const links = [
   { label: "Pricing", href: "/#pricing" },
   { label: "Alternatives", href: "/alternatives" },
   { label: "Docs", href: "https://docs.snapotter.com", external: true },
-  { label: "Contact", href: "/contact" },
+  { label: "Talk to a human", href: "/contact" },
 ];
 ---
 

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -79,7 +79,7 @@ const checkIcon =
           href="/contact"
           class="btn-primary mt-6 block rounded-xl px-6 py-3 text-center text-sm font-semibold"
         >
-          Contact Sales
+          Let's talk
         </a>
 
         <ul class="mt-8 space-y-3">

--- a/apps/landing/src/pages/faq.astro
+++ b/apps/landing/src/pages/faq.astro
@@ -115,7 +115,7 @@ const breadcrumbJsonLd = {
         <h2 class="font-display text-xl font-semibold">Still have questions?</h2>
         <p class="mt-2 text-sm text-muted">Reach out via email or join our community.</p>
         <div class="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-          <a href="/contact" class="btn-primary rounded-lg px-6 py-2.5 text-sm font-semibold">Contact Us</a>
+          <a href="/contact" class="btn-primary rounded-lg px-6 py-2.5 text-sm font-semibold">Talk to a human</a>
           <a href="https://discord.gg/hr3s7HPUsr" target="_blank" rel="noopener noreferrer" class="rounded-lg border border-border px-6 py-2.5 text-sm font-semibold transition-colors hover:bg-background-alt">Join Discord</a>
         </div>
       </div>


### PR DESCRIPTION
Warms up the landing contact CTAs to a friendlier, more human voice.

- Nav "Contact" -> "Talk to a human"
- FAQ "Contact Us" -> "Talk to a human"
- Enterprise pricing "Contact Sales" -> "Let's talk"

All still link to `/contact`; labels only. Verified lint + build clean, the nav fits at desktop widths (and the mobile menu updates from the same links array), and the Pricing/FAQ buttons render correctly.

Deploys automatically to Cloudflare Pages via `deploy-landing.yml` on merge.

https://claude.ai/code/session_01MbQGV1k1mneFidgGyDnmDQ
