### PR TITLE
fix(ai-bundles): lock the numpy-1.x ABI closure so the OCR bundle can't strand scipy

### DIFF
--- a/docker/build-bundle.sh
+++ b/docker/build-bundle.sh
@@ -65,6 +65,32 @@ if '${BUNDLE_ID}' not in m['bundles']:
     sys.exit(1)
 "
 
+# ── Step 0: Write pip constraints (numpy-1.x-ABI closure lock) ────────────
+# Bundle installs below can otherwise pull the latest transitive scientific
+# stack: numpy 2.x plus scipy/scikit-learn/scikit-image/pandas wheels built
+# against the numpy 2.x ABI (e.g. paddleocr[doc-parser] drags numpy 1.26.4 ->
+# 2.5.1 + scipy 1.18). The Step 4 re-pin snaps numpy back to 1.26.4 but leaves
+# those numpy-2.x wheels behind; the Step 6 diff (by dir name, not version)
+# then ships them, and once installed they strand on the numpy==1.26.4 base and
+# raise "numpy.dtype size changed" on import, crashing the dispatcher for
+# EVERY AI tool (e.g. rembg's scipy), not just this bundle. Applying the
+# manifest's constraints to every pip install keeps the whole closure on
+# numpy-1.x-ABI versions so no bundle can strand a numpy-2.x wheel.
+CONSTRAINTS_FILE="/tmp/bundle-constraints.txt"
+python3 -c "
+import json
+with open('${MANIFEST}') as f:
+    m = json.load(f)
+with open('${CONSTRAINTS_FILE}', 'w') as f:
+    f.write('\n'.join(m.get('constraints', [])) + '\n')
+"
+if [[ -s "${CONSTRAINTS_FILE}" ]] && [[ -n "$(tr -d '[:space:]' < "${CONSTRAINTS_FILE}")" ]]; then
+  export PIP_CONSTRAINT="${CONSTRAINTS_FILE}"
+  echo "  Build constraints: $(tr '\n' ' ' < "${CONSTRAINTS_FILE}")"
+else
+  echo "  No build constraints in manifest"
+fi
+
 # Clean previous build artifacts
 rm -rf "${MODELS_DIR}" "${BUILD_DIR}"
 mkdir -p "${MODELS_DIR}" "${BUILD_DIR}/site-packages" "${BUILD_DIR}/models" "${OUTPUT_DIR}"

--- a/docker/feature-manifest.json
+++ b/docker/feature-manifest.json
@@ -3,6 +3,13 @@
   "imageVersion": "2.0.0",
   "pythonVersion": { "amd64": "3.12", "arm64": "3.11" },
   "basePackages": ["numpy==1.26.4", "Pillow==12.2.0", "opencv-python-headless==4.10.0.84"],
+  "constraints": [
+    "numpy==1.26.4",
+    "scipy==1.12.0",
+    "scikit-learn==1.4.2",
+    "scikit-image==0.24.0",
+    "pandas==2.2.2"
+  ],
   "bundleRepo": "deepsafe/feature-bundles",
   "bundles": {
     "background-removal": {

--- a/docker/feature-manifest.json
+++ b/docker/feature-manifest.json
@@ -415,15 +415,15 @@
       "archives": {
         "amd64-gpu": {
           "file": "v2.0.0/ocr-amd64-gpu.tar.gz",
-          "sha256": "80db475eb442899cedad3590b18f080225deaf50985224b302475fbfdf5883f6",
-          "compressedSize": 5927587552,
-          "extractedSize": 9367838720
+          "sha256": "2a00a3184f6a635f1fa9ae2a6517ad740a11f9e5ff58c098d2fd369a2bb1e16b",
+          "compressedSize": 5933794814,
+          "extractedSize": 9343914078
         },
         "arm64-cpu": {
           "file": "v2.0.0/ocr-arm64-cpu.tar.gz",
-          "sha256": "569ca2ddad50529c4887da494ca1704bbe719ddc0253a5eb76002a2d87812c60",
-          "compressedSize": 1974010780,
-          "extractedSize": 3092260263
+          "sha256": "6868c264069dcb74c6675c0b1f58dc1c9f60d9aa4459725e3dbde07a99a6a09a",
+          "compressedSize": 1984611355,
+          "extractedSize": 3103671712
         }
       },
       "packages": {

--- a/docker/verify-bundle.sh
+++ b/docker/verify-bundle.sh
@@ -171,7 +171,11 @@ case "${BUNDLE_ID}" in
     check_imports "torch onnxruntime mediapipe"
     ;;
   ocr)
-    check_imports "paddleocr paddle"
+    # scipy/scikit-learn ship inside this bundle via paddleocr's dependency
+    # closure. Importing them here (not just paddleocr) catches a numpy-2.x-ABI
+    # strand on the numpy==1.26.4 base; the "numpy.dtype size changed" class
+    # that a paddleocr-only import misses because paddle lazy-loads them.
+    check_imports "paddleocr paddle scipy sklearn"
     ;;
   transcription)
     check_imports "faster_whisper"

--- a/tests/unit/features/feature-manifest.test.ts
+++ b/tests/unit/features/feature-manifest.test.ts
@@ -70,6 +70,42 @@ describe("Feature manifest structure", () => {
   });
 });
 
