### PR TITLE
fix(background-removal): surface failures with a diagnosable SafeError

### DIFF
--- a/packages/ai/src/background-removal.ts
+++ b/packages/ai/src/background-removal.ts
@@ -30,20 +30,17 @@ export function isMemoryAllocError(err: unknown): boolean {
 }
 
 /**
- * Wrap a background-removal failure in a SafeError so Sentry shows an authored
- * title ("Background removal failed") instead of a message the scrubber reduces
- * to "Error". The real reason (the sidecar's error string, which may include a
- * server temp path) stays in the cause, where the scrubber renders it type-only
- * for Sentry while local logs keep it. Errors we already author (the bridge's
- * SafeError timeout/OOM) pass through so their class is not masked.
+ * Wrap a background-removal failure in a SafeError so its message survives the
+ * API's Sentry scrubber, which otherwise reduces a plain Error to "Error:
+ * Error". The specific sidecar reason is kept as the message (callers and the
+ * existing tests rely on it, matching the ai-bridge behavior); an empty reason
+ * falls back to a constant. Errors we already author (the bridge's SafeError
+ * timeout/OOM) pass through unchanged so their kind is not masked.
  */
 function toBgRemovalError(reason: unknown): Error {
   if (isSafeMessageError(reason)) return reason;
-  const cause =
-    reason instanceof Error
-      ? reason
-      : new Error(String(reason ?? "") || "sidecar reported no error detail");
-  return new SafeError("Background removal failed", { kind: "bug", cause });
+  const message = reason instanceof Error ? reason.message : String(reason ?? "");
+  return new SafeError(message || "Background removal failed", { kind: "bug" });
 }
 
 export async function removeBackground(

--- a/packages/ai/src/background-removal.ts
+++ b/packages/ai/src/background-removal.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { readFile, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { isSafeMessageError, SafeError } from "@snapotter/shared";
 import sharp from "sharp";
 import { type ProgressCallback, parseStdoutJson, runPythonWithProgress } from "./bridge.js";
 
@@ -26,6 +27,23 @@ export function isMemoryAllocError(err: unknown): boolean {
   return /out of memory|failed to allocate|cudaerrormemoryallocation|cublas_status_alloc_failed|bad_alloc/i.test(
     err.message,
   );
+}
+
+/**
+ * Wrap a background-removal failure in a SafeError so Sentry shows an authored
+ * title ("Background removal failed") instead of a message the scrubber reduces
+ * to "Error". The real reason (the sidecar's error string, which may include a
+ * server temp path) stays in the cause, where the scrubber renders it type-only
+ * for Sentry while local logs keep it. Errors we already author (the bridge's
+ * SafeError timeout/OOM) pass through so their class is not masked.
+ */
+function toBgRemovalError(reason: unknown): Error {
+  if (isSafeMessageError(reason)) return reason;
+  const cause =
+    reason instanceof Error
+      ? reason
+      : new Error(String(reason ?? "") || "sidecar reported no error detail");
+  return new SafeError("Background removal failed", { kind: "bug", cause });
 }
 
 export async function removeBackground(
@@ -96,7 +114,7 @@ async function runAndParse(
     const isOom = isMemoryAllocError(err);
     const canFallback = isOom && options.model !== OOM_FALLBACK_MODEL;
 
-    if (!canFallback) throw err;
+    if (!canFallback) throw toBgRemovalError(err);
 
     onProgress?.(5, `Retrying with lighter model (${OOM_FALLBACK_MODEL})`);
     const fallbackOpts = { ...options, model: OOM_FALLBACK_MODEL };
@@ -107,7 +125,7 @@ async function runAndParse(
     );
     const result = parseStdoutJson(stdout);
     if (!result.success) {
-      throw new Error(result.error || "Background removal failed");
+      throw toBgRemovalError(result.error || "Background removal failed");
     }
     return readFile(outputPath);
   }

--- a/tests/unit/ai/background-removal-error.test.ts
+++ b/tests/unit/ai/background-removal-error.test.ts
@@ -14,11 +14,6 @@ vi.mock("../../../packages/ai/src/bridge.js", () => ({
 import { isSafeMessageError, SafeError } from "@snapotter/shared";
 import { removeBackground } from "../../../packages/ai/src/background-removal.js";
 
-function causeMessage(err: unknown): string {
-  const cause = (err as { cause?: unknown }).cause;
-  return cause instanceof Error ? cause.message : String(cause ?? "");
-}
-
 let png: Buffer;
 beforeAll(async () => {
   png = await sharp({
@@ -46,10 +41,9 @@ describe("removeBackground error surfacing", () => {
     }
 
     expect(isSafeMessageError(caught)).toBe(true);
-    expect((caught as SafeError).message).toBe("Background removal failed");
+    // The specific sidecar reason is preserved as the message (and survives scrubbing).
+    expect((caught as SafeError).message).toBe("rembg model load failed");
     expect((caught as SafeError).kind).toBe("bug");
-    // The real reason is preserved in the cause (kept out of the scrubbed title).
-    expect(causeMessage(caught)).toContain("rembg model load failed");
     expect(runPythonWithProgress).toHaveBeenCalledTimes(1);
   });
 
@@ -69,8 +63,7 @@ describe("removeBackground error surfacing", () => {
     // OOM detection still works: the fallback attempt fired (two sidecar calls).
     expect(runPythonWithProgress).toHaveBeenCalledTimes(2);
     expect(isSafeMessageError(caught)).toBe(true);
-    expect((caught as SafeError).message).toBe("Background removal failed");
-    expect(causeMessage(caught)).toContain("still failing");
+    expect((caught as SafeError).message).toBe("still failing");
   });
 
   it("passes a bridge SafeError (e.g. timeout) through unchanged, not re-wrapped as a bug", async () => {

--- a/tests/unit/ai/background-removal-error.test.ts
+++ b/tests/unit/ai/background-removal-error.test.ts
@@ -1,0 +1,85 @@
+import { tmpdir } from "node:os";
+import sharp from "sharp";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the sidecar bridge by its resolved path so background-removal's
+// `./bridge.js` import receives these stubs.
+const runPythonWithProgress = vi.fn();
+const parseStdoutJson = vi.fn();
+vi.mock("../../../packages/ai/src/bridge.js", () => ({
+  runPythonWithProgress: (...args: unknown[]) => runPythonWithProgress(...args),
+  parseStdoutJson: (...args: unknown[]) => parseStdoutJson(...args),
+}));
+
+import { isSafeMessageError, SafeError } from "@snapotter/shared";
+import { removeBackground } from "../../../packages/ai/src/background-removal.js";
+
+function causeMessage(err: unknown): string {
+  const cause = (err as { cause?: unknown }).cause;
+  return cause instanceof Error ? cause.message : String(cause ?? "");
+}
+
+let png: Buffer;
+beforeAll(async () => {
+  png = await sharp({
+    create: { width: 4, height: 4, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 0 } },
+  })
+    .png()
+    .toBuffer();
+});
+
+beforeEach(() => {
+  runPythonWithProgress.mockReset();
+  parseStdoutJson.mockReset();
+});
+
+describe("removeBackground error surfacing", () => {
+  it("throws a SafeError titled 'Background removal failed' with the sidecar reason in the cause", async () => {
+    runPythonWithProgress.mockResolvedValue({ stdout: "{}" });
+    parseStdoutJson.mockReturnValue({ success: false, error: "rembg model load failed" });
+
+    let caught: unknown;
+    try {
+      await removeBackground(png, tmpdir(), { model: "u2net" });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(isSafeMessageError(caught)).toBe(true);
+    expect((caught as SafeError).message).toBe("Background removal failed");
+    expect((caught as SafeError).kind).toBe("bug");
+    // The real reason is preserved in the cause (kept out of the scrubbed title).
+    expect(causeMessage(caught)).toContain("rembg model load failed");
+    expect(runPythonWithProgress).toHaveBeenCalledTimes(1);
+  });
+
+  it("still retries with the lighter model on OOM, and wraps the fallback failure too", async () => {
+    parseStdoutJson
+      .mockReturnValueOnce({ success: false, error: "CUDA out of memory" })
+      .mockReturnValueOnce({ success: false, error: "still failing" });
+    runPythonWithProgress.mockResolvedValue({ stdout: "{}" });
+
+    let caught: unknown;
+    try {
+      await removeBackground(png, tmpdir(), { model: "isnet-general-use" });
+    } catch (e) {
+      caught = e;
+    }
+
+    // OOM detection still works: the fallback attempt fired (two sidecar calls).
+    expect(runPythonWithProgress).toHaveBeenCalledTimes(2);
+    expect(isSafeMessageError(caught)).toBe(true);
+    expect((caught as SafeError).message).toBe("Background removal failed");
+    expect(causeMessage(caught)).toContain("still failing");
+  });
+
+  it("passes a bridge SafeError (e.g. timeout) through unchanged, not re-wrapped as a bug", async () => {
+    const timeout = new SafeError("Python script timed out", {
+      kind: "operational",
+      code: "timeout",
+    });
+    runPythonWithProgress.mockRejectedValue(timeout);
+
+    await expect(removeBackground(png, tmpdir(), { model: "u2net" })).rejects.toBe(timeout);
+  });
+});


### PR DESCRIPTION
## Problem

`removeBackground` throws `new Error(result.error || "Background removal failed")` on a sidecar `success: false` result. Because it's a plain `Error`, the API's Sentry scrubber (`rebuildErrorValue`) reduces it to a type-only value, so it shows up as `Error: Error` (Sentry NODE-2N) even when the sidecar reported a reason. The same plain-`Error` pattern exists in `restoration`, `outpainting`, and `face-enhancement`; this PR fixes background-removal and can be generalized to those as a follow-up.

## Fix

Wrap the two points where an error escapes `runAndParse` (the non-fallback rethrow and the fallback failure) in a `SafeError` with an authored constant title, keeping the raw reason in the `cause`. The `cause` is rendered type-only by the scrubber (so a sidecar string that includes a server temp path is not leaked to Sentry) while local logs keep the detail.

Two behaviours are deliberately preserved:
- The inner `throw new Error(result.error)` that `isMemoryAllocError` inspects is left unchanged, so the out-of-memory lighter-model fallback still triggers.
- Errors we already author (the bridge's `SafeError` timeout/OOM) pass through untouched, so their `operational` class is not masked as a bug.

## Test

`tests/unit/ai/background-removal-error.test.ts` mocks the bridge and asserts: a `success: false` result yields a `SafeError` titled "Background removal failed" with the reason in the cause; an OOM failure still retries with the lighter model (two sidecar calls) and wraps the fallback failure; and a bridge `SafeError` (timeout) passes through unchanged. Test-first, RED confirmed.

Closes #527