### PR TITLE
fix(demo): point banner "Self-host SnapOtter" link at the docs guide

### DIFF
--- a/apps/demo/src/demo-banner.tsx
+++ b/apps/demo/src/demo-banner.tsx
@@ -11,7 +11,7 @@ export function DemoBanner() {
         This is a live demo. All users, teams, and activity shown are sample data, and file
         processing is disabled.{" "}
         <a
-          href="https://github.com/snapotter-hq/SnapOtter"
+          href="https://docs.snapotter.com/guide/getting-started"
           target="_blank"
           rel="noopener noreferrer"
           className="font-semibold underline underline-offset-2 hover:text-primary-subtle"

--- a/tests/e2e-demo/demo-preview.spec.ts
+++ b/tests/e2e-demo/demo-preview.spec.ts
@@ -18,6 +18,14 @@ test("demo boots straight into the dashboard with no login screen", async ({ pag
   await expect(page.getByText(/live demo/i).first()).toBeVisible();
   await expect(page.getByText(/sample data/i).first()).toBeVisible();
 
+  // "Self-host SnapOtter" points at the getting-started guide, opening a new tab.
+  const selfHostLink = page.getByRole("link", { name: "Self-host SnapOtter" });
+  await expect(selfHostLink).toHaveAttribute(
+    "href",
+    "https://docs.snapotter.com/guide/getting-started",
+  );
+  await expect(selfHostLink).toHaveAttribute("target", "_blank");
+
   const theme = await page.evaluate(() => {
     const bannerLink = Array.from(document.querySelectorAll("a")).find((link) =>
       link.textContent?.includes("Self-host SnapOtter"),


### PR DESCRIPTION
The demo banner's "Self-host SnapOtter" link now opens the getting-started guide (`https://docs.snapotter.com/guide/getting-started`) in a new tab instead of the GitHub repo, which is a friendlier entry point for someone who wants to self-host.

Note: the requested `getting-started.html` 308-redirects to this clean URL, so I linked directly to the 200 destination to avoid the redirect hop.

Verified locally: biome, build, and 4 e2e tests (the banner test now asserts the link href + target=_blank). Auto-deploys to demo.snapotter.com on merge.