### PR TITLE
feat(feedback): route failed-run Report issue through the offline handoff

### DIFF
--- a/apps/web/src/components/feedback/feedback-dialog.tsx
+++ b/apps/web/src/components/feedback/feedback-dialog.tsx
@@ -118,6 +118,14 @@ export function FeedbackDialog({
   const isAdminInstall = source === "admin_installer";
   const isSearchMiss = source === "search_miss";
   const isGlobal = source === "global";
+  const isFailedJob = source === "failed_job";
+  // For a failed run, thread the tool and error into the offline handoff so the
+  // GitHub issue is actionable even if the message box is left empty.
+  const handoffMessage = isFailedJob
+    ? [`Tool: ${toolId ?? "unknown"}`, `Error category: ${errorCategory ?? "unknown"}`, "", message]
+        .join("\n")
+        .trim()
+    : message;
   const canSubmit = Boolean(
     message.trim() || sentiment || feedbackType !== "other" || isAdminInstall,
   );
@@ -206,13 +214,13 @@ export function FeedbackDialog({
 
         {submitted ? (
           <div className="p-6 space-y-4">
-            {isGlobal && !accepted ? (
+            {(isGlobal || isFailedJob) && !accepted ? (
               <div className="space-y-3">
                 <p className="text-sm text-foreground">{t.feedback.offlineDescription}</p>
                 <p className="text-xs text-muted-foreground">{t.feedback.offlinePublicNote}</p>
                 <div className="flex flex-col gap-2">
                   <a
-                    href={buildFeedbackGithubUrl(message)}
+                    href={buildFeedbackGithubUrl(handoffMessage)}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="w-full text-center py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90"
@@ -220,7 +228,7 @@ export function FeedbackDialog({
                     {t.feedback.offlineGithubButton}
                   </a>
                   <a
-                    href={buildFeedbackMailtoUrl(message)}
+                    href={buildFeedbackMailtoUrl(handoffMessage)}
                     className="w-full text-center py-2 rounded-lg border border-border text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
                   >
                     {t.feedback.offlineEmailButton}

--- a/apps/web/src/pages/tool-page.tsx
+++ b/apps/web/src/pages/tool-page.tsx
@@ -51,7 +51,6 @@ import { ICON_MAP } from "@/lib/icon-map";
 import { MULTI_FILE_TOOLS } from "@/lib/tool-display-modes";
 import { getToolName } from "@/lib/tool-i18n";
 import { getToolRegistryEntry } from "@/lib/tool-registry";
-import { useAnalyticsStore } from "@/stores/analytics-store";
 import { useBase64Store } from "@/stores/base64-store";
 import { useCollageStore } from "@/stores/collage-store";
 import { useDuplicateStore } from "@/stores/duplicate-store";
@@ -327,8 +326,6 @@ export function ToolPage() {
   );
   const [mobileSettingsOpen, setMobileSettingsOpen] = useState(false);
   const [failedFeedbackOpen, setFailedFeedbackOpen] = useState(false);
-  const analyticsConfig = useAnalyticsStore((s) => s.config);
-  const feedbackEnabled = Boolean(analyticsConfig?.enabled);
   const [previewTransform, setPreviewTransform] = useState<PreviewTransform | null>(null);
   const [previewFilter, setPreviewFilter] = useState<string>("");
   const [imageWrapperStyle, setImageWrapperStyle] = useState<React.CSSProperties | null>(null);
@@ -791,16 +788,14 @@ export function ToolPage() {
               >
                 {t.toolPage.tryDifferentFile}
               </button>
-              {feedbackEnabled && (
-                <button
-                  type="button"
-                  onClick={() => setFailedFeedbackOpen(true)}
-                  className="px-4 py-2 rounded-md border border-border text-sm text-muted-foreground hover:bg-muted hover:text-foreground inline-flex items-center justify-center gap-2"
-                >
-                  <MessageSquare className="h-3.5 w-3.5" />
-                  {t.feedback.reportIssue}
-                </button>
-              )}
+              <button
+                type="button"
+                onClick={() => setFailedFeedbackOpen(true)}
+                className="px-4 py-2 rounded-md border border-border text-sm text-muted-foreground hover:bg-muted hover:text-foreground inline-flex items-center justify-center gap-2"
+              >
+                <MessageSquare className="h-3.5 w-3.5" />
+                {t.feedback.reportIssue}
+              </button>
             </div>
           </div>
         </div>
@@ -1120,7 +1115,7 @@ export function ToolPage() {
           </Suspense>
         </div>
 
-        {feedbackEnabled && currentEntry?.status === "failed" && (
+        {currentEntry?.status === "failed" && (
           <button
             type="button"
             onClick={() => setFailedFeedbackOpen(true)}

--- a/tests/unit/web/feedback-dialog-offline.test.tsx
+++ b/tests/unit/web/feedback-dialog-offline.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("FeedbackDialog global off-state handoff", () => {
+describe("FeedbackDialog off-state handoff", () => {
   it("reveals GitHub and email handoff when the server does not record the feedback", async () => {
     submitFeedback.mockResolvedValue({ ok: true, accepted: false });
     render(<FeedbackDialog open source="global" onClose={vi.fn()} />);
@@ -47,6 +47,33 @@ describe("FeedbackDialog global off-state handoff", () => {
     const emailBody = new URL(emailLink.getAttribute("href") ?? "").searchParams.get("body");
     expect(emailBody).toBe("The queue stalls on large PDFs");
 
+    expect(screen.queryByText("Thanks for the feedback.")).toBeNull();
+  });
+
+  it("threads tool and error into the handoff for a failed run", async () => {
+    submitFeedback.mockResolvedValue({ ok: true, accepted: false });
+    render(
+      <FeedbackDialog
+        open
+        source="failed_job"
+        toolId="pdf-compress"
+        jobStatus="failed"
+        errorCategory="timeout"
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(MESSAGE_PLACEHOLDER), {
+      target: { value: "It hung on a 50MB file" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send feedback" }));
+
+    const githubLink = await screen.findByRole("link", { name: "Open a GitHub issue" });
+    const details =
+      new URL(githubLink.getAttribute("href") ?? "").searchParams.get("details") ?? "";
+    expect(details).toContain("pdf-compress");
+    expect(details).toContain("timeout");
+    expect(details).toContain("It hung on a 50MB file");
     expect(screen.queryByText("Thanks for the feedback.")).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #428. Applies the same "feedback always reaches you" treatment to the "Report issue" button on failed tool runs.

- Un-gates the two failed-run "Report issue" buttons in `tool-page.tsx` from the analytics toggle (they used the same `feedbackEnabled` gate #428 removed from the nav button), and drops the now-dead analytics selector and import.
- Extends the dialog offline handoff to `source="failed_job"`: when analytics is off and the server returns `accepted: false`, a failed run now gets the GitHub issue plus email handoff instead of a fake "Thanks."
- The failed-run GitHub issue is prefilled with the tool id and error category (which the dialog already has on hand), so it is actionable even if the user leaves the message box empty.

## Stacking

Based on #428, which introduces the handoff mechanism and the `feedback.yml` template. The base is `feat/always-on-feedback-button` so the diff shows only the failed-run changes. Retarget to `main` once #428 merges.

## Test plan

- [x] 1260 web unit tests pass, including a new failed-run handoff test that asserts the tool id, error category, and typed message all reach the GitHub issue
- [x] web typecheck and Biome lint clean
- [ ] Manual smoke: with analytics off, fail a tool run, click "Report issue", confirm the GitHub and email handoff prefilled with the tool and error

## Note

A failed run is arguably a bug, so this could later route to the repo's `bug_report.yml` template instead of the general `feedback.yml`. Reusing `feedback.yml` keeps it consistent with #428 and robust (a single prefill field); switching to the bug form is a possible refinement.

https://claude.ai/code/session_01XVrHKXwzZDWBWgkGQdPZ3A