### PR TITLE
docs: show "200+" for the landing tool-count stat

### DIFF
--- a/apps/landing/src/components/TrustSignals.astro
+++ b/apps/landing/src/components/TrustSignals.astro
@@ -8,7 +8,7 @@ const { display: pullsDisplay } = await getImagePulls();
 
 const stats = [
   {
-    value: "241",
+    value: "200+",
     label: "Processing Tools",
     sublabel: "Across 5 file modalities",
   },


### PR DESCRIPTION
Change the below-hero "Processing Tools" stat from the exact `241` to the drift-proof `200+`, matching the public tool-count phrasing used everywhere else (the neighboring Languages stat already reads `20+`). Keeps the number from going stale as tools are added.

https://claude.ai/code/session_01JQ8LmV8LPLi8yNTayHzSTQ