### PR TITLE
fix(ocr): unblock and harden accurate-OCR install (#552)

### DIFF
--- a/apps/api/src/lib/ocr-runtime-install.ts
+++ b/apps/api/src/lib/ocr-runtime-install.ts
@@ -2002,6 +2002,17 @@ async function purgeOcrRuntimeDownloadsUnderLease(aiDataDir: string): Promise<vo
   }
 }
 
+/**
+ * Remaining installer time budget from an optional deadline. `performance.now()`
+ * is fractional, so a raw `deadline - now` is a float that `runOcrRuntimeInstaller`
+ * rejects as a non-integer timeout. Floor it to a safe integer and keep at least
+ * 1ms so a live install always receives a positive, valid timeout.
+ */
+export function remainingInstallerTimeoutMs(deadlineMs: number | undefined, nowMs: number): number {
+  if (deadlineMs === undefined) return 0;
+  return Math.max(1, Math.floor(deadlineMs - nowMs));
+}
+
 export function buildOcrRuntimeInstallerCommand(
   options: RunOcrRuntimeInstallerOptions,
 ): OcrRuntimeInstallerCommand {

--- a/apps/api/src/lib/ocr-runtime-install.ts
+++ b/apps/api/src/lib/ocr-runtime-install.ts
@@ -65,6 +65,10 @@ const HARD_MAX_RETRY_ATTEMPTS = 6;
 const HARD_MAX_RETRY_DELAY_MS = 30_000;
 const HARD_MAX_RETRY_TOTAL_DELAY_MS = 120_000;
 const RETRYABLE_HTTP_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+// The bundle host answers a runtime index that was never published for this
+// version with one of these. On a public bundle repository they all mean the
+// same thing to a user: the accurate runtime is not available to install yet.
+const RUNTIME_NOT_PUBLISHED_STATUSES = new Set([401, 403, 404, 410]);
 const RETRYABLE_NETWORK_CODES = new Set([
   "EAI_AGAIN",
   "ECONNREFUSED",
@@ -182,6 +186,22 @@ export class OcrRuntimeImportValidationError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
     this.name = "OcrRuntimeImportValidationError";
+  }
+}
+
+/**
+ * The signed OCR runtime index is not published (or not readable) for this
+ * SnapOtter version. This is a definitive "nothing to install here" answer, not
+ * a transient failure, so it is thrown without retrying and carries a message
+ * the install UI can show verbatim.
+ */
+export class OcrRuntimeNotPublishedError extends Error {
+  readonly httpStatus: number;
+
+  constructor(message: string, httpStatus: number, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "OcrRuntimeNotPublishedError";
+    this.httpStatus = httpStatus;
   }
 }
 
@@ -330,6 +350,22 @@ async function assertDownloadResponse(
     throw new RetryableOcrDownloadError(message, retryAfterMilliseconds(retryAfter, now));
   }
   throw new Error(message);
+}
+
+/**
+ * Turn an absent (or forbidden) signed runtime index into a clear, terminal
+ * error instead of a raw "HTTP 404". Callers invoke this before the generic
+ * response check so the message reaches the install UI unretried and unwrapped.
+ */
+function assertOcrRuntimeIndexPublished(response: Response, version: string): void {
+  if (!RUNTIME_NOT_PUBLISHED_STATUSES.has(response.status)) return;
+  cancelResponseBody(response);
+  throw new OcrRuntimeNotPublishedError(
+    `The accurate OCR runtime for SnapOtter ${version} is not available to install yet ` +
+      `(its signed runtime index returned HTTP ${response.status}). Fast OCR still works; ` +
+      `accurate OCR becomes available once its runtime is published for this version.`,
+    response.status,
+  );
 }
 
 function retryDelayMs(error: unknown, completedAttempts: number, policy: ResolvedRetryPolicy) {
@@ -1748,6 +1784,7 @@ async function downloadVerifiedRuntimeReleaseUnderLease(
             signal: controller.signal,
           },
         );
