### PR TITLE
ci(release): keep image attestations in GitHub's API, drop provenance sidecars

### DIFF
--- a/.github/workflows/attest.yml
+++ b/.github/workflows/attest.yml
@@ -2,8 +2,12 @@ name: Attest Provenance
 
 # Generates SLSA build-provenance attestations for an already-published release,
 # so no image rebuild is required. Dispatch it after a release once the image
-# manifest and source archives exist. Provenance is pushed to the registries as
-# OCI referrers (verify with: gh attestation verify oci://<image>@<digest>).
+# manifest and source archives exist.
+#
+# Keep image attestations in GitHub's attestation API instead of pushing them
+# back to registries. GHCR renders OCI fallback sha256-* attestation tags as
+# package versions, which makes the package page recommend non-runtime artifacts.
+# Verify with: gh attestation verify oci://<image>@<digest> -R snapotter-hq/SnapOtter
 
 on:
   workflow_dispatch:
@@ -26,35 +30,21 @@ jobs:
     permissions:
       id-token: write
       attestations: write
-      packages: write
       contents: read
     steps:
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Attest GHCR image
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-name: ghcr.io/snapotter-hq/snapotter
           subject-digest: ${{ inputs.image_digest }}
-          push-to-registry: true
+          push-to-registry: false
 
       - name: Attest Docker Hub image
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-name: docker.io/snapotter/snapotter
           subject-digest: ${{ inputs.image_digest }}
-          push-to-registry: true
+          push-to-registry: false
 
   archives:
     name: Attest source archives

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,10 @@ jobs:
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
           labels: ${{ steps.meta.outputs.labels }}
+          # The manual attestation workflow signs release images. Buildx's
+          # default provenance sidecars show up in GHCR as unknown/unknown
+          # architectures on the package page.
+          provenance: false
           outputs: type=image,"name=snapotter/snapotter,ghcr.io/snapotter-hq/snapotter",push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=ghcr.io/snapotter-hq/snapotter:cache-${{ env.PLATFORM_PAIR }}
           cache-to: type=registry,ref=ghcr.io/snapotter-hq/snapotter:cache-${{ env.PLATFORM_PAIR }},mode=max


### PR DESCRIPTION
## Summary

Clean up the GHCR / Docker Hub **package page** so it stops listing non-runtime artifacts as if they were pullable images.

- **`attest.yml`: `push-to-registry: false`** on both attest steps. Attestations stay in GitHub's attestation API (still verifiable with `gh attestation verify oci://<image>@<digest> -R snapotter-hq/SnapOtter`) instead of being pushed back as OCI referrer tags. GHCR renders those `sha256-*` fallback tags as package versions. Also drops the now-unneeded registry logins and `packages: write` permission.
- **`release.yml`: `provenance: false`** on the multi-arch buildx build. Buildx's default provenance sidecars show up on the GHCR package page as `unknown/unknown` architecture entries. Provenance is handled separately by the manual `attest.yml` workflow, so the inline sidecars are redundant.

## Scope

Two workflow files only. No change to the release/publish flow itself: the manual `publish-images` approval gate, the `RELEASE_TOKEN` push path, and the web Sentry DSN build arg are all untouched.

## Verification

- Both workflow files parse as valid YAML.
- Attestations remain verifiable via the GitHub attestation API.