### PR TITLE
fix(landing): reposition residual meta framing and demote homepage tool count

### DIFF
--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -1,10 +1,8 @@
 ---
 // biome-ignore-all lint/correctness/noUnusedImports: Astro template consumes component imports.
 // biome-ignore-all lint/correctness/noUnusedVariables: Astro template consumes frontmatter values.
-import { TOOLS } from "@snapotter/shared";
 import SectionHeading from "./SectionHeading.astro";
 
-const toolCount = TOOLS.length;
 
 const checkIcon =
   '<svg class="h-4 w-4 shrink-0 text-success" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
@@ -45,7 +43,7 @@ const checkIcon =
 
         <ul class="mt-8 space-y-3">
           {[
-            `All ${toolCount} tools across 5 modalities`,
+            "All 200+ tools across 5 modalities",
             "Unlimited usage, no rate limits",
             "Full REST API with OpenAPI docs",
             "Pipeline automation & batch processing",

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -3,7 +3,6 @@
 // biome-ignore-all lint/correctness/noUnusedVariables: Astro template consumes frontmatter values.
 import SectionHeading from "./SectionHeading.astro";
 
-
 const checkIcon =
   '<svg class="h-4 w-4 shrink-0 text-success" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
 ---

--- a/apps/landing/src/components/ToolGrid.astro
+++ b/apps/landing/src/components/ToolGrid.astro
@@ -6,7 +6,6 @@ import * as lucideIcons from "lucide";
 import type { ModalityFilter, ToolSearchItem } from "../lib/tool-search";
 import SectionHeading from "./SectionHeading.astro";
 
-const toolCount = TOOLS.length;
 const categoryMap = new Map(CATEGORIES.map((c) => [c.id, c]));
 
 type ToolModality = ToolSearchItem["modality"];
@@ -155,7 +154,7 @@ const safeDefaultToolIdsJson = JSON.stringify(defaultToolIds).replace(/</g, "\\u
 <section class="bg-background-alt px-6 py-20 md:py-28" id="features">
   <SectionHeading
     title="One platform. Every file workflow."
-    subtitle={`Search ${toolCount} self-hosted tools by task, format, modality, or workflow.`}
+    subtitle="Search 200+ self-hosted tools by task, format, modality, or workflow."
   />
 
   <div class="mx-auto max-w-6xl">

--- a/apps/landing/src/pages/enterprise.astro
+++ b/apps/landing/src/pages/enterprise.astro
@@ -1,13 +1,11 @@
 ---
 // biome-ignore-all lint/correctness/noUnusedImports: Astro template consumes component imports.
 // biome-ignore-all lint/correctness/noUnusedVariables: Astro template consumes frontmatter values.
-import { TOOLS } from "@snapotter/shared";
 import Footer from "@/components/Footer.astro";
 import JsonLd from "@/components/JsonLd.astro";
 import Navbar from "@/components/Navbar.astro";
 import Base from "@/layouts/Base.astro";
 
-const toolCount = TOOLS.length;
 
 const breadcrumbJsonLd = {
   "@context": "https://schema.org",
@@ -27,7 +25,8 @@ const productJsonLd = {
   "@context": "https://schema.org",
   "@type": "Product",
   name: "SnapOtter Enterprise",
-  description: `Enterprise-grade self-hosted file processing suite with ${toolCount} tools, SAML SSO, audit logging, per-tool permissions, and multi-tenancy.`,
+  description:
+    "Enterprise-grade self-hosted file-processing infrastructure with 200+ tools, SAML SSO, audit logging, per-tool permissions, and multi-tenancy.",
   brand: { "@type": "Organization", name: "SnapOtter" },
   url: "https://snapotter.com/enterprise",
   offers: {

--- a/apps/landing/src/pages/enterprise.astro
+++ b/apps/landing/src/pages/enterprise.astro
@@ -6,7 +6,6 @@ import JsonLd from "@/components/JsonLd.astro";
 import Navbar from "@/components/Navbar.astro";
 import Base from "@/layouts/Base.astro";
 
-
 const breadcrumbJsonLd = {
   "@context": "https://schema.org",
   "@type": "BreadcrumbList",

--- a/apps/landing/src/pages/faq.astro
+++ b/apps/landing/src/pages/faq.astro
@@ -71,7 +71,7 @@ const breadcrumbJsonLd = {
 
 <Base
   title="FAQ | SnapOtter"
-  description="Frequently asked questions about SnapOtter, the self-hosted file processing suite."
+  description="Frequently asked questions about SnapOtter, self-hosted file-processing infrastructure."
   canonical="https://snapotter.com/faq"
 >
   <Fragment slot="head">

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
 // biome-ignore-all lint/correctness/noUnusedImports: Astro template consumes component imports.
 // biome-ignore-all lint/correctness/noUnusedVariables: Astro template consumes frontmatter values.
-import { TOOLS } from "@snapotter/shared";
 import EnterpriseSection from "@/components/EnterpriseSection.astro";
 import FeatureHighlights from "@/components/FeatureHighlights.astro";
 import Footer from "@/components/Footer.astro";
@@ -13,8 +12,6 @@ import Pricing from "@/components/Pricing.astro";
 import ToolGrid from "@/components/ToolGrid.astro";
 import Base from "@/layouts/Base.astro";
 
-const toolCount = TOOLS.length;
-
 const pageTitle = "SnapOtter | Self-Hosted File-Processing Infrastructure";
 const pageDescription =
   "Open-source, self-hosted file-processing infrastructure. Convert, compress, OCR, transcribe, and run local AI across image, video, audio, PDF, and documents, through a UI, REST API, and pipelines. The private, self-hosted alternative to CloudConvert, Smallpdf, and TinyPNG.";
@@ -24,7 +21,8 @@ const websiteSchema = {
   "@type": "WebSite",
   name: "SnapOtter",
   url: "https://snapotter.com",
-  description: `Self-hosted file processing suite with ${toolCount} tools across 5 modalities.`,
+  description:
+    "Open-source, self-hosted file-processing infrastructure with 200+ tools across image, video, audio, PDF, and documents.",
   publisher: {
     "@type": "Organization",
     name: "SnapOtter",
@@ -55,7 +53,7 @@ const softwareSchema = {
   license: "https://www.gnu.org/licenses/agpl-3.0.en.html",
   downloadUrl: "https://hub.docker.com/r/snapotter/snapotter",
   featureList: [
-    `${toolCount} file processing tools`,
+    "200+ file processing tools",
     "5 modalities: image, video, audio, PDF, files",
     "Free layer-based image editor with brushes, shapes, filters, curves, and keyboard shortcuts",
     "Local AI models for background removal, OCR, upscaling, transcription",


### PR DESCRIPTION
Follow-up to the infrastructure repositioning (#469). Cleans up residual surfaces that still carried the old "file processing suite" framing and rendered the exact tool count (241) publicly, which was inconsistent with the new hero and the drift-proof "200+" convention.

## Changes

- **Framing:** the homepage `WebSite` / `SoftwareApplication` JSON-LD and the enterprise/FAQ meta descriptions now say "file-processing infrastructure", not "file processing suite".
- **Count:** the visible homepage counts (ToolGrid section subtitle, Pricing "All 241 tools" bullet) and the SEO meta now say "200+". The `/tools` catalog page and the ToolGrid filter-tab badges keep their exact functional counts (a catalog showing its size, and the per-modality tab counts stay exact and internally consistent).
- Removed the `toolCount` / `TOOLS` references orphaned by the above.

Landing: 62/62 e2e, typecheck 0 errors, build green.
