### PR TITLE
fix(landing): green the landing e2e suite

### DIFF
--- a/apps/landing/src/components/LaunchBanner.astro
+++ b/apps/landing/src/components/LaunchBanner.astro
@@ -13,7 +13,7 @@ const RELEASE = "https://github.com/snapotter-hq/SnapOtter/releases/tag/v2.0.0";
       <span>&#9733; SnapOtter <b>2.0</b> is HERE &#9733; SnapOtter <b>2.0</b> is HERE &#9733; SnapOtter <b>2.0</b> is HERE &#9733; SnapOtter <b>2.0</b> is HERE &#9733; SnapOtter <b>2.0</b> is HERE &#9733;&nbsp;</span>
     </div>
   </div>
-  <a class="lb-btn" href={RELEASE} aria-label="See the SnapOtter 2.0 release notes">Click here!</a>
+  <a class="lb-btn" href={RELEASE} target="_blank" rel="noopener noreferrer" aria-label="See the SnapOtter 2.0 release notes">Click here!</a>
   <button class="lb-x" type="button" data-lb-close aria-label="Dismiss announcement">&#10005;</button>
 </aside>
 

--- a/tests/e2e-landing/accessibility.spec.ts
+++ b/tests/e2e-landing/accessibility.spec.ts
@@ -13,8 +13,8 @@ test.describe("Heading Hierarchy", () => {
   for (const { path, name } of pages) {
     test(`${name} page has exactly one h1`, async ({ page }) => {
       await page.goto(path);
-      const h1Count = await page.locator("h1").count();
-      expect(h1Count).toBe(1);
+      // toHaveCount auto-waits, so it doesn't race the dev server's on-demand render.
+      await expect(page.locator("h1")).toHaveCount(1);
     });
   }
 });

--- a/tests/e2e-landing/interactions.spec.ts
+++ b/tests/e2e-landing/interactions.spec.ts
@@ -47,6 +47,6 @@ test.describe("Mobile Navigation", () => {
     await expect(page.getByRole("link", { name: "Enterprise" }).last()).toBeVisible();
     await expect(page.getByRole("link", { name: "Pricing" }).last()).toBeVisible();
     await expect(page.getByRole("link", { name: "Docs" }).last()).toBeVisible();
-    await expect(page.getByRole("link", { name: "Contact" }).last()).toBeVisible();
+    await expect(page.getByRole("link", { name: "Talk to a human" }).last()).toBeVisible();
   });
 });

--- a/tests/e2e-landing/subpages.spec.ts
+++ b/tests/e2e-landing/subpages.spec.ts
@@ -45,7 +45,7 @@ test.describe("Privacy Page", () => {
       "Overview",
       "Website (snapotter.com)",
       "Self-Hosted Software",
-      "Optional Analytics",
+      "Analytics",
       "Contact Form",
       "Open Source",
       "Changes",
@@ -115,16 +115,16 @@ test.describe("Cross-Page Navigation", () => {
     await expect(page.getByText("Frequently Asked Questions")).toBeVisible();
   });
 
-  test("navbar Contact link navigates to /contact", async ({ page }) => {
+  test("navbar Talk to a human link navigates to /contact", async ({ page }) => {
     await page.goto("/");
-    await page.getByRole("link", { name: "Contact" }).first().click();
+    await page.getByRole("link", { name: "Talk to a human" }).first().click();
     await expect(page).toHaveURL("/contact");
     await expect(page.getByText("Get in touch")).toBeVisible();
   });
 
-  test("pricing Contact Sales links to /contact", async ({ page }) => {
+  test("pricing enterprise CTA links to /contact", async ({ page }) => {
     await page.goto("/");
-    const contactSales = page.getByRole("link", { name: /Contact Sales/ });
-    await expect(contactSales).toHaveAttribute("href", "/contact");
+    const enterpriseCta = page.getByRole("link", { name: /Let.s talk/ }).first();
+    await expect(enterpriseCta).toHaveAttribute("href", "/contact");
   });
 });


### PR DESCRIPTION
Fixes the 6 pre-existing failures in the landing Playwright suite. These fail on `main` and are unrelated to any recent feature work; they were surfaced during QA of the infrastructure-repositioning PR. Full landing e2e is now 62 passed, 0 failed.

## Changes

- **LaunchBanner (real fix):** the temporary 2.0 banner's GitHub "Click here!" link was missing `target="_blank"` and `rel="noopener noreferrer"`. Added them.
- **accessibility "exactly one h1":** switched from `.count()` + `toBe(1)` to `expect(...).toHaveCount(1)`, which auto-waits. The old form raced the dev server's on-demand render and read 0 h1 before the page finished rendering. The homepage has exactly one h1 in the build.
- **Nav label drift (2 specs):** tests expected a link named "Contact"; the nav link is "Talk to a human" (still points at /contact).
- **Privacy headings:** "Optional Analytics" is now "Analytics".
- **Pricing CTA:** "Contact Sales" is now "Let's talk" (Enterprise tier, still points at /contact).
