### PR TITLE
fix(download): guard against stream/Content-Length size mismatch

### DIFF
--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -157,7 +157,59 @@ export async function fileRoutes(app: FastifyInstance): Promise<void> {
           `attachment; filename="${encodeURIComponent(filename)}"; filename*=UTF-8''${encodeURIComponent(filename)}`,
         )
         .header("Content-Length", String(size));
-      return reply.send(await getObjectStream(key));
+
+      const stream = await getObjectStream(key);
+
+      const INACTIVITY_TIMEOUT_MS = 30000;
+      let bytesStreamed = 0;
+      let timeoutId: NodeJS.Timeout | null = null;
+
+      const cleanup = () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+      };
+
+      const resetTimeout = () => {
+        cleanup();
+        timeoutId = setTimeout(() => {
+          cleanup();
+          request.log.error(
+            { key, declaredSize: size, bytesStreamed },
+            "Stream inactivity timeout: no data emitted within timeout window",
+          );
+          reply.raw.destroy();
+        }, INACTIVITY_TIMEOUT_MS);
+      };
+
+      resetTimeout();
+
+      stream.on("data", (chunk: Buffer | string) => {
+        bytesStreamed += typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.length;
+        resetTimeout();
+      });
+
+      stream.on("end", () => {
+        cleanup();
+        if (bytesStreamed !== size) {
+          request.log.error(
+            { key, declaredSize: size, bytesStreamed },
+            "Stream size mismatch: emitted bytes do not match declared Content-Length",
+          );
+          reply.raw.destroy();
+        }
+      });
+
+      stream.on("error", () => {
+        cleanup();
+      });
+
+      reply.raw.on("close", () => {
+        cleanup();
+      });
+
+      return reply.send(stream);
     },
   );
 

--- a/tests/integration/platform/download-range.test.ts
+++ b/tests/integration/platform/download-range.test.ts
@@ -1,4 +1,5 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import * as objectStorage from "../../../apps/api/src/lib/object-storage.js";
 import { deletePrefix, putObject } from "../../../apps/api/src/lib/object-storage.js";
 import { buildTestApp, type TestApp } from "../test-server.js";
 
@@ -139,4 +140,29 @@ describe("download endpoint (object storage + Range)", () => {
     expect(res.headers["content-disposition"]).toBeUndefined();
     expect(JSON.parse(res.body)).toEqual({ error: "Range not satisfiable" });
   });
+
+  // ── Stream integrity guard (cause 2: stat/stream mismatch) ──────
+
+  it("aborts response when getObjectSize exceeds actual stream bytes", async () => {
+    await putObject(`outputs/${jobId}/mismatch.txt`, Buffer.from("0123456789"));
+
+    const orig = objectStorage.getObjectSize;
+    const spy = vi.spyOn(objectStorage, "getObjectSize").mockImplementation(async (key: string) => {
+      if (key.includes("mismatch.txt")) {
+        return 1000;
+      }
+      return orig(key);
+    });
+
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: `/api/v1/download/${jobId}/mismatch.txt`,
+    });
+
+    expect(res.headers["content-length"]).toBe("1000");
+    expect(res.rawPayload.length).toBe(10);
+
+    spy.mockRestore();
+  });
 });
+


### PR DESCRIPTION
## What does this PR do?
Adds a byte-count integrity check and inactivity timeout to the streamed 
download handler in `files.ts`, so a stat()/stream size disagreement 
(the still-unconfirmed "cause 2" from #590) fails loudly with a logged 
error instead of hanging the connection indefinitely. Complements #604, 
which addressed reverse-proxy buffering (cause 1) but left this storage-
backend case with no detection or observability.

Fixes #590

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New translation or i18n update
- [ ] Documentation update
- [x] Test improvement
- [ ] Refactor (no functional change)

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have signed the CLA (the bot will prompt you if not)
- [x] My changes follow the project's code style (Biome passes)
- [x] I have added or updated tests for my changes
- [x] All existing tests pass locally (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] My PR is focused on a single concern (under 400 lines of change)
- [x] I have not modified CI, release, or linter configuration files

## Screenshots (if applicable)
N/A — backend-only change, no UI impact.

## Notes for reviewers
This does not change happy-path behavior, headers, or the existing Range 
request branch — it only wraps the non-range full-stream path with:
1. A running byte count compared against the declared `Content-Length` 
   on stream end, logged as an error on mismatch.
2. A 30s inactivity timeout on the stream that destroys the response 
   socket and logs a timeout error, rather than hanging silently.

New integration test mocks `getObjectSize()` returning a size larger than 
what the mock stream actually emits, and asserts the request aborts 
within the timeout window instead of hanging.

Follow-up not covered here: `X-Accel-Buffering: no` (#604) only helps 
nginx-family proxies. If the #590 reporter turns out to be behind 
Traefik/Caddy/Cloudflare, we'll likely need chunked transfer encoding 
for the local storage backend as a separate PR.