### PR TITLE
fix: give remove-background job timeouts an actionable failure message instead of a bare timeout

### DIFF
--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -369,7 +369,7 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
       const finalError = isCanceled
         ? "Canceled"
         : isTimeout
-          ? `Timed out after ${Math.round(timeoutMs / 1000)}s`
+          ? `Timed out after ${Math.round(timeoutMs / 1000)}s. On the first run the background-removal model may still be downloading; the image may be too large for CPU inference; or the worker may be busy or unavailable. Retry once the model has downloaded, or try a smaller image.`
           : errorMessage;
 
       // Log genuine processing faults at error level (clients only ever see

--- a/tests/integration/platform/worker-timeout.test.ts
+++ b/tests/integration/platform/worker-timeout.test.ts
@@ -116,6 +116,10 @@ describe("Worker timeout classification", () => {
     // Error message must mention timeout
     const error = finalRow?.error as { message: string };
     expect(error.message).toMatch(/timed out after 1s/i);
+    // Fail-fast message must include actionable guidance (issue #494)
+    expect(error.message).toMatch(
+      /model may still be downloading|too large for CPU|worker may be busy/i,
+    );
 
     // Both attempts ran (attempts column is set at the start of each attempt)
     expect(finalRow?.attempts).toBe(2);


### PR DESCRIPTION
## What does this PR do?

Gives remove-background (and other tool) job timeouts a clear, actionable failure message instead of a bare `Timed out after Ns`, so a reporter who hits the timeout guard sees why it happened and what to try next.

Fixes #494

The issue accepts either outcome: complete and return a result, or fail fast with a clear, actionable message. This ships the fail-fast branch. In `apps/api/src/jobs/worker.ts`, the catch block already distinguishes a timeout (`signal.reason === "timeout"`) from a user cancel; the timeout branch previously set the failure detail to `Timed out after ${Math.round(timeoutMs / 1000)}s`. It now extends that into a single-line message that keeps the `Timed out after Ns` prefix and appends the likely causes and next steps the issue calls out: a first-run model download still in progress, an input image too large for CPU inference, or the worker being busy or unavailable, with guidance to retry once the model has downloaded or with a smaller image.

The prefix is preserved deliberately so the `error_code: "timeout"` classification, the terminal SSE replay payload, and the existing timeout assertions keep working unchanged. The message stays under the 280-character `friendlyError()` threshold and on a single line, so it reaches the client verbatim rather than collapsing to the generic fallback. No change to `errors.ts`, and no call sites outside `worker.ts` are touched.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New translation or i18n update
- [ ] Documentation update
- [ ] Test improvement
- [ ] Refactor (no functional change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/snapotter-hq/snapotter/blob/main/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://github.com/snapotter-hq/snapotter/blob/main/CLA.md) (the bot will prompt you if not)
- [x] My changes follow the project's code style (Biome passes)
- [x] I have added or updated tests for my changes
- [ ] All existing tests pass locally (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] My PR is focused on a single concern (under 400 lines of change)
- [x] I have not modified CI, release, or linter configuration files

## Screenshots (if applicable)

Not applicable; this is a server-side failure-message change with no UI surface.

The existing timeout classification test in `tests/integration/platform/worker-timeout.test.ts` is extended with an assertion that the failure message includes the actionable guidance, alongside the preserved assertions that the job still classifies as `failed` (not `canceled`), that the message still matches the timeout text, and that the terminal SSE replay is not `"Canceled"`.
