### PR TITLE
fix(landing): stop mangling #hash fragments in localized links

### DIFF
--- a/apps/landing/src/lib/i18n-page.ts
+++ b/apps/landing/src/lib/i18n-page.ts
@@ -5,10 +5,18 @@ import { isRtl, LANDING_LOCALES } from "@/i18n";
 /** Absolute site origin used for canonical + hreflang hrefs. */
 export const SITE = "https://snapotter.com";
 
-/** Prefix a path for a locale ("/faq" -> "/de/faq" for de, "/faq" for en). */
+/**
+ * Prefix a path for a locale ("/faq" -> "/de/faq" for de, "/faq" for en).
+ * A trailing "#hash" is split off first and reattached untouched, since
+ * Astro's URL builder would otherwise treat it as part of the path and
+ * mangle it with a trailing slash (e.g. "/#pricing" -> "/#pricing/").
+ */
 export function localizeHref(locale: string, path: string): string {
-  const clean = path.startsWith("/") ? path.slice(1) : path;
-  return getRelativeLocaleUrl(locale, clean);
+  const hashIndex = path.indexOf("#");
+  const pathname = hashIndex === -1 ? path : path.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? "" : path.slice(hashIndex);
+  const clean = pathname.startsWith("/") ? pathname.slice(1) : pathname;
+  return `${getRelativeLocaleUrl(locale, clean)}${hash}`;
 }
 
 /** Direction attribute for the current locale. */

--- a/tests/e2e-landing/subpages.spec.ts
+++ b/tests/e2e-landing/subpages.spec.ts
@@ -127,4 +127,24 @@ test.describe("Cross-Page Navigation", () => {
     const enterpriseCta = page.getByRole("link", { name: /Let.s talk/ }).first();
     await expect(enterpriseCta).toHaveAttribute("href", "/contact");
   });
+
+  test("navbar Pricing link scrolls to the pricing section", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    const pricingLink = page.locator("nav").getByRole("link", { name: "Pricing" });
+    await expect(pricingLink).toHaveAttribute("href", "/#pricing");
+    await pricingLink.click();
+    await expect(page).toHaveURL(/\/#pricing$/);
+    await expect(page.locator("#pricing")).toBeInViewport();
+  });
+
+  test("navbar Enterprise link scrolls to the enterprise section", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    const enterpriseLink = page.locator("nav").getByRole("link", { name: "Enterprise" });
+    await expect(enterpriseLink).toHaveAttribute("href", "/#enterprise");
+    await enterpriseLink.click();
+    await expect(page).toHaveURL(/\/#enterprise$/);
+    await expect(page.locator("#enterprise")).toBeInViewport();
+  });
 });


### PR DESCRIPTION
## Bug
Clicking Pricing/Enterprise in the nav or footer updated the URL to `/#pricing/` (trailing slash after the hash) but the page never scrolled — reported live on snapotter.com.

## Root cause
`localizeHref()` passes the whole href (including `#pricing`) into Astro's `getRelativeLocaleUrl`, which treats it as a path segment and appends a trailing slash per the site's URL config: `/#pricing` -> `/#pricing/`. That fragment doesn't match any element's `id`, so the browser updates the URL and does nothing.

8 call sites go through this one function (nav/footer Enterprise, Pricing, Open Source links, plus two in-page CTAs), so fixing `localizeHref` once fixes all of them.

## Fix
Split the `#hash` off before localizing the pathname, then reattach it untouched:
`/#pricing` -> pathname `""`, hash `#pricing` -> `getRelativeLocaleUrl(locale, "")` + `#pricing` -> `/#pricing` (or `/de/#pricing` for a locale prefix).

## Test plan
- [x] Manually verified: clicking Pricing/Enterprise now actually scrolls to the section, in English and in a locale-prefixed page (`/de/#pricing`)
- [x] `npx astro check`: 0 errors
- [x] biome check: clean
- [x] Added 2 regression tests (`tests/e2e-landing/subpages.spec.ts`) asserting both the fixed href and that the target section actually scrolls into viewport
- [x] Full relevant e2e suite (`homepage`, `accessibility`, `subpages`, `i18n-switcher`): same pass/fail counts as unmodified main (5 pre-existing unrelated trailing-slash failures, confirmed via `git stash` against main earlier in this branch's history)