### PR TITLE
fix(jobs): classify BullMQ stall (UnrecoverableError) as operational

### DIFF
--- a/apps/api/src/lib/error-report.ts
+++ b/apps/api/src/lib/error-report.ts
@@ -64,6 +64,12 @@ export function classifyError(err: unknown, source?: ReportContext["source"]): E
     // a worker-side ZodError is schema drift (our bug); only expected on http.
     if (e?.name === "ZodError") return "expected";
   }
+  // BullMQ raises UnrecoverableError from its own worker run loop when a job
+  // loses its lock (a stall), e.g. a heavy upscale under CPU/memory pressure.
+  // We never throw it ourselves, so it always means the instance could not keep
+  // the job's lock alive: an environmental strain, not a defect in our code.
+  // Operational (one warning/hour) instead of bug spam (NODE-27).
+  if (e?.name === "UnrecoverableError") return "operational";
   if (isSafeMessageError(err)) return err.kind === "bug" ? "bug" : "operational";
   if (connectivityClass(err)) return "operational";
   if (isEnvironmentalDbError(err)) return "operational";

--- a/tests/unit/api/error-report.test.ts
+++ b/tests/unit/api/error-report.test.ts
@@ -99,6 +99,18 @@ describe("classifyError", () => {
     expect(classifyError(e, "http")).toBe("expected");
     expect(classifyError(e)).toBe("expected");
   });
+  it("operational: a BullMQ UnrecoverableError (stalled/lock-lost job) is a strained instance, not our bug", () => {
+    // BullMQ raises UnrecoverableError from its own worker loop when a job loses
+    // its lock (a stall), e.g. a heavy `upscale` under CPU/memory pressure. We
+    // never throw it ourselves, so it always means the instance could not keep
+    // the job's lock alive -- environmental, worth one warning/hour not bug spam
+    // (NODE-27). A ReplyError (a real Redis command failure) stays a bug.
+    const stalled = Object.assign(new Error("Missing lock for job 42. moveToFinished"), {
+      name: "UnrecoverableError",
+    });
+    expect(classifyError(stalled, "worker")).toBe("operational");
+    expect(classifyError(stalled)).toBe("operational");
+  });
 });
 
 describe("throttle", () => {


### PR DESCRIPTION
BullMQ raises `UnrecoverableError` from its own worker run loop when a job loses its lock (a stall). We never throw it ourselves, so it always means the instance could not keep a job's lock alive, not a defect in our code. `classifyError` now returns `operational` for it, which drops it from up to 10 bug-class events per hour to one warning, fingerprinted into a single issue. `ReplyError` stays a `bug`, since a real Redis command failure is our fault.

Found in a Sentry re-triage of the `node` project: issue NODE-27, ~20 events, still recurring on 2.1.0. On strained boxes it fires for heavy jobs like `upscale` and it tracks the upscale OOMs in NODE-2E. It was the one live issue that was real noise rather than an already-fixed-pending-release problem.

Test: added a `classifyError` case for the stall (`UnrecoverableError` maps to `operational`, on the worker source and the default). Watched it fail (`expected 'bug' to be 'operational'`), then pass. Full file green, 17/17; typecheck and Biome clean.
