### PR TITLE
fix(web): use h-dvh for app shells so mobile tool controls stay reachable

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -64,7 +64,7 @@ class ErrorBoundary extends Component<
   render() {
     if (this.state.hasError) {
       return (
-        <div className="flex h-screen items-center justify-center bg-background text-foreground">
+        <div className="flex h-dvh items-center justify-center bg-background text-foreground">
           <div className="text-center space-y-4 max-w-md px-6">
             <h1 className="text-xl font-semibold">{en.common.somethingWentWrong}</h1>
             <p className="text-sm text-muted-foreground">
@@ -108,7 +108,7 @@ function AuthGuard({ children }: { children: React.ReactNode }) {
 
   if (loading) {
     return (
-      <div className="flex h-screen items-center justify-center bg-background text-foreground">
+      <div className="flex h-dvh items-center justify-center bg-background text-foreground">
         <div className="text-center space-y-3">
           <div className="h-8 w-8 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto" />
           <p className="text-sm text-muted-foreground">{en.common.loading}</p>
@@ -132,7 +132,7 @@ function AuthGuard({ children }: { children: React.ReactNode }) {
 // Single page-level loading fallback — shown while JS for a route downloads.
 function PageLoader() {
   return (
-    <div className="flex h-screen items-center justify-center bg-background text-foreground">
+    <div className="flex h-dvh items-center justify-center bg-background text-foreground">
       <div className="h-8 w-8 border-2 border-primary border-t-transparent rounded-full animate-spin" />
     </div>
   );

--- a/apps/web/src/components/layout/app-layout.tsx
+++ b/apps/web/src/components/layout/app-layout.tsx
@@ -35,9 +35,14 @@ export function AppLayout({ children, breadcrumb, navVariant }: AppLayoutProps) 
   }, [fetchSettings]);
 
   return (
+    // h-dvh (dynamic viewport height), not h-screen/100vh: on mobile browsers
+    // 100vh is the *tall* viewport (URL bar retracted), so with overflow-hidden
+    // the fixed bottom nav and the in-flow "Process" peek bar render below the
+    // visible area and can't be scrolled to after a file is uploaded. dvh tracks
+    // the actual visible viewport, keeping the bottom controls reachable.
     <div
       className={cn(
-        "flex flex-col h-screen bg-background text-foreground overflow-hidden",
+        "flex flex-col h-dvh bg-background text-foreground overflow-hidden",
         bannerVisible && "pt-9",
       )}
     >

--- a/apps/web/src/pages/change-password-page.tsx
+++ b/apps/web/src/pages/change-password-page.tsx
@@ -118,7 +118,7 @@ export function ChangePasswordPage() {
   };
 
   return (
-    <div className="flex h-screen bg-background">
+    <div className="flex h-dvh bg-background">
       <div className="flex-1 flex items-center justify-center p-8">
         <div className="w-full max-w-md space-y-8">
           <div>

--- a/apps/web/src/pages/editor-page.tsx
+++ b/apps/web/src/pages/editor-page.tsx
@@ -157,7 +157,7 @@ export function EditorPage() {
   }
 
   return (
-    <main className="flex flex-col h-screen overflow-hidden bg-background text-foreground">
+    <main className="flex flex-col h-dvh overflow-hidden bg-background text-foreground">
       <h1 className="sr-only">{t.editor.welcome.heading}</h1>
       <EditorMenuBar
         onNewDocument={() => setShowNewDocument(true)}

--- a/apps/web/src/pages/login-page.tsx
+++ b/apps/web/src/pages/login-page.tsx
@@ -246,7 +246,7 @@ export function LoginPage() {
   };
 
   return (
-    <main className="flex h-screen bg-background">
+    <main className="flex h-dvh bg-background">
       <div className="flex-1 flex items-center justify-center p-8">
         <div className="w-full max-w-md space-y-8">
           <div>

--- a/apps/web/src/pages/not-found-page.tsx
+++ b/apps/web/src/pages/not-found-page.tsx
@@ -5,7 +5,7 @@ export function NotFoundPage() {
   const { t } = useTranslation();
 
   return (
-    <div className="flex h-screen items-center justify-center bg-background text-foreground">
+    <div className="flex h-dvh items-center justify-center bg-background text-foreground">
       <div className="text-center space-y-4 max-w-md px-6">
         <h1 className="text-6xl font-bold text-primary">404</h1>
         <h2 className="text-xl font-semibold">{t.common.pageNotFound}</h2>

--- a/tests/unit/web/app-shell-viewport.test.ts
+++ b/tests/unit/web/app-shell-viewport.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guard for the mobile "can't reach the Process button" bug.
+ *
+ * The full-height, overflow-hidden app shells must size to the *dynamic* viewport
+ * (`h-dvh` / 100dvh), never `h-screen` (100vh). On mobile browsers 100vh is the
+ * tall viewport measured with the URL bar retracted, so a 100vh shell with
+ * `overflow: hidden` pushes its bottom strip (the fixed bottom nav and the in-flow
+ * tool "Process" peek bar) below the visible area with no way to scroll to it.
+ * `dvh` tracks the actual visible viewport, keeping those controls reachable.
+ *
+ * This can't be caught by a behavioral e2e test: headless Chromium has no dynamic
+ * URL bar, so `100vh === visible height` there and the bug never reproduces. A
+ * source-level guard is the only thing that stops a well-meaning "cleanup" from
+ * reverting `h-dvh` to `h-screen`.
+ */
+const SHELL = "flex flex-col h-dvh";
+const BROKEN = "flex flex-col h-screen";
+
+const SHELLS = {
+  "app-layout.tsx": "../../../apps/web/src/components/layout/app-layout.tsx",
+  "editor-page.tsx": "../../../apps/web/src/pages/editor-page.tsx",
+} as const;
+
+describe("full-height app shells use the dynamic viewport unit", () => {
+  for (const [name, rel] of Object.entries(SHELLS)) {
+    const src = readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+
+    it(`${name} sizes the shell with h-dvh`, () => {
+      expect(src).toContain(SHELL);
+    });
+
+    it(`${name} does not use h-screen for the shell`, () => {
+      expect(src).not.toContain(BROKEN);
+    });
+  }
+});


### PR DESCRIPTION
## What

On mobile, after uploading a file to any tool (Compress and the rest), the "Process" control is off-screen and unreachable. Reported on demo.snapotter.com. It is not related to file size.

## Root cause

The app shell is pinned to the large/layout viewport: `AppLayout` uses `h-screen` (`100vh`), `html/body/#root` use `height: 100%`, and `overflow: hidden` is set throughout. On mobile browsers `100vh` is the tall viewport measured as if the URL bar were retracted. While the URL bar is on screen, the real viewport is shorter than `100vh`, so the bottom strip of the layout renders below the fold, and `overflow: hidden` prevents scrolling to it.

Before an upload the tool page is a scrollable, centered dropzone, so it looks fine. After an upload the layout becomes a fixed, non-scrolling view whose bottom control is the in-flow "Process" peek bar (`tool-page.tsx`), which is exactly what gets clipped. Because the trap is in the shared `AppLayout` shell, every tool is affected.

## Fix

Switch the fixed-height shells from `h-screen` (`100vh`) to `h-dvh` (`100dvh`), the dynamic viewport unit that tracks the visible area as the URL bar shows and hides.

- `AppLayout` is the key change and covers every tool page.
- Same sweep applied to the other fixed-height shells that share the pattern: editor, login, change-password, 404, and the error/loading screens.
- `min-h-screen` on the privacy page is left as is (it is a normal scrolling document, not a fixed overflow-hidden shell).

On desktop `dvh` equals `vh`, so desktop is visually unchanged. `dvh` is already used elsewhere in the codebase (`BottomSheet`, `crop-canvas`, the usage survey), so support is established.

## Tests

Added `tests/unit/web/app-shell-viewport.test.ts`, a source-level regression guard asserting the interactive shells use `h-dvh` and not `h-screen`.

Why a source guard and not an e2e: this bug cannot be reproduced in headless or desktop Chromium, which has no dynamic URL bar, so there `100vh` always equals the visible height and a behavioral test would pass with or without the fix. The guard stops a silent revert to `h-screen`.

## Verification

- Biome clean on all changed files.
- Guard assertions pass.
- Real-device confirmation happens once this merges and the demo redeploys: after an upload the Process bar should sit just above the bottom nav.

## Risk

Low. `dvh` equals `vh` on desktop, and the change is limited to shell height utilities.
