### PR TITLE
fix(settings): let admins relax the minimum password length to 1

### DIFF
--- a/apps/web/src/components/settings/settings-dialog.tsx
+++ b/apps/web/src/components/settings/settings-dialog.tsx
@@ -1241,7 +1241,7 @@ export function AdminSecuritySettings() {
           onChange={(e) => updateSetting("passwordMinLength", e.target.value)}
           aria-label={t.settings.security.passwordMinLength}
           className="px-3 py-1.5 rounded-lg border border-border bg-background text-sm text-foreground w-24"
-          min={4}
+          min={1}
           max={128}
         />
       </SettingRow>

--- a/tests/unit/web/admin-security-settings-save-error.test.tsx
+++ b/tests/unit/web/admin-security-settings-save-error.test.tsx
@@ -33,6 +33,14 @@ describe("AdminSecuritySettings save errors", () => {
     expect(message).toHaveClass("text-destructive");
   });
 
+  it("lets admins relax the minimum password length down to 1", async () => {
+    render(<AdminSecuritySettings />);
+    await waitFor(() => expect(apiGet).toHaveBeenCalled());
+
+    const input = screen.getByLabelText("Minimum Password Length");
+    expect(input).toHaveAttribute("min", "1");
+  });
+
   it("falls back to a generic message when the save rejects with a non-Error value", async () => {
     apiPut.mockRejectedValue("network exploded");
 


### PR DESCRIPTION
## Summary

#136 asks for a way to disable password requirements on homelab installs. Almost all of it already exists: Settings -> Security has toggles for every character-class rule (uppercase, lowercase, digit, special) plus a configurable minimum length, and the API enforces exactly what those settings say with no hardcoded floor (`validatePasswordStrength` in `apps/api/src/plugins/auth.ts`).

The one real gap was the UI: the minimum-length input clamped at `min={4}`, so an admin couldn't deliberately allow a password like `123`. This lowers the input floor to 1 and pins it with a unit test. The default stays 8; nothing changes unless an admin opts in.

Closes #136

## Testing

- `tests/unit/web/admin-security-settings-save-error.test.tsx` extended with an assertion on the input floor; all 3 tests pass
- `pnpm --filter @snapotter/web typecheck` clean
- Biome clean