### PR TITLE
fix: offline CodeFormer face-enhance (ship RealESRGAN_x2plus in upscale-enhance bundle)

### DIFF
--- a/docker/feature-manifest.json
+++ b/docker/feature-manifest.json
@@ -235,6 +235,12 @@
           "minSize": 60000000
         },
         {
+          "id": "realesrgan-x2plus",
+          "url": "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.1/RealESRGAN_x2plus.pth",
+          "path": "realesrgan/RealESRGAN_x2plus.pth",
+          "minSize": 60000000
+        },
+        {
           "id": "gfpgan-v1.3",
           "url": "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.3.pth",
           "path": "gfpgan/GFPGANv1.3.pth",

--- a/docker/feature-manifest.json
+++ b/docker/feature-manifest.json
@@ -194,15 +194,15 @@
       "archives": {
         "amd64-gpu": {
           "file": "v2.0.0/upscale-enhance-amd64-gpu.tar.gz",
-          "sha256": "37f0e7a62dcb83b2dc0760532fb41ac9d1c40d336abe1aea01d889ad039ebc65",
-          "compressedSize": 5314188723,
-          "extractedSize": 8412712960
+          "sha256": "089fdecbcd36090013ed4adf3a96650c757ce06871c2e1f1b155ccdd8487e413",
+          "compressedSize": 5376987856,
+          "extractedSize": 8455327174
         },
         "arm64-cpu": {
           "file": "v2.0.0/upscale-enhance-arm64-cpu.tar.gz",
-          "sha256": "de65321f1cc5d5664c63e38e49cd39c36fe88e0569d666821e982ff6d6999bea",
-          "compressedSize": 2262502457,
-          "extractedSize": 0
+          "sha256": "b9e948c8308371ccb3defce4323a85884e46d5bde52791115d34d1c1f92e4f23",
+          "compressedSize": 2335658971,
+          "extractedSize": 3661453942
         }
       },
       "packages": {

--- a/packages/ai/python/offline_guard.py
+++ b/packages/ai/python/offline_guard.py
@@ -82,11 +82,11 @@ def prepare_codeformer_weights(models_base):
     """Resolve codeformer-pip's cwd-relative weights offline.
 
     codeformer-pip 0.0.4 downloads four weights into a cwd-relative
-    CodeFormer/weights/ tree at import time of codeformer.app. Three of them
-    ship in the feature bundles and are linked here so they never re-download;
-    RealESRGAN_x2plus.pth (a background-upscale helper this app never invokes)
-    is not bundled, so it downloads once on first use unless strict offline
-    mode blocks it.
+    CodeFormer/weights/ tree at import time of codeformer.app -- unconditionally,
+    even though this app calls inference_app with background_enhance=False and so
+    never uses the RealESRGAN background upsampler (RealESRGAN_x2plus.pth). All
+    four ship in the upscale-enhance bundle and are linked here from models_base
+    so the import never triggers a download; strict offline mode then works.
     """
     expected = {
         os.path.join("CodeFormer", "weights", "CodeFormer", "codeformer.pth"): os.path.join(
@@ -98,11 +98,10 @@ def prepare_codeformer_weights(models_base):
         os.path.join("CodeFormer", "weights", "facelib", "parsing_parsenet.pth"): os.path.join(
             models_base, "gfpgan", "facelib", "parsing_parsenet.pth"
         ),
+        os.path.join("CodeFormer", "weights", "realesrgan", "RealESRGAN_x2plus.pth"): os.path.join(
+            models_base, "realesrgan", "RealESRGAN_x2plus.pth"
+        ),
     }
     for link, target in expected.items():
         if not link_bundled_weight(link, target):
             ensure_download_allowed(f"CodeFormer weight {os.path.basename(link)}")
-
-    x2plus = os.path.join("CodeFormer", "weights", "realesrgan", "RealESRGAN_x2plus.pth")
-    if not os.path.exists(x2plus):
-        ensure_download_allowed("CodeFormer helper weight RealESRGAN_x2plus.pth")

--- a/packages/shared/src/features.ts
+++ b/packages/shared/src/features.ts
@@ -112,6 +112,11 @@ export function getToolsForBundle(bundleId: string): string[] {
  */
 export const TOOL_EXTRA_BUNDLES: Record<string, string[]> = {
   "passport-photo": ["face-detection"],
+  // enhance-faces runs MediaPipe face detection (blaze_face) before CodeFormer/
+  // GFPGAN; that model ships in face-detection, not its primary upscale-enhance
+  // bundle, so require both or it fails on a standalone install (offline: hard
+  // error; online: a surprise download).
+  "enhance-faces": ["face-detection"],
 };
 
 /**


### PR DESCRIPTION
## What was broken

Explicit CodeFormer face-enhance (`enhance-faces` with `model=codeformer`, and `model=auto` which tries CodeFormer first) failed in **strict offline mode** (`SNAPOTTER_ALLOW_MODEL_DOWNLOAD=0`) on a host that had never cached the weights. `codeformer-pip 0.0.4` downloads `RealESRGAN_x2plus.pth` at *import* of `codeformer.app`, unconditionally, even though this app calls `inference_app(background_enhance=False, ...)` and never uses the background upsampler. That weight was not in any bundle, so the import blocked on the offline guard. (Default mode worked by downloading it once; `model=auto` fell back to GFPGAN, which is why it wasn't caught earlier.)

A second, related gap surfaced during verification: `enhance-faces` runs MediaPipe face detection (`blaze_face_short_range.tflite`) *before* CodeFormer, and that model ships in the **face-detection** bundle, not its primary **upscale-enhance** bundle. So a standalone upscale-enhance install failed face detection first.

## Fix

- **Ship `RealESRGAN_x2plus.pth` in the upscale-enhance bundle** (only that bundle uses codeformer-pip; photo-restoration uses the CodeFormer ONNX path). Added to the manifest models list; `offline_guard.prepare_codeformer_weights` now links all four CodeFormer weights from the bundle instead of guarding x2plus. Both archives (amd64-gpu + arm64-cpu) rebuilt with the weight baked in; manifest SHA256/sizes updated.
- **Declare the face-detection dependency** for `enhance-faces` in `TOOL_EXTRA_BUNDLES` (like `passport-photo`), so the UI requires both bundles and `blaze_face` is present.

## Verification (live, RTX 4070 + local arm64)

- amd64-gpu archive built and **offline-imported into a strict-offline container**: `enhance-faces model=codeformer` completed with an enhanced image and **zero downloads** (offline_guard symlinked the bundled weight into codeformer's cwd tree); `model=auto` no regression. x2plus confirmed inside the tar and at `/data/ai/models/realesrgan/`.
- arm64-cpu archive rebuilt (gzip-verified intact, x2plus present).
- `features` unit-test assertions (primary-first, no-dupes, valid-extras) all hold for the new `enhance-faces` entry.

## Delivery

Archives re-uploaded to `deepsafe/feature-bundles/v2.0.0/` (both arches). This interim publish is done out-of-band because the 2.0 release (and its automatic bundle rebuild) is on hold; the CI `ai-bundles` workflow will rebuild these with x2plus at release time.

https://claude.ai/code/session_01XGB4pGvTvb7sUX4JN745U7