### PR TITLE
fix(landing): clarify OIDC is free, SAML is enterprise on pricing

### DIFF
--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -45,6 +45,7 @@ const checkIcon =
           "Pipeline automation & batch processing",
           "19 local AI tools",
           "Multi-user with role-based access",
+          "OIDC / SSO login (Google, Okta, any provider)",
           "21 languages",
           "Docker, Kubernetes, bare metal",
           "ARM and x86, air-gapped ready",
@@ -86,7 +87,7 @@ const checkIcon =
           {[
             "Everything in Open Source",
             "Commercial license (no AGPL)",
-            "SAML SSO + OIDC integration",
+            "SAML SSO + SSO enforcement",
             "SCIM provisioning",
             "Multi-factor authentication",
             "Multi-tenancy",


### PR DESCRIPTION
## What

The pricing page listed **"SAML SSO + OIDC integration"** under the Enterprise tier, and the Open Source column didn't mention OIDC at all. This read as if OIDC login were paywalled. A self-hoster flagged it in Discord.

OIDC login is part of the free open-source build: set `OIDC_ENABLED=true` plus issuer/client env vars and the SSO button appears (`apps/api/src/plugins/oidc.ts`, gated only by env, no license check). Only SAML and SSO enforcement are enterprise-licensed.

## Changes

- Add `OIDC / SSO login (Google, Okta, any provider)` to the Open Source tier.
- Narrow the Enterprise bullet from `SAML SSO + OIDC integration` to `SAML SSO + SSO enforcement`.

Landing-only copy change. Builds clean (`pnpm --filter @snapotter/landing build`, 267 pages). Auto-deploys to snapotter.com on merge.