### PR TITLE
test(docs): make search and nav e2e tests hydration-aware (#551)

### DIFF
--- a/tests/e2e-docs/helpers.ts
+++ b/tests/e2e-docs/helpers.ts
@@ -1,0 +1,45 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+/**
+ * Wait for VitePress to finish the initial client hydration.
+ *
+ * The docs navbar (the Pagefind search box, the appearance toggle) is
+ * server-rendered, so it's present in the DOM the instant the page loads, but
+ * its Vue click handlers aren't wired until the app hydrates. A click that
+ * lands before then is silently swallowed. That's the flaky "search won't
+ * open" race behind issue #551: the bundle for 21 locales takes a few hundred
+ * ms to hydrate, and a fast (or automated) click inside that window does
+ * nothing. Playwright's actionability checks don't cover framework hydration,
+ * so tests have to wait for it explicitly.
+ *
+ * Vue assigns `__vue_app__` to the mount container inside `app.mount()`, which
+ * for SSR is the same call that hydrates the initial tree. Its presence on
+ * `#app` is therefore a deterministic, side-effect-free signal that handlers
+ * are attached.
+ */
+export async function waitForHydration(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const app = document.getElementById("app");
+      return app !== null && "__vue_app__" in app;
+    },
+    null,
+    { timeout: 15_000 },
+  );
+}
+
+/**
+ * Open the Pagefind search dialog and return its input locator.
+ *
+ * Waits for hydration first (so the click registers), then asserts the dialog
+ * input is visible. The selector is placeholder-agnostic on purpose: the docs
+ * config overrides the input placeholder, so keying off a hard-coded string
+ * (as the old tests did) breaks whenever that copy changes.
+ */
+export async function openDocsSearch(page: Page): Promise<Locator> {
+  await waitForHydration(page);
+  await page.locator(".nav-search-btn-wait").first().click();
+  const input = page.locator("[command-dialog-wrapper] input").first();
+  await expect(input).toBeVisible({ timeout: 5_000 });
+  return input;
+}

--- a/tests/e2e-docs/homepage.spec.ts
+++ b/tests/e2e-docs/homepage.spec.ts
@@ -1,8 +1,12 @@
 import { expect, test } from "@playwright/test";
