### PR TITLE
fix(landing): open Product dropdown below the navbar bottom line

### DIFF
--- a/apps/landing/src/components/Navbar.astro
+++ b/apps/landing/src/components/Navbar.astro
@@ -58,7 +58,9 @@ const links: NavItem[] = [
           {t(locale, "nav.product")}
           <svg class="h-4 w-4 transition-transform group-hover:rotate-180 group-focus-within:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
         </button>
-        <div class="absolute left-0 top-full hidden pt-3 group-hover:block group-focus-within:block">
+        <!-- pt clears the button-to-navbar-bottom gap so the panel opens below the
+             navbar's bottom border line instead of overlapping up through it. -->
+        <div class="absolute left-0 top-full hidden pt-8 group-hover:block group-focus-within:block">
           <div class="w-64 rounded-xl border border-border bg-surface p-2 shadow-lg">
             {productLinks.map((item) => (
               <a


### PR DESCRIPTION
## What

The Product menu in the landing navbar had the decorative navbar bottom-border line cutting horizontally across the top of the open dropdown.

## Root cause

The panel was anchored to the button with `top-full pt-3`. The button sits vertically centered in the `h-16` navbar, so its bottom edge is 22px above the navbar's bottom border line, and `pt-3` (12px) only bridged part of that. The panel landed at y≈102 while the navbar line sits at y≈112, so the card overlapped 10px up past the line. Since that line spans the full viewport width, it appeared to pass straight through the top of the menu.

Verified with measured geometry (card top 102, line 112, line crosses card) and a red-line paint test, reproduced identically in Chromium and WebKit at Retina DPR 2.

## Fix

Bump the panel's top padding `pt-3` to `pt-8` so it clears the button-to-navbar-bottom gap and opens ~10px below the line. Confirmed `lineCrossesCard: false` after the change. The wider padding also enlarges the invisible hover-bridge, making the menu slightly easier to keep open.

One line in the shared `Navbar.astro`, so it applies to every landing page.