### PR TITLE
feat(landing): add Twelve Tools and Wired Business footer badges

### DIFF
--- a/apps/landing/public/badges/twelve-tools.svg
+++ b/apps/landing/public/badges/twelve-tools.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?><svg width="200" height="54" viewBox="0 0 200 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect stroke="#d8d8d8" stroke-width="1" fill="#eee" x="0.5" y="0.5" width="199" height="53" rx="8"></rect>
+        <text font-family="Helvetica-Bold, Helvetica, Arial, sans-serif" font-size="14" font-weight="bold" fill="#7C6850">
+            <tspan x="16" y="21">FEATURED ON</tspan>
+        </text>
+        <text font-family="Helvetica-Bold, Helvetica, Arial, sans-serif" font-size="20" font-weight="bold" fill="#000">
+            <tspan x="16" y="45">twelve.tools</tspan>
+        </text>
+        <g transform="translate(145,2) scale(0.4)" viewBox="0 0 120 120">
+            <style type="text/css">
+            	.st0{fill:#FFC54D;}
+            	.st1{fill:#7C6850;}
+            	.st2{fill:#FFFFFF;}
+            </style>
+            <g>
+                <path class="st0" d="M61.8,16.5l10.3,20.6c0.3,0.5,0.8,1.1,1.6,1.1l22.8,3.3c1.6,0.3,2.2,2.2,1.1,3.5L81,61   c-0.5,0.5-0.8,1.1-0.5,1.9l3.8,22.8c0.3,1.6-1.4,3-3,2.2L60.9,77c-0.5-0.3-1.4-0.3-1.9,0L38.7,87.9c-1.4,0.8-3.3-0.5-3-2.2   l3.8-22.8c0-0.5,0-1.4-0.5-1.9L22.4,45c-1.1-1.1-0.5-3.3,1.1-3.5l22.8-3.3c0.5,0,1.1-0.5,1.6-1.1l10.3-20.6   C59.1,14.9,60.9,14.9,61.8,16.5z"></path>
+                <path class="st1" d="M91.1,83.8H28.9c-1.3,0-2.3,0.9-2.6,2.1l-3.6,15.5c-0.4,1.7,0.9,3.3,2.6,3.3h69.5c1.7,0,3-1.6,2.6-3.3   l-3.6-15.5C93.5,84.6,92.4,83.8,91.1,83.8z"></path>
+                <path class="st2" d="M73.6,98.3H46.4c-0.6,0-1.2-0.5-1.2-1.2v-5.9c0-0.6,0.5-1.2,1.2-1.2h27.1c0.6,0,1.2,0.5,1.2,1.2v5.9   C74.7,97.8,74.2,98.3,73.6,98.3z"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/apps/landing/public/badges/wired-business.svg
+++ b/apps/landing/public/badges/wired-business.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?><svg width="200" height="54" viewBox="0 0 200 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect stroke="#d8d8d8" stroke-width="1" fill="#eee" x="0.5" y="0.5" width="199" height="53" rx="8"></rect>
+        <text font-family="Helvetica-Bold, Helvetica, Arial, sans-serif" font-size="11" font-weight="bold" fill="#7C6850">
+            <tspan x="50" y="21">FEATURED ON</tspan>
+        </text>
+        <text font-family="Helvetica-Bold, Helvetica, Arial, sans-serif" font-size="17" font-weight="bold" fill="#000">
+            <tspan x="50" y="42">Wired Business</tspan>
+        </text>
+        
+        <g transform="translate(0,3) scale(0.4)" viewBox="0 0 120 120">
+            <style type="text/css">
+            	.st0{fill:#285FFF;}
+            	.st1{fill:#FFC54D;}
+            	.st2{fill:#E8B04B;}
+            	.st3{fill:#FFFFFF;}
+            </style>
+            <g>
+                <polygon class="st0" points="75.7,107.4 60,97.5 44.3,107.4 44.3,41.1 75.7,41.1  "/>
+                <circle class="st1" cx="60" cy="44.8" r="32.2"/>
+                <circle class="st2" cx="60" cy="44.8" r="25.3"/>
+                <path class="st3" d="M61.2,29.7l4.2,8.4c0.2,0.4,0.6,0.7,1,0.8l9.3,1.4c1.1,0.2,1.6,1.5,0.8,2.3l-6.7,6.6c-0.3,0.3-0.5,0.8-0.4,1.2   l1.6,9.3c0.2,1.1-1,2-2,1.4l-8.3-4.4c-0.4-0.2-0.9-0.2-1.3,0L51,61.1c-1,0.5-2.2-0.3-2-1.4l1.6-9.3c0.1-0.4-0.1-0.9-0.4-1.2   l-6.7-6.6c-0.8-0.8-0.4-2.2,0.8-2.3l9.3-1.4c0.4-0.1,0.8-0.3,1-0.8l4.2-8.4C59.3,28.7,60.7,28.7,61.2,29.7z"/>
+            </g>
+        </g>
+        <!--
+        <g transform="translate(145,2) scale(0.4)" viewBox="0 0 120 120">
+            <style type="text/css">
+            	.st0{fill:#FFC54D;}
+            	.st1{fill:#7C6850;}
+            	.st2{fill:#FFFFFF;}
+            </style>
+            <g>
+                <path class="st0" d="M61.8,16.5l10.3,20.6c0.3,0.5,0.8,1.1,1.6,1.1l22.8,3.3c1.6,0.3,2.2,2.2,1.1,3.5L81,61   c-0.5,0.5-0.8,1.1-0.5,1.9l3.8,22.8c0.3,1.6-1.4,3-3,2.2L60.9,77c-0.5-0.3-1.4-0.3-1.9,0L38.7,87.9c-1.4,0.8-3.3-0.5-3-2.2   l3.8-22.8c0-0.5,0-1.4-0.5-1.9L22.4,45c-1.1-1.1-0.5-3.3,1.1-3.5l22.8-3.3c0.5,0,1.1-0.5,1.6-1.1l10.3-20.6   C59.1,14.9,60.9,14.9,61.8,16.5z"></path>
+                <path class="st1" d="M91.1,83.8H28.9c-1.3,0-2.3,0.9-2.6,2.1l-3.6,15.5c-0.4,1.7,0.9,3.3,2.6,3.3h69.5c1.7,0,3-1.6,2.6-3.3   l-3.6-15.5C93.5,84.6,92.4,83.8,91.1,83.8z"></path>
+                <path class="st2" d="M73.6,98.3H46.4c-0.6,0-1.2-0.5-1.2-1.2v-5.9c0-0.6,0.5-1.2,1.2-1.2h27.1c0.6,0,1.2,0.5,1.2,1.2v5.9   C74.7,97.8,74.2,98.3,73.6,98.3z"></path>
+            </g>
+        </g>
+        -->
+    </g>
+</svg>

--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -139,6 +139,14 @@ const columns = [
     <p class="text-xs text-muted">
       {t(locale, "footer.copyright", { year })}
     </p>
+    <a
+      href="https://twelve.tools"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Featured on Twelve Tools"
+    >
+      <img src="/badges/twelve-tools.svg" alt="Featured on Twelve Tools" width="200" height="54" class="h-[27px] w-auto" />
+    </a>
     <p class="text-xs text-muted">
       contact@snapotter.com
     </p>

--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -139,14 +139,24 @@ const columns = [
     <p class="text-xs text-muted">
       {t(locale, "footer.copyright", { year })}
     </p>
-    <a
-      href="https://twelve.tools"
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label="Featured on Twelve Tools"
-    >
-      <img src="/badges/twelve-tools.svg" alt="Featured on Twelve Tools" width="200" height="54" class="h-[27px] w-auto" />
-    </a>
+    <div class="flex items-center gap-3">
+      <a
+        href="https://twelve.tools"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Featured on Twelve Tools"
+      >
+        <img src="/badges/twelve-tools.svg" alt="Featured on Twelve Tools" width="200" height="54" class="h-[27px] w-auto" />
+      </a>
+      <a
+        href="https://wired.business"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Featured on Wired Business"
+      >
+        <img src="/badges/wired-business.svg" alt="Featured on Wired Business" width="200" height="54" class="h-[27px] w-auto" />
+      </a>
+    </div>
     <p class="text-xs text-muted">
       contact@snapotter.com
     </p>


### PR DESCRIPTION
## Summary
- Add self-hosted (not hotlinked) footer badges linking to twelve.tools and wired.business
- Both badges satisfy the backlink requirement for SnapOtter's listings on those directories

## Test plan
- [x] Verified locally with `pnpm dev`: both badges render correctly in the footer bottom bar on the homepage
- [x] Verified badge SVG assets load (200 response) from `/badges/twelve-tools.svg` and `/badges/wired-business.svg`