### PR TITLE
feat(telemetry): add a safe input_format tag to worker error reports

### DIFF
--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -39,7 +39,7 @@ import { db, schema } from "../db/index.js";
 import { trackEvent } from "../lib/analytics.js";
 import { analyticsEnabled } from "../lib/analytics-gate.js";
 import { resolveConcurrency } from "../lib/env.js";
-import { reportError } from "../lib/error-report.js";
+import { reportError, safeFormatTag } from "../lib/error-report.js";
 import { friendlyError } from "../lib/errors.js";
 import { logger } from "../lib/logger.js";
 import { jobDuration, jobsTotal } from "../lib/metrics.js";
@@ -1047,6 +1047,7 @@ export function startWorkers(): void {
         source: "worker",
         pool,
         toolId: (job.data as ToolJobData | undefined)?.toolId,
+        inputFormat: safeFormatTag((job.data as ToolJobData | undefined)?.filename),
       });
     });
 

--- a/apps/api/src/lib/error-report.ts
+++ b/apps/api/src/lib/error-report.ts
@@ -34,6 +34,8 @@ export interface ReportContext {
   method?: string;
   statusCode?: number;
   subsystem?: string;
+  /** Safe input format (file extension) for triage; never the filename. */
+  inputFormat?: string;
 }
 
 export function classifyError(err: unknown, source?: ReportContext["source"]): ErrorClass {
@@ -97,6 +99,17 @@ export function errorSignature(err: unknown): string {
   return `${name}:${code}:${frame}`;
 }
 
+/**
+ * The lowercase file extension as a safe, non-PII tag value, or undefined. The
+ * filename itself can carry user data, but a short alphanumeric extension (jpg,
+ * png, pdf, mp4) is a safe triage signal for which input format failed.
+ */
+export function safeFormatTag(filename?: string): string | undefined {
+  if (!filename) return undefined;
+  const m = filename.match(/\.([a-z0-9]{1,8})$/i);
+  return m ? m[1].toLowerCase() : undefined;
+}
+
 /** Fire-and-forget; never throws, never blocks. */
 export async function reportError(err: unknown, ctx: ReportContext): Promise<void> {
   try {
@@ -113,6 +126,7 @@ export async function reportError(err: unknown, ctx: ReportContext): Promise<voi
       scope.setTag("error_class", cls);
       const code = extractErrorCode(err);
       if (code) scope.setTag("error_code", code);
+      if (ctx.inputFormat) scope.setTag("input_format", ctx.inputFormat);
       if (ctx.toolId) scope.setTag("tool_id", ctx.toolId);
       if (ctx.pool) scope.setTag("pool", ctx.pool);
       if (ctx.route) scope.setTag("route", ctx.route);

--- a/apps/api/src/lib/sentry-scrub.ts
+++ b/apps/api/src/lib/sentry-scrub.ts
@@ -22,6 +22,7 @@ const TAG_ALLOWLIST = new Set([
   "deploy_mode",
   "subsystem",
   "status_code",
+  "input_format",
 ]);
 
 const URL_RE = /https?:\/\/[^\s"')]+/g;

--- a/tests/unit/api/error-report.test.ts
+++ b/tests/unit/api/error-report.test.ts
@@ -4,8 +4,22 @@ import {
   classifyError,
   errorSignature,
   resetThrottleForTests,
+  safeFormatTag,
   shouldReport,
 } from "../../../apps/api/src/lib/error-report.js";
+
+describe("safeFormatTag", () => {
+  it("returns the lowercase extension as a safe, non-PII tag", () => {
+    expect(safeFormatTag("photo.JPEG")).toBe("jpeg");
+    expect(safeFormatTag("doc.pdf")).toBe("pdf");
+    expect(safeFormatTag("clip.final.mp4")).toBe("mp4");
+  });
+  it("returns undefined when there is no plausible extension", () => {
+    expect(safeFormatTag(undefined)).toBeUndefined();
+    expect(safeFormatTag("noext")).toBeUndefined();
+    expect(safeFormatTag("weird.name-with-dashes")).toBeUndefined();
+  });
+});
 
 describe("classifyError", () => {
   it("expected: tool input, aborts, worker cancel/timeout strings, zod, upload validation", () => {

--- a/tests/unit/api/sentry-scrub.test.ts
+++ b/tests/unit/api/sentry-scrub.test.ts
@@ -14,7 +14,7 @@ const evt = (over: AnyEvent = {}): AnyEvent => ({
     runtime: { name: "node", version: "22.1.0" },
     device: { hostname: "leak" },
   },
-  tags: { tool_id: "resize", secret_tag: "leak" },
+  tags: { tool_id: "resize", input_format: "webp", secret_tag: "leak" },
   exception: {
     values: [
       {
@@ -99,6 +99,7 @@ describe("buildBeforeSend (api)", () => {
       runtime: { name: "node", version: "22.1.0" },
     });
     expect(out.tags.tool_id).toBe("resize");
+    expect(out.tags.input_format).toBe("webp");
     expect(out.tags.secret_tag).toBeUndefined();
   });
   it("drops contexts entirely when nothing allowlisted survives", () => {


### PR DESCRIPTION
## Why

Captured tool errors carry `tool_id`, `pool`, `error_code`, and a stack (file:line), but not what the *input* was. The input that triggers a failure is often the fastest path to a repro ("convert fails on webp, not on png"). The filename can't go to Sentry (PII), but the **extension** is a safe, high-signal proxy.

## What

- `safeFormatTag(filename)` returns the lowercase extension when it's a short alphanumeric token (jpg, png, pdf, mp4, ...), else undefined. The filename itself is never used.
- `reportError` sets an `input_format` tag from `ReportContext.inputFormat`.
- The worker's `failed` handler derives it from the job's filename, so **every** tool error is enriched with one change, no per-tool edits.
- `input_format` is added to the scrubber allowlist so it survives `beforeSend`.

## Test

- `error-report.test.ts`: `safeFormatTag` returns the lowercase extension and undefined for no-extension / non-extension names.
- `sentry-scrub.test.ts`: `input_format` survives scrubbing while non-allowlisted tags are still dropped.

## Scope note

This is the "richer tags" half of the log-quality work. I deliberately did **not** do an exhaustive `throw new Error` → typed-error sweep across all ~200 tool throw sites: the tools that actually surfaced opaque/misclassified errors are already fixed (#532-539), and converting the rest is speculative churn. Specific tools can be converted on demand.

Part of #478