### PR TITLE
test(ocr): make the retry-abort deadline test deterministic

### DIFF
--- a/tests/unit/features/ocr-runtime-install.test.ts
+++ b/tests/unit/features/ocr-runtime-install.test.ts
@@ -1866,17 +1866,33 @@ describe("downloadVerifiedRuntimeRelease", () => {
     temporaryDirectories.push(directory);
     const nativeSetTimeout = globalThis.setTimeout;
     const retryTimers: ReturnType<typeof setTimeout>[] = [];
+    let startDeadline: (() => void) | undefined;
     vi.spyOn(globalThis, "setTimeout").mockImplementation(((handler, delay, ...args) => {
+      // Defer the overall 100ms deadline until the first fetch is dispatched, so a
+      // loaded CI runner cannot fire it before fetch is even called (the source of
+      // this test's flakiness). Mirrors the deferred-deadline trick used above.
+      if (delay === 100 && !startDeadline) {
+        const placeholder = nativeSetTimeout(() => {}, 60_000);
+        startDeadline = () => {
+          clearTimeout(placeholder);
+          nativeSetTimeout(handler, delay, ...args);
+        };
+        return placeholder;
+      }
       const timer = nativeSetTimeout(handler, delay, ...args);
       if (delay === 500) retryTimers.push(timer);
       return timer;
     }) as typeof setTimeout);
     const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response("temporary outage", {
-        status: 503,
-      }),
-    );
+    let armed = false;
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => {
+      if (!armed) {
+        if (!startDeadline) throw new Error("overall deadline was not registered before fetch");
+        startDeadline();
+        armed = true;
+      }
+      return new Response("temporary outage", { status: 503 });
+    });
 
     await expect(
       downloadVerifiedRuntimeRelease({


### PR DESCRIPTION
## Problem

`ocr-runtime-install.test.ts` > "clears the built-in retry timer when the overall deadline aborts" randomly failed CI with `expected "spy" to be called once, but got 0 times` (seen on #537, unrelated to that PR). It scheduled its 100ms overall deadline immediately, then relied on the first `fetch` being dispatched within that 100ms window. On a loaded runner the deadline's `setTimeout(() => controller.abort(), 100)` fired before `fetchImpl` was ever called, so the download aborted with zero fetches.

## Fix

Defer the overall deadline until the first fetch is actually dispatched, then arm it from inside the fetch mock, so the deadline can never fire before fetch. This is the same deferred-deadline trick the sibling "timed out after 20ms" test already uses a few lines above. No production code changes; the retry-timer capture and all assertions are unchanged.

## Verification

- Ran the previously-flaky test **25/25 green** in a loop.
- Full `ocr-runtime-install.test.ts` file green (86 passed, 1 skipped).
- typecheck clean.