### PR TITLE
chore(landing): regenerate _redirects for remove-gif-background

### DIFF
--- a/apps/landing/public/_redirects
+++ b/apps/landing/public/_redirects
@@ -31,6 +31,8 @@
 /tools/color-blindness /tools/image/color-blindness/ 301
 /tools/remove-background/ /tools/image/remove-background/ 301
 /tools/remove-background /tools/image/remove-background/ 301
+/tools/remove-gif-background/ /tools/image/remove-gif-background/ 301
+/tools/remove-gif-background /tools/image/remove-gif-background/ 301
 /tools/upscale/ /tools/image/upscale/ 301
 /tools/upscale /tools/image/upscale/ 301
 /tools/erase-object/ /tools/image/erase-object/ 301


### PR DESCRIPTION
Regenerates `apps/landing/public/_redirects` from the tool catalog.

The file is generated by `scripts/generate-redirects.mjs` (which runs in the landing prebuild) but was last committed on 2026-06-29, before the `remove-gif-background` tool was added. The committed source drifted out of sync with its generator, missing the two 301 lines for that tool.

No user-facing impact: the deploy regenerates `_redirects` at build time regardless, and the new tool never had an old flat URL to redirect from. This resyncs the committed source so `astro dev` and `git diff` stay honest, and avoids the "unexpected modified file" surprise the next time someone builds landing.

Found while working on #555.

## Follow-up worth considering

There's no CI guard that `_redirects` stays in sync with the generator, which is why this drifted silently for a few weeks. A small check (run the generator, then `git diff --exit-code apps/landing/public/_redirects`) in a landing PR job would catch it next time, mirroring the existing tool-registry-drift guards. Happy to add it if you want.
