### PR TITLE
fix(docker): harden Postgres readiness checks in compose and startup

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -58,6 +58,7 @@ services:
     image: postgres:17-alpine
     environment:
       POSTGRES_USER: snapotter
+      # Change this for any non-local deployment.
       POSTGRES_PASSWORD: snapotter
       POSTGRES_DB: snapotter
     volumes: ["SnapOtter-pgdata:/var/lib/postgresql/data"]

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ services:
     image: postgres:17-alpine
     environment:
       POSTGRES_USER: snapotter
+      # Change this for any non-local deployment.
       POSTGRES_PASSWORD: snapotter
       POSTGRES_DB: snapotter
     volumes: ["SnapOtter-pgdata:/var/lib/postgresql/data"]

--- a/docker/docker-compose-gpu.yml
+++ b/docker/docker-compose-gpu.yml
@@ -122,7 +122,7 @@ services:
     container_name: SnapOtter-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-snapotter}
-      # Set a strong password -- CHANGE THIS for any non-local deployment.
+      # Set a strong password. CHANGE THIS for any non-local deployment.
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-snapotter}
       POSTGRES_DB: ${POSTGRES_DB:-snapotter}
     volumes:
@@ -130,7 +130,7 @@ services:
     restart: unless-stopped
     mem_limit: 1g
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-snapotter}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-snapotter} -d ${POSTGRES_DB:-snapotter}"]
       interval: 10s
       timeout: 5s
       retries: 12

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -114,7 +114,7 @@ services:
     container_name: SnapOtter-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-snapotter}
-      # Set a strong password -- CHANGE THIS for any non-local deployment.
+      # Set a strong password. CHANGE THIS for any non-local deployment.
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-snapotter}
       POSTGRES_DB: ${POSTGRES_DB:-snapotter}
     volumes:
@@ -122,7 +122,7 @@ services:
     restart: unless-stopped
     mem_limit: 1g
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-snapotter}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-snapotter} -d ${POSTGRES_DB:-snapotter}"]
       interval: 10s
       timeout: 5s
       retries: 12

--- a/docker/wait-for-postgres.mjs
+++ b/docker/wait-for-postgres.mjs
@@ -1,9 +1,26 @@
 import { connect } from "node:net";
 
 const url = new URL(process.env.DATABASE_URL);
