### PR TITLE
fix: reword sponsor button to "Support us"

### DIFF
--- a/packages/shared/src/i18n/ar.ts
+++ b/packages/shared/src/i18n/ar.ts
@@ -3841,7 +3841,7 @@ export const ar: TranslationKeys = {
     connectionError: "خطأ في الاتصال",
   },
   sidebar: {
-    sponsor: "أبقِه مجانيًا",
+    sponsor: "ادعمنا",
     tools: "الأدوات",
     grid: "شبكة",
     automate: "أتمتة",

--- a/packages/shared/src/i18n/de.ts
+++ b/packages/shared/src/i18n/de.ts
@@ -3891,7 +3891,7 @@ export const de: TranslationKeys = {
     connectionError: "Verbindungsfehler",
   },
   sidebar: {
-    sponsor: "Kostenlos halten",
+    sponsor: "Uns unterstützen",
     tools: "Werkzeuge",
     grid: "Raster",
     automate: "Automatisieren",

--- a/packages/shared/src/i18n/en.ts
+++ b/packages/shared/src/i18n/en.ts
@@ -3817,7 +3817,7 @@ export const en = {
     automate: "Automate",
     editor: "Editor",
     files: "Files",
-    sponsor: "Keep it free",
+    sponsor: "Support us",
     help: "Help",
     settings: "Settings",
   },

--- a/packages/shared/src/i18n/es.ts
+++ b/packages/shared/src/i18n/es.ts
@@ -3868,7 +3868,7 @@ export const es: TranslationKeys = {
     connectionError: "Error de conexión",
   },
   sidebar: {
-    sponsor: "Mantenlo gratis",
+    sponsor: "Apóyanos",
     tools: "Herramientas",
     grid: "Cuadrícula",
     automate: "Automatizar",

--- a/packages/shared/src/i18n/fr.ts
+++ b/packages/shared/src/i18n/fr.ts
@@ -3893,7 +3893,7 @@ export const fr: TranslationKeys = {
     connectionError: "Erreur de connexion",
   },
   sidebar: {
-    sponsor: "Gardons-le gratuit",
+    sponsor: "Soutenez-nous",
     tools: "Outils",
     grid: "Grille",
     automate: "Automatiser",

--- a/packages/shared/src/i18n/hi.ts
+++ b/packages/shared/src/i18n/hi.ts
@@ -3671,7 +3671,7 @@ export const hi: TranslationKeys = {
     connectionError: "कनेक्शन त्रुटि",
   },
   sidebar: {
-    sponsor: "इसे मुफ़्त रखें",
+    sponsor: "हमारा समर्थन करें",
     tools: "टूल्स",
     grid: "ग्रिड",
     automate: "ऑटोमेट",

--- a/packages/shared/src/i18n/id.ts
+++ b/packages/shared/src/i18n/id.ts
@@ -3868,7 +3868,7 @@ export const id: TranslationKeys = {
     connectionError: "Kesalahan koneksi",
   },
   sidebar: {
-    sponsor: "Jaga tetap gratis",
+    sponsor: "Dukung kami",
     tools: "Alat",
     grid: "Kisi",
     automate: "Otomasi",

--- a/packages/shared/src/i18n/it.ts
+++ b/packages/shared/src/i18n/it.ts
@@ -3881,7 +3881,7 @@ export const it: TranslationKeys = {
     connectionError: "Errore di connessione",
   },
   sidebar: {
-    sponsor: "Mantienilo gratuito",
+    sponsor: "Sostienici",
     tools: "Strumenti",
     grid: "Griglia",
     automate: "Automatizza",

--- a/packages/shared/src/i18n/ja.ts
+++ b/packages/shared/src/i18n/ja.ts
@@ -3820,7 +3820,7 @@ export const ja: TranslationKeys = {
     connectionError: "接続エラー",
   },
   sidebar: {
-    sponsor: "無料を守る",
+    sponsor: "支援する",
     tools: "ツール",
     grid: "グリッド",
     automate: "自動化",

--- a/packages/shared/src/i18n/ko.ts
+++ b/packages/shared/src/i18n/ko.ts
@@ -3800,7 +3800,7 @@ export const ko: TranslationKeys = {
     connectionError: "연결 오류",
   },
   sidebar: {
-    sponsor: "무료로 유지하기",
+    sponsor: "후원하기",
     tools: "도구",
     grid: "그리드",
     automate: "자동화",

--- a/packages/shared/src/i18n/nl.ts
+++ b/packages/shared/src/i18n/nl.ts
@@ -3877,7 +3877,7 @@ export const nl: TranslationKeys = {
     connectionError: "Verbindingsfout",
   },
   sidebar: {
-    sponsor: "Houd het gratis",
+    sponsor: "Steun ons",
     tools: "Tools",
     grid: "Raster",
     automate: "Automatiseren",

--- a/packages/shared/src/i18n/pl.ts
+++ b/packages/shared/src/i18n/pl.ts
@@ -3882,7 +3882,7 @@ export const pl: TranslationKeys = {
     connectionError: "Błąd połączenia",
   },
   sidebar: {
-    sponsor: "Zachowaj darmowość",
+    sponsor: "Wesprzyj nas",
     tools: "Narzędzia",
     grid: "Siatka",
     automate: "Automatyzacja",

--- a/packages/shared/src/i18n/pt-BR.ts
+++ b/packages/shared/src/i18n/pt-BR.ts
@@ -3875,7 +3875,7 @@ export const ptBR: TranslationKeys = {
     connectionError: "Erro de conexão",
   },
   sidebar: {
-    sponsor: "Mantenha gratuito",
+    sponsor: "Apoie-nos",
     tools: "Ferramentas",
     grid: "Grade",
     automate: "Automatizar",

--- a/packages/shared/src/i18n/ru.ts
+++ b/packages/shared/src/i18n/ru.ts
@@ -3871,7 +3871,7 @@ export const ru: TranslationKeys = {
     connectionError: "Ошибка подключения",
   },
   sidebar: {
-    sponsor: "Пусть будет бесплатным",
+    sponsor: "Поддержите нас",
     tools: "Инструменты",
     grid: "Сетка",
     automate: "Автоматизация",

--- a/packages/shared/src/i18n/sv.ts
+++ b/packages/shared/src/i18n/sv.ts
@@ -3864,7 +3864,7 @@ export const sv: TranslationKeys = {
     connectionError: "Anslutningsfel",
   },
   sidebar: {
-    sponsor: "Håll det gratis",
+    sponsor: "Stöd oss",
     tools: "Verktyg",
     grid: "Rutnät",
     automate: "Automatisera",

--- a/packages/shared/src/i18n/th.ts
+++ b/packages/shared/src/i18n/th.ts
@@ -3821,7 +3821,7 @@ export const th: TranslationKeys = {
     connectionError: "ข้อผิดพลาดในการเชื่อมต่อ",
   },
   sidebar: {
-    sponsor: "ให้ใช้ฟรีต่อไป",
+    sponsor: "สนับสนุนเรา",
     tools: "เครื่องมือ",
     grid: "กริด",
     automate: "อัตโนมัติ",

--- a/packages/shared/src/i18n/tr.ts
+++ b/packages/shared/src/i18n/tr.ts
@@ -3875,7 +3875,7 @@ export const tr: TranslationKeys = {
     connectionError: "Bağlantı hatası",
   },
   sidebar: {
-    sponsor: "Ücretsiz kalsın",
+    sponsor: "Bize destek olun",
     tools: "Araçlar",
     grid: "Izgara",
     automate: "Otomatikleştir",

--- a/packages/shared/src/i18n/uk.ts
+++ b/packages/shared/src/i18n/uk.ts
@@ -3872,7 +3872,7 @@ export const uk: TranslationKeys = {
     connectionError: "Помилка з'єднання",
   },
   sidebar: {
-    sponsor: "Нехай буде безкоштовним",
+    sponsor: "Підтримайте нас",
     tools: "Інструменти",
     grid: "Сітка",
     automate: "Автоматизація",

--- a/packages/shared/src/i18n/vi.ts
+++ b/packages/shared/src/i18n/vi.ts
@@ -3865,7 +3865,7 @@ export const vi: TranslationKeys = {
     connectionError: "Lỗi kết nối",
   },
   sidebar: {
-    sponsor: "Giữ nó miễn phí",
+    sponsor: "Ủng hộ chúng tôi",
     tools: "Công cụ",
     grid: "Lưới",
     automate: "Tự động hóa",

--- a/packages/shared/src/i18n/zh-CN.ts
+++ b/packages/shared/src/i18n/zh-CN.ts
@@ -3603,7 +3603,7 @@ export const zhCN: TranslationKeys = {
     connectionError: "连接错误",
   },
   sidebar: {
-    sponsor: "保持免费",
+    sponsor: "支持我们",
     tools: "工具",
     grid: "网格",
     automate: "自动化",

--- a/packages/shared/src/i18n/zh-TW.ts
+++ b/packages/shared/src/i18n/zh-TW.ts
@@ -3604,7 +3604,7 @@ export const zhTW: TranslationKeys = {
     connectionError: "連線錯誤",
   },
   sidebar: {
-    sponsor: "保持免費",
+    sponsor: "支持我們",
     tools: "工具",
     grid: "格線",
     automate: "自動化",

--- a/tests/e2e/sponsor-button.spec.ts
+++ b/tests/e2e/sponsor-button.spec.ts
@@ -14,7 +14,7 @@ test.describe("Sponsor button", () => {
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("target", "_blank");
     await expect(link).toHaveAttribute("rel", "noopener noreferrer");
-    await expect(link).toContainText(/keep it free/i);
+    await expect(link).toContainText(/support us/i);
     await expect(link).toHaveClass(/bg-pink-50/);
     await expect(link).toHaveClass(/text-pink-700/);
     await expect(link).toHaveClass(/border-pink-200/);


### PR DESCRIPTION
## What

Rewords the top-nav sponsor button from "Keep it free" to "Support us" across all 21 locales, and updates the e2e assertion.

## Why

"Keep it free" carried three issues for this project:

- Ambiguous for a dual-licensed (AGPL + commercial) product: "free" reads as no-cost, open-source/libre, or "don't make me pay".
- Mild guilt framing that self-hosting developers tend to bristle at.
- Splits into gratis vs libre across the 20 non-English locales, easy to mistranslate.

"Support us" is honest and low-pressure, and it matches the existing aria-label ("Support SnapOtter on GitHub Sponsors"). The pink heart already carries the warmth.

## Scope

- `packages/shared/src/i18n/*.ts` (21 locales): `sidebar.sponsor`
- `tests/e2e/sponsor-button.spec.ts`: `/keep it free/i` to `/support us/i`

Button color and style are unchanged (the pink restyle from `37a3cfc8` stays). Translations are idiomatic best-effort; a native pass could refine register (notably the German infinitive, and ja/ko dropping the literal "us").
