### PR TITLE
docs: point home modality chips at the sectioned tool pages

### DIFF
--- a/apps/docs/.vitepress/theme/DocsHome.vue
+++ b/apps/docs/.vitepress/theme/DocsHome.vue
@@ -18,11 +18,11 @@ const entLinks = [
   { label: "Compliance & SBOM", href: "/guide/security#compliance-artifacts" },
 ];
 const modalities = [
-  { label: "Image", count: 64, href: "/tools/resize" },
-  { label: "Video", count: 29, href: "/tools/convert-video" },
-  { label: "Audio", count: 17, href: "/tools/convert-audio" },
-  { label: "PDF", count: 37, href: "/tools/merge-pdf" },
-  { label: "Files", count: 10, href: "/tools/chart-maker" },
+  { label: "Image", count: 64, href: "/tools/image/resize" },
+  { label: "Video", count: 29, href: "/tools/video/convert-video" },
+  { label: "Audio", count: 17, href: "/tools/audio/convert-audio" },
+  { label: "PDF", count: 37, href: "/tools/pdf/merge-pdf" },
+  { label: "Files", count: 10, href: "/tools/files/chart-maker" },
 ];
 const shared = [
   { label: "REST API", sub: "Keys, endpoints & OpenAPI", href: "/api/rest" },

--- a/tests/e2e-docs/homepage.spec.ts
+++ b/tests/e2e-docs/homepage.spec.ts
@@ -43,6 +43,24 @@ test.describe("docs homepage (Two Doors)", () => {
     await expect(page.getByRole("link", { name: /Image/ })).toBeVisible();
   });
 
+  test("modality chips navigate to live tool pages client-side", async ({ page }) => {
+    const chips = [
+      { label: /^Image/, href: "/tools/image/resize" },
+      { label: /^Video/, href: "/tools/video/convert-video" },
+      { label: /^Audio/, href: "/tools/audio/convert-audio" },
+      { label: /^PDF/, href: "/tools/pdf/merge-pdf" },
+      { label: /^Files/, href: "/tools/files/chart-maker" },
+    ];
+    for (const chip of chips) {
+      await expect(page.getByRole("link", { name: chip.label })).toHaveAttribute("href", chip.href);
+    }
+    // Click through one chip: SPA navigation bypasses the _redirects shim,
+    // so a stale href 404s here even though a full page load would redirect.
+    await page.getByRole("link", { name: /^Image/ }).click();
+    await expect(page).toHaveURL(/\/tools\/image\/resize/);
+    await expect(page.getByRole("heading", { level: 1, name: "Resize" })).toBeVisible();
+  });
+
   test("nav links work", async ({ page }) => {
     await expect(page.getByRole("link", { name: "Guide" }).first()).toBeVisible();
     await page.getByRole("link", { name: "Guide" }).first().click();


### PR DESCRIPTION
## What

The tool reference moved to /tools/<section>/<toolId> (with a Cloudflare _redirects shim for the old flat URLs), but the five modality chips on the docs home still pointed at the old flat paths. On a full page load Cloudflare 301s you to the right place, which is why a refresh works. VitePress client-side navigation never touches Cloudflare, so clicking a chip landed on the 404 page (/tools/resize.html, "This page swam away").

The chips now link to /tools/image/resize, /tools/video/convert-video, /tools/audio/convert-audio, /tools/pdf/merge-pdf, and /tools/files/chart-maker directly.

## Anything else stale?

Swept the whole built site with an internal link checker over dist: these five chips were the only remaining dead internal links. The other /tools/ hits in source (developer guide, REST API reference) are code examples and endpoint paths, not links, and the nav/sidebar already use sectioned paths. Also grepped every other surface (landing, web, README, llms.txt) for old-style docs tool URLs: none.

## Test

The homepage e2e spec now pins all five chip hrefs and click-navigates one chip, asserting the tool page renders. Click-through exercises SPA routing, which is exactly the path the _redirects shim can't save, so this rots loudly next time pages move. Locally 8/8.