### PR TITLE
feat(landing): move language switcher from navbar to footer

### DIFF
--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -1,12 +1,15 @@
 ---
+// biome-ignore-all lint/correctness/noUnusedImports: Astro template consumes component imports.
 // biome-ignore-all lint/correctness/noUnusedVariables: Astro template consumes frontmatter values.
+import LanguageSwitcher from "@/components/LanguageSwitcher.astro";
 import { t } from "@/i18n";
 import { localizeHref } from "@/lib/i18n-page";
 
 interface Props {
   locale?: string;
+  path?: string;
 }
-const { locale = "en" } = Astro.props;
+const { locale = "en", path = "/" } = Astro.props;
 
 const year = new Date().getFullYear();
 
@@ -109,6 +112,9 @@ const columns = [
         >
           <svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
         </a>
+      </div>
+      <div class="mt-4">
+        <LanguageSwitcher locale={locale} path={path} />
       </div>
     </div>
 

--- a/apps/landing/src/components/LanguageSwitcher.astro
+++ b/apps/landing/src/components/LanguageSwitcher.astro
@@ -35,7 +35,7 @@ const options = LANDING_LOCALES.map((code) => ({
     <span>{nativeName(locale)}</span>
   </button>
   <ul
-    class="absolute end-0 z-50 mt-2 hidden max-h-80 w-44 overflow-y-auto rounded-xl border border-border bg-surface py-1.5 text-sm shadow-xl"
+    class="absolute start-0 z-50 mt-2 hidden max-h-80 w-44 overflow-y-auto rounded-xl border border-border bg-surface py-1.5 text-sm shadow-xl"
     role="listbox"
     data-switcher-menu
   >

--- a/apps/landing/src/components/Navbar.astro
+++ b/apps/landing/src/components/Navbar.astro
@@ -1,15 +1,13 @@
 ---
 // biome-ignore-all lint/correctness/noUnusedVariables: Astro template consumes frontmatter values.
-import LanguageSwitcher from "@/components/LanguageSwitcher.astro";
 import { t } from "@/i18n";
 import { localizeHref } from "@/lib/i18n-page";
 import { formatCompact, getStarCount } from "@/lib/stats";
 
 interface Props {
   locale?: string;
-  path?: string;
 }
-const { locale = "en", path = "/" } = Astro.props;
+const { locale = "en" } = Astro.props;
 
 // Fetched at build time; refreshed by the scheduled landing rebuild.
 const starCount = formatCompact(await getStarCount());
@@ -87,7 +85,6 @@ const links: NavItem[] = [
 
     <!-- Desktop CTAs -->
     <div class="hidden shrink-0 items-center gap-3 md:flex">
-      <LanguageSwitcher locale={locale} path={path} />
       <a
         href="https://github.com/snapotter-hq/snapotter"
         target="_blank"

--- a/apps/landing/src/pages/[...locale]/alternatives/[slug].astro
+++ b/apps/landing/src/pages/[...locale]/alternatives/[slug].astro
@@ -96,7 +96,7 @@ const allJsonLd = [breadcrumbJsonLd, ...(faqJsonLd ? [faqJsonLd] : [])];
     <JsonLd data={allJsonLd} />
   </Fragment>
 
-  <Navbar locale={locale} path={PATH} />
+  <Navbar locale={locale} />
 
   <main id="main">
     <!-- Breadcrumb -->
@@ -336,5 +336,5 @@ const allJsonLd = [breadcrumbJsonLd, ...(faqJsonLd ? [faqJsonLd] : [])];
     <EnterpriseCtaBand />
   </main>
 
-  <Footer locale={locale} />
+  <Footer locale={locale} path={PATH} />
 </Base>

--- a/apps/landing/src/pages/[...locale]/alternatives/index.astro
+++ b/apps/landing/src/pages/[...locale]/alternatives/index.astro
@@ -68,7 +68,7 @@ const formatReviewDate = (date: string) =>
     <JsonLd data={allJsonLd} />
   </Fragment>
 
-  <Navbar locale={locale} path={PATH} />
+  <Navbar locale={locale} />
 
   <main id="main">
     <!-- Hero -->
@@ -216,5 +216,5 @@ const formatReviewDate = (date: string) =>
     </section>
   </main>
 
-  <Footer locale={locale} />
+  <Footer locale={locale} path={PATH} />
 </Base>

--- a/apps/landing/src/pages/[...locale]/contact.astro
+++ b/apps/landing/src/pages/[...locale]/contact.astro
@@ -64,7 +64,7 @@ const subjects = [
     <JsonLd data={breadcrumbJsonLd} />
   </Fragment>
 
-  <Navbar locale={locale} path={PATH} />
+  <Navbar locale={locale} />
 
   <main id="main" class="px-6 pt-32 pb-20 md:pt-40 md:pb-28">
     <div class="mx-auto grid max-w-5xl gap-16 md:grid-cols-2">
@@ -139,5 +139,5 @@ const subjects = [
     </div>
   </main>
 
-  <Footer locale={locale} />
+  <Footer locale={locale} path={PATH} />
 </Base>

--- a/apps/landing/src/pages/[...locale]/enterprise.astro
+++ b/apps/landing/src/pages/[...locale]/enterprise.astro
@@ -190,7 +190,7 @@ const xSvg =
     <JsonLd data={[breadcrumbJsonLd, productJsonLd]} />
   </Fragment>
 
-  <Navbar locale={locale} path={PATH} />
+  <Navbar locale={locale} />
 
   <main id="main">
 
@@ -456,5 +456,5 @@ const xSvg =
 
   </main>
 
-  <Footer locale={locale} />
+  <Footer locale={locale} path={PATH} />
 </Base>

--- a/apps/landing/src/pages/[...locale]/faq.astro
+++ b/apps/landing/src/pages/[...locale]/faq.astro
@@ -65,7 +65,7 @@ const breadcrumbJsonLd = {
     <JsonLd data={[faqJsonLd, breadcrumbJsonLd]} />
   </Fragment>
 
-  <Navbar locale={locale} path={PATH} />
+  <Navbar locale={locale} />
 
   <main id="main" class="px-6 pt-32 pb-20 md:pt-40 md:pb-28">
     <div class="mx-auto max-w-3xl">
@@ -109,5 +109,5 @@ const breadcrumbJsonLd = {
     </div>
   </main>
 
-  <Footer locale={locale} />
+  <Footer locale={locale} path={PATH} />
 </Base>

--- a/apps/landing/src/pages/[...locale]/index.astro
+++ b/apps/landing/src/pages/[...locale]/index.astro
@@ -126,7 +126,7 @@ const navSchema = {
     <JsonLd data={[websiteSchema, softwareSchema, navSchema]} />
   </Fragment>
 
-  <Navbar locale={locale} path={PATH} />
+  <Navbar locale={locale} />
 
   <main id="main">
     <Hero locale={locale} />
@@ -137,5 +137,5 @@ const navSchema = {
     <OpenSource locale={locale} />
   </main>
 
-  <Footer locale={locale} />
+  <Footer locale={locale} path={PATH} />
 </Base>

--- a/apps/landing/src/pages/[...locale]/privacy.astro
+++ b/apps/landing/src/pages/[...locale]/privacy.astro
@@ -44,7 +44,7 @@ const breadcrumbJsonLd = {
     <JsonLd data={breadcrumbJsonLd} />
   </Fragment>
 
-  <Navbar locale={locale} path={PATH} />
+  <Navbar locale={locale} />
 
   <main id="main" class="px-6 pt-32 pb-20 md:pt-40 md:pb-28">
     <div class="mx-auto max-w-3xl">
@@ -141,5 +141,5 @@ const breadcrumbJsonLd = {
     </div>
   </main>
 
-  <Footer locale={locale} />
+  <Footer locale={locale} path={PATH} />
 </Base>

--- a/apps/landing/src/pages/[...locale]/terms.astro
+++ b/apps/landing/src/pages/[...locale]/terms.astro
@@ -44,7 +44,7 @@ const breadcrumbJsonLd = {
     <JsonLd data={breadcrumbJsonLd} />
   </Fragment>
 
-  <Navbar locale={locale} path={PATH} />
+  <Navbar locale={locale} />
 
   <main id="main" class="px-6 pt-32 pb-20 md:pt-40 md:pb-28">
     <div class="mx-auto max-w-3xl">
@@ -144,5 +144,5 @@ const breadcrumbJsonLd = {
     </div>
   </main>
 
-  <Footer locale={locale} />
+  <Footer locale={locale} path={PATH} />
 </Base>

--- a/apps/landing/src/pages/[...locale]/tools/[section]/index.astro
+++ b/apps/landing/src/pages/[...locale]/tools/[section]/index.astro
@@ -56,7 +56,7 @@ const toolDesc = (id: string, fallback: string) => toolStrings[id]?.description 
   locale={locale}
   path={PATH}
 >
-  <Navbar locale={locale} path={PATH} />
+  <Navbar locale={locale} />
 
   <main id="main">
     <nav class="mx-auto max-w-6xl px-6 pt-28 md:pt-36" aria-label="Breadcrumb">
@@ -120,5 +120,5 @@ const toolDesc = (id: string, fallback: string) => toolStrings[id]?.description 
     </section>
   </main>
 
-  <Footer locale={locale} />
+  <Footer locale={locale} path={PATH} />
 </Base>

--- a/apps/landing/src/pages/[...locale]/tools/index.astro
+++ b/apps/landing/src/pages/[...locale]/tools/index.astro
@@ -127,7 +127,7 @@ const collectionJsonLd = {
     <JsonLd data={[breadcrumbJsonLd, collectionJsonLd]} />
   </Fragment>
 
-  <Navbar locale={locale} path={PATH} />
+  <Navbar locale={locale} />
 
   <main id="main">
     <!-- Breadcrumb -->
@@ -382,5 +382,5 @@ const collectionJsonLd = {
     }
   </script>
 
-  <Footer locale={locale} />
+  <Footer locale={locale} path={PATH} />
 </Base>


### PR DESCRIPTION
## Summary
- Remove `LanguageSwitcher` from the desktop-only navbar CTA row
- Add it to the footer's brand column instead (below the social icons), threading a `path` prop through `Footer.astro` and its ~10 locale-aware call sites
- Flip the dropdown menu's alignment from `end-0` to `start-0` since it's now the leftmost element on the page instead of the rightmost item in the navbar
- Drop the now-unused `path` prop from `Navbar.astro`

## Why
Frees up navbar space, and makes locale switching reachable on mobile — the old navbar switcher was desktop-only (`hidden ... md:flex`), so mobile users had no way to change language at all. The footer renders on every viewport.

## Test plan
- [x] `npx astro check`: 0 errors
- [x] `pnpm vitest`/biome lint on touched files: clean
- [x] Verified locally with `pnpm dev`: switcher gone from navbar, present in footer brand column, dropdown opens correctly aligned, all 21 locales listed
- [x] Verified on mobile viewport (390px): switcher visible and usable in footer
- [x] `tests/e2e-landing/i18n-switcher.spec.ts`: 3/3 pass
- [x] `tests/e2e-landing/homepage.spec.ts`, `accessibility.spec.ts`, `subpages.spec.ts`: same pass/fail counts as unmodified main (5 pre-existing trailing-slash failures unrelated to this change, confirmed via `git stash`)