-const socket = connect(Number(url.port || 5432), url.hostname, () => {
+const host = url.hostname;
+const port = Number(url.port || 5432);
+
+const socket = connect(port, host, () => {
   socket.end();
   process.exit(0);
 });
-socket.on("error", () => process.exit(1));
-setTimeout(() => process.exit(1), 3000).unref();
+
+socket.on("error", (err) => {
+  // Surface the actual reason instead of exiting silently, so the container
+  // log distinguishes DNS failure (ENOTFOUND), refused connection
+  // (ECONNREFUSED), and unreachable host instead of just looping on
+  // "Waiting for Postgres...". This is a raw TCP probe, so it cannot report
+  // authentication or "database does not exist" errors; those surface later
+  // when the app's Postgres driver connects.
+  console.error(`Postgres not reachable at ${host}:${port}: ${err.code || err.message}`);
+  process.exit(1);
+});
+
+setTimeout(() => {
+  console.error(`Postgres connection to ${host}:${port} timed out after 3s`);
+  process.exit(1);
+}, 3000).unref();

--- a/tests/unit/docker/wait-for-postgres.test.ts
+++ b/tests/unit/docker/wait-for-postgres.test.ts
@@ -1,0 +1,27 @@
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const script = resolve(here, "../../../docker/wait-for-postgres.mjs");
+
+function runProbe(databaseUrl: string) {
+  return spawnSync(process.execPath, [script], {
+    env: { ...process.env, DATABASE_URL: databaseUrl },
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+}
+
+describe("wait-for-postgres probe", () => {
+  it("names the unreachable target instead of failing silently", () => {
+    // `.invalid` never resolves (RFC 2606), so the probe fails fast rather than
+    // waiting for a real host. The point of the fix is that the container log
+    // now says which host:port could not be reached (DNS failure, refused
+    // connection, or timeout) instead of just "Waiting for Postgres..." forever.
+    const res = runProbe("postgres://user:pass@snapotter-db-nope.invalid:5432/snapotter");
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain("snapotter-db-nope.invalid:5432");
+  });
+});

--- a/tests/unit/security/dockerfile-build-args.test.ts
+++ b/tests/unit/security/dockerfile-build-args.test.ts
@@ -150,4 +150,22 @@ describe("Dockerfile build args", () => {
       expect(Number(fallback?.[1])).toBeGreaterThanOrEqual(dockerfileDefault);
     }
   });
+
+  it("targets the app database (not the role) in the compose Postgres healthchecks", () => {
+    // pg_isready with no -d defaults the probe database to the username. When
+    // POSTGRES_USER and POSTGRES_DB differ, the healthcheck silently keeps
+    // reporting healthy while its underlying query fails, and Postgres logs
+    // `FATAL: database "<user>" does not exist` on a loop. Pin the probe to
+    // POSTGRES_DB so it fails loudly when the database is genuinely missing.
+    for (const [name, compose] of [
+      ["docker-compose.yml", composeCpu],
+      ["docker-compose-gpu.yml", composeGpu],
+    ] as const) {
+      const line = compose.split(/\r?\n/).find((l) => l.includes("pg_isready"));
+      expect(line, `${name} should have a pg_isready healthcheck`).toBeDefined();
+      expect(line, `${name} pg_isready must target POSTGRES_DB with -d`).toContain(
+        "-d ${POSTGRES_DB",
+      );
+    }
+  });
 });


### PR DESCRIPTION
## What

Three papercuts from a self-hoster's Compose deployment (reported via feedback), all traced to SnapOtter's own reference files.

### 1. Fragile Postgres healthcheck

`docker/docker-compose.yml` and `docker/docker-compose-gpu.yml` probed health with `pg_isready -U ${POSTGRES_USER:-snapotter}` and no `-d`. `pg_isready` with no `-d` defaults the target database to the username, so the moment someone sets a distinct `POSTGRES_USER`, the probe targets a database that does not exist: the healthcheck keeps reporting `healthy` while its query fails, and Postgres logs `FATAL: database "<user>" does not exist` on a loop. Pin the probe to `POSTGRES_DB`. The embedded-Postgres readiness script already did this (`-d snapotter`); the compose files did not.

### 2. Opaque startup log

`docker/wait-for-postgres.mjs` discarded the socket error (`socket.on("error", () => process.exit(1))`), so an unreachable database produced only a repeating "Waiting for Postgres..." with no host, no error code, and no way to tell a DNS failure from a refused connection. It now logs `Postgres not reachable at <host>:<port>: <code>` (ENOTFOUND / ECONNREFUSED / etc.) and a distinct timeout message. This is a raw TCP probe, so it deliberately does not claim to diagnose auth or "database does not exist" errors; those surface later when the app's driver connects.

### 3. Default password with no nudge

Added a "change this" note next to `POSTGRES_PASSWORD: snapotter` in the README and Docker Hub compose snippets (the surfaces labeled "production"), and reworded a compose comment that used a double hyphen.

## Tests

- `tests/unit/security/dockerfile-build-args.test.ts`: asserts both compose healthchecks target `POSTGRES_DB` with `-d`. Red before the fix, green after.
- `tests/unit/docker/wait-for-postgres.test.ts` (new): spawns the probe against an unresolvable `.invalid` host and asserts it names the host:port on stderr and exits non-zero (instead of failing silently). Red before, green after.

Both run in the normal Unit Tests job.

## Deferred

The `apps/docs` Compose examples carry the same bare `pg_isready` form across all 21 locales (105 files). Those are managed by the i18n source-hash pipeline (`scripts/i18n`), so editing them ad hoc would desync the locale stamps. That sweep is a follow-up that goes through `i18n:translate` rather than hand edits.

Refs #592
