### PR TITLE
fix(seo): emit clean docs URLs and de-index the demo

### DIFF
--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -14,7 +14,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://demo.snapotter.com" />
     <meta property="og:image" content="https://snapotter.com/og-image.png" />
-    <meta name="robots" content="index, follow" />
+    <!-- Demo mirrors the real app and lives under the same domain property; keep it
+         out of search to avoid thin/duplicate pages (GSC "Crawled - currently not indexed"). -->
+    <meta name="robots" content="noindex, nofollow" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -117,6 +117,14 @@ export default defineConfig({
   outDir: "./.vitepress/dist",
   ignoreDeadLinks: [/localhost/],
 
+  // Extension-less URLs in both internal links and the sitemap, so they match
+  // the clean canonical/hreflang emitted in transformHead below. Without this
+  // the sitemap listed .html URLs that Cloudflare Pages 308-redirects to the
+  // clean form, so Google indexed the redirecting variant and overrode our
+  // canonical (GSC "Duplicate, Google chose different canonical"). CF Pages
+  // serves the clean URL at 200, so no extra server config is needed.
+  cleanUrls: true,
+
   sitemap: { hostname: "https://docs.snapotter.com" },
 
   head: [


### PR DESCRIPTION
## Why

Two GSC indexing problems surfaced in the Search Console report, both traced to config that feeds Google URLs it then can't index cleanly.

### 1. Docs sitemap vs canonicals disagree (`.html` vs clean)

The VitePress sitemap listed 3,822 URLs all ending in `.html` (`.../markdown-to-pdf.html`), but every page's own `<link rel=canonical>` and hreflang already point at the clean, extension-less URL. Cloudflare Pages 308-redirects the `.html` form to clean and serves the clean form at 200, so the sitemap was pointing Google at redirecting URLs that contradict the on-page canonical.

Result: Google indexed the redirecting `.html` variant and overrode the declared canonical. Confirmed live via the URL Inspection API:

```
docs.snapotter.com/nl/tools/files/markdown-to-pdf.html
  user_canonical:   .../markdown-to-pdf        (what the page declares)
  google_canonical: .../markdown-to-pdf.html    (Google overrode it)
```

This is the "Duplicate, Google chose different canonical than user" bucket, plus wasted crawl budget re-fetching redirecting sitemap URLs.

**Fix:** `cleanUrls: true` in the VitePress config. Verified against the installed VitePress 1.6.4 source (`dist/node/index.js`, sitemap URL builder): `.replace(/\.md$/, config.cleanUrls ? "" : ".html")`. It makes the sitemap and internal links extension-less so they match the canonicals. It does not change output filenames (still `.html` on disk), and CF Pages already serves the clean URL at 200, so there is no hosting change to make. Legacy indexed `.html` hits consolidate via the existing 308.

### 2. Demo site is fully indexable

`demo.snapotter.com` shipped `<meta name="robots" content="index, follow">` with no robots.txt, and it's linked from the landing. Its routes (e.g. `/editor`) were getting crawled and indexed as thin duplicates of the real app under the same domain property.

**Fix:** mark the demo shell `noindex, nofollow`. It stays crawlable so Google sees the directive; the SPA shell serves it on first fetch for every route.

## Not included (verified already resolved)

- The stale `snapotter.com/sitemap.xml` (163 pre-reorg flat tool URLs that 301 to the nested paths, driving "Page with redirect") 404s live and just needs to be unsubmitted in GSC. Console action, no code.
- Lowercase `/pt-br/` 404s are historical: PR #562 fixed the link casing, and live localized pages now emit only `pt-BR`. They will age out of GSC.

## Testing

- Verified CF Pages serving behavior live: clean docs URL = 200, `.html` = 308 to clean, old flat landing tool URL = 301 to nested.
- Confirmed the `cleanUrls` -> sitemap coupling in the installed VitePress source rather than only the docs.
- `biome check` passes on the changed config.