### PR TITLE
fix(landing): rework footer badge/switcher layout

### DIFF
--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -113,9 +113,6 @@ const columns = [
           <svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
         </a>
       </div>
-      <div class="mt-4">
-        <LanguageSwitcher locale={locale} path={path} />
-      </div>
     </div>
 
     <!-- Link columns -->
@@ -139,32 +136,27 @@ const columns = [
     ))}
   </div>
 
-  <!-- Bottom bar -->
+  <!-- Featured-on badges -->
   <div class="section-divider mx-auto mt-12 max-w-6xl"></div>
-  <div class="mx-auto mt-6 flex max-w-6xl flex-col items-center justify-between gap-3 sm:flex-row">
+  <div class="mx-auto flex max-w-6xl flex-wrap items-center gap-5 pt-8">
+    <a href="https://twelve.tools" target="_blank" rel="noopener noreferrer" aria-label="Featured on Twelve Tools">
+      <img src="/badges/twelve-tools.svg" alt="Featured on Twelve Tools" width="200" height="54" class="h-9 w-auto" />
+    </a>
+    <a href="https://wired.business" target="_blank" rel="noopener noreferrer" aria-label="Featured on Wired Business">
+      <img src="/badges/wired-business.svg" alt="Featured on Wired Business" width="200" height="54" class="h-9 w-auto" />
+    </a>
+  </div>
+
+  <!-- Bottom bar -->
+  <div class="mx-auto mt-8 flex max-w-6xl flex-col items-center justify-between gap-3 sm:flex-row">
     <p class="text-xs text-muted">
       {t(locale, "footer.copyright", { year })}
     </p>
-    <div class="flex items-center gap-3">
-      <a
-        href="https://twelve.tools"
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="Featured on Twelve Tools"
-      >
-        <img src="/badges/twelve-tools.svg" alt="Featured on Twelve Tools" width="200" height="54" class="h-[27px] w-auto" />
-      </a>
-      <a
-        href="https://wired.business"
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="Featured on Wired Business"
-      >
-        <img src="/badges/wired-business.svg" alt="Featured on Wired Business" width="200" height="54" class="h-[27px] w-auto" />
-      </a>
+    <div class="flex items-center gap-4">
+      <p class="text-xs text-muted">
+        contact@snapotter.com
+      </p>
+      <LanguageSwitcher locale={locale} path={path} />
     </div>
-    <p class="text-xs text-muted">
-      contact@snapotter.com
-    </p>
   </div>
 </footer>

--- a/apps/landing/src/components/LanguageSwitcher.astro
+++ b/apps/landing/src/components/LanguageSwitcher.astro
@@ -35,7 +35,7 @@ const options = LANDING_LOCALES.map((code) => ({
     <span>{nativeName(locale)}</span>
   </button>
   <ul
-    class="absolute start-0 z-50 mt-2 hidden max-h-80 w-44 overflow-y-auto rounded-xl border border-border bg-surface py-1.5 text-sm shadow-xl"
+    class="absolute end-0 bottom-full z-50 mb-2 hidden max-h-80 w-44 overflow-y-auto rounded-xl border border-border bg-surface py-1.5 text-sm shadow-xl"
     role="listbox"
     data-switcher-menu
   >


### PR DESCRIPTION
## Summary
- Give the twelve.tools/wired.business "featured on" badges their own full-width row (they were cramped into the bottom bar) and size them up from 27px to 36px tall — they're SVGs so this costs nothing in quality
- Move the language switcher to the right side of the bottom bar, next to the contact email, matching where Stripe/Cloudflare/Notion-style footers put locale selectors
- Flip the switcher's dropdown to open upward (`bottom-full` instead of `top-full`), since it's now anchored at the very bottom of the page

## Test plan
- [x] `npx astro check`: 0 errors
- [x] biome check on touched files: clean
- [x] Verified locally with `pnpm dev` on desktop (1400px) and mobile (390px) viewports
- [x] `tests/e2e-landing/i18n-switcher.spec.ts`: 3/3 pass