### PR TITLE
fix(pdf): restore downloads on PDF conversion preset pages

### DIFF
--- a/apps/api/src/openapi.yaml
+++ b/apps/api/src/openapi.yaml
@@ -2424,6 +2424,15 @@ paths:
                 properties:
                   jobId:
                     type: string
+                  downloadUrl:
+                    type: string
+                    description: URL to download all pages as ZIP
+                  originalSize:
+                    type: integer
+                    description: Input PDF size in bytes
+                  processedSize:
+                    type: integer
+                    description: Output ZIP size in bytes
                   pageCount:
                     type: integer
                     description: Total pages in the PDF

--- a/apps/api/src/routes/tools/pdf-to-image.ts
+++ b/apps/api/src/routes/tools/pdf-to-image.ts
@@ -396,14 +396,18 @@ export function registerPdfToImageRoute(
       await zipDone;
       const zipBuffer = Buffer.concat(zipChunks);
       await putObject(`outputs/${jobId}/${zipFilename}`, zipBuffer);
+      const zipUrl = `/api/v1/download/${jobId}/${encodeURIComponent(zipFilename)}`;
 
       return reply.send({
         jobId,
+        downloadUrl: zipUrl,
+        originalSize: fileBuffer.length,
+        processedSize: zipBuffer.length,
         pageCount: totalPages,
         selectedPages,
         format: settings.format,
         pages,
-        zipUrl: `/api/v1/download/${jobId}/${encodeURIComponent(zipFilename)}`,
+        zipUrl,
         zipSize: zipBuffer.length,
       });
     } catch (err) {

--- a/tests/e2e/pdf-to-image.spec.ts
+++ b/tests/e2e/pdf-to-image.spec.ts
@@ -72,3 +72,20 @@ test.describe("PDF to Image tool", () => {
     await expect(page.locator("text=3 of 3 pages selected")).toBeVisible();
   });
 });
+
+test.describe("PDF conversion preset pages", () => {
+  for (const toolId of ["pdf-to-png", "pdf-to-jpg"]) {
+    test(`${toolId} shows the ZIP download after synchronous conversion`, async ({
+      loggedInPage: page,
+    }) => {
+      await page.goto(`/pdf/${toolId}`);
+      await uploadPdf(page);
+
+      await page.getByTestId("preset-submit").click();
+
+      const download = page.getByTestId("preset-download");
+      await expect(download).toBeVisible({ timeout: 15_000 });
+      await expect(download).toHaveAttribute("href", /\/api\/v1\/download\/[^/]+\/pdf-pages\.zip$/);
+    });
+  }
+});

--- a/tests/integration/tools/conversion-presets.test.ts
+++ b/tests/integration/tools/conversion-presets.test.ts
@@ -8,6 +8,7 @@ import {
   type Tool,
   toolSection,
 } from "@snapotter/shared";
+import AdmZip from "adm-zip";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { fixtures, readFixture } from "../../fixtures/index.js";
 import {
@@ -213,4 +214,49 @@ describe("conversion presets (all)", () => {
       90_000,
     );
   }
+});
+
+describe("PDF to image conversion presets", () => {
+  it.each([
+    ["pdf-to-png", "png"],
+    ["pdf-to-jpg", "jpg"],
+    ["pdf-to-tiff", "tiff"],
+  ])("%s returns the standard synchronous result and a downloadable ZIP", async (toolId, ext) => {
+    const input = readFixture(fixtures.document.tiny("pdf"));
+    const { body, contentType } = createMultipartPayload([
+      {
+        name: "file",
+        filename: "input.pdf",
+        contentType: "application/pdf",
+        content: input,
+      },
+      { name: "settings", content: JSON.stringify({ dpi: 72 }) },
+    ]);
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: `/api/v1/tools/pdf/${toolId}`,
+      headers: { authorization: `Bearer ${token}`, "content-type": contentType },
+      body,
+    });
+
+    expect(res.statusCode, res.body).toBe(200);
+    const result = JSON.parse(res.body);
+    expect(result.downloadUrl).toBe(result.zipUrl);
+    expect(result.originalSize).toBe(input.length);
+    expect(result.processedSize).toBe(result.zipSize);
+
+    const download = await testApp.app.inject({
+      method: "GET",
+      url: result.downloadUrl,
+    });
+    expect(download.statusCode).toBe(200);
+    expect(download.headers["content-type"]).toContain("application/zip");
+
+    const entries = new AdmZip(download.rawPayload).getEntries();
+    expect(entries).toHaveLength(result.selectedPages.length);
+    for (const entry of entries) {
+      expect(entry.entryName).toMatch(new RegExp(`\\.${ext}$`));
+      expect(entry.header.size).toBeGreaterThan(0);
+    }
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Makes the synchronous `pdf-to-image` response satisfy the standard tool-result contract consumed by conversion preset pages, while preserving the dedicated PDF-to-image response fields. Adds API-level ZIP validation and browser regressions for the affected PNG/JPG pages.

Fixes #623

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New translation or i18n update
- [ ] Documentation update
- [ ] Test improvement
- [ ] Refactor (no functional change)

## Root cause

The PDF conversion presets use the generic tool processor, whose synchronous `200` path consumes `downloadUrl`, `originalSize`, and `processedSize`. The shared PDF-to-image route returned only `zipUrl` and `zipSize`, so conversion completed but the preset UI received no standard download URL and did not render its download action.

This fixes the response at the route contract boundary instead of adding preset-specific frontend fallbacks or artificial async/SSE completion events.

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @snapotter/api typecheck`
- `pnpm vitest run --config vitest.config.ts tests/integration/tools/conversion-presets.test.ts -t "PDF to image conversion presets" --reporter=verbose` (3 passed)
- `pnpm playwright test tests/e2e/pdf-to-image.spec.ts --project=chromium --reporter=line` (7 passed)
- OpenAPI YAML parse and `git diff --check`
- Manual verification of both PDF-to-PNG and PDF-to-JPG preset pages

A full `pnpm test` run was attempted locally but could not complete cleanly because the development environment lacks optional system dependencies used by unrelated suites (ImageMagick, qpdf, and `.venv/bin/python3`) and encountered local PostgreSQL/Docker failures under low disk space. The targeted integration and end-to-end regression paths pass.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/snapotter-hq/snapotter/blob/main/CONTRIBUTING.md)
- [ ] I have signed the [CLA](https://github.com/snapotter-hq/snapotter/blob/main/CLA.md) (the bot will prompt me if not)
- [x] My changes follow the project's code style (Biome passes)
- [x] I have added or updated tests for my changes
- [ ] All existing tests pass locally (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] My PR is focused on a single concern (under 400 lines of change)
- [x] I have not modified CI, release, or linter configuration files

## Screenshots (if applicable)

Not included: this restores the existing download action without changing the UI.