+        assertOcrRuntimeIndexPublished(indexResponse, options.version);
         await assertDownloadResponse(indexResponse, "OCR runtime index", retryPolicy.now);
         return readBoundedResponse(
           indexResponse,

--- a/apps/api/src/routes/features.ts
+++ b/apps/api/src/routes/features.ts
@@ -89,6 +89,7 @@ import {
   prepareOfflineRuntimeIndex,
   prepareOfflineRuntimeRelease,
   purgeOcrRuntimeDownloads,
+  remainingInstallerTimeoutMs,
   runOcrRuntimeInstaller,
   runOcrRuntimeMaintenance,
   waitWithOcrRuntimeHeartbeat,
@@ -227,7 +228,7 @@ function startOcrInstall(bundleId: string, jobId: string, installLockFd: number)
           release,
           aiDataDir: getAiDir(),
           installLockFd,
-          timeoutMs: installDeadline ? Math.max(1, installDeadline - performance.now()) : 0,
+          timeoutMs: remainingInstallerTimeoutMs(installDeadline, performance.now()),
         }),
         reportActivation,
       );

--- a/tests/unit/features/ocr-runtime-install.test.ts
+++ b/tests/unit/features/ocr-runtime-install.test.ts
@@ -33,6 +33,7 @@ import {
   prepareOfflineRuntimeIndex,
   prepareOfflineRuntimeRelease,
   purgeOcrRuntimeDownloads as purgeOcrRuntimeDownloadsWithLease,
+  remainingInstallerTimeoutMs,
   verifyRuntimeIndex,
   writeBufferFully,
 } from "../../../apps/api/src/lib/ocr-runtime-install.js";
@@ -157,6 +158,28 @@ function signedIndex(
   };
   return { artifact, index, raw: Buffer.from(canonicalRuntimeJson(index)), trustKey };
 }
