### PR TITLE
fix(files): record the source tool in toolChain on Save to Files

### DIFF
--- a/apps/api/src/routes/user-files.ts
+++ b/apps/api/src/routes/user-files.ts
@@ -254,7 +254,16 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
 
       const parts = request.parts();
 
+      // Optional "toolId" field records the tool that produced these files so the
+      // library shows it under "Tools Used". Sent before the file part(s).
+      let sourceToolId: string | null = null;
+
       for await (const part of parts) {
+        if (part.type === "field" && part.fieldname === "toolId") {
+          const value = typeof part.value === "string" ? part.value : "";
+          if (/^[a-z0-9-]{1,40}$/.test(value)) sourceToolId = value;
+          continue;
+        }
         if (part.type !== "file") continue;
 
         // Consume the stream into a buffer
@@ -304,7 +313,7 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
             height: isValidImage ? validation.height : null,
             version: 1,
             parentId: null,
-            toolChain: null,
+            toolChain: sourceToolId ? [sourceToolId] : null,
           });
         } catch {
           return reply.status(409).send({ error: "Failed to save file record" });

--- a/apps/web/src/components/common/review-panel.tsx
+++ b/apps/web/src/components/common/review-panel.tsx
@@ -88,6 +88,9 @@ export function ReviewPanel({
       const res = await fetch(downloadUrl);
       const blob = await res.blob();
       const formData = new FormData();
+      // Record which tool produced this file so the library shows it under
+      // "Tools Used" (append before the file so the field is parsed first).
+      if (currentToolId) formData.append("toolId", currentToolId);
       formData.append("file", new File([blob], filename, { type: fileType }));
       const uploadRes = await fetch("/api/v1/files/upload", {
         method: "POST",
@@ -100,7 +103,7 @@ export function ReviewPanel({
       setSaveStatus("error");
       setTimeout(() => setSaveStatus("idle"), 3000);
     }
-  }, [downloadUrl, filename, fileType]);
+  }, [downloadUrl, filename, fileType, currentToolId]);
 
   const hasBatchStats =
     totalCount != null && totalCount > 1 && successCount != null && failedCount != null;


### PR DESCRIPTION
Minor polish surfaced during the v2.0.0 final QA pass.

Saving a single-tool result to the library via "Save to Files" posted only the blob to `/api/v1/files/upload`, so `userFiles.toolChain` stayed null and the library showed **"Tools Used: None"** for a file the tool had just produced. The pipeline/editor save path already records the chain; only the direct library upload hardcoded null.

This threads the producing `toolId` (already available in `ReviewPanel` as `currentToolId`) through the upload as a validated optional field and stores it as a one-element `toolChain`.

- **Frontend**: append `toolId` before the file part so it parses first.
- **API**: capture the `toolId` field (validated `^[a-z0-9-]{1,40}$`), set `toolChain: [toolId]`.

Cosmetic, isolated, no change to processing. typecheck + biome clean. Safe to include in 2.0.0 or ship as 2.0.1 — the v2.0.0 RC (cf884b52) is otherwise a clean GO (zero product bugs across four machines).

https://claude.ai/code/session_01UvVCMNUBrgpghk8gye5gav