### PR TITLE
docs(readme): drop Otter.ai from the alternatives list

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <p align="center">
   <strong>Self-hosted file toolkit. 200+ tools across image, video, audio, PDF, and files.</strong><br />
-  The open-source alternative to Smallpdf, iLovePDF, TinyPNG, TinyWow, CloudConvert, and Otter.ai, in one stack you host yourself.
+  The open-source alternative to Smallpdf, iLovePDF, TinyPNG, TinyWow, and CloudConvert, in one stack you host yourself.
 </p>
 
 ![SnapOtter - Dashboard](branding/dashboard.gif)


### PR DESCRIPTION
Removes Otter.ai from the README "open-source alternative to ..." line. It's a transcription-only service and reads as off-topic next to the file-conversion tools; the list conjunction is fixed to keep it grammatical.

Docs-only change, no deploy impact.

https://claude.ai/code/session_01EhgRGhvhNGJVQHcdFdcNMa