+import { waitForHydration } from "./helpers";
 
 test.describe("docs homepage (Two Doors)", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
+    // Some tests click nav/chip links, which route client-side; wait for Vue to
+    // hydrate first so the click isn't swallowed (the #551 pre-hydration race).
+    await waitForHydration(page);
   });
 
   test("title contains SnapOtter", async ({ page }) => {

--- a/tests/e2e-docs/i18n.spec.ts
+++ b/tests/e2e-docs/i18n.spec.ts
@@ -1,5 +1,6 @@
 // tests/e2e-docs/i18n.spec.ts
 import { expect, test } from "@playwright/test";
+import { openDocsSearch } from "./helpers";
 
 test.describe("docs i18n (English + seeded German locale)", () => {
   test("English home still renders at root", async ({ page }) => {
@@ -50,9 +51,8 @@ test.describe("docs i18n (English + seeded German locale)", () => {
 
   test("pagefind returns results within the German locale", async ({ page }) => {
     await page.goto("/de/guide/getting-started");
-    await page.locator(".blog-search").first().click();
-    const input = page.locator("input[placeholder]").first();
+    const input = await openDocsSearch(page);
     await input.fill("docker");
-    await expect(page.locator('[role="option"]').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('[role="option"]').first()).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/tests/e2e-docs/search-and-theme.spec.ts
+++ b/tests/e2e-docs/search-and-theme.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { openDocsSearch, waitForHydration } from "./helpers";
 
 test.describe("docs search (Pagefind)", () => {
   test("search button is visible", async ({ page }) => {
@@ -8,16 +9,18 @@ test.describe("docs search (Pagefind)", () => {
 
   test("clicking search opens the dialog with an input", async ({ page }) => {
     await page.goto("/");
-    await page.locator(".blog-search").first().click();
-    await expect(page.locator('input[placeholder="Search Docs"]')).toBeVisible();
+    const input = await openDocsSearch(page);
+    // It's the real search combobox with a (config-driven) placeholder. Don't
+    // assert the exact placeholder copy, just that one is present.
+    await expect(input).toHaveAttribute("role", "combobox");
+    await expect(input).toHaveAttribute("placeholder", /\S/);
   });
 
   test("typing a query shows results", async ({ page }) => {
     await page.goto("/");
-    await page.locator(".blog-search").first().click();
-    const input = page.locator('input[placeholder="Search Docs"]');
+    const input = await openDocsSearch(page);
     await input.fill("docker");
-    await expect(page.locator('[role="option"]').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('[role="option"]').first()).toBeVisible({ timeout: 10_000 });
   });
 });
 
@@ -32,13 +35,16 @@ test.describe("Theme Toggle", () => {
 
   test("clicking theme toggle changes appearance", async ({ page }) => {
     await page.goto("/guide/getting-started");
+    // The appearance switch is a Vue handler, so wait for hydration before the
+    // single click (otherwise the click is swallowed and the class never flips).
+    await waitForHydration(page);
+
     const html = page.locator("html");
-    const initialClass = await html.getAttribute("class");
-    const wasDark = initialClass?.includes("dark") ?? false;
+    const wasDark = ((await html.getAttribute("class")) ?? "").includes("dark");
 
     // Click the visible toggle inside our custom nav area (the hidden default
     // VPNavBarAppearance is first in DOM order, so a bare querySelector would
-    // hit it instead). Playwright's click auto-waits for hydration.
+    // hit it instead).
     await page.locator('.nav-bar-right button[role="switch"]').click();
 
     // Assert the dark class actually toggled

--- a/tests/e2e-docs/sidebar.spec.ts
+++ b/tests/e2e-docs/sidebar.spec.ts
@@ -1,8 +1,12 @@
 import { expect, test } from "@playwright/test";
+import { waitForHydration } from "./helpers";
 
 test.describe("Docs Sidebar - Guide Section", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/guide/getting-started");
+    // Sidebar links route client-side; wait for hydration so the click lands
+    // (otherwise it's swallowed pre-hydration, the #551 race).
+    await waitForHydration(page);
   });
 
   test("sidebar renders all guide links", async ({ page }) => {
@@ -53,6 +57,7 @@ test.describe("Docs Sidebar - Guide Section", () => {
 test.describe("Docs Sidebar - API Reference Section", () => {
   test("clicking REST API navigates correctly", async ({ page }) => {
     await page.goto("/guide/getting-started");
+    await waitForHydration(page);
     await page.locator(".VPSidebar a, aside a").filter({ hasText: "REST API" }).click();
     await expect(page).toHaveURL(/\/api\/rest/);
     await expect(page.getByText("REST API Reference")).toBeVisible();
@@ -60,12 +65,14 @@ test.describe("Docs Sidebar - API Reference Section", () => {
 
   test("clicking Image engine navigates correctly", async ({ page }) => {
     await page.goto("/api/rest");
+    await waitForHydration(page);
     await page.locator(".VPSidebar a, aside a").filter({ hasText: "Image engine" }).click();
     await expect(page).toHaveURL(/\/api\/image-engine/);
   });
 
   test("clicking AI engine navigates correctly", async ({ page }) => {
     await page.goto("/api/rest");
+    await waitForHydration(page);
     await page.locator(".VPSidebar a, aside a").filter({ hasText: "AI engine" }).click();
     await expect(page).toHaveURL(/\/api\/ai/);
   });


### PR DESCRIPTION
## What

Issue #551 reported that the docs Pagefind search "does not initialize into a working input." It does work. Building the docs (all 21 locales + Pagefind index) and driving the built output shows the dialog opens on fresh loads and after client-side navigation, and typing returns results (34 for `docker`, 29 for `compress`), with no JS errors.

The real defect is a **pre-hydration click race**. The server-rendered navbar is visible immediately, but its Vue `@click` handlers aren't wired until the app hydrates the large multi-locale bundle (~300ms). A click inside that window is silently swallowed:

```
click <150ms after DOMContentLoaded -> dialog opens 0/8
click  400ms after DOMContentLoaded -> dialog opens 8/8
```

The old e2e search test compounded this: it matched `input[placeholder="Search Docs"]`, but the config overrides the placeholder, so it failed even against a working build. That failing test is what the QA sweep flagged. Switching to VitePress built-in local search (the issue's alternative) wouldn't help; its button is also a Vue `@click` with the same gap.

## Change (test-only)

- New `tests/e2e-docs/helpers.ts`: `waitForHydration()` gates on `#app.__vue_app__` (Vue sets it inside `app.mount()`, so it's a deterministic, side-effect-free "handlers are attached" signal), plus `openDocsSearch()`.
- `search-and-theme.spec.ts`: search tests wait for hydration and use placeholder-agnostic selectors, asserting open + results; theme-toggle waits for hydration before its single click.
- `i18n.spec.ts`: German-locale search test hardened the same way.
- `homepage.spec.ts` / `sidebar.spec.ts`: the same root cause was deterministically failing 3 nav tests (they click nav/sidebar/chip links before hydration; the Image-chip test even documents that it needs the SPA path). Hardened with the same helper.

No production or docs-site code changed. Search behaviour is unchanged.

## Verification

- Full docs e2e suite: 43/43 green, run twice (was red on search + theme + 3 nav).
- Search-open and theme-toggle repeated 5x each: 35/35 stable.
- Biome clean on all five files.

Closes #551