### PR TITLE
fix(auth): give OIDC/SAML logins a real MFA challenge instead of a hard block

### DIFF
--- a/apps/api/src/plugins/mfa.ts
+++ b/apps/api/src/plugins/mfa.ts
@@ -106,6 +106,22 @@ export function isMfaRequiredForUser(policy: MfaPolicy, userRole: string): boole
   return false;
 }
 
+// The post-authentication MFA decision, shared by every login path (local
+// password, OIDC, SAML) so a new auth method can't silently diverge from the
+// others the way OIDC/SAML once did (they blocked on policy alone, with no
+// totpEnabled check and no challenge step -- snapotter-hq/SnapOtter#533).
+export type ExternalMfaOutcome = "proceed" | "challenge" | "enrollment_required";
+
+export function resolveExternalLoginMfaOutcome(
+  policy: MfaPolicy,
+  userRole: string,
+  totpEnabled: boolean,
+): ExternalMfaOutcome {
+  if (totpEnabled) return "challenge";
+  if (isMfaRequiredForUser(policy, userRole)) return "enrollment_required";
+  return "proceed";
+}
+
 // ── MFA plugin registration ───────────────────────────────────────
 
 export async function registerMfa(app: FastifyInstance): Promise<void> {

--- a/apps/api/src/plugins/oidc.ts
+++ b/apps/api/src/plugins/oidc.ts
@@ -1,8 +1,11 @@
+import { randomUUID } from "node:crypto";
 import type {} from "@fastify/cookie";
+import { eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import * as oidc from "openid-client";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
+import { sharedRedis } from "../jobs/connection.js";
 import { auditFromRequest, sanitizeAuditInput } from "../lib/audit.js";
 import { resolveExternalUser, sanitizeUsername } from "../lib/external-auth-resolver.js";
 import { authAttempts } from "../lib/metrics.js";
@@ -274,22 +277,42 @@ export async function oidcRoutes(app: FastifyInstance): Promise<void> {
 
       const resolvedUser = result.user;
 
-      let mfaRequired = false;
+      let mfaOutcome: "proceed" | "challenge" | "enrollment_required" = "proceed";
       try {
-        const { getMfaPolicy, isMfaRequiredForUser } = await import("./mfa.js");
+        const { getMfaPolicy, resolveExternalLoginMfaOutcome } = await import("./mfa.js");
+        const [dbUser] = await db
+          .select({ totpEnabled: schema.users.totpEnabled })
+          .from(schema.users)
+          .where(eq(schema.users.id, resolvedUser.id));
         const policy = await getMfaPolicy();
-        mfaRequired = isMfaRequiredForUser(policy, resolvedUser.role);
+        mfaOutcome = resolveExternalLoginMfaOutcome(
+          policy,
+          resolvedUser.role,
+          dbUser?.totpEnabled ?? false,
+        );
       } catch {
         // MFA plugin not loaded
       }
-      if (mfaRequired) {
+
+      if (mfaOutcome === "challenge") {
+        const mfaToken = randomUUID();
+        const redis = sharedRedis();
+        await redis.setex(`mfa:${mfaToken}`, 300, resolvedUser.id);
+        await audit("MFA_CHALLENGE_ISSUED", {
+          userId: resolvedUser.id,
+          username: resolvedUser.username,
+        });
+        return reply.redirect(`/login?mfaToken=${mfaToken}`);
+      }
+
+      if (mfaOutcome === "enrollment_required") {
         authAttempts.inc({ method: "oidc", result: "failure" });
         await audit("OIDC_LOGIN_FAILED", {
           userId: resolvedUser.id,
           username: resolvedUser.username,
-          reason: "mfa_required",
+          reason: "mfa_enrollment_required",
         });
-        return redirectToLogin(reply, "mfa_required");
+        return redirectToLogin(reply, "mfa_enrollment_required");
       }
 
       // 5. Create session

--- a/apps/api/src/plugins/oidc.ts
+++ b/apps/api/src/plugins/oidc.ts
@@ -277,13 +277,33 @@ export async function oidcRoutes(app: FastifyInstance): Promise<void> {
 
       const resolvedUser = result.user;
 
-      let mfaOutcome: "proceed" | "challenge" | "enrollment_required" = "proceed";
+      // Unguarded on purpose: this read decides whether MFA gets checked at
+      // all, so a DB error here must fail the login, not silently skip MFA
+      // for an enrolled user. The try/catch below is scoped only to the
+      // optional MFA plugin/policy lookup, same as it always was.
+      let dbUser: { totpEnabled: boolean } | undefined;
       try {
-        const { getMfaPolicy, resolveExternalLoginMfaOutcome } = await import("./mfa.js");
-        const [dbUser] = await db
+        [dbUser] = await db
           .select({ totpEnabled: schema.users.totpEnabled })
           .from(schema.users)
           .where(eq(schema.users.id, resolvedUser.id));
+      } catch (err) {
+        request.log.error(
+          { err, userId: resolvedUser.id },
+          "OIDC callback: failed to read MFA enrollment status",
+        );
+        authAttempts.inc({ method: "oidc", result: "failure" });
+        await audit("OIDC_LOGIN_FAILED", {
+          userId: resolvedUser.id,
+          username: resolvedUser.username,
+          reason: "mfa_check_error",
+        });
+        return redirectToLogin(reply, "oidc_auth_failed");
+      }
+
+      let mfaOutcome: "proceed" | "challenge" | "enrollment_required" = "proceed";
+      try {
+        const { getMfaPolicy, resolveExternalLoginMfaOutcome } = await import("./mfa.js");
         const policy = await getMfaPolicy();
         mfaOutcome = resolveExternalLoginMfaOutcome(
           policy,

--- a/apps/api/src/plugins/saml.ts
+++ b/apps/api/src/plugins/saml.ts
@@ -1,9 +1,12 @@
+import { randomUUID } from "node:crypto";
 import { parse as parseQs } from "node:querystring";
 import type {} from "@fastify/cookie";
 import { SAML } from "@node-saml/node-saml";
+import { eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
+import { sharedRedis } from "../jobs/connection.js";
 import { auditFromRequest } from "../lib/audit.js";
 import {
   findUniqueUsername,
@@ -164,22 +167,42 @@ export async function registerSaml(app: FastifyInstance): Promise<void> {
 
       const resolvedUser = result.user;
 
-      let mfaRequired = false;
+      let mfaOutcome: "proceed" | "challenge" | "enrollment_required" = "proceed";
       try {
-        const { getMfaPolicy, isMfaRequiredForUser } = await import("./mfa.js");
+        const { getMfaPolicy, resolveExternalLoginMfaOutcome } = await import("./mfa.js");
+        const [dbUser] = await db
+          .select({ totpEnabled: schema.users.totpEnabled })
+          .from(schema.users)
+          .where(eq(schema.users.id, resolvedUser.id));
         const policy = await getMfaPolicy();
-        mfaRequired = isMfaRequiredForUser(policy, resolvedUser.role);
+        mfaOutcome = resolveExternalLoginMfaOutcome(
+          policy,
+          resolvedUser.role,
+          dbUser?.totpEnabled ?? false,
+        );
       } catch {
         // MFA plugin not loaded
       }
-      if (mfaRequired) {
+
+      if (mfaOutcome === "challenge") {
+        const mfaToken = randomUUID();
+        const redis = sharedRedis();
+        await redis.setex(`mfa:${mfaToken}`, 300, resolvedUser.id);
+        await audit("MFA_CHALLENGE_ISSUED", {
+          userId: resolvedUser.id,
+          username: resolvedUser.username,
+        });
+        return reply.redirect(`/login?mfaToken=${mfaToken}`);
+      }
+
+      if (mfaOutcome === "enrollment_required") {
         authAttempts.inc({ method: "saml", result: "failure" });
         await audit("SAML_LOGIN_FAILED", {
           userId: resolvedUser.id,
           username: resolvedUser.username,
-          reason: "mfa_required",
+          reason: "mfa_enrollment_required",
         });
-        return redirectToLogin(reply, "mfa_required");
+        return redirectToLogin(reply, "mfa_enrollment_required");
       }
 
       // Create session (same pattern as OIDC)

--- a/apps/api/src/plugins/saml.ts
+++ b/apps/api/src/plugins/saml.ts
@@ -167,13 +167,33 @@ export async function registerSaml(app: FastifyInstance): Promise<void> {
 
       const resolvedUser = result.user;
 
-      let mfaOutcome: "proceed" | "challenge" | "enrollment_required" = "proceed";
+      // Unguarded on purpose: this read decides whether MFA gets checked at
+      // all, so a DB error here must fail the login, not silently skip MFA
+      // for an enrolled user. The try/catch below is scoped only to the
+      // optional MFA plugin/policy lookup, same as it always was.
+      let dbUser: { totpEnabled: boolean } | undefined;
       try {
-        const { getMfaPolicy, resolveExternalLoginMfaOutcome } = await import("./mfa.js");
-        const [dbUser] = await db
+        [dbUser] = await db
           .select({ totpEnabled: schema.users.totpEnabled })
           .from(schema.users)
           .where(eq(schema.users.id, resolvedUser.id));
+      } catch (err) {
+        request.log.error(
+          { err, userId: resolvedUser.id },
+          "SAML callback: failed to read MFA enrollment status",
+        );
+        authAttempts.inc({ method: "saml", result: "failure" });
+        await audit("SAML_LOGIN_FAILED", {
+          userId: resolvedUser.id,
+          username: resolvedUser.username,
+          reason: "mfa_check_error",
+        });
+        return redirectToLogin(reply, "saml_auth_failed");
+      }
+
+      let mfaOutcome: "proceed" | "challenge" | "enrollment_required" = "proceed";
+      try {
+        const { getMfaPolicy, resolveExternalLoginMfaOutcome } = await import("./mfa.js");
         const policy = await getMfaPolicy();
         mfaOutcome = resolveExternalLoginMfaOutcome(
           policy,

--- a/apps/web/src/pages/login-page.tsx
+++ b/apps/web/src/pages/login-page.tsx
@@ -129,7 +129,7 @@ function LanguageSelector() {
 export function LoginPage() {
   const { t } = useTranslation();
   const { oidcEnabled, oidcProviderName, samlEnabled, samlProviderName, ssoEnforced } = useAuth();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -150,6 +150,11 @@ export function LoginPage() {
       setMfaToken(redirectedMfaToken);
       setShowMfaPrompt(true);
       setTimeout(() => mfaInputRef.current?.focus(), 100);
+      // Drop it from the URL: it's a one-time credential and has no business
+      // sitting in browser history or a Referer header for the rest of the
+      // challenge. Also stops a later effect re-run (e.g. a locale switch)
+      // from reopening the prompt after the user has moved past it.
+      setSearchParams({}, { replace: true });
       return;
     }
 
@@ -167,8 +172,9 @@ export function LoginPage() {
         mfa_enrollment_required: t.auth.mfaEnrollmentRequired,
       };
       setError(errorMessages[authError] || t.auth.oidcGenericError);
+      setSearchParams({}, { replace: true });
     }
-  }, [searchParams, t]);
+  }, [searchParams, setSearchParams, t]);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();

--- a/apps/web/src/pages/login-page.tsx
+++ b/apps/web/src/pages/login-page.tsx
@@ -141,6 +141,18 @@ export function LoginPage() {
   const mfaInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    // A successful OIDC/SAML login for an already-enrolled user redirects
+    // here with a one-time mfaToken instead of completing the session
+    // directly, so the TOTP challenge can be completed the same way a local
+    // login's challenge is.
+    const redirectedMfaToken = searchParams.get("mfaToken");
+    if (redirectedMfaToken) {
+      setMfaToken(redirectedMfaToken);
+      setShowMfaPrompt(true);
+      setTimeout(() => mfaInputRef.current?.focus(), 100);
+      return;
+    }
+
     const authError = searchParams.get("error");
     if (authError) {
       const errorMessages: Record<string, string> = {
@@ -152,6 +164,7 @@ export function LoginPage() {
         saml_auth_failed: t.auth.samlAuthFailed,
         saml_user_not_authorized: t.auth.samlUserNotAuthorized,
         saml_user_limit_reached: t.auth.samlUserLimitReached,
+        mfa_enrollment_required: t.auth.mfaEnrollmentRequired,
       };
       setError(errorMessages[authError] || t.auth.oidcGenericError);
     }

--- a/tests/integration/platform/oidc-mfa-callback.test.ts
+++ b/tests/integration/platform/oidc-mfa-callback.test.ts
@@ -12,6 +12,8 @@
  */
 import { randomUUID } from "node:crypto";
 import { createServer, type Server } from "node:http";
+import { eq } from "drizzle-orm";
+import * as OTPAuth from "otpauth";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 const authorizationCodeGrantMock = vi.hoisted(() => vi.fn());
@@ -20,6 +22,10 @@ vi.mock("openid-client", async (importOriginal) => {
   const actual: Record<string, unknown> = await importOriginal();
   return { ...actual, authorizationCodeGrant: authorizationCodeGrantMock };
 });
+
+vi.resetModules();
+const { mockEnterpriseFeatures } = await import("../../helpers/enterprise-mock.js");
+mockEnterpriseFeatures(["mfa"]);
 
 const { env } = await import("../../../apps/api/src/config.js");
 const { db, schema } = await import("../../../apps/api/src/db/index.js");
@@ -50,6 +56,11 @@ async function startOidcLoginAndGetStateCookie() {
   return { cookieValue, state };
 }
 
+function generateTotpCode(uri: string): string {
+  const totp = OTPAuth.URI.parse(uri) as OTPAuth.TOTP;
+  return totp.generate();
+}
+
 async function insertOidcUser(opts: { role?: string; totpEnabled?: boolean } = {}) {
   const externalId = `sub-${randomUUID()}`;
   const userId = randomUUID();
@@ -67,6 +78,50 @@ async function insertOidcUser(opts: { role?: string; totpEnabled?: boolean } = {
     totpEnabled: opts.totpEnabled ?? false,
   });
   return { userId, username, externalId };
+}
+
+/**
+ * Inserts an OIDC user and drives them through the REAL self-service TOTP
+ * enrollment flow (enroll -> generate a real code -> verify), the same way
+ * `apps/web/src/components/settings/two-factor-settings.tsx` does it. This
+ * leaves a genuine, working, encrypted totpSecret in the DB -- not just a
+ * `totpEnabled: true` flag -- so a challenge issued for this user can
+ * actually be completed with a generated code, proving the OIDC-issued
+ * challenge is real and not just a Redis key that happens to exist.
+ */
+async function insertAndEnrollOidcUser(opts: { role?: string } = {}) {
+  const { userId, username, externalId } = await insertOidcUser({
+    role: opts.role,
+    totpEnabled: false,
+  });
+
+  const sessionToken = randomUUID();
+  await db.insert(schema.sessions).values({
+    id: sessionToken,
+    userId,
+    expiresAt: new Date(Date.now() + 3_600_000),
+  });
+
+  const enrollRes = await oidcApp.app.inject({
+    method: "POST",
+    url: "/api/auth/mfa/enroll",
+    headers: { authorization: `Bearer ${sessionToken}` },
+  });
+  const { uri } = JSON.parse(enrollRes.body) as { uri: string };
+
+  const verifyRes = await oidcApp.app.inject({
+    method: "POST",
+    url: "/api/auth/mfa/verify",
+    headers: { authorization: `Bearer ${sessionToken}` },
+    payload: { code: generateTotpCode(uri) },
+  });
+  expect(verifyRes.statusCode).toBe(200);
+
+  // This bootstrap session isn't the one under test; drop it so it can't
+  // mask a bug where the OIDC callback fails to mint its own.
+  await db.delete(schema.sessions).where(eq(schema.sessions.id, sessionToken));
+
+  return { userId, username, externalId, totpUri: uri };
 }
 
 async function callbackAsUser(externalId: string) {
@@ -175,8 +230,8 @@ describe("OIDC callback MFA outcomes", () => {
     expect(String(setCookie ?? "")).not.toContain("snapotter-session=");
   });
 
-  it("issues an MFA challenge (not a hard block) when the user has already enrolled TOTP", async () => {
-    const { externalId } = await insertOidcUser({ role: "user", totpEnabled: true });
+  it("issues an MFA challenge that is genuinely completable end to end with a real TOTP code", async () => {
+    const { username, externalId, totpUri } = await insertAndEnrollOidcUser({ role: "user" });
     await setMfaPolicy("required");
 
     const res = await callbackAsUser(externalId);
@@ -187,17 +242,51 @@ describe("OIDC callback MFA outcomes", () => {
     const setCookie = res.headers["set-cookie"];
     expect(String(setCookie ?? "")).not.toContain("snapotter-session=");
 
-    // The token is real: it resolves via Redis to this exact user, and
-    // completing it with a real TOTP code creates a session, proving the
-    // challenge is actually completable end to end.
     const mfaToken = location.split("mfaToken=")[1];
     const redis = sharedRedis();
-    const storedUserId = await redis.get(`mfa:${mfaToken}`);
-    expect(storedUserId).toBeTruthy();
+    expect(await redis.get(`mfa:${mfaToken}`)).toBeTruthy();
+
+    // Actually complete it -- this is the real end-to-end proof, not just
+    // that a Redis key exists.
+    const completeRes = await oidcApp.app.inject({
+      method: "POST",
+      url: "/api/auth/mfa/complete",
+      payload: { mfaToken, code: generateTotpCode(totpUri) },
+    });
+    expect(completeRes.statusCode).toBe(200);
+    const body = JSON.parse(completeRes.body);
+    expect(body.token).toBeDefined();
+    expect(body.user.username).toBe(username);
   });
 
-  it("still creates a session directly when the user is enrolled but policy is optional", async () => {
-    const { externalId } = await insertOidcUser({ totpEnabled: true });
+  it("rejects completing an OIDC-issued challenge with an invalid code, and does not create a session", async () => {
+    const { externalId } = await insertAndEnrollOidcUser({ role: "user" });
+    await setMfaPolicy("required");
+
+    const res = await callbackAsUser(externalId);
+    const mfaToken = (res.headers.location as string).split("mfaToken=")[1];
+
+    const completeRes = await oidcApp.app.inject({
+      method: "POST",
+      url: "/api/auth/mfa/complete",
+      payload: { mfaToken, code: "000000" },
+    });
+    expect(completeRes.statusCode).toBe(401);
+    expect(JSON.parse(completeRes.body).code).toBe("INVALID_CODE");
+  });
+
+  it("rejects completing with an unknown/expired mfaToken", async () => {
+    const completeRes = await oidcApp.app.inject({
+      method: "POST",
+      url: "/api/auth/mfa/complete",
+      payload: { mfaToken: randomUUID(), code: "123456" },
+    });
+    expect(completeRes.statusCode).toBe(401);
+    expect(JSON.parse(completeRes.body).code).toBe("MFA_EXPIRED");
+  });
+
+  it("challenges an enrolled user even when policy is optional (enrollment beats policy)", async () => {
+    const { externalId } = await insertAndEnrollOidcUser({});
     await setMfaPolicy("optional");
 
     const res = await callbackAsUser(externalId);
@@ -213,5 +302,36 @@ describe("OIDC callback MFA outcomes", () => {
     const res = await callbackAsUser(externalId);
 
     expect(res.headers.location).toBe("/");
+  });
+
+  it("fails closed (does not create a session) when the MFA enrollment-status query throws", async () => {
+    const { externalId } = await insertOidcUser({ role: "user", totpEnabled: true });
+    await setMfaPolicy("required");
+
+    const originalSelect = db.select.bind(db);
+    const selectSpy = vi.spyOn(db, "select").mockImplementation((...args: unknown[]) => {
+      const selection = args[0] as Record<string, unknown> | undefined;
+      if (selection && "totpEnabled" in selection) {
+        throw new Error("simulated DB failure");
+      }
+      // biome-ignore lint/suspicious/noExplicitAny: passthrough to the real overloaded implementation
+      return (originalSelect as any)(...args);
+    });
+
+    try {
+      const res = await callbackAsUser(externalId);
+
+      // Must NOT silently proceed without MFA and must NOT issue a challenge
+      // either -- a broken enrollment-status read means the login fails,
+      // full stop, not "let them in" or "pretend they're unenrolled".
+      expect(res.statusCode).toBe(302);
+      const location = res.headers.location as string;
+      expect(location).not.toBe("/");
+      expect(location).not.toMatch(/^\/login\?mfaToken=/);
+      const setCookie = res.headers["set-cookie"];
+      expect(String(setCookie ?? "")).not.toContain("snapotter-session=");
+    } finally {
+      selectSpy.mockRestore();
+    }
   });
 });

--- a/tests/integration/platform/oidc-mfa-callback.test.ts
+++ b/tests/integration/platform/oidc-mfa-callback.test.ts
@@ -1,0 +1,217 @@
+/**
+ * End-to-end reproduction + regression coverage for the OIDC MFA gap
+ * (snapotter-hq/SnapOtter#533): before the fix, a successful OIDC login for a
+ * user under an MFA-required policy was unconditionally blocked, with no
+ * check of whether the user had actually enrolled TOTP and no challenge step.
+ *
+ * The real cryptographic token exchange (PKCE/nonce/JWT signature
+ * verification) is mocked at the `openid-client` boundary so this test can
+ * drive the REAL callback route, REAL cookie/state handling, REAL Redis
+ * challenge token, and REAL MFA decision code end to end without needing a
+ * full mock IdP with signed JWTs.
+ */
+import { randomUUID } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+const authorizationCodeGrantMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openid-client", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  return { ...actual, authorizationCodeGrant: authorizationCodeGrantMock };
+});
+
+const { env } = await import("../../../apps/api/src/config.js");
+const { db, schema } = await import("../../../apps/api/src/db/index.js");
+const { sharedRedis } = await import("../../../apps/api/src/jobs/connection.js");
+const { buildTestApp } = await import("../test-server.js");
+
+import type { TestApp } from "../test-server.js";
+
+let oidcApp: TestApp;
+let mockServer: Server;
+let mockPort: number;
+
+const origOidcEnabled = env.OIDC_ENABLED;
+const origExternalUrl = env.EXTERNAL_URL;
+const origIssuerUrl = env.OIDC_ISSUER_URL;
+const origClientId = env.OIDC_CLIENT_ID;
+const origClientSecret = env.OIDC_CLIENT_SECRET;
+
+async function startOidcLoginAndGetStateCookie() {
+  const loginRes = await oidcApp.app.inject({ method: "GET", url: "/api/auth/oidc/login" });
+  expect(loginRes.statusCode).toBe(302);
+  const rawCookies = loginRes.headers["set-cookie"];
+  const cookieStr = Array.isArray(rawCookies) ? rawCookies[0] : rawCookies || "";
+  const cookieMatch = cookieStr.match(/oidc-state=([^;]+)/);
+  const cookieValue = decodeURIComponent(cookieMatch?.[1] ?? "");
+  const redirectUrl = new URL(loginRes.headers.location as string);
+  const state = redirectUrl.searchParams.get("state") ?? "";
+  return { cookieValue, state };
+}
+
+async function insertOidcUser(opts: { role?: string; totpEnabled?: boolean } = {}) {
+  const externalId = `sub-${randomUUID()}`;
+  const userId = randomUUID();
+  const username = `oidc_mfa_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+  await db.insert(schema.users).values({
+    id: userId,
+    username,
+    passwordHash: null,
+    role: opts.role ?? "user",
+    team: "default-team-00000000",
+    mustChangePassword: false,
+    authProvider: "oidc",
+    externalId,
+    email: `${username}@example.com`,
+    totpEnabled: opts.totpEnabled ?? false,
+  });
+  return { userId, username, externalId };
+}
+
+async function callbackAsUser(externalId: string) {
+  authorizationCodeGrantMock.mockResolvedValueOnce({
+    claims: () => ({ sub: externalId, email: `${externalId}@example.com` }),
+    id_token: "fake-id-token",
+  });
+  const { cookieValue, state } = await startOidcLoginAndGetStateCookie();
+  return oidcApp.app.inject({
+    method: "GET",
+    url: `/api/auth/oidc/callback?code=abc&state=${state}`,
+    cookies: { "oidc-state": cookieValue },
+  });
+}
+
+async function setMfaPolicy(value: "optional" | "admins_only" | "required") {
+  await db
+    .insert(schema.settings)
+    .values({ key: "mfaPolicy", value })
+    .onConflictDoUpdate({ target: schema.settings.key, set: { value } });
+}
+
+beforeAll(async () => {
+  mockServer = createServer((req, res) => {
+    if (req.url === "/.well-known/openid-configuration") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          issuer: `http://localhost:${mockPort}`,
+          authorization_endpoint: `http://localhost:${mockPort}/authorize`,
+          token_endpoint: `http://localhost:${mockPort}/token`,
+          jwks_uri: `http://localhost:${mockPort}/jwks`,
+          response_types_supported: ["code"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["RS256"],
+          code_challenge_methods_supported: ["S256"],
+        }),
+      );
+      return;
+    }
+    if (req.url === "/jwks") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ keys: [] }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => {
+    mockServer.listen(0, "127.0.0.1", () => {
+      const addr = mockServer.address();
+      mockPort = typeof addr === "object" && addr ? addr.port : 0;
+      resolve();
+    });
+  });
+
+  (env as any).OIDC_ENABLED = true;
+  (env as any).EXTERNAL_URL = "http://localhost:9999";
+  (env as any).OIDC_ISSUER_URL = `http://localhost:${mockPort}`;
+  (env as any).OIDC_CLIENT_ID = "test-client-id";
+  (env as any).OIDC_CLIENT_SECRET = "test-client-secret";
+
+  oidcApp = await buildTestApp();
+}, 30_000);
+
+afterEach(async () => {
+  await setMfaPolicy("optional");
+  authorizationCodeGrantMock.mockReset();
+});
+
+afterAll(async () => {
+  (env as any).OIDC_ENABLED = origOidcEnabled;
+  (env as any).EXTERNAL_URL = origExternalUrl;
+  (env as any).OIDC_ISSUER_URL = origIssuerUrl;
+  (env as any).OIDC_CLIENT_ID = origClientId;
+  (env as any).OIDC_CLIENT_SECRET = origClientSecret;
+  await oidcApp.cleanup();
+  await new Promise<void>((resolve) => mockServer.close(() => resolve()));
+}, 10_000);
+
+describe("OIDC callback MFA outcomes", () => {
+  it("creates a session directly when MFA is optional and the user isn't enrolled", async () => {
+    const { externalId } = await insertOidcUser({ totpEnabled: false });
+    await setMfaPolicy("optional");
+
+    const res = await callbackAsUser(externalId);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe("/");
+    const setCookie = res.headers["set-cookie"];
+    expect(String(setCookie)).toContain("snapotter-session=");
+  });
+
+  it("blocks with a distinct enrollment-required error when policy requires MFA and the user hasn't enrolled -- this is the bug in #533", async () => {
+    const { externalId } = await insertOidcUser({ role: "user", totpEnabled: false });
+    await setMfaPolicy("required");
+
+    const res = await callbackAsUser(externalId);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe("/login?error=mfa_enrollment_required");
+    // Must NOT be the old generic code that the frontend doesn't even map to a message.
+    expect(res.headers.location).not.toBe("/login?error=mfa_required");
+    const setCookie = res.headers["set-cookie"];
+    expect(String(setCookie ?? "")).not.toContain("snapotter-session=");
+  });
+
+  it("issues an MFA challenge (not a hard block) when the user has already enrolled TOTP", async () => {
+    const { externalId } = await insertOidcUser({ role: "user", totpEnabled: true });
+    await setMfaPolicy("required");
+
+    const res = await callbackAsUser(externalId);
+
+    expect(res.statusCode).toBe(302);
+    const location = res.headers.location as string;
+    expect(location).toMatch(/^\/login\?mfaToken=/);
+    const setCookie = res.headers["set-cookie"];
+    expect(String(setCookie ?? "")).not.toContain("snapotter-session=");
+
+    // The token is real: it resolves via Redis to this exact user, and
+    // completing it with a real TOTP code creates a session, proving the
+    // challenge is actually completable end to end.
+    const mfaToken = location.split("mfaToken=")[1];
+    const redis = sharedRedis();
+    const storedUserId = await redis.get(`mfa:${mfaToken}`);
+    expect(storedUserId).toBeTruthy();
+  });
+
+  it("still creates a session directly when the user is enrolled but policy is optional", async () => {
+    const { externalId } = await insertOidcUser({ totpEnabled: true });
+    await setMfaPolicy("optional");
+
+    const res = await callbackAsUser(externalId);
+
+    const location = res.headers.location as string;
+    expect(location).toMatch(/^\/login\?mfaToken=/);
+  });
+
+  it("does not block a user outside the policy's scope (admins_only, non-admin role)", async () => {
+    const { externalId } = await insertOidcUser({ role: "user", totpEnabled: false });
+    await setMfaPolicy("admins_only");
+
+    const res = await callbackAsUser(externalId);
+
+    expect(res.headers.location).toBe("/");
+  });
+});

--- a/tests/unit/api/mfa.test.ts
+++ b/tests/unit/api/mfa.test.ts
@@ -4,6 +4,7 @@ import {
   createTotp,
   hashRecoveryCodes,
   isMfaRequiredForUser,
+  resolveExternalLoginMfaOutcome,
   verifyRecoveryCode,
   verifyTotpCode,
 } from "../../../apps/api/src/plugins/mfa.js";
@@ -186,6 +187,31 @@ describe("MFA", () => {
     it("returns false for admins_only policy when role is not admin", () => {
       expect(isMfaRequiredForUser("admins_only", "editor")).toBe(false);
       expect(isMfaRequiredForUser("admins_only", "user")).toBe(false);
+    });
+  });
+
+  describe("resolveExternalLoginMfaOutcome", () => {
+    it("challenges an already-enrolled user regardless of policy", () => {
+      expect(resolveExternalLoginMfaOutcome("optional", "user", true)).toBe("challenge");
+      expect(resolveExternalLoginMfaOutcome("required", "admin", true)).toBe("challenge");
+    });
+
+    it("proceeds when unenrolled and policy doesn't require MFA for this role", () => {
+      expect(resolveExternalLoginMfaOutcome("optional", "user", false)).toBe("proceed");
+      expect(resolveExternalLoginMfaOutcome("admins_only", "user", false)).toBe("proceed");
+    });
+
+    it("requires enrollment when unenrolled and policy requires MFA for this role", () => {
+      expect(resolveExternalLoginMfaOutcome("required", "user", false)).toBe("enrollment_required");
+      expect(resolveExternalLoginMfaOutcome("admins_only", "admin", false)).toBe(
+        "enrollment_required",
+      );
+    });
+
+    it("enrollment takes priority: an enrolled user is challenged even under a required policy", () => {
+      expect(resolveExternalLoginMfaOutcome("required", "admin", true)).not.toBe(
+        "enrollment_required",
+      );
     });
   });
 });

--- a/tests/unit/api/mfa.test.ts
+++ b/tests/unit/api/mfa.test.ts
@@ -191,21 +191,27 @@ describe("MFA", () => {
   });
 
   describe("resolveExternalLoginMfaOutcome", () => {
-    it("challenges an already-enrolled user regardless of policy", () => {
-      expect(resolveExternalLoginMfaOutcome("optional", "user", true)).toBe("challenge");
-      expect(resolveExternalLoginMfaOutcome("required", "admin", true)).toBe("challenge");
-    });
-
-    it("proceeds when unenrolled and policy doesn't require MFA for this role", () => {
-      expect(resolveExternalLoginMfaOutcome("optional", "user", false)).toBe("proceed");
-      expect(resolveExternalLoginMfaOutcome("admins_only", "user", false)).toBe("proceed");
-    });
-
-    it("requires enrollment when unenrolled and policy requires MFA for this role", () => {
-      expect(resolveExternalLoginMfaOutcome("required", "user", false)).toBe("enrollment_required");
-      expect(resolveExternalLoginMfaOutcome("admins_only", "admin", false)).toBe(
-        "enrollment_required",
-      );
+    // Exhaustive over the full input space: 3 policies x 2 roles x 2
+    // totpEnabled states. Role only matters via isMfaRequiredForUser, which
+    // branches solely on role === "admin", so {admin, user} covers it.
+    it.each([
+      ["optional", "user", false, "proceed"],
+      ["optional", "user", true, "challenge"],
+      ["optional", "admin", false, "proceed"],
+      ["optional", "admin", true, "challenge"],
+      ["admins_only", "user", false, "proceed"],
+      ["admins_only", "user", true, "challenge"],
+      ["admins_only", "admin", false, "enrollment_required"],
+      ["admins_only", "admin", true, "challenge"],
+      // required+user+enrolled is the exact shape of the #533 bug: an
+      // enrolled non-admin user under a required policy must be challenged,
+      // not hard-blocked.
+      ["required", "user", false, "enrollment_required"],
+      ["required", "user", true, "challenge"],
+      ["required", "admin", false, "enrollment_required"],
+      ["required", "admin", true, "challenge"],
+    ] as const)("policy=%s role=%s totpEnabled=%s -> %s", (policy, role, totpEnabled, expected) => {
+      expect(resolveExternalLoginMfaOutcome(policy, role, totpEnabled)).toBe(expected);
     });
 
     it("enrollment takes priority: an enrolled user is challenged even under a required policy", () => {

--- a/tests/unit/web/login-page-oidc-mfa-redirect.test.tsx
+++ b/tests/unit/web/login-page-oidc-mfa-redirect.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const useAuth = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/use-auth", () => ({ useAuth }));
+
+import { LoginPage } from "@/pages/login-page";
+
+afterEach(() => {
+  cleanup();
+  useAuth.mockReset();
+});
+
+function renderLoginPage(path: string) {
+  useAuth.mockReturnValue({
+    oidcEnabled: true,
+    oidcProviderName: "Test IdP",
+    samlEnabled: false,
+    samlProviderName: null,
+    ssoEnforced: false,
+  });
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <LoginPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("LoginPage OIDC/SAML MFA redirect handling", () => {
+  it("shows the TOTP prompt automatically when redirected back with an mfaToken", () => {
+    renderLoginPage("/login?mfaToken=abc-123");
+    expect(screen.getByText(/enter your authentication code/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("000000")).toBeInTheDocument();
+  });
+
+  it("shows the enrollment-required message for the mfa_enrollment_required error code", () => {
+    renderLoginPage("/login?error=mfa_enrollment_required");
+    expect(screen.getByText(/multi-factor authentication/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/web/login-page-oidc-mfa-redirect.test.tsx
+++ b/tests/unit/web/login-page-oidc-mfa-redirect.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const useAuth = vi.hoisted(() => vi.fn());
@@ -16,7 +16,13 @@ afterEach(() => {
   useAuth.mockReset();
 });
 
-function renderLoginPage(path: string) {
+function LocationProbe({ onChange }: { onChange: (search: string) => void }) {
+  const location = useLocation();
+  onChange(location.search);
+  return null;
+}
+
+function renderLoginPage(path: string, onLocationChange?: (search: string) => void) {
   useAuth.mockReturnValue({
     oidcEnabled: true,
     oidcProviderName: "Test IdP",
@@ -26,6 +32,7 @@ function renderLoginPage(path: string) {
   });
   return render(
     <MemoryRouter initialEntries={[path]}>
+      {onLocationChange && <LocationProbe onChange={onLocationChange} />}
       <LoginPage />
     </MemoryRouter>,
   );
@@ -41,5 +48,32 @@ describe("LoginPage OIDC/SAML MFA redirect handling", () => {
   it("shows the enrollment-required message for the mfa_enrollment_required error code", () => {
     renderLoginPage("/login?error=mfa_enrollment_required");
     expect(screen.getByText(/multi-factor authentication/i)).toBeInTheDocument();
+  });
+
+  it("does not show the TOTP prompt for an empty mfaToken param", () => {
+    renderLoginPage("/login?mfaToken=");
+    expect(screen.queryByPlaceholderText("000000")).not.toBeInTheDocument();
+  });
+
+  it("prioritizes an mfaToken over a simultaneous error param", () => {
+    renderLoginPage("/login?mfaToken=abc-123&error=oidc_auth_failed");
+    expect(screen.getByText(/enter your authentication code/i)).toBeInTheDocument();
+    expect(screen.queryByText(/authentication error/i)).not.toBeInTheDocument();
+  });
+
+  it("strips mfaToken from the URL after consuming it", async () => {
+    let currentSearch = "";
+    renderLoginPage("/login?mfaToken=abc-123", (search) => {
+      currentSearch = search;
+    });
+    await waitFor(() => expect(currentSearch).toBe(""));
+  });
+
+  it("strips the error param from the URL after consuming it", async () => {
+    let currentSearch = "";
+    renderLoginPage("/login?error=mfa_enrollment_required", (search) => {
+      currentSearch = search;
+    });
+    await waitFor(() => expect(currentSearch).toBe(""));
   });
 });


### PR DESCRIPTION
## Summary

Fixes #533, found while working on #529/#531: OIDC and SAML logins hard-block on the MFA policy with zero check of whether the user actually enrolled TOTP, and no challenge step at all (unlike local login's `requiresMfa` flow). Once an admin turns on an MFA-required policy, every SSO user is permanently locked out regardless of enrollment status.

- `apps/api/src/plugins/mfa.ts`: new `resolveExternalLoginMfaOutcome()`, the same three-way decision (challenge / enrollment-required / proceed) local login already makes, extracted so OIDC and SAML can't independently reinvent it and diverge again the way they just did
- `apps/api/src/plugins/oidc.ts` + `apps/api/src/plugins/saml.ts`: an already-enrolled user now gets a real challenge (an `mfaToken` redirect into the existing, auth-method-agnostic `POST /api/auth/mfa/complete` flow) instead of being blocked; an unenrolled user under a required policy gets a distinct `mfa_enrollment_required` redirect instead of the old generic one
- `apps/web/src/pages/login-page.tsx`: auto-shows the TOTP prompt when redirected back with an `mfaToken`, and maps `mfa_enrollment_required` to the existing (previously unused) `t.auth.mfaEnrollmentRequired` string

This branch was cut from `main` before #531 merged, so it doesn't have that PR's local-login fixes yet. Both touch `login-page.tsx`'s error handling in adjacent but non-overlapping ways; expect a small, easy conflict to resolve whichever merges second.

Known gap, not addressed here: there is currently no integration test coverage for SAML at all in this repo (no `saml-auth.test.ts` equivalent to `oidc-auth.test.ts`), and building one requires a signed XML assertion harness, a bigger lift than this fix. `saml.ts`'s change is a structural line-for-line mirror of the OIDC fix (verified by manual side-by-side review) and calls the same unit-tested `resolveExternalLoginMfaOutcome()`, but it isn't exercised end-to-end the way the OIDC path now is.

## Test plan

- [x] TDD: `resolveExternalLoginMfaOutcome()` has 4 new unit tests covering all three outcomes and the enrolled-takes-priority-over-policy case, written and failing before the implementation existed
- [x] Live-reproduced the actual bug: wrote a full HTTP-level OIDC callback test (mocks only the `openid-client` token-exchange boundary, everything else — real Fastify route, real cookie/state validation, real Redis, real MFA logic — is exercised for real), then **temporarily reverted `oidc.ts` to the pre-fix code and confirmed 3 of 5 new tests failed** (an enrolled user got hard-blocked with a generic error instead of challenged), then restored the fix and confirmed all 5 pass — this is the actual regression the bug describes, caught and fixed
- [x] `tests/integration/platform/oidc-mfa-callback.test.ts` (new, 5 tests): optional+unenrolled proceeds, required+unenrolled gets `mfa_enrollment_required`, enrolled gets a real challenge with a working Redis token, enrolled+optional still challenges, admins_only+non-admin proceeds
- [x] `tests/unit/web/login-page-oidc-mfa-redirect.test.tsx` (new, 2 tests): `mfaToken` param auto-shows the TOTP prompt, `mfa_enrollment_required` maps to the correct message
- [x] Existing `tests/integration/platform/oidc-auth.test.ts` (28 tests) and `tests/integration/platform/mfa-endpoints.test.ts` (15 tests) still pass, no regressions
- [x] Full regression: web unit suite (75 files / 1339 tests), backend (`mfa`, `oidc-auth`, `oidc-mfa-callback`, `auth-edge-cases`, `permissions`, 6 files / 125 tests) all green
- [x] `tsc --noEmit` clean on api and web; `biome check` clean (only pre-existing `as any` warnings already accepted in the sibling `oidc-auth.test.ts` file)