### PR TITLE
fix(ai-bridge): surface sidecar exit reasons in Sentry via SafeError

### DIFF
--- a/packages/ai/src/bridge.ts
+++ b/packages/ai/src/bridge.ts
@@ -80,6 +80,39 @@ function getPythonPath(): string {
 /**
  * Extract a user-friendly error from a Python process error.
  */
+const OOM_EXIT_TEXT =
+  /out of memory|failed to allocate|cudaerrormemoryallocation|cublas_status_alloc_failed|bad_alloc/i;
+
+/**
+ * Build the error to reject a non-zero Python exit with. The extracted reason is
+ * kept as the message (it is already surfaced to callers) but wrapped in a
+ * SafeError so it survives the API's Sentry scrubber, which otherwise reduces a
+ * plain Error to "Error: Error" (NODE-24). Classification is deliberate: a kill
+ * signal / OS OOM (SIGKILL, exit 137) and a segfault (SIGSEGV, exit 139) are
+ * operational, and their constant messages keep the "out of memory" text so
+ * memory-aware callers still retry on a lighter model. Any other non-zero exit
+ * is a bug, with the extracted reason (or an OOM reported in-band) preserved.
+ */
+function pythonExitError(code: number | null, signal: string | null, extracted: string): SafeError {
+  if (signal === "SIGSEGV" || code === 139) {
+    return new SafeError("Process crashed (segmentation fault)", {
+      kind: "operational",
+      code: `exit-${code ?? signal ?? "unknown"}`,
+    });
+  }
+  if (signal === "SIGKILL" || code === 137) {
+    return new SafeError("Process killed (out of memory) -- try a lighter model or smaller image", {
+      kind: "operational",
+      code: `exit-${code ?? signal ?? "unknown"}`,
+    });
+  }
+  const message = extracted || `Python script exited with code ${code}`;
+  return new SafeError(message, {
+    kind: OOM_EXIT_TEXT.test(message) ? "operational" : "bug",
+    code: `exit-${code ?? "unknown"}`,
+  });
+}
+
 function extractPythonError(error: unknown): string {
   if (error && typeof error === "object") {
     const pErr = error as {
@@ -331,20 +364,7 @@ export class PythonDispatcher {
                   stdout: response.stdout,
                   stderr: req.stderrLines.join("\n"),
                 });
-                if (!extracted && (response.exitCode === 137 || response.exitCode === 139)) {
-                  req.reject(
-                    new SafeError(
-                      response.exitCode === 137
-                        ? "Process killed (out of memory) -- try a lighter model or smaller image"
-                        : "Process crashed (segmentation fault)",
-                      { kind: "operational", code: `exit-${response.exitCode}` },
-                    ),
-                  );
-                } else {
-                  req.reject(
-                    new Error(extracted || `Python script exited with code ${response.exitCode}`),
-                  );
-                }
+                req.reject(pythonExitError(response.exitCode, null, extracted));
               } else {
                 req.resolve({
                   stdout: response.stdout || "",
@@ -567,24 +587,9 @@ export class PythonDispatcher {
           const stderr = stderrLines.join("\n");
 
           if (code !== 0) {
-            // When the process was killed by a signal, use a clear message
-            // instead of surfacing unrelated stderr (e.g. CUDA warnings).
-            const signalMsg =
-              signal === "SIGKILL" || code === 137
-                ? "Process killed (out of memory) -- try a lighter model or smaller image"
-                : signal === "SIGSEGV" || code === 139
-                  ? "Process crashed (segmentation fault)"
-                  : null;
-            if (signalMsg) {
-              rejectPromise(
-                new SafeError(signalMsg, { kind: "operational", code: `exit-${code ?? signal}` }),
-              );
-              return;
-            }
-            const errorText =
-              extractPythonError({ stdout: stdout.trim(), stderr }) ||
-              `Python script exited with code ${code}`;
-            rejectPromise(new Error(errorText));
+            rejectPromise(
+              pythonExitError(code, signal, extractPythonError({ stdout: stdout.trim(), stderr })),
+            );
             return;
           }
 

--- a/tests/unit/ai/bridge.test.ts
+++ b/tests/unit/ai/bridge.test.ts
@@ -203,11 +203,16 @@ describe("bridge - runPythonWithProgress (per-request fallback)", () => {
     mock.stderr.emit("data", Buffer.from("RuntimeError: model not found\n"));
     mock.emitEvent("close", 1, null);
 
-    const err = (await promise.catch((e: unknown) => e)) as Error & { isSafeMessage?: unknown };
+    const err = (await promise.catch((e: unknown) => e)) as Error & {
+      isSafeMessage?: unknown;
+      kind?: string;
+    };
     expect(err).toBeInstanceOf(Error);
     expect(err.message).toContain("RuntimeError: model not found");
-    // Variable python-derived text must stay a plain Error, never a SafeError
-    expect(err.isSafeMessage).toBeUndefined();
+    // The sidecar reason is wrapped in a SafeError so it survives the Sentry
+    // scrubber instead of showing as "Error: Error" (NODE-24).
+    expect(err.isSafeMessage).toBe(true);
+    expect(err.kind).toBe("bug");
   });
 
   it("rejects with OOM message on exit code 137 (SIGKILL)", async () => {
@@ -1585,7 +1590,7 @@ describe("bridge - dispatcher stdin JSON-RPC protocol", () => {
     expect(err.code).toBe("exit-139");
   });
 
-  it("keeps extracted python text as a plain Error even on dispatcher exitCode 137", async () => {
+  it("classifies dispatcher exitCode 137 as an operational OOM SafeError", async () => {
     const mock = await setupReadyDispatcher();
 
     const promise = runPythonWithProgress("heavy.py", []);
@@ -1594,7 +1599,8 @@ describe("bridge - dispatcher stdin JSON-RPC protocol", () => {
     const line = mock.stdinWrites.join("").split("\n").filter(Boolean)[0];
     const id = JSON.parse(line).id;
 
-    // Extractable error text takes precedence over the constant signal message
+    // 137 is an OS OOM kill: the operational message keeps "out of memory" so
+    // memory-aware callers retry, and it does not surface possibly-unrelated stderr.
     mock.stdout.emit(
       "data",
       Buffer.from(
@@ -1602,10 +1608,13 @@ describe("bridge - dispatcher stdin JSON-RPC protocol", () => {
       ),
     );
 
-    const err = (await promise.catch((e: unknown) => e)) as Error & { isSafeMessage?: unknown };
-    expect(err).toBeInstanceOf(Error);
-    expect(err.message).toBe("CUDA out of memory");
-    expect(err.isSafeMessage).toBeUndefined();
+    const err = (await promise.catch((e: unknown) => e)) as Error & {
+      isSafeMessage?: unknown;
+      kind?: string;
+    };
+    expect(err.message).toContain("out of memory");
+    expect(err.isSafeMessage).toBe(true);
+    expect(err.kind).toBe("operational");
   });
 
   it("ignores stdout lines that are not valid JSON", async () => {
@@ -2312,6 +2321,48 @@ describe("bridge - extractPythonError via dispatcher responses", () => {
     mock.stdout.emit("data", Buffer.from(`${JSON.stringify({ id, exitCode: 42, stdout: "" })}\n`));
 
     await expect(promise).rejects.toThrow("exited with code 42");
+  });
+
+  it("rejects a non-zero exit with a bug-classed SafeError so the reason survives Sentry scrubbing", async () => {
+    const mock = await setupReadyDispatcher();
+    const promise = runPythonWithProgress("test.py", []);
+    await new Promise((r) => setTimeout(r, 10));
+    const line = mock.stdinWrites.join("").split("\n").filter(Boolean)[0];
+    const id = JSON.parse(line).id;
+    mock.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({ id, exitCode: 1, stdout: '{"error": "model not found"}' })}\n`,
+      ),
+    );
+    const err = (await promise.catch((e: unknown) => e)) as Error & {
+      isSafeMessage?: unknown;
+      kind?: string;
+    };
+    expect(err.message).toBe("model not found");
+    expect(err.isSafeMessage).toBe(true);
+    expect(err.kind).toBe("bug");
+  });
+
+  it("classifies an out-of-memory exit reported in-band as operational", async () => {
+    const mock = await setupReadyDispatcher();
+    const promise = runPythonWithProgress("test.py", []);
+    await new Promise((r) => setTimeout(r, 10));
+    const line = mock.stdinWrites.join("").split("\n").filter(Boolean)[0];
+    const id = JSON.parse(line).id;
+    mock.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({ id, exitCode: 1, stdout: '{"error": "CUDA out of memory"}' })}\n`,
+      ),
+    );
+    const err = (await promise.catch((e: unknown) => e)) as Error & {
+      isSafeMessage?: unknown;
+      kind?: string;
+    };
+    expect(err.isSafeMessage).toBe(true);
+    expect(err.kind).toBe("operational");
+    expect(err.message).toContain("out of memory");
   });
 });
 


### PR DESCRIPTION
## Problem

When a Python sidecar process exits non-zero, both exit paths in `bridge.ts` (the dispatcher response handler and the per-request `close` handler) rejected with a plain `Error`. The API's Sentry scrubber (`rebuildErrorValue`) preserves only `SafeError` messages, so these surfaced as `Error: Error` with the reason invisible (Sentry NODE-24, 35 events across upscale/enhance-faces/noise-removal/restore-photo/etc.).

## Design note

The bridge previously kept these as plain `Error`s on purpose, to keep python-derived text out of Sentry (there was a guard test asserting exactly that). Per maintainer decision, we now surface the sidecar's error text to Sentry for diagnosability, so that stance is revised and the guard test updated. The text is already surfaced to callers today; this change also lets it reach Sentry.

## Fix

Route both exit paths through one `pythonExitError(code, signal, extracted)` helper. It keeps the extracted reason as the message but wraps it in a `SafeError`, and classifies deliberately:
- A kill signal / OS OOM (`SIGKILL`, exit 137) or a segfault (`SIGSEGV`, exit 139) is `operational`, with a constant message that keeps the "out of memory" text so memory-aware callers (`isMemoryAllocError` in background-removal and transparency-fixer) still retry on a lighter model.
- An out-of-memory error reported in-band (OOM text in the output) is also `operational`.
- Anything else is a `bug`.

## Test

`tests/unit/ai/bridge.test.ts`: the exit-137 test and the non-zero-exit invariant test are rewritten to the new contract, and two dispatcher tests are added (a bug-classed `SafeError` that preserves the reason; an in-band OOM classified `operational`). All existing message assertions are preserved because the message content is unchanged. Full suite green (132 tests).

Closes #526