### PR TITLE
test(landing): fix stale homepage e2e assertions to match current hero copy

### DIFF
--- a/tests/e2e-landing/homepage.spec.ts
+++ b/tests/e2e-landing/homepage.spec.ts
@@ -7,13 +7,13 @@ test.describe("Landing Homepage", () => {
 
   test("page loads with self-hosted title", async ({ page }) => {
     await expect(page).toHaveTitle(
-      /SnapOtter \| Self-Hosted File Processing \(Image, Video, Audio, PDF, Files\)/,
+      /SnapOtter \| Self-Hosted File Processing for Privacy-Sensitive Teams/,
     );
   });
 
   test("navbar renders brand and navigation links", async ({ page }) => {
     await expect(page.getByText("SnapOtter").first()).toBeVisible();
-    for (const name of ["Features", "Enterprise", "Pricing", "Docs", "Contact"]) {
+    for (const name of ["Features", "Enterprise", "Pricing", "Docs", "Talk to a human"]) {
       await expect(page.getByRole("link", { name }).first()).toBeVisible();
     }
   });
@@ -22,17 +22,18 @@ test.describe("Landing Homepage", () => {
     await expect(page.getByRole("link", { name: "Book a Demo" }).first()).toBeVisible();
   });
 
-  test("hero renders the rotating headline and privacy promise", async ({ page }) => {
-    await expect(page.locator("h1")).toContainText("tool you need.");
-    await expect(page.locator("h1")).toContainText("Your files never leave your network.");
+  test("hero renders the headline", async ({ page }) => {
+    await expect(page.locator("h1")).toContainText("File processing for privacy-sensitive teams.");
   });
 
-  test("hero renders the enterprise subtitle", async ({ page }) => {
-    await expect(page.getByText("for teams that keep sensitive data in-house")).toBeVisible();
+  test("hero renders the subtitle", async ({ page }) => {
+    await expect(
+      page.getByText("Run image, video, audio, PDF, and file tools with local AI"),
+    ).toBeVisible();
   });
 
-  test("hero renders enterprise trust badges", async ({ page }) => {
-    for (const badge of ["On-premise", "Privacy-first", "Air-gap ready", "Audit logging"]) {
+  test("hero renders trust badges", async ({ page }) => {
+    for (const badge of ["Self-hosted", "Open source", "Air-gap capable", "Compliance-friendly"]) {
       await expect(page.getByText(badge, { exact: true }).first()).toBeVisible();
     }
   });


### PR DESCRIPTION
## What

The `tests/e2e-landing/homepage.spec.ts` hero assertions referenced pre-redesign copy and were failing against the current landing. Updated all of them to the live copy:

- **Page title** — was `… (Image, Video, Audio, PDF, Files)`, now `… for Privacy-Sensitive Teams`.
- **Headline** — was "tool you need." / "Your files never leave your network.", now "File processing for privacy-sensitive teams."
- **Subtitle** — was "for teams that keep sensitive data in-house", now the current "Run image, video, audio, PDF, and file tools with local AI, …" line.
- **Trust badges** — were On-premise / Privacy-first / Air-gap ready / Audit logging, now Self-hosted / Open source / Air-gap capable / Compliance-friendly.
- **Navbar link** — the contact entry is labeled "Talk to a human", not "Contact".

Also renamed the three hero test titles that described the old design ("rotating headline", "enterprise subtitle", "enterprise trust badges").

## Verification

`playwright test --config playwright.landing.config.ts tests/e2e-landing/homepage.spec.ts` → **18/18 passing** (was 13/18, with these 5 failing).

## Notes

- Test-only change; no product code touched.
- The landing e2e suite runs nightly rather than on PRs, so these assertions had gone stale silently after the hero redesign.
