### PR TITLE
feat(landing): refocus hero on privacy-sensitive teams

### DIFF
--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -7,12 +7,9 @@ import TrustSignals from "./TrustSignals.astro";
 
 const trustBadges = [
   "Self-hosted",
-  "Privacy-sensitive",
-  "Compliance-friendly",
-  "Air-gap capable",
-  "SAML SSO",
-  "Audit logging",
   "Open source",
+  "Air-gap capable",
+  "Compliance-friendly",
 ];
 ---
 
@@ -44,8 +41,7 @@ const trustBadges = [
 
     <!-- Headline: one precise promise for privacy-sensitive buyers -->
     <h1 class="animate-fade-up mt-8 font-display text-4xl font-extrabold tracking-tight text-white sm:text-5xl md:text-6xl lg:text-7xl" style="animation-delay: 0.1s; text-shadow: 0 2px 30px rgba(90, 20, 0, 0.28);">
-      Private file processing, self-hosted.
-      <span class="mt-3 block text-2xl font-bold text-white/90 sm:text-3xl md:text-4xl">Inside your infrastructure.</span>
+      File processing for privacy-sensitive teams.
     </h1>
 
     <!-- Subtitle: one calm supporting line -->

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -15,6 +15,10 @@ import Base from "@/layouts/Base.astro";
 
 const toolCount = TOOLS.length;
 
+const pageTitle = "SnapOtter | Self-Hosted File Processing for Privacy-Sensitive Teams";
+const pageDescription =
+  "Self-hosted file processing for privacy-sensitive teams. Image, video, audio, PDF, and file tools with local AI and enterprise controls, on infrastructure you own. The open-source alternative to Smallpdf, iLovePDF, and CloudConvert.";
+
 const websiteSchema = {
   "@context": "https://schema.org",
   "@type": "WebSite",
@@ -100,7 +104,7 @@ const navSchema = {
 };
 ---
 
-<Base canonical="https://snapotter.com">
+<Base title={pageTitle} description={pageDescription} canonical="https://snapotter.com">
   <Fragment slot="head">
     <JsonLd data={[websiteSchema, softwareSchema, navSchema]} />
   </Fragment>


### PR DESCRIPTION
## What

Repositions the landing hero around the privacy-sensitive team buyer.

- Hero headline: "Private file processing, self-hosted." -> "File processing for privacy-sensitive teams." Dropped the "Inside your infrastructure." subline.
- Trust badges trimmed 7 -> 4: Self-hosted, Open source, Air-gap capable, Compliance-friendly. Dropped the now-redundant "Privacy-sensitive" badge and moved the specific enterprise features (SAML SSO, Audit logging) off the hero row.
- Homepage `<title>` and meta description overridden to match the new positioning (homepage only; other pages keep the site-wide defaults).

## Why

The hero and homepage meta now lead with the audience and the self-hosted/privacy promise instead of a generic product description.

## Deploy

Landing-only change. Merging to main triggers `deploy-landing.yml`, which rebuilds and deploys to Cloudflare Pages prod.

https://claude.ai/code/session_01EhgRGhvhNGJVQHcdFdcNMa