### PR TITLE
feat(landing): restore Developers nav link (swap out Features)

### DIFF
--- a/apps/landing/src/components/Navbar.astro
+++ b/apps/landing/src/components/Navbar.astro
@@ -6,10 +6,10 @@ import { formatCompact, getStarCount } from "@/lib/stats";
 const starCount = formatCompact(await getStarCount());
 
 const links = [
-  { label: "Features", href: "/#features" },
   { label: "Enterprise", href: "/#enterprise" },
   { label: "Pricing", href: "/#pricing" },
   { label: "Alternatives", href: "/alternatives" },
+  { label: "Developers", href: "/self-hosted/file-conversion-api" },
   { label: "Docs", href: "https://docs.snapotter.com", external: true },
   { label: "Talk to a human", href: "/contact" },
 ];

--- a/tests/e2e-landing/homepage.spec.ts
+++ b/tests/e2e-landing/homepage.spec.ts
@@ -11,7 +11,14 @@ test.describe("Landing Homepage", () => {
 
   test("navbar renders brand and navigation links", async ({ page }) => {
     await expect(page.getByText("SnapOtter").first()).toBeVisible();
-    for (const name of ["Features", "Enterprise", "Pricing", "Docs", "Talk to a human"]) {
+    for (const name of [
+      "Enterprise",
+      "Pricing",
+      "Alternatives",
+      "Developers",
+      "Docs",
+      "Talk to a human",
+    ]) {
       await expect(page.getByRole("link", { name }).first()).toBeVisible();
     }
   });

--- a/tests/e2e-landing/interactions.spec.ts
+++ b/tests/e2e-landing/interactions.spec.ts
@@ -43,7 +43,7 @@ test.describe("Mobile Navigation", () => {
     await page.goto("/");
     const toggle = page.getByLabel("Toggle menu");
     await toggle.click();
-    await expect(page.getByRole("link", { name: "Features" }).last()).toBeVisible();
+    await expect(page.getByRole("link", { name: "Developers" }).last()).toBeVisible();
     await expect(page.getByRole("link", { name: "Enterprise" }).last()).toBeVisible();
     await expect(page.getByRole("link", { name: "Pricing" }).last()).toBeVisible();
     await expect(page.getByRole("link", { name: "Docs" }).last()).toBeVisible();


### PR DESCRIPTION
Restores the "Developers" link to the top nav (the earlier overflow fix in #473 had removed it to de-crowd the bar). To make room without re-crowding, this swaps out "Features", which was just a `/#features` homepage-section anchor.

Nav is now: Enterprise, Pricing, Alternatives, Developers, Docs, Talk to a human. Still a flat six-link bar, so it fits at the same widths (horizontal at `>=1120px`, hamburger below).

Also updates the two landing e2e assertions that checked for a "Features" nav link. Verified visually at 1120 and 1280px (fits, no wrapping) and with the full landing e2e (62/62).
