### PR TITLE
fix(landing-i18n): commit missed landing-seo re-translation (remove.bg comparison)

### DIFF
--- a/apps/landing/src/data/i18n/alternatives.ar.json
+++ b/apps/landing/src/data/i18n/alternatives.ar.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "6ea786759f3a",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "يركّز remove.bg على مهمة واحدة ويؤديها بإتقان. أما SnapOtter فيُشغّل إزالة الخلفية محليًا، ثم يضيف الضغط والتحويل ورفع الدقة و OCR وبقية مجموعة الأدوات ضمن عملية نشر واحدة.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "a9b1ffd9f9ca",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "نعم. تعمل ميزة إزالة الخلفية في SnapOtter محليًا بعد تثبيت حزمة النموذج لمرة واحدة، لذا لا تغادر الصور شبكتك أبدًا ولا توجد أي أرصدة لكل صورة.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "c3ab2246eecd",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "هل يوجد بديل مستضاف ذاتيًا لـ remove.bg؟",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "585dfafa708e",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "لا. يعمل على وحدة المعالجة المركزية CPU، ويستخدم وحدة معالجة الرسومات GPU تلقائيًا إن توفّرت لتسريع معالجة الدُفعات.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "d0450caf8787",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "هل يحتاج إلى وحدة معالجة رسومات GPU؟",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "14350436c910",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "البديل مفتوح المصدر والمستضاف ذاتيًا لـ remove.bg",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "51d26a8512d5",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg أداة سريعة لإزالة الخلفية تعمل عبر الاستضافة السحابية. أما SnapOtter فهو البديل المستضاف ذاتيًا الذي يُشغّل النوع نفسه من الذكاء الاصطناعي على عتادك الخاص، بحيث لا تصل صور المنتجات والأشخاص أبدًا إلى أي خدمة خارجية.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "8d55b2bf65f6",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "يزيل remove.bg خلفيات الصور عبر السحابة. أما SnapOtter فيُشغّل إزالة الخلفية محليًا على خادمك الخاص، مع أكثر من 200 أداة إضافية ضمن المنصة نفسها.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "3576e7a96fbf",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "البديل مفتوح المصدر والمستضاف ذاتيًا لـ remove.bg",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "51d26a8512d5",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "خدمة ويب مستضافة",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "2526febbc9db",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "نموذج النشر",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "05e5497610f8",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "مستضاف ذاتيًا على خادمك",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "54fcdb44ac3c",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "تُرفع الصور إلى API مستضاف لدى المزوّد لمعالجتها",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "1ff4fb646275",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "موقع معالجة الملفات",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "4edb3bbe9b16",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "بنيتك التحتية الخاصة",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "7b389db4c0f8",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "تسعير قائم على الأرصدة لكل صورة",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "c7655d073564",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "التحكم في التكلفة",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "ff1e22fcab46",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "مجاني بموجب AGPLv3؛ الحدود هي حدود عتادك",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "6d7f6f74f743",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "مصمّم للاستخدام عبر الإنترنت من المتصفح",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "a82889328ae2",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "الاستخدام دون اتصال أو في بيئة معزولة",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "4363c7fc214b",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "مدعوم عند النشر داخل شبكتك",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "e228685f2fef",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "إزالة الخلفية",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "8ce1d211eac0",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "ما يتجاوز إزالة الخلفية",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "0da6d2b4f5b3",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "الصور والفيديو والصوت و PDF والملفات",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "bc9c803406a1",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "خدمة يديرها المزوّد؛ إتاحة المصدر ليست جزءًا من نموذج المنتج",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "a735875c4a4a",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "المصدر وقابلية التدقيق",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "0a3884580ff0",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "المصدر متاح بموجب AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "2ae2c27e25cc",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "API مستضاف لدى المزوّد مع أرصدة لكل صورة",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "ce14d890d3d7",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "الأتمتة",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "41676cbdcf03",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "REST API وسلاسل معالجة ضمن عملية نشرك",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "fbf5beef3825",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "يركّز Smallpdf على ملفات PDF، وهو تحديدًا ما يحتاجه كثيرون. يغطي SnapOtter هذا المجال عبر الدمج والتقسيم والضغط والتحويل والتنقيح وOCR والمزيد، ثم يضيف مسارات عمل للصور والفيديو والصوت والملفات ضمن التثبيت نفسه.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.de.json
+++ b/apps/landing/src/data/i18n/alternatives.de.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "56359577be7e",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg konzentriert sich auf eine Aufgabe und erledigt sie gut. SnapOtter entfernt Hintergründe lokal und ergänzt das um Komprimierung, Konvertierung, Hochskalierung, OCR und den restlichen Katalog in einer einzigen Installation.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "d5b311656824",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Ja. Die Hintergrundentfernung von SnapOtter läuft nach einer einmaligen Installation des Modellpakets lokal, sodass Bilder Ihr Netzwerk niemals verlassen und keine Kosten pro Bild anfallen.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "80d4947fa8d9",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "Gibt es eine selbst gehostete Alternative zu remove.bg?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "22936d06cac8",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "Nein. Es läuft auf der CPU und nutzt für schnellere Stapelverarbeitung automatisch eine GPU, sofern eine verfügbar ist.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "d267e5bb6b20",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "Wird eine GPU benötigt?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "9c00522319c6",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "Die quelloffene, selbst gehostete Alternative zu remove.bg",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "4065678837c5",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg ist ein schneller, gehosteter Hintergrundentferner. SnapOtter ist die selbst gehostete Alternative, die dieselbe Art von KI auf Ihrer eigenen Hardware ausführt, sodass Produkt- und Personenbilder niemals an einen Drittanbieter gelangen.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "4a71b51a81cc",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg entfernt Bildhintergründe in der Cloud. SnapOtter führt die Hintergrundentfernung lokal auf Ihrem eigenen Server aus, mit über 200 weiteren Tools im selben Stack.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "dd78df272296",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "Die quelloffene, selbst gehostete Alternative zu remove.bg",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "4065678837c5",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Gehosteter Webdienst",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "e6818129fd5c",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Bereitstellungsmodell",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "02c033d40b7b",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Selbst gehostet auf Ihrem Server",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "7ec22056b7a0",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "Bilder werden zur Verarbeitung an eine vom Anbieter gehostete API hochgeladen",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "584348756baf",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Ort der Dateiverarbeitung",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "4473b43796c3",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "Ihre Infrastruktur",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "0e6e3f4051aa",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Guthabenbasierte Preise pro Bild",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "3ded9728ba36",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Kostenkontrolle",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "b40d044578bd",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "Kostenlos unter AGPLv3; die Grenzen setzt Ihre Hardware",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "f11b08153eab",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Für die browserbasierte Online-Nutzung ausgelegt",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "4dc1dd31021f",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Offline- / Air-Gap-Nutzung",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "759c006ff6fd",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Unterstützt bei Bereitstellung innerhalb Ihres Netzwerks",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "ea93262ac9b1",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Hintergrundentfernung",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "5558fd7a6f11",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Über die Hintergrundentfernung hinaus",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "b3354b86a6eb",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Bild, Video, Audio, PDF und Dateien",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "b85551f71594",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Vom Anbieter betriebener Dienst; die Verfügbarkeit des Quellcodes ist nicht Teil des Produktmodells",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "3e18b970d9f8",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Quellcode und Nachvollziehbarkeit",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "53194a849437",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Quellcode verfügbar unter AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "32688f43c25a",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "Vom Anbieter gehostete API mit Guthaben pro Bild",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "927cad83a1c4",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Automatisierung",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "08c56becd2e4",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "REST-API und Pipelines in Ihrer Installation",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "04398f1cf61f",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf konzentriert sich auf PDFs, und genau das ist für viele genau richtig. SnapOtter deckt diesen Bereich mit Zusammenführen, Teilen, Komprimieren, Konvertieren, Schwärzen, OCR und mehr ab und ergänzt ihn im selben Deployment um Workflows für Bild, Video, Audio und Dateien.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.es.json
+++ b/apps/landing/src/data/i18n/alternatives.es.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "04a0963b78f0",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg se centra en una sola tarea y la hace bien. SnapOtter ejecuta la eliminación de fondos localmente y, además, añade compresión, conversión, escalado, OCR y el resto del catálogo en un único despliegue.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "3f3a1485c84f",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Sí. La eliminación de fondos de SnapOtter se ejecuta localmente tras una instalación única del paquete de modelos, de modo que las imágenes nunca salen de tu red y no hay créditos por imagen.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "d592727d4944",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "¿Existe una alternativa autoalojada a remove.bg?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "5af6587c344c",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "No. Funciona en CPU y usa una GPU automáticamente si hay una disponible para procesar lotes más rápido.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "3e571e200b5d",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "¿Necesita una GPU?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "71940ac2f798",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "La alternativa de código abierto y autoalojada a remove.bg",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "f28d96530b37",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg es un eliminador de fondos alojado y rápido. SnapOtter es la alternativa autoalojada que ejecuta el mismo tipo de IA en tu propio hardware, de modo que las imágenes de productos y personas nunca llegan a un servicio de terceros.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "6379ddc571a5",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg elimina fondos de imágenes en la nube. SnapOtter ejecuta la eliminación de fondos localmente en tu propio servidor, con más de 200 herramientas adicionales en el mismo stack.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "acf707e5ba21",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "La alternativa de código abierto y autoalojada a remove.bg",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "f28d96530b37",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Servicio web alojado",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "a9b6abd1d488",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Modelo de despliegue",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "a4384c992368",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Autoalojado en tu servidor",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "44ce8594857f",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "Las imágenes se suben a una API alojada por el proveedor para su procesamiento",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "e2d574b06b34",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Ubicación del procesamiento de archivos",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "0a4d78414d2f",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "Tu infraestructura",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "c570e0ed1ce2",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Precios basados en créditos por imagen",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "c3b1e30d8c9f",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Control de costes",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "6fdd90bf88df",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "Gratis bajo AGPLv3; los límites son los de tu hardware",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "b997870c16fe",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Diseñado para uso en línea desde el navegador",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "9978fc3bda85",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Uso sin conexión o aislado de la red",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "aff6cd34f083",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Compatible cuando se despliega dentro de tu red",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "6b6358ad92cd",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Eliminación de fondos",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "37cb9a70f64d",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Más allá de la eliminación de fondos",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "7a35063b2340",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Imagen, vídeo, audio, PDF y archivos",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "52da8ed1731e",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Servicio operado por el proveedor; la disponibilidad del código fuente no forma parte del modelo del producto",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "1b979a73428c",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Código fuente y auditabilidad",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "30bb122e991c",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Código fuente disponible bajo AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "b32aca1ac67b",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "API alojada por el proveedor con créditos por imagen",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "a39b67756e08",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Automatización",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "2f7b761b1a40",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "API REST y pipelines en tu despliegue",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "04a0963b78f0",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf se centra en los PDF, que es justo lo que muchas personas necesitan. SnapOtter cubre ese terreno con unión, división, compresión, conversión, redacción, OCR y más, y luego añade flujos de trabajo de imagen, vídeo, audio y archivos en el mismo despliegue.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.fr.json
+++ b/apps/landing/src/data/i18n/alternatives.fr.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "d7b62c82fdde",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg se concentre sur une seule tâche et l'accomplit bien. SnapOtter réalise la suppression d'arrière-plan en local, puis ajoute la compression, la conversion, l'agrandissement, l'OCR et le reste du catalogue dans un seul déploiement.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "9470edbb9ba2",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Oui. La suppression d'arrière-plan de SnapOtter s'exécute en local après une installation unique du pack de modèles, de sorte que les images ne quittent jamais votre réseau et qu'aucun crédit n'est facturé à l'image.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "0bf0e2d258b5",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "Existe-t-il une alternative auto-hébergée à remove.bg ?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "585baeb98f84",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "Non. Le traitement fonctionne sur CPU et utilise automatiquement un GPU, s'il en existe un, pour accélérer les traitements par lots.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "78b877662ad0",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "Un GPU est-il nécessaire ?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "fed4bc49133a",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "L'alternative open source et auto-hébergée à remove.bg",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "1b6aa75fed81",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg est un outil de suppression d'arrière-plan hébergé et rapide. SnapOtter est l'alternative auto-hébergée qui exécute le même type d'IA sur votre propre matériel, afin que vos images de produits et de personnes ne soient jamais envoyées à un service tiers.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "98870147b4fd",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg supprime l'arrière-plan des images dans le cloud. SnapOtter effectue la suppression d'arrière-plan localement, sur votre propre serveur, avec plus de 200 outils supplémentaires dans le même environnement.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "d7d3286d2363",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "L'alternative open source et auto-hébergée à remove.bg",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "1b6aa75fed81",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Service web hébergé",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "a0c1a168ede2",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Modèle de déploiement",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "e50370113c92",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Auto-hébergé sur votre serveur",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "36d67a67afb5",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "Les images sont envoyées à une API hébergée par le fournisseur pour être traitées",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "0c90ca0f2003",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Emplacement du traitement des fichiers",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "f357957503f9",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "Votre infrastructure",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "0c9d076ddf3e",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Tarification par image basée sur des crédits",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "b3f8c02213bc",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Maîtrise des coûts",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "50c6c37b999d",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "Gratuit sous AGPLv3 ; vos seules limites sont celles de votre matériel",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "b92282889587",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Conçu pour une utilisation en ligne via le navigateur",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "160ae5658150",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Utilisation hors ligne / en réseau isolé",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "7afc795eb3d0",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Pris en charge en cas de déploiement au sein de votre réseau",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "006e3488bd0f",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Suppression d'arrière-plan",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "2cd3e50747f0",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Au-delà de la suppression d'arrière-plan",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "881d28cec010",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Image, vidéo, audio, PDF et fichiers",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "7696f3985782",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Service exploité par le fournisseur ; la disponibilité du code source ne fait pas partie du modèle du produit",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "5285d031f4a0",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Code source et auditabilité",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "93995130ee6a",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Code source disponible sous AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "52ae3e0cf64e",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "API hébergée par le fournisseur avec des crédits facturés à l'image",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "5c2a6e589a7d",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Automatisation",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "2b8c8c172c38",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "API REST et pipelines dans votre déploiement",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "d7b62c82fdde",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf se concentre sur les PDF, ce qui correspond exactement au besoin de beaucoup de gens. SnapOtter couvre ce terrain avec la fusion, la division, la compression, la conversion, le caviardage, l'OCR et plus encore, puis ajoute les flux de travail image, vidéo, audio et fichier dans le même déploiement.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.hi.json
+++ b/apps/landing/src/data/i18n/alternatives.hi.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "9d07075e2235",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg एक ही काम पर ध्यान देता है और उसे बखूबी करता है। SnapOtter लोकल बैकग्राउंड रिमूवल चलाता है, और फिर एक ही डिप्लॉयमेंट में कंप्रेशन, कन्वर्ज़न, अपस्केलिंग, OCR और बाकी पूरा कैटलॉग जोड़ देता है।",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "6950710190ef",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "हाँ। SnapOtter का बैकग्राउंड रिमूवल एक बार मॉडल-बंडल इंस्टॉल करने के बाद लोकल रूप से चलता है, इसलिए इमेज कभी आपके नेटवर्क से बाहर नहीं जातीं और कोई प्रति-इमेज क्रेडिट नहीं लगता।",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "cb75c9403633",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "क्या remove.bg का कोई सेल्फ-होस्टेड विकल्प है?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "49b2cf77df68",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "नहीं। यह CPU पर चलता है, और तेज़ बैच के लिए GPU उपलब्ध होने पर उसका अपने आप उपयोग कर लेता है।",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "d2eb002712a0",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "क्या इसके लिए GPU ज़रूरी है?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "2560255847d1",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "remove.bg का ओपन-सोर्स, सेल्फ-होस्टेड विकल्प",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "3d0ab5f0382f",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg एक तेज़ होस्टेड बैकग्राउंड रिमूवर है। SnapOtter वह सेल्फ-होस्टेड विकल्प है जो उसी तरह का AI आपके अपने हार्डवेयर पर चलाता है, ताकि प्रोडक्ट और लोगों की तस्वीरें कभी किसी थर्ड-पार्टी सेवा तक न जाएँ।",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "662f23d32bb6",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg क्लाउड में इमेज बैकग्राउंड हटाता है। SnapOtter बैकग्राउंड रिमूवल को आपके अपने सर्वर पर लोकल रूप से चलाता है, और उसी स्टैक में 200+ अतिरिक्त टूल देता है।",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "9d899627ce33",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "remove.bg का ओपन-सोर्स, सेल्फ-होस्टेड विकल्प",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "3d0ab5f0382f",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "होस्टेड वेब सेवा",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "d9a0e518e909",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "डिप्लॉयमेंट मॉडल",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "935cd67f0c39",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "आपके सर्वर पर सेल्फ-होस्टेड",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "dd8682ff3f8f",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "इमेज प्रोसेसिंग के लिए वेंडर-होस्टेड API पर अपलोड की जाती हैं",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "63c1191802bf",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "फ़ाइल प्रोसेसिंग की जगह",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "850e3da2cb3e",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "आपका इंफ्रास्ट्रक्चर",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "49f7b6ad658c",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "प्रति इमेज क्रेडिट-आधारित मूल्य निर्धारण",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "c2801320f9cc",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "लागत नियंत्रण",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "a924e8562515",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "AGPLv3 के तहत मुफ़्त; सीमाएँ बस आपके हार्डवेयर तक",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "bc13d6a4a6b1",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "ब्राउज़र-आधारित ऑनलाइन उपयोग के लिए डिज़ाइन किया गया",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "dd61e72f4564",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "ऑफ़लाइन / एयर-गैप्ड उपयोग",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "adab4e319411",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "आपके नेटवर्क के अंदर डिप्लॉय करने पर समर्थित",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "2712c42a2897",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "बैकग्राउंड रिमूवल",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "ff31324c5794",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "बैकग्राउंड रिमूवल से आगे",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "e8e5ea7d184d",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "इमेज, वीडियो, ऑडियो, PDF और फ़ाइलें",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "ca486b962648",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "वेंडर-संचालित सेवा; सोर्स की उपलब्धता इसका प्रोडक्ट मॉडल नहीं है",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "b87ca049f567",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "सोर्स और ऑडिट क्षमता",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "9ec6b89ad813",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "AGPLv3 के तहत सोर्स उपलब्ध",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "674dba4b5e59",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "प्रति-इमेज क्रेडिट के साथ वेंडर-होस्टेड API",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "c3dbc77d69b0",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "ऑटोमेशन",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "af8f313cc83f",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "आपके डिप्लॉयमेंट में REST API और पाइपलाइनें",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "2d0c2e929490",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf का ध्यान PDF पर है, और यही कई लोगों को चाहिए भी होता है। SnapOtter इस दायरे को मर्ज, स्प्लिट, कंप्रेस, कन्वर्ट, रिडैक्ट, OCR और बहुत कुछ के साथ कवर करता है, फिर उसी डिप्लॉयमेंट में इमेज, वीडियो, ऑडियो और फ़ाइल वर्कफ़्लो भी जोड़ देता है।",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.id.json
+++ b/apps/landing/src/data/i18n/alternatives.id.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "0fe4d5d55062",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg fokus pada satu tugas dan melakukannya dengan baik. SnapOtter menjalankan penghapusan latar belakang secara lokal, lalu menambahkan kompresi, konversi, upscaling, OCR, dan seluruh katalog lainnya dalam satu deployment.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "5e65913d1a01",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Ya. Penghapusan latar belakang SnapOtter berjalan secara lokal setelah pemasangan model-bundle satu kali, sehingga gambar tidak pernah keluar dari jaringan Anda dan tidak ada kredit per gambar.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "c54a925c7ccb",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "Apakah ada alternatif self-hosted untuk remove.bg?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "dba36af53067",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "Tidak. Ia berjalan di CPU, dan menggunakan GPU secara otomatis jika tersedia untuk mempercepat pemrosesan batch.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "62733cb033ce",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "Apakah membutuhkan GPU?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "248ea7e8bd48",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "Alternatif remove.bg yang open-source dan self-hosted",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "f3c6184e9e80",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg adalah penghapus latar belakang hosted yang cepat. SnapOtter adalah alternatif self-hosted yang menjalankan jenis AI yang sama di perangkat keras Anda sendiri, sehingga gambar produk dan orang tidak pernah dikirim ke layanan pihak ketiga.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "05ada0e397f8",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg menghapus latar belakang gambar di cloud. SnapOtter menjalankan penghapusan latar belakang secara lokal di server Anda sendiri, dengan 200+ tool lainnya dalam satu stack yang sama.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "3218e6240d21",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "Alternatif remove.bg yang Open-Source dan Self-Hosted",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "0ce7a21ff21d",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Layanan web hosted",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "18c0864aa8f1",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Model deployment",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "3a84d1dd78d7",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Self-hosted di server Anda",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "4e500df7b2b9",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "Gambar diunggah ke API milik vendor untuk diproses",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "a3bfd202c3d5",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Lokasi pemrosesan file",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "47edcdf01b47",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "Infrastruktur Anda sendiri",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "82cdc90ebd50",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Penetapan harga berbasis kredit per gambar",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "e3e7a28a9aad",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Kendali biaya",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "cf264e79ddda",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "Gratis dengan lisensi AGPLv3; batasannya hanya perangkat keras Anda",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "6408375f9490",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Dirancang untuk penggunaan online berbasis browser",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "04694cd2d170",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Penggunaan offline / air-gapped",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "931b79ecf028",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Didukung saat di-deploy di dalam jaringan Anda",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "fd7b6a6293b6",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Penghapusan latar belakang",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "c7b06b1ea612",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Selain penghapusan latar belakang",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "9b86cfeb4339",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Gambar, video, audio, PDF, dan file",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "77f19c1fa745",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Layanan yang dioperasikan vendor; ketersediaan kode sumber bukan bagian dari model produknya",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "4536d2a91b4e",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Sumber dan kemampuan audit",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "8398912ccdc7",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Kode sumber tersedia di bawah lisensi AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "09d32c0f3b45",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "API milik vendor dengan kredit per gambar",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "7ff0d6ac967b",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Otomasi",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "63acc300e886",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "REST API dan pipeline di dalam deployment Anda",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "8c4fcf0a26ff",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf fokus pada PDF, dan itulah yang dibutuhkan banyak orang. SnapOtter menutup jalur itu dengan penggabungan, pemisahan, kompresi, konversi, redaksi, OCR, dan lainnya, lalu menambahkan alur kerja gambar, video, audio, dan file dalam deployment yang sama.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.it.json
+++ b/apps/landing/src/data/i18n/alternatives.it.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "73fff4004f8a",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg si concentra su un solo compito e lo svolge bene. SnapOtter esegue la rimozione dello sfondo in locale e aggiunge compressione, conversione, upscaling, OCR e il resto del catalogo in un'unica installazione.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "5c66e06f7456",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Sì. La rimozione dello sfondo di SnapOtter viene eseguita in locale dopo un'installazione una tantum del pacchetto del modello, quindi le immagini non lasciano mai la tua rete e non ci sono crediti per immagine.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "3982500c0e65",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "Esiste un'alternativa self-hosted a remove.bg?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "25123dd274ae",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "No. Funziona su CPU e utilizza automaticamente una GPU, se disponibile, per elaborare i lotti più velocemente.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "0c9f1292ef16",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "Serve una GPU?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "69114ed2f799",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "L'alternativa open-source e self-hosted a remove.bg",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "15d9e4c6d11e",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg è un servizio ospitato e veloce per rimuovere lo sfondo. SnapOtter è l'alternativa self-hosted che esegue lo stesso tipo di AI sul tuo hardware, così le immagini di prodotti e persone non vengono mai inviate a servizi di terze parti.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "6dddc4227d42",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg rimuove lo sfondo dalle immagini nel cloud. SnapOtter esegue la rimozione dello sfondo in locale, sul tuo server, con oltre 200 strumenti in più nello stesso stack.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "ae985073ebce",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "L'alternativa open-source e self-hosted a remove.bg",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "15d9e4c6d11e",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Servizio web ospitato",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "49547113c9e6",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Modello di distribuzione",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "066af478b5a3",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Self-hosted sul tuo server",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "588ef705e77e",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "Le immagini vengono caricate su un'API ospitata dal fornitore per l'elaborazione",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "532add994a5c",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Luogo di elaborazione dei file",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "f94dee6f9865",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "La tua infrastruttura",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "475466749824",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Prezzi a crediti per immagine",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "a950cd426207",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Controllo dei costi",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "a13cbcc77a96",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "Gratuito con licenza AGPLv3; i limiti sono quelli del tuo hardware",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "5b65423c44f1",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Pensato per l'uso online tramite browser",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "14e7d03defa6",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Uso offline / air-gapped",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "91108a50473e",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Supportato quando è installato all'interno della tua rete",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "cc593ea9da94",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Rimozione dello sfondo",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "cd95f8b45858",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Oltre alla rimozione dello sfondo",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "c86d23bbaf3a",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Immagini, video, audio, PDF e file",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "de4c6fecd357",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Servizio gestito dal fornitore; la disponibilità del codice sorgente non fa parte del modello di prodotto",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "33c23fd4dd5f",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Codice sorgente e verificabilità",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "c55b592d2fce",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Codice sorgente disponibile con licenza AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "2b016a24fd01",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "API ospitata dal fornitore con crediti per immagine",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "ba6823667977",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Automazione",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "34883b6ce9b6",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "API REST e pipeline nella tua installazione",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "73fff4004f8a",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf è concentrato sui PDF, che è esattamente ciò di cui molti hanno bisogno. SnapOtter copre quel terreno con unione, divisione, compressione, conversione, oscuramento, OCR e altro, e poi aggiunge flussi di lavoro per immagini, video, audio e file nella stessa installazione.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.ja.json
+++ b/apps/landing/src/data/i18n/alternatives.ja.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200以上",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "58443c7104e4",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "dc61d6f2773d",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bgは一つの作業に特化し、それを見事にこなします。SnapOtterはローカルで背景を除去したうえで、圧縮、変換、アップスケーリング、OCR、そしてその他のツール群まで、すべてを一つの環境で提供します。",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "30e870681631",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "はい。SnapOtterの背景除去は、一度モデルバンドルをインストールすればローカルで実行されるため、画像がネットワークの外に出ることはなく、画像ごとのクレジット課金もありません。",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "e07ab0038853",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "remove.bgのセルフホスト型代替ツールはありますか？",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "011831de6e21",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "いいえ。CPUで動作し、GPUが利用できる場合は自動的に活用してバッチ処理を高速化します。",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "2ddb11023b77",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "GPUは必要ですか？",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "bb61c3d4e351",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "remove.bgのオープンソース・セルフホスト型代替ツール",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "cffefb71efb9",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bgは高速なホスト型の背景除去サービスです。SnapOtterは同種のAIを自分のハードウェア上で動かすセルフホスト型の代替ツールで、商品画像や人物画像を第三者のサービスに送信することは一切ありません。",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "3cbe296b0bc4",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bgは画像の背景をクラウドで除去します。SnapOtterは背景除去を自分のサーバー上でローカルに実行し、同じ環境の中でさらに200以上のツールを利用できます。",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "844c99faad67",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "remove.bgのオープンソース・セルフホスト型代替ツール",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "cffefb71efb9",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "ホスト型のWebサービス",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "e7b8fff9689f",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "デプロイ形態",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "87845ee1158b",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "自分のサーバーでセルフホスト",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "ab10c6ffc2f7",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "処理のため画像はベンダーがホストするAPIにアップロードされます",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "8194b89050d4",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "ファイル処理の場所",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "3844acce7218",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "自社のインフラ",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "783326459d91",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "画像ごとのクレジット制課金",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "9c0748fef35d",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "コスト管理",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "e42052d80da0",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "AGPLv3で無料。上限は自分のハードウェア次第",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "046948da31f1",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "ブラウザベースのオンライン利用を前提に設計",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "f2e60442e24a",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "オフライン / エアギャップ環境での利用",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "4d6d893ee168",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "自社ネットワーク内にデプロイすれば対応可能",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "a4f25ecc7022",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "背景除去",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "bda0aeac44e6",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "背景除去にとどまらない機能",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "32b94ff7803e",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "画像、動画、音声、PDF、ファイル",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "1ed2c203cac6",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "ベンダー運営のサービス。ソース公開は事業モデルの対象外",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "ffa2cc4a5ac2",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "ソースと監査可能性",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "8f4077640738",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "AGPLv3のもとでソース公開",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "c03c32552966",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "画像ごとのクレジット制のベンダーホスト型API",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "eb38fb2cc332",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "自動化",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "ad3a6e25729d",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "自社環境内でのREST APIとパイプライン",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "207313bfc866",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf は PDF に特化しており、それこそが多くの人に必要なものです。SnapOtter はその領域を結合、分割、圧縮、変換、墨消し、OCR などでカバーし、さらに同じ環境で画像、動画、音声、ファイルのワークフローも扱えます。",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200以上",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "58443c7104e4",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.ko.json
+++ b/apps/landing/src/data/i18n/alternatives.ko.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "6dd41a6f2530",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg는 한 가지 작업에 집중해 이를 훌륭히 처리합니다. SnapOtter는 로컬에서 배경을 제거하고, 여기에 더해 압축, 변환, 업스케일링, OCR을 비롯한 나머지 도구 전체를 하나의 배포 환경에서 함께 제공합니다.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "42604dffb3b3",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "네. SnapOtter의 배경 제거는 최초 한 번 모델 번들을 설치한 뒤 로컬에서 실행되므로, 이미지가 네트워크를 벗어나지 않으며 이미지당 크레딧도 들지 않습니다.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "86fd355b73b4",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "remove.bg의 셀프 호스팅 대안이 있나요?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "ab7415f49b1c",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "아니요. CPU에서 실행되며, GPU가 있으면 더 빠른 일괄 처리를 위해 자동으로 사용합니다.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "c3fdce81775c",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "GPU가 필요한가요?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "18829fb73d03",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "remove.bg의 오픈소스 셀프 호스팅 대안",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "1ea77f58cac6",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg는 빠른 호스팅형 배경 제거 서비스입니다. SnapOtter는 같은 종류의 AI를 여러분의 하드웨어에서 직접 실행하는 셀프 호스팅 대안으로, 제품과 인물 이미지가 외부 서비스로 전송되는 일이 없습니다.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "b90ed3f39f8d",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg는 클라우드에서 이미지 배경을 제거합니다. SnapOtter는 배경 제거를 여러분의 자체 서버에서 로컬로 실행하며, 같은 스택 안에 200개가 넘는 추가 도구를 제공합니다.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "4a739165eb29",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "remove.bg의 오픈소스 셀프 호스팅 대안",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "1ea77f58cac6",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "호스팅형 웹 서비스",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "803c99390637",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "배포 방식",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "4f0fd43b48bf",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "여러분의 서버에서 셀프 호스팅",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "804daba4465c",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "이미지가 처리를 위해 공급업체 호스팅 API로 업로드됨",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "5cd0ae6443bb",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "파일 처리 위치",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "f54faf14101f",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "여러분의 인프라",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "73dbf893b004",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "이미지당 크레딧 기반 요금제",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "7120dc543bb7",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "비용 통제",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "5ee136710741",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "AGPLv3로 무료, 한계는 여러분의 하드웨어뿐",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "96de1aa35799",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "브라우저 기반 온라인 사용에 맞춰 설계됨",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "9e4a2bfe1f6a",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "오프라인 / 에어갭 환경 사용",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "ec549aba0ec3",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "여러분의 네트워크 내에 배포하면 지원됨",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "1b54b730b387",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "배경 제거",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "064dd02936b7",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "배경 제거를 넘어서",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "04d13536379a",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "이미지, 비디오, 오디오, PDF, 파일",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "8bb6dbfda41a",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "공급업체가 운영하는 서비스로, 소스 공개는 제공 모델이 아님",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "9b07d6c61bd7",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "소스 코드와 감사 가능성",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "9c3eb07b2a4a",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "AGPLv3로 소스 공개",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "1b3c6c817686",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "이미지당 크레딧이 부과되는 공급업체 호스팅 API",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "d183c7a988e6",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "자동화",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "fc13d6bb5487",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "여러분의 배포 환경 내 REST API와 파이프라인",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "2d9bc8c0af35",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf는 PDF에 집중하며, 이는 많은 사람에게 정확히 필요한 부분입니다. SnapOtter는 병합, 분할, 압축, 변환, 마스킹, OCR 등으로 그 영역을 다루고, 같은 배포 환경에서 이미지, 비디오, 오디오, 파일 워크플로까지 추가로 지원합니다.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.nl.json
+++ b/apps/landing/src/data/i18n/alternatives.nl.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "69d86711bad5",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg richt zich op één taak en doet die goed. SnapOtter draait achtergrondverwijdering lokaal en voegt daarnaast compressie, conversie, upscaling, OCR en de rest van de catalogus toe in één installatie.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "88d7a44d3ae4",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Ja. De achtergrondverwijdering van SnapOtter draait lokaal na een eenmalige installatie van het modelpakket, zodat afbeeldingen je netwerk nooit verlaten en er geen credits per afbeelding zijn.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "92be7a6ada4c",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "Is er een zelf-gehost alternatief voor remove.bg?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "3ab231d3e460",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "Nee. Het draait op de CPU en gebruikt automatisch een GPU als die beschikbaar is voor snellere batches.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "3dc8a838b8f8",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "Is er een GPU nodig?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "82a929e7497d",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "Het open-source, zelf-gehoste alternatief voor remove.bg",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "472a3533d29d",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg is een snelle, gehoste achtergrondverwijderaar. SnapOtter is het zelf-gehoste alternatief dat hetzelfde soort AI op je eigen hardware draait, zodat product- en persoonsafbeeldingen nooit naar een externe dienst gaan.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "88ab014b32c8",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg verwijdert achtergronden van afbeeldingen in de cloud. SnapOtter voert achtergrondverwijdering lokaal uit op je eigen server, met 200+ extra tools in dezelfde stack.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "a36ba12c06c8",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "Het open-source, zelf-gehoste alternatief voor remove.bg",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "472a3533d29d",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Gehoste webdienst",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "379fea34ce80",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Implementatiemodel",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "61e9f087dd89",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Zelf-gehost op je eigen server",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "9b15a1768b22",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "Afbeeldingen worden geüpload naar een door de leverancier gehoste API voor verwerking",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "4e49df9e3ac7",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Locatie van bestandsverwerking",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "54ef54d9f453",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "Je eigen infrastructuur",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "d6c7e7b0f4c3",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Prijsstelling op basis van credits per afbeelding",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "900ed5f58839",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Kostenbeheersing",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "8687cd14afd7",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "Gratis onder AGPLv3; je hardware is de enige limiet",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "e12c1e2777a9",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Ontworpen voor online gebruik via de browser",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "0e344a061ccb",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Offline / air-gapped gebruik",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "c8ab119e1317",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Ondersteund bij implementatie binnen je eigen netwerk",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "baf7757d5390",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Achtergrondverwijdering",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "9292dbc4ae1b",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Meer dan achtergrondverwijdering",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "02d328a7d6a4",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Afbeelding, video, audio, PDF en bestanden",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "5541fda8037e",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Door de leverancier beheerde dienst; beschikbaarheid van broncode maakt geen deel uit van het model",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "79077e9ed7dd",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Broncode en controleerbaarheid",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "a7069bb61c8b",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Broncode beschikbaar onder AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "823f927f0e97",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "Door de leverancier gehoste API met credits per afbeelding",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "a170d5ef6a33",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Automatisering",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "8efedca1b9cc",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "REST API en pipelines in je eigen installatie",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "d21a4ef2fbef",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf richt zich op PDF's, en dat is precies wat veel mensen nodig hebben. SnapOtter dekt dat terrein met samenvoegen, splitsen, comprimeren, converteren, redigeren, OCR en meer, en voegt daar in dezelfde implementatie workflows voor beeld, video, audio en bestanden aan toe.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.pl.json
+++ b/apps/landing/src/data/i18n/alternatives.pl.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "Ponad 200",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "e9f6933d96fa",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "b0515170af23",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg skupia się na jednym zadaniu i robi je dobrze. SnapOtter uruchamia lokalne usuwanie tła, a następnie dodaje kompresję, konwersję, powiększanie, OCR i resztę katalogu w ramach jednego wdrożenia.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "01af10715b88",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Tak. Usuwanie tła w SnapOtter działa lokalnie po jednorazowej instalacji pakietu modelu, dzięki czemu zdjęcia nigdy nie opuszczają Twojej sieci i nie ma żadnych kredytów naliczanych za zdjęcie.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "794c9f8c0dc0",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "Czy istnieje samodzielnie hostowana alternatywa dla remove.bg?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "1f813eb5ab50",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "Nie. Działa na CPU, a jeśli dostępna jest karta GPU, automatycznie z niej korzysta, aby szybciej przetwarzać partie plików.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "a02f9fcad638",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "Czy wymaga karty GPU?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "c361983c5b87",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "Otwartoźródłowa, samodzielnie hostowana alternatywa dla remove.bg",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "827d2b404341",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg to szybkie, hostowane narzędzie do usuwania tła. SnapOtter to samodzielnie hostowana alternatywa, która uruchamia ten sam rodzaj AI na Twoim własnym sprzęcie, dzięki czemu zdjęcia produktów i osób nigdy nie trafiają do zewnętrznej usługi.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "b4e4b336211b",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg usuwa tło ze zdjęć w chmurze. SnapOtter usuwa tło lokalnie na Twoim własnym serwerze, a do tego oferuje ponad 200 kolejnych narzędzi w tym samym środowisku.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "fb1fe1c080bb",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "Otwartoźródłowa, samodzielnie hostowana alternatywa dla remove.bg",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "827d2b404341",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Hostowana usługa internetowa",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "25df8179eef6",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Model wdrożenia",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "ec84dbe9a1d0",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Samodzielnie hostowany na Twoim serwerze",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "5f09e1bc8fb1",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "Zdjęcia są przesyłane do przetwarzania przez API hostowane przez dostawcę",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "4a5ffac67991",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Miejsce przetwarzania plików",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "511ca9e896f6",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "Twoja infrastruktura",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "38350709f8cd",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Cennik oparty na kredytach za każde zdjęcie",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "b2be8ec4b189",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Kontrola kosztów",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "68d00bced425",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "Bezpłatnie na licencji AGPLv3; ograniczeniem jest tylko Twój sprzęt",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "a3ff21f6502f",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Zaprojektowana do pracy online w przeglądarce",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "6f723037c945",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Praca offline / w izolowanej sieci",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "3257157eb62b",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Obsługiwana po wdrożeniu wewnątrz Twojej sieci",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "4f8d14f44fb1",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Usuwanie tła",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "3436f4b5a6b4",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Więcej niż usuwanie tła",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "4840282785b2",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Obraz, wideo, dźwięk, PDF i pliki",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "db86fab9a6d3",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Usługa obsługiwana przez dostawcę; dostępność kodu źródłowego nie jest częścią modelu produktu",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "3507226cf7bd",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Kod źródłowy i możliwość audytu",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "fff53d72a74e",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Kod źródłowy dostępny na licencji AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "038d949d9fdb",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "API hostowane przez dostawcę z kredytami za każde zdjęcie",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "45b672ae6fb7",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Automatyzacja",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "f7cd954b756c",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "API REST i potoki w Twoim wdrożeniu",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "9c72230127a1",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf skupia się na plikach PDF, czego wielu osobom właśnie potrzeba. SnapOtter obsługuje ten obszar, oferując scalanie, dzielenie, kompresję, konwersję, redakcję, OCR i więcej, a następnie dodaje procesy pracy z obrazem, wideo, dźwiękiem i plikami w tym samym wdrożeniu.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "Ponad 200",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "e9f6933d96fa",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.pt-BR.json
+++ b/apps/landing/src/data/i18n/alternatives.pt-BR.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "4f7bb092d763",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "O remove.bg se concentra em uma única tarefa e a faz bem. O SnapOtter faz a remoção de fundo localmente e, em seguida, acrescenta compressão, conversão, ampliação, OCR e o restante do catálogo em uma só implantação.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "c898f5bade36",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Sim. A remoção de fundo do SnapOtter roda localmente após uma instalação única do pacote de modelo, então as imagens nunca saem da sua rede e não há cobrança de crédito por imagem.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "d94a0c385552",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "Existe uma alternativa auto-hospedada ao remove.bg?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "a6b471fb63aa",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "Não. Ele roda na CPU e usa uma GPU automaticamente, se houver uma disponível, para acelerar os lotes.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "26190b09d8b9",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "É preciso ter uma GPU?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "dd07dcc4d91d",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "A alternativa open-source e auto-hospedada ao remove.bg",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "8657bede04fe",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "O remove.bg é um removedor de fundo hospedado e rápido. O SnapOtter é a alternativa auto-hospedada que roda o mesmo tipo de IA no seu próprio hardware, para que imagens de produtos e de pessoas nunca sejam enviadas a um serviço de terceiros.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "e0658a7bc896",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "O remove.bg remove fundos de imagens na nuvem. O SnapOtter executa a remoção de fundo localmente no seu próprio servidor, com mais de 200 ferramentas no mesmo conjunto.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "c5e752e6320a",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "A alternativa open-source e auto-hospedada ao remove.bg",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "8657bede04fe",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Serviço web hospedado",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "25cb3b97c974",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Modelo de implantação",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "05a8256f1322",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Auto-hospedado no seu servidor",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "087409fa237f",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "As imagens são enviadas para uma API hospedada pelo fornecedor para processamento",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "a0d13ccab457",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Local de processamento de arquivos",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "da954e0d114f",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "Sua infraestrutura",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "127ff3ff2524",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Preços por imagem baseados em créditos",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "6b26074838e3",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Controle de custos",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "04feb6ab96f0",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "Gratuito sob AGPLv3; os limites são o seu hardware",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "b9572a5565c9",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Projetado para uso online no navegador",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "2dc1adab6780",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Uso offline / em rede isolada",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "2e6cf69c39b5",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Compatível quando implantado dentro da sua rede",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "16d81f740d05",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Remoção de fundo",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "ebb2bff79d63",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Além da remoção de fundo",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "ad0415bec2eb",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Imagem, vídeo, áudio, PDF e arquivos",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "dc808083e254",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Serviço operado pelo fornecedor; a disponibilidade do código-fonte não faz parte do modelo do produto",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "8969b9dd0739",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Código-fonte e auditabilidade",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "2703bcfe28f1",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Código-fonte disponível sob AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "7e54f5624da1",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "API hospedada pelo fornecedor com créditos por imagem",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "70cb2d04295c",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Automação",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "0c177757203d",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "API REST e pipelines na sua implantação",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "4f7bb092d763",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "O Smallpdf é focado em PDFs, que é exatamente o que muita gente precisa. O SnapOtter cobre essa área com junção, divisão, compressão, conversão, redação, OCR e mais, e ainda acrescenta fluxos de imagem, vídeo, áudio e arquivos na mesma implantação.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.ru.json
+++ b/apps/landing/src/data/i18n/alternatives.ru.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "692267601a98",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg сосредоточен на одной задаче и справляется с ней отлично. SnapOtter выполняет удаление фона локально, а затем добавляет сжатие, конвертацию, увеличение разрешения, OCR и остальной каталог в рамках одного развёртывания.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "c8fcdac395c8",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Да. Удаление фона в SnapOtter работает локально после однократной установки пакета моделей, поэтому изображения никогда не покидают вашу сеть, и нет оплаты за каждое изображение.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "c673bd182458",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "Есть ли самостоятельно размещаемая альтернатива remove.bg?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "0dfdcaa94878",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "Нет. Он работает на CPU и автоматически использует GPU, если он доступен, для ускорения пакетной обработки.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "fa79d5857f3b",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "Нужен ли графический процессор?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "213e25152d75",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "Открытая самостоятельно размещаемая альтернатива remove.bg",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "33757e1e2f6a",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg — это быстрый облачный сервис для удаления фона. SnapOtter — это самостоятельно размещаемая альтернатива, которая запускает такой же ИИ на вашем собственном оборудовании, поэтому изображения товаров и людей никогда не попадают к стороннему сервису.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "9d1ab0976787",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg удаляет фон изображений в облаке. SnapOtter выполняет удаление фона локально на вашем собственном сервере и добавляет ещё 200+ инструментов в том же стеке.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "37c6d5f77625",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "Открытая самостоятельно размещаемая альтернатива remove.bg",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "33757e1e2f6a",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Облачный веб-сервис",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "4372ee08eef4",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Модель развёртывания",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "c8e8659c5096",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Размещение на вашем сервере",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "f066555735a2",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "Изображения загружаются для обработки в размещённый у поставщика API",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "8ed26c6aec72",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Место обработки файлов",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "5a77a6a68362",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "Ваша инфраструктура",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "94855dde47fe",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Оплата по кредитам за каждое изображение",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "bdb908112419",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Контроль затрат",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "d4a8e86801fb",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "Бесплатно по AGPLv3; ограничения задаёт ваше оборудование",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "b9056917f2bc",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Рассчитан на работу онлайн через браузер",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "320efabd0fcf",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Работа офлайн и в изолированной сети",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "39d45af164d4",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Поддерживается при развёртывании внутри вашей сети",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "e8cf789fe08b",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Удаление фона",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "3f3e245106f1",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Возможности сверх удаления фона",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "f0e23821962f",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Изображения, видео, аудио, PDF и файлы",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "f803dacb0e9b",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Сервис управляется поставщиком; открытость исходного кода не является частью модели продукта",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "98001b1cf393",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Исходный код и возможность аудита",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "f3164ebe81bd",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Исходный код доступен по лицензии AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "5a6bc5a979ac",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "Размещённый у поставщика API с оплатой кредитами за изображение",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "2a8b6a53faad",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Автоматизация",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "ef3f5a55db58",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "REST API и пайплайны в вашем развёртывании",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "804f23bed17d",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf сосредоточен на PDF, и многим именно это и нужно. SnapOtter закрывает это направление объединением, разделением, сжатием, конвертацией, редактированием с сокрытием, OCR и не только, а затем добавляет рабочие процессы для изображений, видео, аудио и файлов в том же развёртывании.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.sv.json
+++ b/apps/landing/src/data/i18n/alternatives.sv.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "43b6123b70ef",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg fokuserar på en enda uppgift och gör den bra. SnapOtter kör lokal bakgrundsborttagning och lägger sedan till komprimering, konvertering, uppskalning, OCR och resten av katalogen i en och samma installation.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "3f314e219312",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Ja. SnapOtters bakgrundsborttagning körs lokalt efter en engångsinstallation av modellpaketet, så bilderna lämnar aldrig ditt nätverk och det finns ingen kredit per bild.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "0f81898b665c",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "Finns det ett självhostat alternativ till remove.bg?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "06ea213bf535",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "Nej. Den körs på CPU och använder automatiskt en GPU om en sådan finns tillgänglig för snabbare batchar.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "39779d3a90b5",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "Behövs det en GPU?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "b1b071fdddc5",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "Det öppna, självhostade alternativet till remove.bg",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "a76f907dd59f",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg är en snabb molnbaserad bakgrundsborttagare. SnapOtter är det självhostade alternativet som kör samma sorts AI på din egen hårdvara, så att produkt- och personbilder aldrig skickas till en tredjepartstjänst.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "a6181d203e81",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg tar bort bildbakgrunder i molnet. SnapOtter kör bakgrundsborttagning lokalt på din egen server, med 200+ fler verktyg i samma stack.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "69503cc06c65",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "Det öppna, självhostade alternativet till remove.bg",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "a76f907dd59f",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Molnbaserad webbtjänst",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "2155435fa86b",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Driftmodell",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "d97df98caae5",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Självhostad på din server",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "6e438ca8c45c",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "Bilder laddas upp till ett leverantörshostat API för behandling",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "95701964d422",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Plats för filbehandling",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "08d668e93598",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "Din infrastruktur",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "99cb2416167d",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Kreditbaserad prissättning per bild",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "f031444ec2be",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Kostnadskontroll",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "5035b517e475",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "Gratis under AGPLv3; gränserna sätts av din hårdvara",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "e5ae008926bc",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Utformad för webbläsarbaserad onlineanvändning",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "a50f8c7e8c7e",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Offline- och luftgapad användning",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "efc7be7db833",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Stöds när den distribueras inom ditt nätverk",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "1ba4e62a4c53",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Bakgrundsborttagning",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "c85dccbde95a",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Utöver bakgrundsborttagning",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "a6175cf99dad",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Bild, video, ljud, PDF och filer",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "bc18133d425a",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Leverantörsdriven tjänst; tillgänglig källkod är inte en del av affärsmodellen",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "3bcfc061374c",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Källkod och granskningsbarhet",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "339abebb73b6",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Källkod tillgänglig under AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "81f560258672",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "Leverantörshostat API med krediter per bild",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "b87a662562de",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Automatisering",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "8efedca1b9cc",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "REST API och pipelines i din installation",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "43b6123b70ef",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf är inriktat på PDF-filer, vilket är precis vad många behöver. SnapOtter täcker det området med slå ihop, dela, komprimera, konvertera, redigera bort, OCR och mer, och lägger sedan till arbetsflöden för bild, video, ljud och filer i samma installation.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.th.json
+++ b/apps/landing/src/data/i18n/alternatives.th.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "d02b672ee5a8",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg มุ่งเน้นทำงานเดียวและทำได้ดี ส่วน SnapOtter รันการลบพื้นหลังในเครื่อง แล้วยังเพิ่มการบีบอัด การแปลงไฟล์ การขยายความละเอียด OCR และเครื่องมืออื่นๆ ทั้งหมดในการติดตั้งเดียว",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "60ea7f23444f",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "มี การลบพื้นหลังของ SnapOtter ทำงานในเครื่องหลังจากติดตั้งชุดโมเดลเพียงครั้งเดียว รูปภาพจึงไม่ออกจากเครือข่ายของคุณ และไม่มีค่าเครดิตต่อรูปภาพ",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "a934f303d539",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "มีทางเลือกแบบ self-hosted แทน remove.bg ไหม?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "4d36883ef2f3",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "ไม่ต้อง ทำงานบน CPU ได้ และจะใช้ GPU โดยอัตโนมัติหากมี เพื่อประมวลผลแบบชุดได้เร็วขึ้น",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "aa7c62c4458a",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "ต้องใช้ GPU ไหม?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "9e97645a4968",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "ทางเลือกโอเพนซอร์สแบบ self-hosted แทน remove.bg",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "459b6e0ce65c",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg เป็นตัวลบพื้นหลังแบบโฮสต์ที่ทำงานได้รวดเร็ว ส่วน SnapOtter เป็นทางเลือกแบบ self-hosted ที่รัน AI ประเภทเดียวกันบนฮาร์ดแวร์ของคุณเอง รูปภาพสินค้าและรูปภาพบุคคลจึงไม่ถูกส่งออกไปยังบริการของบุคคลที่สามเลย",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "ae579f45dd6c",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg ลบพื้นหลังรูปภาพบนคลาวด์ ส่วน SnapOtter ประมวลผลการลบพื้นหลังในเครื่องบนเซิร์ฟเวอร์ของคุณเอง พร้อมเครื่องมืออีกกว่า 200+ ตัวในสแตกเดียวกัน",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "1901aaa0c116",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "ทางเลือกโอเพนซอร์สแบบ Self-Hosted แทน remove.bg",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "f98651759f01",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "บริการเว็บแบบโฮสต์",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "6ac04ced7d38",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "รูปแบบการติดตั้ง",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "6d02db248e6b",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Self-hosted บนเซิร์ฟเวอร์ของคุณ",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "bcd7ddd66057",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "รูปภาพถูกอัปโหลดไปยัง API ที่ผู้ให้บริการโฮสต์เพื่อประมวลผล",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "87e8926c8295",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "ตำแหน่งการประมวลผลไฟล์",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "0ddfc0890b93",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "โครงสร้างพื้นฐานของคุณเอง",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "00cb9ede6cc8",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "คิดราคาตามเครดิตต่อรูปภาพ",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "e2bc0350ec20",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "การควบคุมค่าใช้จ่าย",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "637f8359899c",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "ฟรีภายใต้ AGPLv3 ข้อจำกัดขึ้นอยู่กับฮาร์ดแวร์ของคุณ",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "d5a0acc1e90a",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "ออกแบบมาสำหรับการใช้งานออนไลน์ผ่านเบราว์เซอร์",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "3e62df5e9806",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "การใช้งานแบบออฟไลน์ / air-gapped",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "510015bd5fda",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "รองรับเมื่อติดตั้งภายในเครือข่ายของคุณ",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "8f6c6eb30a57",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "การลบพื้นหลัง",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "e1d17e53f52a",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "นอกเหนือจากการลบพื้นหลัง",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "a20205938348",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "รูปภาพ วิดีโอ เสียง PDF และไฟล์ต่างๆ",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "f7f209ca8556",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "บริการที่ดำเนินการโดยผู้ให้บริการ การเปิดเผยซอร์สโค้ดไม่ใช่รูปแบบของผลิตภัณฑ์",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "f337bc053077",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "ซอร์สโค้ดและการตรวจสอบได้",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "d47b7cf0421d",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "เปิดเผยซอร์สโค้ดภายใต้ AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "fabaccc94c09",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "API ที่ผู้ให้บริการโฮสต์ พร้อมเครดิตต่อรูปภาพ",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "3dcc434495e5",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "การทำงานอัตโนมัติ",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "7d36984256d4",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "REST API และไปป์ไลน์ในการติดตั้งของคุณ",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "2defe3af3412",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf โฟกัสที่งาน PDF ซึ่งก็ตรงกับสิ่งที่หลายคนต้องการพอดี SnapOtter ครอบคลุมงานสายนั้นด้วยการรวม แยก บีบอัด แปลง ลบข้อมูลลับ OCR และอื่น ๆ แล้วยังเพิ่มเวิร์กโฟลว์ด้านภาพ วิดีโอ เสียง และไฟล์ไว้ในการดีพลอยเดียวกัน",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.tr.json
+++ b/apps/landing/src/data/i18n/alternatives.tr.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "6d3db6aaeea7",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg tek bir işe odaklanır ve onu iyi yapar. SnapOtter yerel arka plan kaldırma işlemini çalıştırır, ardından tek bir kurulumda sıkıştırma, dönüştürme, büyütme, OCR ve kataloğun geri kalanını da ekler.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "d7f1bdc1ca86",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Evet. SnapOtter'ın arka plan kaldırma özelliği, tek seferlik bir model paketi kurulumundan sonra yerel olarak çalışır; böylece görseller ağınızdan hiç çıkmaz ve görsel başına kredi ödemezsiniz.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "8b987500d812",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "remove.bg'ye kendi sunucunuzda barındırılan bir alternatif var mı?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "c6a1b231ee3b",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "Hayır. CPU üzerinde çalışır ve daha hızlı toplu işlemler için bir GPU mevcutsa onu otomatik olarak kullanır.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "6d2a31b0e959",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "GPU gerektirir mi?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "cb9c6584ef5b",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "remove.bg'ye açık kaynaklı, kendi sunucunuzda barındırılan alternatif",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "64973f5bf0a2",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg, hızlı ve bulutta barındırılan bir arka plan kaldırma aracıdır. SnapOtter ise aynı türden yapay zekayı kendi donanımınızda çalıştıran, kendi sunucunuzda barındırılan alternatiftir; böylece ürün ve insan görselleri asla üçüncü taraf bir hizmete gitmez.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "d97f29d0c645",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg, görsel arka planlarını bulutta kaldırır. SnapOtter ise arka plan kaldırma işlemini kendi sunucunuzda yerel olarak çalıştırır ve aynı yapıda 200+ tane daha araç sunar.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "28b055999b58",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "remove.bg'ye Açık Kaynaklı, Kendi Sunucunuzda Barındırılan Alternatif",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "395aa1438c5a",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Bulutta barındırılan web hizmeti",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "958290736ee5",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Kurulum modeli",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "95c35fd47e11",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Kendi sunucunuzda barındırılır",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "91ca1f670263",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "Görseller işlenmek üzere sağlayıcı tarafından barındırılan bir API'ye yüklenir",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "2ad818880416",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Dosya işleme konumu",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "7cb36fa99dea",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "Sizin altyapınız",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "8a4e479f326d",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Görsel başına kredi tabanlı fiyatlandırma",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "eb5e5024dd3c",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Maliyet kontrolü",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "2302303bfb18",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "AGPLv3 ile ücretsiz; sınırlar donanımınızdır",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "1e8c45dfeee9",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Tarayıcı tabanlı çevrimiçi kullanım için tasarlanmıştır",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "6569d553f2e8",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Çevrimdışı / ağdan yalıtılmış kullanım",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "7a8562e0c970",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Kendi ağınızın içinde dağıtıldığında desteklenir",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "a65028bba608",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Arka plan kaldırma",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "02d5269d63e6",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Arka plan kaldırmanın ötesinde",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "f9b5e3a44c6f",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Görsel, video, ses, PDF ve dosyalar",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "1a6349a7df6a",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Sağlayıcı tarafından işletilen hizmet; kaynak erişilebilirliği ürün modelinin bir parçası değildir",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "48392c2b1db7",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Kaynak ve denetlenebilirlik",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "15b262db4200",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Kaynak kodu AGPLv3 altında erişilebilir",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "207a47bf0a51",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "Görsel başına kredi ile sağlayıcı tarafından barındırılan API",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "865e2236aa1d",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Otomasyon",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "2dd23b6cb0c3",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "Kendi kurulumunuzda REST API ve iş akışları",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "229fe3d390d8",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf, PDF'lere odaklanır ve pek çok kişinin ihtiyacı da tam olarak budur. SnapOtter bu alanı birleştirme, bölme, sıkıştırma, dönüştürme, sansürleme, OCR ve daha fazlasıyla kapsar, ardından aynı kuruluma görüntü, video, ses ve dosya iş akışlarını ekler.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.uk.json
+++ b/apps/landing/src/data/i18n/alternatives.uk.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "2e40c073bd14",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg зосереджений на одному завданні й виконує його добре. SnapOtter локально видаляє тло, а потім додає стиснення, конвертацію, збільшення роздільної здатності, OCR та решту каталогу в одному розгортанні.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "5a7b343f1456",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Так. Видалення тла в SnapOtter працює локально після одноразового встановлення набору моделей, тож зображення ніколи не залишають вашу мережу й немає плати за кожне зображення.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "5da6e5023609",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "Чи існує альтернатива remove.bg із самостійним хостингом?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "aa70ede15bc7",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "Ні. Він працює на процесорі й автоматично використовує графічний процесор, якщо той доступний, для швидшої обробки пакетів.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "49fff2cbd12d",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "Чи потрібен графічний процесор?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "36d8e9ffeb37",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "Альтернатива remove.bg з відкритим кодом і самостійним хостингом",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "063c8f70238b",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg це швидкий хмарний сервіс для видалення тла. SnapOtter це альтернатива з самостійним хостингом, яка запускає такий самий ШІ на вашому власному обладнанні, тож зображення товарів і людей ніколи не потрапляють до стороннього сервісу.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "948e2296aed2",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg видаляє тло зображень у хмарі. SnapOtter виконує видалення тла локально на вашому власному сервері, з понад 200 додатковими інструментами в одному стеку.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "95e9ea1c3230",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "Альтернатива remove.bg з відкритим кодом і самостійним хостингом",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "063c8f70238b",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Хмарний вебсервіс",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "51c753e9de5f",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Модель розгортання",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "e3ae7484b84b",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Самостійний хостинг на вашому сервері",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "f12ce1563bd3",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "Зображення завантажуються для обробки на API, розміщений постачальником",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "75a901b6aa97",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Місце обробки файлів",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "4b28671d386f",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "Ваша інфраструктура",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "9e88aa9c9224",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Ціноутворення на основі кредитів за кожне зображення",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "7c040e3854ee",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Контроль витрат",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "6f209a3600e2",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "Безкоштовно за AGPLv3; обмеження задає лише ваше обладнання",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "d018d64a0d89",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Розроблено для роботи онлайн у браузері",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "403562fd18a0",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Робота офлайн та в ізольованій мережі",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "cffaf0950bfb",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Підтримується під час розгортання всередині вашої мережі",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "267c2a70780d",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Видалення тла",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "46e8ff0b452e",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Більше, ніж видалення тла",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "2948dc85ea62",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Зображення, відео, аудіо, PDF та файли",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "2c761a5a3e28",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Сервіс, керований постачальником; доступність вихідного коду не є частиною моделі продукту",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "1737f8926159",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Вихідний код і можливість аудиту",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "34c5e637ecac",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Вихідний код доступний за ліцензією AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "a263a058cb27",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "API, розміщений постачальником, з кредитами за кожне зображення",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "c1ef1d3043dd",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Автоматизація",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "f15b6272d7b6",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "REST API та конвеєри у вашому розгортанні",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "2e40c073bd14",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf зосереджений на PDF, і саме це потрібно багатьом людям. SnapOtter закриває цей напрямок обʼєднанням, розділенням, стисненням, конвертацією, редагуванням, OCR та іншим, а потім додає роботу із зображеннями, відео, аудіо та файлами в межах того самого розгортання.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.vi.json
+++ b/apps/landing/src/data/i18n/alternatives.vi.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "8cec7fdce571",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg tập trung vào một nhiệm vụ và làm rất tốt. SnapOtter chạy xóa nền ngay tại chỗ, rồi bổ sung thêm nén ảnh, chuyển đổi định dạng, phóng to, OCR và toàn bộ danh mục công cụ còn lại trong một lần triển khai.",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "aef9f4be095e",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "Có. Tính năng xóa nền của SnapOtter chạy ngay tại chỗ sau khi cài đặt gói mô hình một lần, nhờ vậy ảnh không bao giờ rời khỏi mạng của bạn và không tính tín dụng cho mỗi ảnh.",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "4bf665be8e3d",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "Có giải pháp tự lưu trữ nào thay thế cho remove.bg không?",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "4a6aa2848269",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "Không. Công cụ chạy được trên CPU, và tự động dùng GPU nếu có sẵn để xử lý hàng loạt nhanh hơn.",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "65f1b9c77bbd",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "Có cần GPU không?",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "a72056b7c763",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "Giải pháp thay thế mã nguồn mở, tự lưu trữ cho remove.bg",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "3dcbf124597a",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg là công cụ xóa nền được lưu trữ trên đám mây, xử lý nhanh chóng. SnapOtter là giải pháp tự lưu trữ chạy cùng loại AI đó trên phần cứng của chính bạn, nhờ vậy ảnh sản phẩm và ảnh con người không bao giờ phải gửi đến dịch vụ bên thứ ba.",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "b80651747165",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg xóa nền ảnh trên đám mây. SnapOtter chạy xóa nền ngay tại máy chủ của riêng bạn, cùng với hơn 200 công cụ khác trong cùng một hệ thống.",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "285dc773a478",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "Giải pháp thay thế mã nguồn mở, tự lưu trữ cho remove.bg",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "3dcbf124597a",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "Dịch vụ web được lưu trữ trên đám mây",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "97f389ce1140",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "Mô hình triển khai",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "9f39cffbcf2a",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "Tự lưu trữ trên máy chủ của bạn",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "f513f2657065",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "Ảnh được tải lên API do nhà cung cấp lưu trữ để xử lý",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "0fc8f38d8435",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "Nơi xử lý tệp",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "450bb7052ed9",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "Hạ tầng của bạn",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "a00f058732df",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "Giá tính theo tín dụng cho mỗi ảnh",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "625cf80722ae",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "Kiểm soát chi phí",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "7dfc2b8e76f5",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "Miễn phí theo AGPLv3; giới hạn phụ thuộc vào phần cứng của bạn",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "b2b5c80276ac",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "Được thiết kế để dùng trực tuyến qua trình duyệt",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "770f71d63be9",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "Sử dụng ngoại tuyến / trong mạng cô lập",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "b634ed4c7a4f",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "Được hỗ trợ khi triển khai bên trong mạng nội bộ của bạn",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "0cd69ebc8012",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "Xóa nền",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "a2780c30aac6",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "Ngoài xóa nền",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "afbadb4f5152",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "Ảnh, video, âm thanh, PDF và tệp",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "acabdde9a8b3",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "Dịch vụ do nhà cung cấp vận hành; công khai mã nguồn không phải là mô hình sản phẩm",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "00867578f4e6",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "Mã nguồn và khả năng kiểm toán",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "6aa5ce1e5499",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "Mã nguồn công khai theo giấy phép AGPLv3",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "9b4e740591c1",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "API do nhà cung cấp lưu trữ, tính tín dụng cho mỗi ảnh",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "63eac094253d",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "Tự động hóa",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "64fa0ee04267",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "REST API và quy trình xử lý ngay trong bản triển khai của bạn",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "a45706bf61e5",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf tập trung vào PDF, đúng thứ mà nhiều người cần. SnapOtter bao quát mảng đó với gộp, tách, nén, chuyển đổi, che thông tin, OCR và nhiều hơn nữa, rồi bổ sung thêm các quy trình xử lý ảnh, video, âm thanh và tệp trong cùng một lần triển khai.",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.zh-CN.json
+++ b/apps/landing/src/data/i18n/alternatives.zh-CN.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "dfb49851df48",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg 专注于把一件事做好。SnapOtter 在本地运行背景去除的同时，还在同一次部署中加入了压缩、格式转换、放大、OCR 以及整套工具目录。",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "0479d2c907bc",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "有。SnapOtter 的背景去除功能在一次性安装模型包后即可本地运行，图片绝不会离开你的网络，也没有按图片计费的积分。",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "908e9d1a665e",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "有没有 remove.bg 的自托管替代方案？",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "622f5f76bfbb",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "不需要。它可在 CPU 上运行，若检测到可用的 GPU 则会自动使用，从而更快地处理批量任务。",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "491b28ac1e8f",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "需要 GPU 吗？",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "6d63a824dbb2",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "remove.bg 的开源自托管替代方案",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "fc1c856d13a7",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg 是一款快速的托管式背景去除工具。SnapOtter 则是自托管替代方案，在你自己的硬件上运行同类 AI，因此产品图和人物照片绝不会发送给任何第三方服务。",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "cadc7180761d",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg 在云端去除图片背景。SnapOtter 在你自己的服务器上本地运行背景去除，同一套系统中还内置了 200+ 更多工具。",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "3feb40ebe70a",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "remove.bg 的开源自托管替代方案",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "fc1c856d13a7",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "托管式网络服务",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "fa097f85669a",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "部署模式",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "eb02e1bc8d97",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "在你自己的服务器上自托管",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "79d06e2c0134",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "图片会上传到厂商托管的 API 进行处理",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "dc24f26754de",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "文件处理位置",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "f7197b9d0d37",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "你自己的基础设施",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "5f3ed1045200",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "按图片计费的积分制定价",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "19ebfbbec31c",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "成本控制",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "6936ad230a9c",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "免费，采用 AGPLv3 许可；上限取决于你的硬件",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "f7fbd3b11105",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "为基于浏览器的在线使用而设计",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "16f0394b5adb",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "离线 / 隔离网络使用",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "a615c0394865",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "在你的网络内部署时即可支持",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "bea45e300e49",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "背景去除",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "bf36a9a386ee",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "背景去除之外",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "c4d7917b4d07",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "图片、视频、音频、PDF 和文件",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "322dc74bb0af",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "厂商运营的服务；源代码公开并非其产品模式",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "fbf4aa74f971",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "源代码与可审计性",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "ff9bfe148722",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "源代码依据 AGPLv3 公开可获取",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "7e533e3b80e6",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "厂商托管的 API，按图片计积分",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "33396891093d",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "自动化",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "829a35554fa1",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "在你的部署中提供 REST API 和处理流水线",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "a0eff7668fcf",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf 专注于 PDF，这正是许多人所需要的。SnapOtter 同样覆盖这一领域，提供合并、拆分、压缩、转换、涂黑、OCR 等功能，并在同一次部署中加入图像、视频、音频和文件处理流程。",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {

--- a/apps/landing/src/data/i18n/alternatives.zh-TW.json
+++ b/apps/landing/src/data/i18n/alternatives.zh-TW.json
@@ -791,10 +791,10 @@
     "stale": false
   },
   "alt:convertx:rows.4.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:convertx:rows.5.competitor": {
@@ -1679,6 +1679,216 @@
     "outputHash": "164feffb8ba1",
     "stale": false
   },
