### PR TITLE
feat(landing): swap Try Demo for Get Started Free CTA in top nav

### DIFF
--- a/apps/landing/src/components/Navbar.astro
+++ b/apps/landing/src/components/Navbar.astro
@@ -49,18 +49,18 @@ const links = [
         <span id="gh-stars" class="text-xs">{starCount}</span>
       </a>
       <a
-        href="https://demo.snapotter.com"
-        target="_blank"
-        rel="noopener noreferrer"
+        href="/contact"
         class="rounded-lg border border-border px-4 py-1.5 text-sm font-medium transition-colors hover:bg-background-alt"
       >
-        Try Demo
+        Book a Demo
       </a>
       <a
-        href="/contact"
+        href="https://docs.snapotter.com/guide/getting-started.html"
+        target="_blank"
+        rel="noopener noreferrer"
         class="btn-primary rounded-lg px-4 py-1.5 text-sm font-semibold"
       >
-        Book a Demo
+        Get Started Free
       </a>
     </div>
 
@@ -87,18 +87,18 @@ const links = [
     ))}
     <div class="mt-3 flex flex-col gap-2">
       <a
-        href="https://demo.snapotter.com"
-        target="_blank"
-        rel="noopener noreferrer"
+        href="/contact"
         class="block rounded-lg border border-border px-4 py-2 text-center text-sm font-medium"
       >
-        Try Demo
+        Book a Demo
       </a>
       <a
-        href="/contact"
+        href="https://docs.snapotter.com/guide/getting-started.html"
+        target="_blank"
+        rel="noopener noreferrer"
         class="btn-primary block rounded-lg px-4 py-2 text-center text-sm font-semibold"
       >
-        Book a Demo
+        Get Started Free
       </a>
     </div>
   </div>


### PR DESCRIPTION
## What

Reworks the top-navigation CTAs on the landing site, in both the desktop bar and the mobile menu.

Outline (secondary) button: was "Try Demo" pointing at demo.snapotter.com, now "Book a Demo" pointing at /contact.

Primary button: was "Book a Demo" pointing at /contact, now "Get Started Free" pointing at https://docs.snapotter.com/guide/getting-started.html (opens in a new tab).

Net effect: "Try Demo" is gone from the nav, "Book a Demo" moves into the secondary slot, and a new "Get Started Free" primary CTA drives visitors to the docs getting-started guide.

## Scope

Top navigation only. The Footer "Image Editor" link to demo.snapotter.com/editor stays in place, since it is a live product link rather than the Try Demo CTA.

## Verification

Landing build passes (267 pages, no errors). The compiled index.html renders both new CTAs, with the Get Started Free links carrying target="_blank", and contains no "Try Demo" in the nav.

https://claude.ai/code/session_01STf4CGEkYKNwN26rMxVpn6