+
+describe("remainingInstallerTimeoutMs", () => {
+  it("floors a fractional remaining budget to the safe integer the installer requires", () => {
+    // The deadline is set at one performance.now() read and the remaining time is
+    // computed at a later read, so `deadline - later` is fractional in practice.
+    const started = 1_000.4269;
+    const deadline = started + 7_200_000;
+    const later = 1_500.8731;
+    // The old caller passed this raw float; runOcrRuntimeInstaller rejected it as
+    // a non-integer timeout, which broke every default-config install.
+    expect(Number.isSafeInteger(deadline - later)).toBe(false);
+    const remaining = remainingInstallerTimeoutMs(deadline, later);
+    expect(Number.isSafeInteger(remaining)).toBe(true);
+    expect(remaining).toBe(Math.floor(deadline - later));
+  });
+
+  it("returns 0 when there is no deadline and clamps a passed deadline to at least 1ms", () => {
+    expect(remainingInstallerTimeoutMs(undefined, 5)).toBe(0);
+    expect(remainingInstallerTimeoutMs(10.9, 10.1)).toBe(1);
+    expect(remainingInstallerTimeoutMs(5, 999.7)).toBe(1);
+  });
+});
 
 describe("verifyRuntimeIndex", () => {
   it("loads the independently pinned release key from the official image environment", () => {

--- a/tests/unit/features/ocr-runtime-install.test.ts
+++ b/tests/unit/features/ocr-runtime-install.test.ts
@@ -28,6 +28,7 @@ import {
   downloadVerifiedRuntimeRelease as downloadVerifiedRuntimeReleaseWithLease,
   loadOcrRuntimeTrustKeys,
   OcrRuntimeImportValidationError,
+  OcrRuntimeNotPublishedError,
   type OcrRuntimeTrustKey,
   prepareOfflineRuntimeIndex,
   prepareOfflineRuntimeRelease,
@@ -449,6 +450,64 @@ describe("downloadVerifiedRuntimeRelease", () => {
     expect(sleep).toHaveBeenCalledExactlyOnceWith(1_000);
     expect(canceled).toHaveBeenCalledOnce();
     expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("reports a clear not-published error when the runtime index is absent", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "snapotter-ocr-index-absent-"));
+    temporaryDirectories.push(directory);
+    const canceled = vi.fn();
+    const missingBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(Buffer.from("Entry not found"));
+      },
+      cancel: canceled,
+    });
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(missingBody, { status: 404 }));
+
+    const error = await downloadVerifiedRuntimeRelease({
+      aiDataDir: directory,
+      bundleRepo: "snapotter-hq/feature-bundles",
+      version: "2.1.0",
+      target: TARGET,
+      trustKeys: [],
+      fetchImpl,
+    }).then(
+      () => {
+        throw new Error("expected the absent runtime index to reject");
+      },
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toBeInstanceOf(OcrRuntimeNotPublishedError);
+    const message = (error as Error).message;
+    expect(message).toContain("2.1.0");
+    expect(message).toContain("Fast OCR");
+    expect(message).toContain("404");
+    // Absent means absent: this is not a transient failure and must not retry.
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(canceled).toHaveBeenCalledOnce();
+  });
+
+  it("treats a forbidden runtime index as not published rather than a hard error", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "snapotter-ocr-index-forbidden-"));
+    temporaryDirectories.push(directory);
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response("Forbidden", { status: 403 }));
+
+    await expect(
+      downloadVerifiedRuntimeRelease({
+        aiDataDir: directory,
+        bundleRepo: "snapotter-hq/feature-bundles",
+        version: "2.1.0",
+        target: TARGET,
+        trustKeys: [],
+        fetchImpl,
+      }),
+    ).rejects.toBeInstanceOf(OcrRuntimeNotPublishedError);
+    expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
   it("does not retry an oversized index and cancels its unconsumed body", async () => {


### PR DESCRIPTION
Two independent OCR-install fixes for #552, both surfaced while proving the accurate-OCR (v3 runtime) path works end to end from the bundle host.

## 1. Installer timeout must be an integer (the impactful one)

`startOcrInstall` computed the installer's remaining budget as `Math.max(1, installDeadline - performance.now())`. `performance.now()` is fractional, so that is a **float**, and `runOcrRuntimeInstaller` rejects a non-integer timeout ("OCR runtime installer timeout must be a non-negative integer"). With the default `INSTALL_MAX_MS` (7_200_000), this fails **every** accurate-OCR install via the HTTP/app path, right after the download completes.

It was masked by the unpublished runtime (the index 404s before install is reached), and CI drives `install_runtime.py` directly, so it never surfaced there. It would have broken accurate OCR for every default-config user the moment the runtime was published.

Fix: extract `remainingInstallerTimeoutMs()` (floors to a safe integer, min 1ms) and use it at the call site.

Found by an end-to-end dress rehearsal: built the arm64 v3 runtime inside the official image, signed it, pushed it to the bundle host, then installed it through the real app in a locally-built official image. The install got past the download and hit this on the activation step.

## 2. Clear message when the runtime index is unpublished

When the signed runtime index has not been published for the running version, the installer surfaced a raw `HTTP 404`. This classifies an absent or forbidden index (`401/403/404/410`) as `OcrRuntimeNotPublishedError` with an actionable, terminal message ("accurate OCR is not available to install yet ... Fast OCR still works ...") and does not retry. Proven live against the real bundle host.

## Scope / safety

- No change to signature verification, the trusted-host allowlist, or the version-locking contract. The download path stays fail-closed.
- Only the runtime index fetch is classified for (2); the archive path is untouched.

## Tests

- New unit tests: `remainingInstallerTimeoutMs` floors a fractional budget to a safe integer, returns 0 with no deadline, clamps to >= 1ms; absent (`404`) / forbidden (`403`) index rejects with `OcrRuntimeNotPublishedError`, carries version + `Fast OCR` + status, is not retried, cancels the body.
- `tests/unit/features/ocr-runtime-install.test.ts`: 90 passing.
- `pnpm --filter @snapotter/api typecheck` and `biome check` clean.
- Verified end to end in a real official image: HF pull -> verify against baked key -> install -> OCR "The quick brown fox 12345" at the best tier.

Refs #552