+describe("Feature manifest: numpy-2.x-ABI closure lock (regression for OCR bundle strand)", () => {
+  // paddleocr[doc-parser] (OCR bundle) drags numpy 1.26.4 -> 2.5.1 and pulls
+  // scipy/scikit-learn/pandas wheels built against the numpy 2.x ABI. Re-pinning
+  // numpy alone leaves those stranded on the numpy==1.26.4 base, which the bundle
+  // diff ships, breaking rembg's scipy import (a dispatcher-wide AI outage) after
+  // a last-writer-wins merge. build-bundle.sh applies `constraints` to every pip
+  // install to keep the whole closure on numpy-1.x-ABI versions.
+  const constraints = (manifest.constraints ?? []) as string[];
+
+  it("manifest declares a non-empty constraints array", () => {
+    expect(manifest.constraints).toBeInstanceOf(Array);
+    expect(constraints.length).toBeGreaterThan(0);
+  });
+
+  it("constraints pin every numpy-2.x-closure package to an exact version", () => {
+    const pinned = new Map<string, string>();
+    for (const c of constraints) {
+      const m = c.match(/^([A-Za-z0-9_.-]+)==(.+)$/);
+      expect(m, `constraint "${c}" must be an exact ==pin`).not.toBeNull();
+      if (m) pinned.set(m[1].toLowerCase(), m[2]);
+    }
+    for (const pkg of ["numpy", "scipy", "scikit-learn", "scikit-image", "pandas"]) {
+      expect(pinned.has(pkg), `constraints must pin ${pkg} to a numpy-1.x-ABI version`).toBe(true);
+    }
+  });
+
+  it("constraints numpy matches basePackages numpy (single source of truth)", () => {
+    const cNumpy = constraints.find((c) => c.toLowerCase().startsWith("numpy=="));
+    const bNumpy = (manifest.basePackages as string[]).find((c) =>
+      c.toLowerCase().startsWith("numpy=="),
+    );
+    expect(cNumpy).toBeDefined();
+    expect(cNumpy).toBe(bNumpy);
+  });
+});
+
 describe("Feature manifest: mediapipe dependency (regression for #129)", () => {
   it("upscale-enhance bundle includes mediapipe for amd64", () => {
     expect(archPackagesInclude("upscale-enhance", "amd64", "mediapipe")).toBe(true);


### PR DESCRIPTION
## The bug

The OCR bundle installs `paddleocr[doc-parser]>=3.4.0,<3.5.0`. Its dependency
closure drags **numpy 1.26.4 up to 2.5.1** and pulls **scipy / scikit-learn /
pandas wheels built against the numpy 2.x ABI**.

`build-bundle.sh` re-pins only `basePackages` (numpy, Pillow, opencv) after
installing a bundle's packages, so those numpy-2.x wheels stay behind. The Step 6
site-packages diff is by top-level dir name (not version), so it ships them. Once
`install_feature.py` merges the bundle onto the numpy==1.26.4 base (last writer
wins on overlapping files), importing scipy raises `numpy.dtype size changed`.

The dispatcher pre-imports every ML library at startup and disables **all** AI
after 5 crashes in 60s, so one stranded scipy takes down every AI tool, not just
OCR. Observed on a CPU-only host during the 2.0 hardware sweep: remove-background
worked before the OCR bundle and broke after it. All-7 installs escaped it by
last-writer-wins ordering; a subset install did not, which is why it surfaced only
intermittently.

## The fix

- **`docker/feature-manifest.json`**: new top-level `constraints` list pinning the
  numpy-2.x closure (numpy 1.26.4, scipy 1.12.0, scikit-learn 1.4.2, scikit-image
  0.24.0, pandas 2.2.2) to numpy-1.x-ABI versions.
- **`docker/build-bundle.sh`**: writes those constraints to a file and exports
  `PIP_CONSTRAINT`, so **every** bundle pip install is capped and no bundle can
  pull a numpy-2.x wheel.
- **`docker/verify-bundle.sh`**: the OCR check now imports `scipy sklearn`, so CI
  catches this ABI class in isolation (it previously imported only `paddleocr`).
- **`tests/unit/features/feature-manifest.test.ts`**: regression test for the
  constraints.

## Validation

- Reproduced: unconstrained `pip install paddleocr[doc-parser]` bumps numpy
  1.26.4 -> 2.5.1 and pulls scipy 1.18.0 (numpy-2.x).
- Fix proven: with `PIP_CONSTRAINT` set, paddleocr 3.4.1 resolves, numpy stays
  1.26.4, and scipy 1.12.0 / scikit-learn 1.4.2 / pandas 2.2.2 are selected; all
  import cleanly on numpy 1.26.4 (no `dtype size changed`).

## Stopgap republish (done)

The OCR bundle was rebuilt for both arches with these constraints and republished
to `deepsafe/feature-bundles/v2.0.0`, and the baked manifest sha256/sizes were
updated to match (second commit). Verified by content: both tars ship scipy
1.12.0 / scikit-learn 1.4.2 / pandas 2.2.2, zero numpy-2.x.

  amd64-gpu  5.93 GB  sha 2a00a318...
  arm64-cpu  1.98 GB  sha 6868c264...

These were built against the `ghcr.io latest` base (the 2.0.0 image is not on
GHCR), so they are a functional stopgap, not byte-identical to a CI build. **When
`ai-bundles.yml` rebuilds at the 2.0.0 release, it mints fresh shas and this
manifest must be re-synced to them** (the workflow does not commit the manifest).

https://claude.ai/code/session_01UvVCMNUBrgpghk8gye5gav
