### PR TITLE
fix(landing): keep mixed-case locale casing in emitted URLs (#554)

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -33,6 +33,34 @@ jobs:
           # fetch isn't rate-limited on shared runner IPs (60 req/hr unauth).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Astro's getRelativeLocaleUrl lowercases locale segments by default, so a
+      # regression could re-emit /zh-cn/ etc. in hrefs and hreflang. Those 404 on
+      # case-sensitive Cloudflare Pages while the built dirs + sitemap keep canonical
+      # mixed case, and the mismatch is invisible on a case-insensitive dev machine.
+      # Fail the deploy if any lowercased variant of a mixed-case locale directory
+      # leaks into the emitted HTML. See #554.
+      - name: Guard against lowercased locale URLs
+        run: |
+          set -uo pipefail
+          dist=apps/landing/dist
+          fail=0
+          for dir in "$dist"/*/; do
+            name=$(basename "$dir")
+            lower=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
+            [ "$name" = "$lower" ] && continue
+            hits=$(grep -rIl --include='*.html' "/$lower/" "$dist" || true)
+            if [ -n "$hits" ]; then
+              echo "::error::Lowercased locale path /$lower/ found in built HTML (canonical is /$name/); it would 404 on Cloudflare Pages. See #554."
+              printf '%s\n' "$hits" | head -5
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "Deploy blocked: lowercased locale URLs would 404 on case-sensitive hosting."
+            exit 1
+          fi
+          echo "Locale URL casing OK: no lowercased locale paths in built output."
+
       - name: Deploy to Cloudflare Pages
         run: npx wrangler pages deploy apps/landing/dist --project-name snapotter-landing --branch main --commit-dirty=true
         env:

--- a/apps/landing/src/lib/i18n-page.ts
+++ b/apps/landing/src/lib/i18n-page.ts
@@ -10,13 +10,20 @@ export const SITE = "https://snapotter.com";
  * A trailing "#hash" is split off first and reattached untouched, since
  * Astro's URL builder would otherwise treat it as part of the path and
  * mangle it with a trailing slash (e.g. "/#pricing" -> "/#pricing/").
+ *
+ * `normalizeLocale: false` keeps the locale segment identical to its code.
+ * By default Astro lowercases it (getRelativeLocaleUrl runs normalizeTheLocale,
+ * so "zh-CN" -> "zh-cn", "pt-BR" -> "pt-br"), but our routes are built from the
+ * raw codes (getStaticPaths -> /zh-CN/, /pt-BR/) and the sitemap keeps that same
+ * mixed case. The lowercased links resolve fine on case-insensitive local hosting
+ * but 404 on case-sensitive hosts like Cloudflare Pages, so we pin the casing here.
  */
 export function localizeHref(locale: string, path: string): string {
   const hashIndex = path.indexOf("#");
   const pathname = hashIndex === -1 ? path : path.slice(0, hashIndex);
   const hash = hashIndex === -1 ? "" : path.slice(hashIndex);
   const clean = pathname.startsWith("/") ? pathname.slice(1) : pathname;
-  return `${getRelativeLocaleUrl(locale, clean)}${hash}`;
+  return `${getRelativeLocaleUrl(locale, clean, { normalizeLocale: false })}${hash}`;
 }
 
 /**

--- a/tests/e2e-landing/i18n-seo-rtl.spec.ts
+++ b/tests/e2e-landing/i18n-seo-rtl.spec.ts
@@ -24,6 +24,26 @@ test.describe("landing hreflang, RTL, and banner", () => {
     expect(enFromDe).toBe("https://snapotter.com/faq/");
   });
 
+  // Regression guard for #554. Astro's getRelativeLocaleUrl lowercases the locale
+  // segment by default (normalizeTheLocale: "zh-CN" -> "zh-cn"), but the built
+  // directories and the sitemap keep canonical mixed case. The lowercased links
+  // resolve on case-insensitive local hosting but 404 on Cloudflare Pages. This
+  // reads the emitted href string, so it catches the mismatch regardless of the
+  // local filesystem's case sensitivity (which is why the specs above missed it).
+  test("mixed-case locales keep their exact casing in hreflang links", async ({ page }) => {
+    await page.goto("/faq");
+    for (const code of ["zh-CN", "zh-TW", "pt-BR"]) {
+      const href = await page
+        .locator(`link[rel="alternate"][hreflang="${code}"]`)
+        .getAttribute("href");
+      expect(href, `hreflang ${code} must preserve casing`).toBe(
+        `https://snapotter.com/${code}/faq/`,
+      );
+      // The lowercased path (the bug) must not appear.
+      expect(href).not.toContain(code.toLowerCase());
+    }
+  });
+
   test("Arabic renders dir=rtl on <html>", async ({ page }) => {
     await page.goto("/ar/faq");
     await expect(page.locator("html")).toHaveAttribute("dir", "rtl");


### PR DESCRIPTION
Closes #554.

## The bug

On the Chinese and Brazilian-Portuguese locales, `<a>` hrefs and `hreflang` alternates were emitted lowercase (`/zh-cn/`, `/zh-tw/`, `/pt-br/`), but the built directories and the sitemap are canonical mixed case (`/zh-CN/`, `/zh-TW/`, `/pt-BR/`). On case-insensitive hosting (local APFS) this is masked; on Cloudflare Pages the lowercased links 404.

## Root cause

Astro's `getRelativeLocaleUrl` lowercases the locale segment by default. In `astro/dist/i18n/index.js`, `getLocaleRelativeUrl` computes `normalizedLocale = normalizeLocale ? normalizeTheLocale(codeToUse) : codeToUse`, and `normalizeTheLocale` does `.replaceAll("_","-").toLowerCase()`. So `zh-CN` becomes `zh-cn`. Meanwhile the route directories come from `getStaticPaths` over the raw `SUPPORTED_LOCALES` codes, and the sitemap uses the object form, so both keep mixed case. The links and the directories disagree.

## Why not the config change the issue proposed

The issue suggested giving `i18n.locales` the `{ path, codes }` object form. That does not fix it on Astro 6.4.8: `peekCodePathToUse` returns the object's `path`, but `getLocaleRelativeUrl` still runs `normalizeTheLocale` on it, so `path: "zh-CN"` is lowercased to `zh-cn` all the same. Verified against the vendored source.

## The fix

One line at the single chokepoint. `localizeHref` (the only caller of `getRelativeLocaleUrl` in the landing) now passes `{ normalizeLocale: false }`, so the emitted locale segment stays byte-identical to the locale code for every locale. No config change needed. Every emitted URL (canonicals, hreflang, og alternates, JSON-LD, breadcrumbs, nav/footer/switcher links) routes through `localizeHref`, so they are all covered in one place.

`pt-BR` had the same latent bug (the issue mentioned only `zh-CN`/`zh-TW`); this covers all three. The client-side locale recall in `Base.astro` and the `LanguageSwitcher` localStorage value already used the raw mixed-case codes, so they now agree with the fixed links.

## Verification

- Full landing build before and after: the lowercased locale paths dropped from 797 files (every page) to 0. Mixed case now matches the built directories; lowercase-only locales (`de`, `ja`, ...) and English at root are unchanged; the sitemap is unchanged.
- `astro check` + `tsc --noEmit` pass. Biome passes.
- New e2e guard (`i18n-seo-rtl.spec.ts`) asserts the `zh-CN`/`zh-TW`/`pt-BR` hreflang hrefs keep their casing. It reads the emitted string, so it catches the mismatch regardless of the local filesystem's case sensitivity (which is why the existing i18n specs missed it).
- New deploy-time guard in `deploy-landing.yml` fails the Cloudflare build if any lowercased variant of a mixed-case locale directory leaks into the built HTML. It derives the locale set from the built directories, so it auto-covers future mixed-case locales. Tested locally: passes on the fixed build, fails on an injected `/zh-cn/` path.

## Note (out of scope)

Six landing e2e tests fail on `main` independently of this change (one stale tool-detail route test, five `subpages` navigation tests). I confirmed they fail identically on the unfixed baseline, so this PR introduces no new failures. The landing e2e suite is not wired into CI today, which is a separate pre-existing gap; happy to file a follow-up.
