### PR TITLE
fix(security): bump Pillow to 12.3.0, fixes 5 disclosed CVEs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -365,7 +365,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     /opt/venv/bin/pip install --upgrade "pip==26.1.2" && \
     /opt/venv/bin/pip install --upgrade "wheel==0.47.0" "setuptools==78.1.1" "jaraco.context==6.1.0" && \
     /opt/venv/bin/pip install \
-        Pillow==12.2.0 \
+        Pillow==12.3.0 \
         numpy==1.26.4 \
         opencv-python-headless==4.10.0.84 \
         "huggingface-hub[hf_xet,hf_transfer]==0.36.2" \

--- a/docker/feature-manifest.json
+++ b/docker/feature-manifest.json
@@ -4,7 +4,7 @@
   "pythonVersion": { "amd64": "3.12", "arm64": "3.11" },
   "basePackages": [
     "numpy==1.26.4",
-    "Pillow==12.2.0",
+    "Pillow==12.3.0",
     "opencv-python-headless==4.10.0.84",
     "huggingface-hub[hf_xet,hf_transfer]==0.36.2"
   ],

--- a/packages/ai/python/requirements-gpu.txt
+++ b/packages/ai/python/requirements-gpu.txt
@@ -12,7 +12,7 @@ paddlepaddle-gpu==3.0.0
 mediapipe>=0.10.21
 onnxruntime-gpu==1.20.1
 numpy==1.26.4
-Pillow==12.2.0
+Pillow==12.3.0
 opencv-python-headless==4.10.0.84
 codeformer-pip==0.0.4
 

--- a/packages/ai/python/requirements.txt
+++ b/packages/ai/python/requirements.txt
@@ -12,7 +12,7 @@ paddlepaddle>=3.0.0,<3.1.0
 mediapipe>=0.10.21
 onnxruntime==1.20.1
 numpy==1.26.4
-Pillow==12.2.0
+Pillow==12.3.0
 opencv-python-headless==4.10.0.84
 codeformer-pip==0.0.4
 


### PR DESCRIPTION
## Summary
`Pillow==12.2.0` (pinned in 4 places) has 5 disclosed CVEs — PYSEC-2026-2253 through 2257 — fixed in 12.3.0. This was failing the Python Dependency Audit check on every PR since disclosure.

## Safety verification
Pillow has no transitive dependencies of its own, and nothing else in the AI sidecar's dependency tree pins it tightly, so the risk here is purely "does this codebase's own PIL usage still work":

- `pip install --dry-run` against both the unmodified and bumped `requirements.txt`: identical resolved dependency tree in every package except `pillow` itself. `numpy` stays at `1.26.4`, and the fragile pins called out in the file's own comments (`rembg==2.0.69`, `realesrgan==0.3.0`, `codeformer-pip==0.0.4`) are untouched.
- Smoke-tested every PIL API this codebase actually calls against Pillow 12.3.0 directly: `Image.open`/save roundtrip, `alpha_composite`, `resize` with `LANCZOS`, `ImageFilter.GaussianBlur`, `split`/`merge`, `ImageSequence.Iterator` (animated frame iteration), and `quantize` with `ADAPTIVE`/`MEDIANCUT`. All pass.
- Ran the exact CI `pip-audit` command locally against the bumped `requirements.txt`: "No known vulnerabilities found, 3 ignored."

## Changes
Updated all four places this version is pinned, so they don't drift:
- `packages/ai/python/requirements.txt`
- `packages/ai/python/requirements-gpu.txt`
- `docker/Dockerfile` (baked base venv)
- `docker/feature-manifest.json` (`basePackages`, covered by its own consistency test)

## Test plan
- [x] `tests/unit/features/feature-manifest.test.ts`, `feature-status.test.ts`, `install-feature-prebuilt.test.ts`: 151/151 pass
- [x] `pip-audit` (exact CI invocation) against bumped requirements: clean
- [x] Dependency dry-run diff: Pillow is the only version that changes
- [x] Direct smoke test of all PIL APIs used in `packages/ai/python/*.py`