### PR TITLE
fix(video): write faststart mp4/mov output from stabilize-video

### DIFF
--- a/apps/api/src/routes/tools/stabilize-video.ts
+++ b/apps/api/src/routes/tools/stabilize-video.ts
@@ -47,6 +47,20 @@ function codecForContainer(ext: string): {
   };
 }
 
+/**
+ * mp4/mov muxers write the moov atom at the end of the file by default. A
+ * progressive player (browsers, the in-app player, most mobile players) then
+ * cannot start playback or seek until the whole file is downloaded, so the
+ * stabilized result looks broken or "corrupted" on preview. +faststart moves
+ * the moov atom to the front. Mirrors convert-video / compress-video (#588).
+ */
+function faststartArgs(ext: string): string[] {
+  const lower = ext.toLowerCase();
+  return lower === ".mp4" || lower === ".m4v" || lower === ".mov"
+    ? ["-movflags", "+faststart"]
+    : [];
+}
+
 export function registerStabilizeVideo(app: FastifyInstance) {
   createToolRoute(app, {
     toolId: "stabilize-video",
@@ -98,6 +112,7 @@ export function registerStabilizeVideo(app: FastifyInstance) {
           `vidstabtransform=input=${trf}:smoothing=${settings.smoothing}`,
           ...encodeArgs,
           ...audioArgs,
+          ...faststartArgs(origExt),
           outPath,
         ],
         info.durationS,

--- a/tests/integration/tools/video/stabilize-video.test.ts
+++ b/tests/integration/tools/video/stabilize-video.test.ts
@@ -67,7 +67,8 @@ async function resolveResult(res: Awaited<ReturnType<typeof runTool>>): Promise<
     await new Promise((r) => setTimeout(r, 500));
   }
   expect(row?.status).toBe("completed");
-  const outName = (row?.outputRefs as string[])[0].split("/").pop() as string;
+  if (!row) throw new Error("job row not found after polling");
+  const outName = (row.outputRefs as string[])[0].split("/").pop() as string;
   const dl = await testApp.app.inject({
     method: "GET",
     url: `/api/v1/download/${jobId}/${encodeURIComponent(outName)}`,
@@ -88,6 +89,32 @@ describe.skipIf(!ffmpegAvailable())("stabilize-video (requires ffmpeg)", () => {
     const info = await probeMedia(probeFile);
     const v = info.streams.find((s) => s.type === "video");
     expect(v).toBeDefined();
+  }, 120_000);
+
+  it("produces a faststart mp4 with the moov atom before mdat", async () => {
+    const res = await runTool({});
+    const { downloadPayload } = await resolveResult(res);
+
+    const moov = downloadPayload.indexOf("moov");
+    const mdat = downloadPayload.indexOf("mdat");
+    expect(moov).toBeGreaterThanOrEqual(0);
+    expect(mdat).toBeGreaterThanOrEqual(0);
+    // Without -movflags +faststart the moov atom lands after mdat, so browsers
+    // and mobile players cannot start progressive playback and report the file
+    // as broken until it is fully downloaded (issue #588).
+    expect(moov).toBeLessThan(mdat);
+  }, 120_000);
+
+  it("keeps the audio stream intact through stabilization", async () => {
+    const res = await runTool({});
+    const { downloadPayload } = await resolveResult(res);
+
+    const tmpDir = mkdtempSync(join(tmpdir(), "stab-audio-"));
+    const probeFile = join(tmpDir, "stabilized.mp4");
+    writeFileSync(probeFile, downloadPayload);
+    const info = await probeMedia(probeFile);
+    // The tiny fixture carries an audio track; a mux mismatch would drop it.
+    expect(info.streams.some((s) => s.type === "audio")).toBe(true);
   }, 120_000);
 
   it("rejects smoothing out of range with 400", async () => {


### PR DESCRIPTION
## What

`stabilize-video` produced mp4/mov output with the `moov` atom at the end of the file (ffmpeg's default). Progressive players (browsers, the in-app player, most mobile players) cannot start playback or seek until the entire file is downloaded, so the stabilized result looks broken or "corrupted" on preview. A user reported exactly this ("Corrompe el video").

Add `-movflags +faststart` for mp4/mov/m4v output, matching how `convert-video` and `compress-video` already write their output.

## Root cause verified

Reproduced with real ffmpeg 7.1 by running the exact pass-2 command:

- Before: `moov@6268 mdat@44` (moov after mdat, not faststart)
- After `+faststart`: `moov@36 mdat@2483` (moov first)

The other hypotheses from the issue did not reproduce and are intentionally out of scope here:

- Audio `-c:a copy` is valid when the container is preserved (the input codec was already muxed into that container). The audio stream stays intact; a new test asserts this.
- Rotation is handled by ffmpeg's default autorotate, which bakes the display matrix into the filtered frames, so portrait input comes out upright.
- The VP9/Theora `pix_fmt` note is a codebase-wide consistency item (the shared `videoEncodeArgsForContainer` helper omits it too), not specific to this tool; left for a separate change.

## Tests

`tests/integration/tools/video/stabilize-video.test.ts` (ffmpeg-gated):

- New: asserts the stabilized mp4 has `moov` before `mdat`. Confirmed red before the fix (`expected 6268 to be less than 44`), green after.
- New: asserts the audio stream survives stabilization.
- Also narrows a pre-existing unsafe optional chain in the same file so the pre-commit lint passes.

All 4 tests pass locally. Note: CI integration shards have no ffmpeg, so this suite skips there (same as before); it was verified locally against ffmpeg 7.1.1.

Fixes #588
