### PR TITLE
fix(telemetry): classify environmental database errors as operational

### DIFF
--- a/apps/api/src/lib/error-report.ts
+++ b/apps/api/src/lib/error-report.ts
@@ -15,6 +15,7 @@ import {
   connectivityClass,
   extractErrorCode,
   isClientAbort,
+  isEnvironmentalDbError,
   isSafeMessageError,
   isToolInputError,
 } from "@snapotter/shared";
@@ -59,6 +60,7 @@ export function classifyError(err: unknown, source?: ReportContext["source"]): E
   }
   if (isSafeMessageError(err)) return err.kind === "bug" ? "bug" : "operational";
   if (connectivityClass(err)) return "operational";
+  if (isEnvironmentalDbError(err)) return "operational";
   if (e?.code && OPERATIONAL_CODES.has(e.code)) return "operational";
   return "bug";
 }

--- a/packages/shared/src/analytics/error-sanitize.ts
+++ b/packages/shared/src/analytics/error-sanitize.ts
@@ -146,6 +146,33 @@ export function connectivityClass(err: unknown): ConnectivityClass | null {
   }
 }
 
+// pg SQLSTATE classes that mean the deployment's database is misconfigured or
+// resource-starved (the operator's environment), not that our code is wrong:
+// class 28 (invalid authorization), 53 (insufficient resources), 57 (operator
+// intervention). 42501 is insufficient_privilege, the one access code in class
+// 42 (otherwise our query bugs). Connection loss (class 08 / 57P0x) is already
+// covered by connectivityClass; overlap here is harmless.
+const ENVIRONMENTAL_PG_CLASS = /^(28|53|57)/;
+
+/**
+ * True when the error chain carries a pg SQLSTATE indicating an environmental
+ * database problem (bad credentials, missing privilege, exhausted resources,
+ * operator shutdown) rather than a bug in our queries. Lets self-hosters' DB
+ * misconfiguration classify as operational instead of a code bug.
+ */
+export function isEnvironmentalDbError(err: unknown): boolean {
+  try {
+    return chain(err).some((l) => {
+      if (typeof l.code !== "string" || !SQLSTATE.test(l.code) || NODE_CODE.test(l.code)) {
+        return false;
+      }
+      return ENVIRONMENTAL_PG_CLASS.test(l.code) || l.code === "42501";
+    });
+  } catch {
+    return false;
+  }
+}
+
 /** Client went away mid-request; operational noise, never reported. */
 export function isClientAbort(err: unknown): boolean {
   try {

--- a/tests/unit/api/error-report.test.ts
+++ b/tests/unit/api/error-report.test.ts
@@ -35,6 +35,29 @@ describe("classifyError", () => {
       "operational",
     );
   });
+  it("operational: environmental database errors (auth, permission, resources), not query bugs", () => {
+    // The deployment's DB is misconfigured or starved -- the operator's
+    // environment, not our code. These flooded the bug view as pg auth /
+    // permission failures from background sweeps (NODE-1G/1F/1D).
+    expect(
+      classifyError(Object.assign(new Error("password authentication failed"), { code: "28P01" })),
+    ).toBe("operational");
+    // drizzle wraps the pg error, so the SQLSTATE is on the cause, not the top level.
+    expect(
+      classifyError(
+        Object.assign(new Error("Failed query: DELETE FROM jobs"), {
+          cause: Object.assign(new Error("permission denied for relation jobs"), { code: "42501" }),
+        }),
+      ),
+    ).toBe("operational");
+    expect(
+      classifyError(Object.assign(new Error("no space left on device"), { code: "53100" })),
+    ).toBe("operational");
+    // A pg SYNTAX error is our query bug, not the environment -- must stay a bug.
+    expect(
+      classifyError(Object.assign(new Error("syntax error at or near"), { code: "42601" })),
+    ).toBe("bug");
+  });
   it("bug: everything else, including bug-kind SafeError and ReplyError", () => {
     expect(classifyError(new Error("undefined is not a function"))).toBe("bug");
     expect(classifyError(new SafeError("Impossible state", { kind: "bug" }))).toBe("bug");


### PR DESCRIPTION
## Problem

`classifyError` only treats pg **connection** failures (SQLSTATE class `08` / `57P0x`, via `connectivityClass`) as operational. Postgres **auth** (`28P01`), **permission** (`42501`), **resource-exhaustion** (class `53`), and **operator-intervention** (class `57`) failures fell through to `bug`. These are self-hosters' database misconfiguration, not our code, and they're the loudest issues in the tracker — NODE-1G (166), NODE-1F (124), NODE-1D (107) — all from background sweeps (`storageTtlSweep`, `retentionSweep`, session lookups). They bury the real bugs.

## Fix

Add `isEnvironmentalDbError`, which walks the cause chain (drizzle wraps the pg error, so the SQLSTATE is on the cause, not the top level) and returns true for the environmental pg classes. `classifyError` uses it to return `operational` — reported at `warning` level, not `error`, and no longer counted as a bug.

Deliberately narrow: pg **query** bugs (e.g. `42601` syntax error) stay `bug`, so a real bad query still surfaces. Connection loss (class `08` / `57P0x`) is unchanged (already operational + fingerprinted by `connectivityClass`).

## Test

`tests/unit/api/error-report.test.ts`: a new case asserts pg `28P01` (auth), wrapped `42501` (permission, on the cause), and `53100` (disk full) classify as `operational`, while `42601` (syntax) stays `bug`. Full error-report + error-sanitize suites green (37 tests).

Part of #478 (the environmental-infra reclassification from the 2.1.0 telemetry triage).