+  "alt:removebg:breadth": {
+    "text": "remove.bg 專注做好一件事。SnapOtter 除了本機背景移除，還在同一次部署中提供壓縮、格式轉換、放大、OCR 以及完整工具目錄中的其他功能。",
+    "_sourceHash": "a6e13984792c",
+    "provenance": "machine",
+    "outputHash": "ace6f28390b1",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.a": {
+    "text": "有。SnapOtter 的背景移除只需一次性安裝模型套件，之後即在本機運行，圖片絕不離開你的網路，也沒有每張圖片的點數費用。",
+    "_sourceHash": "4a0966445802",
+    "provenance": "machine",
+    "outputHash": "970ff623e468",
+    "stale": false
+  },
+  "alt:removebg:faqs.0.q": {
+    "text": "有沒有 remove.bg 的自架替代方案？",
+    "_sourceHash": "f82403b5e42c",
+    "provenance": "machine",
+    "outputHash": "c429d4535aff",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.a": {
+    "text": "不需要。它可在 CPU 上運行，若有可用的 GPU，也會自動使用以加速批次處理。",
+    "_sourceHash": "45938e537dea",
+    "provenance": "machine",
+    "outputHash": "8f3eb769fe69",
+    "stale": false
+  },
+  "alt:removebg:faqs.1.q": {
+    "text": "需要 GPU 嗎？",
+    "_sourceHash": "2fa610ebdf19",
+    "provenance": "machine",
+    "outputHash": "002a7d2a0b4a",
+    "stale": false
+  },
+  "alt:removebg:h1": {
+    "text": "remove.bg 的開源自架替代方案",
+    "_sourceHash": "e797312a375c",
+    "provenance": "machine",
+    "outputHash": "da212a943241",
+    "stale": false
+  },
+  "alt:removebg:intro": {
+    "text": "remove.bg 是速度飛快的雲端背景移除服務。SnapOtter 則是自架替代方案，在你自己的硬體上運行同類型的 AI，讓產品與人物圖片永遠不會傳送到第三方服務。",
+    "_sourceHash": "3ce831680d32",
+    "provenance": "machine",
+    "outputHash": "98b45582b10e",
+    "stale": false
+  },
+  "alt:removebg:metaDescription": {
+    "text": "remove.bg 在雲端移除圖片背景。SnapOtter 在你自己的伺服器上進行本機背景移除，同一套系統還內建 200+ 種工具。",
+    "_sourceHash": "4ae6f4194ec0",
+    "provenance": "machine",
+    "outputHash": "45599602674c",
+    "stale": false
+  },
+  "alt:removebg:pageTitle": {
+    "text": "remove.bg 的開源自架替代方案",
+    "_sourceHash": "87c485b2a42f",
+    "provenance": "machine",
+    "outputHash": "da212a943241",
+    "stale": false
+  },
+  "alt:removebg:rows.0.competitor": {
+    "text": "雲端網頁服務",
+    "_sourceHash": "a7a016748e17",
+    "provenance": "machine",
+    "outputHash": "df1bde4a24b4",
+    "stale": false
+  },
+  "alt:removebg:rows.0.feature": {
+    "text": "部署方式",
+    "_sourceHash": "48b995f6f08d",
+    "provenance": "machine",
+    "outputHash": "597320937748",
+    "stale": false
+  },
+  "alt:removebg:rows.0.snapotter": {
+    "text": "自架於你自己的伺服器",
+    "_sourceHash": "b1dac99272dd",
+    "provenance": "machine",
+    "outputHash": "5877822f12f8",
+    "stale": false
+  },
+  "alt:removebg:rows.1.competitor": {
+    "text": "圖片會上傳到廠商託管的 API 進行處理",
+    "_sourceHash": "10ba97e44e6c",
+    "provenance": "machine",
+    "outputHash": "8c5ba4a0cf8b",
+    "stale": false
+  },
+  "alt:removebg:rows.1.feature": {
+    "text": "檔案處理位置",
+    "_sourceHash": "0ceb74dd7de8",
+    "provenance": "machine",
+    "outputHash": "be666df93ccf",
+    "stale": false
+  },
+  "alt:removebg:rows.1.snapotter": {
+    "text": "你自己的基礎架構",
+    "_sourceHash": "23d6fa83321f",
+    "provenance": "machine",
+    "outputHash": "f72eaa6caa01",
+    "stale": false
+  },
+  "alt:removebg:rows.2.competitor": {
+    "text": "依每張圖片計費的點數制定價",
+    "_sourceHash": "829521ab58e0",
+    "provenance": "machine",
+    "outputHash": "681b67d8e625",
+    "stale": false
+  },
+  "alt:removebg:rows.2.feature": {
+    "text": "成本掌控",
+    "_sourceHash": "22be6dda6262",
+    "provenance": "machine",
+    "outputHash": "3aae1e7d7b5b",
+    "stale": false
+  },
+  "alt:removebg:rows.2.snapotter": {
+    "text": "免費採用 AGPLv3 授權；上限取決於你的硬體",
+    "_sourceHash": "687e241f57c1",
+    "provenance": "machine",
+    "outputHash": "5987b66518c5",
+    "stale": false
+  },
+  "alt:removebg:rows.3.competitor": {
+    "text": "專為瀏覽器線上使用而設計",
+    "_sourceHash": "8907a163d968",
+    "provenance": "machine",
+    "outputHash": "d0b9305908d7",
+    "stale": false
+  },
+  "alt:removebg:rows.3.feature": {
+    "text": "離線／隔離網路使用",
+    "_sourceHash": "e4a80d68819d",
+    "provenance": "machine",
+    "outputHash": "861f364d695c",
+    "stale": false
+  },
+  "alt:removebg:rows.3.snapotter": {
+    "text": "部署於你的內部網路時即可支援",
+    "_sourceHash": "4beb5ebfedbf",
+    "provenance": "machine",
+    "outputHash": "b9bdc8280268",
+    "stale": false
+  },
+  "alt:removebg:rows.4.competitor": {
+    "text": "背景移除",
+    "_sourceHash": "719d0ee714fc",
+    "provenance": "machine",
+    "outputHash": "5c9b5646272e",
+    "stale": false
+  },
+  "alt:removebg:rows.4.feature": {
+    "text": "背景移除之外",
+    "_sourceHash": "59d03d7534b5",
+    "provenance": "machine",
+    "outputHash": "99725ba1ca6f",
+    "stale": false
+  },
+  "alt:removebg:rows.4.snapotter": {
+    "text": "圖片、影片、音訊、PDF 與檔案",
+    "_sourceHash": "e7a2fc51966a",
+    "provenance": "machine",
+    "outputHash": "6bb4eb43fbe4",
+    "stale": false
+  },
+  "alt:removebg:rows.5.competitor": {
+    "text": "由廠商營運的服務；公開原始碼並非其產品模式",
+    "_sourceHash": "bc334341e970",
+    "provenance": "machine",
+    "outputHash": "8453a31ec5f0",
+    "stale": false
+  },
+  "alt:removebg:rows.5.feature": {
+    "text": "原始碼與可稽核性",
+    "_sourceHash": "787c52535666",
+    "provenance": "machine",
+    "outputHash": "749f99f80fd2",
+    "stale": false
+  },
+  "alt:removebg:rows.5.snapotter": {
+    "text": "原始碼依 AGPLv3 授權公開",
+    "_sourceHash": "01dd659eb6f9",
+    "provenance": "machine",
+    "outputHash": "47f582bfd863",
+    "stale": false
+  },
+  "alt:removebg:rows.6.competitor": {
+    "text": "廠商託管的 API，按每張圖片扣點",
+    "_sourceHash": "ac59af091ef8",
+    "provenance": "machine",
+    "outputHash": "3fdff083407b",
+    "stale": false
+  },
+  "alt:removebg:rows.6.feature": {
+    "text": "自動化",
+    "_sourceHash": "d909750b1bbb",
+    "provenance": "machine",
+    "outputHash": "ad3a6e25729d",
+    "stale": false
+  },
+  "alt:removebg:rows.6.snapotter": {
+    "text": "在你的部署中提供 REST API 與流程管線",
+    "_sourceHash": "c201df2119aa",
+    "provenance": "machine",
+    "outputHash": "45516d723c2d",
+    "stale": false
+  },
   "alt:smallpdf:breadth": {
     "text": "Smallpdf 專注於 PDF，這正是許多人所需要的。SnapOtter 同樣涵蓋這個領域，提供合併、分割、壓縮、轉檔、遮蔽、OCR 等功能，並在同一套部署中加上影像、影片、音訊與檔案工作流程。",
     "_sourceHash": "f9e4c7657edb",
@@ -2044,10 +2254,10 @@
     "stale": false
   },
   "alt:stirling-pdf:rows.3.snapotter": {
-    "text": "241",
-    "_sourceHash": "749fc650cacb",
+    "text": "200+",
+    "_sourceHash": "ed98fc54e23b",
     "provenance": "machine",
-    "outputHash": "749fc650cacb",
+    "outputHash": "ed98fc54e23b",
     "stale": false
   },
   "alt:stirling-pdf:rows.4.competitor": {


### PR DESCRIPTION
## Summary

During the main-branch merge for the i18n code PR, `main` had added a new remove.bg comparison page and tweaked a couple of alternatives rows. I re-translated those landing-seo units into all 20 languages and imported them, but the alternatives catalogs (`apps/landing/src/data/i18n/alternatives.<locale>.json`) were not included in that commit, so PR #484 shipped without them. On the live site the remove.bg comparison rendered in English on all 20 locales.

This commits those 20 catalog files. `pnpm i18n:check` now passes on all four surfaces (previously landing-seo had 640 stale/missing units on main); landing build is clean.