### PR TITLE
chore(deps): pin nvidia/cuda base to 12.6.x (block dependabot 12.9 bumps)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,14 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # nvidia/cuda base is pinned to 12.6.x on purpose. The AI bundle wheels are
+      # cu126 (torch/paddle/onnxruntime-gpu), libcublas-12-6 matches it, and a 12.9
+      # base requires driver R575+ so the container fails to start on common 570.x
+      # production drivers. See the comment above the FROM in docker/Dockerfile.
+      # Allow 12.6.x patch bumps; block 12.7+ until the wheels and driver baseline
+      # move together (closed dependabot #441 for this reason).
+      - dependency-name: "nvidia/cuda"
+        versions: [">= 12.7"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Why

Dependabot opened #441 to bump the CUDA base image `nvidia/cuda` from `12.6.3` to `12.9.2`. That is a **minor** bump, so the docker ecosystem's existing `version-update:semver-major` ignore did not catch it.

The `12.6` pin is deliberate (see the comment above the `FROM` in `docker/Dockerfile`):

- The AI bundle wheels are **cu126** (torch, paddle, onnxruntime-gpu).
- `libcublas-12-6` is apt-installed to match.
- A `12.9` base sets `NVIDIA_REQUIRE_CUDA` to require driver **R575+**, so the container **fails to start** on common `570.x` production drivers (verified: the RTX 4070 test box runs `570.133.07`).

This is the exact regression PR #334 fixed by moving `12.9 -> 12.6`.

## Change

Add a targeted ignore so dependabot stops re-proposing `12.7+` while still allowing `12.6.x` patch bumps:

```yaml
- dependency-name: "nvidia/cuda"
  versions: [">= 12.7"]
```

Closing #441 alongside this. When the wheels and driver baseline intentionally move together, remove this ignore.
