### PR TITLE
docs: GPU-runs-on-CPU troubleshooting note (#490)

### DIFF
--- a/apps/docs/guide/deployment.md
+++ b/apps/docs/guide/deployment.md
@@ -198,12 +198,16 @@ volumes:
 docker compose -f docker-compose-gpu.yml up -d
 ```
 
+### Verify GPU acceleration {#verify-gpu-acceleration}
+
 Check CUDA detection in the logs:
 
 ```bash
 docker logs SnapOtter 2>&1 | head -20
 # Look for: [gpu] CUDA available via torch
 ```
+
+If AI tools run on CPU even though `--gpus all` and the NVIDIA Container Toolkit are set up correctly, reinstall the affected bundle (for example Background Removal) from **Settings → AI Features**. The installer restores the GPU build of ONNX Runtime, which a CPU-only build pulled in by another bundle (such as transcription) can otherwise shadow in the shared AI environment. If reinstalling from the UI doesn't restore GPU on an older image, see the manual repair in [issue #490](https://github.com/snapotter-hq/SnapOtter/issues/490).
 
 ## Hardware Requirements {#hardware-requirements}
 

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -37,7 +37,7 @@ Add `--gpus all` for NVIDIA CUDA-accelerated background removal, upscaling, face
 docker run -d --name SnapOtter -p 1349:1349 --gpus all -v SnapOtter-data:/data snapotter/snapotter:latest
 ```
 
-Requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). Falls back to CPU automatically when CUDA is unavailable. Intel/AMD iGPU acceleration through VA-API, Quick Sync, or OpenCL is not supported for AI inference today. See [Docker Tags](/guide/docker-tags) for benchmarks.
+Requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). Falls back to CPU automatically when CUDA is unavailable. Intel/AMD iGPU acceleration through VA-API, Quick Sync, or OpenCL is not supported for AI inference today. See [Docker Tags](/guide/docker-tags) for benchmarks. If AI tools run on CPU despite `--gpus all`, see [Verify GPU acceleration](/guide/deployment#verify-gpu-acceleration).
 :::
 
 ::: details Also on GHCR


### PR DESCRIPTION
## What

Community feedback on #490 (comment) noted the GPU-falls-back-to-CPU fix was hard to find, buried in a closed issue. This surfaces it in the docs.

- **deployment.md**: new `### Verify GPU acceleration` subsection under the NVIDIA CUDA quick start. Covers confirming CUDA in the logs and recovering when AI tools run on CPU despite `--gpus all` (reinstall the affected bundle from Settings → AI Features; the installer restores the GPU ONNX Runtime build that a CPU-only build from another bundle can shadow). Manual pip repair is linked to #490 rather than reproduced, since it's version-pinned and would rot.
- **getting-started.md**: one-line pointer to that section from the NVIDIA CUDA tip, where users first look.

Written forward-looking so it stays correct after the #544 self-heal fix ships (it's on main, lands in the next release; latest published is v2.1.0).

## Notes

- English reference only. The 21 locale copies of these two guide pages will refresh through the i18n pipeline (docs-md adapter); not a CI blocker.
- Docs-only change, no code touched.