### PR TITLE
fix(image): decode real iPhone HEIC files instead of rejecting them at validation

### DIFF
--- a/apps/api/src/lib/file-validation.ts
+++ b/apps/api/src/lib/file-validation.ts
@@ -175,6 +175,7 @@ const CLI_DECODED_FORMATS = new Set([
   "ppm",
   "pgm",
   "pbm",
+  "heif",
 ]);
 
 /**

--- a/apps/api/src/routes/tools/erase-object.ts
+++ b/apps/api/src/routes/tools/erase-object.ts
@@ -172,6 +172,17 @@ export function registerEraseObject(app: FastifyInstance) {
           imageBuffer = await decodeToSharpCompat(imageBuffer, imageValidation.format);
         }
         imageBuffer = await autoOrient(imageBuffer);
+
+        // The mask goes through the same CLI-decoded formats the main image
+        // does. Without this, a HEIC/RAW/etc. mask reaches the unguarded
+        // sharp() calls inside inpaint() and fails with a generic, misclassified
+        // error instead of the clear message the image gets right above.
+        if (maskValidation.format === "heif") {
+          maskBuffer = await decodeHeic(maskBuffer);
+        }
+        if (needsCliDecode(maskValidation.format)) {
+          maskBuffer = await decodeToSharpCompat(maskBuffer, maskValidation.format);
+        }
       } catch (err) {
         request.log.error({ err, toolId: "erase-object" }, "Input decoding failed");
         return reply.status(422).send({
@@ -188,6 +199,7 @@ export function registerEraseObject(app: FastifyInstance) {
       } else {
         await putObject(imageKey, imageBuffer);
       }
+      await putObject(maskKey, maskBuffer);
 
       // Enqueue with both image and mask as inputRefs; the worker handler
       // reads them via getObjectBuffer.

--- a/tests/integration/tools/image/erase-object-mask.test.ts
+++ b/tests/integration/tools/image/erase-object-mask.test.ts
@@ -26,8 +26,20 @@ vi.mock("../../../../apps/api/src/lib/feature-status.js", async (importOriginal)
   return { ...mod, isToolInstalled: () => true };
 });
 
+// Spies on the real decodeHeic (still calls through to the actual heif-convert
+// CLI) so the mask-decode regression test below can assert it fires for a
+// HEIC mask, the same way it already fires for a HEIC main image.
+vi.mock("../../../../apps/api/src/lib/heic-converter.js", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("../../../../apps/api/src/lib/heic-converter.js")>();
+  return { ...mod, decodeHeic: vi.fn(mod.decodeHeic) };
+});
+
+import { decodeHeic } from "../../../../apps/api/src/lib/heic-converter.js";
+
 const JPG = readFixture(fixtures.image.base.jpg100);
 const PNG = readFixture(fixtures.image.base.png200);
+const HEIC = readFixture(fixtures.image.base.heic200);
 // Large first file: widens the window in which the request stream fully
 // buffers (firing "close") while the first part is still streaming to
 // storage, which is what dropped the trailing mask part.
@@ -63,6 +75,28 @@ describe("erase-object multipart contract", () => {
       payload: body,
     });
     expect(res.statusCode, res.body).toBeLessThan(400);
+  });
+
+  it("decodes a HEIC mask before enqueueing, mirroring the main image's decode path", {
+    timeout: 60_000,
+  }, async () => {
+    vi.mocked(decodeHeic).mockClear();
+    const { body, contentType } = createMultipartPayload([
+      { name: "file", filename: "photo.jpg", contentType: "image/jpeg", content: JPG },
+      { name: "mask", filename: "mask.heic", contentType: "image/heic", content: HEIC },
+      { name: "clientJobId", content: randomUUID() },
+    ]);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/tools/image/erase-object",
+      headers: { authorization: `Bearer ${adminToken}`, "content-type": contentType },
+      payload: body,
+    });
+    expect(res.statusCode, res.body).toBeLessThan(400);
+    // The main image here is a plain JPG, so a single decodeHeic call means
+    // the mask (and only the mask) was decoded.
+    expect(vi.mocked(decodeHeic)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(decodeHeic)).toHaveBeenCalledWith(HEIC);
   });
 
   it("keeps trailing parts across reused keep-alive connections", async () => {

--- a/tests/unit/api/file-validation-mutation.test.ts
+++ b/tests/unit/api/file-validation-mutation.test.ts
@@ -432,13 +432,11 @@ describe("validateImageBuffer - ftyp brand verification", () => {
 
   const heifBrands = ["heic", "heix", "mif1", "msf1", "hevc", "hevx"];
   for (const brand of heifBrands) {
-    it(`accepts the heif brand "${brand}" (detected, then synthetic decode fails)`, async () => {
-      // Each brand must pass the L349 includes() check; on a synthetic buffer
-      // the format is heif (not CLI-decoded) and sharp fails -> metadata error.
-      expectRejected(
-        await validateImageBuffer(withFtypBrand(brand)),
-        "Failed to read image metadata",
-      );
+    it(`accepts the heif brand "${brand}" and returns early without a sharp decode`, async () => {
+      // Each brand must pass the L349 includes() check; heif is CLI-decoded
+      // (real HEVC decode happens later via decodeHeic()), so this must return
+      // valid immediately, the same as the CR3->raw arm below.
+      expectValid(await validateImageBuffer(withFtypBrand(brand)), "heif", 0, 0);
     });
   }
 

--- a/tests/unit/api/file-validation-mutation.test.ts
+++ b/tests/unit/api/file-validation-mutation.test.ts
@@ -430,6 +430,10 @@ describe("validateImageBuffer - ftyp brand verification", () => {
     expectRejected(await validateImageBuffer(buf), "Unrecognized image format");
   });
 
+  // Uses a synthetic buffer, not a real fixture, because sharp's metadata()
+  // reads HEIF dimensions from the box-level `ispe` data and succeeds on real
+  // HEVC-coded fixtures regardless of codec support (only pixel decode needs
+  // it). A real fixture here would pass even without the fix below.
   const heifBrands = ["heic", "heix", "mif1", "msf1", "hevc", "hevx"];
   for (const brand of heifBrands) {
     it(`accepts the heif brand "${brand}" and returns early without a sharp decode`, async () => {


### PR DESCRIPTION
## Summary

- `validateImageBuffer()` was missing `"heif"` from `CLI_DECODED_FORMATS`, exactly as diagnosed in #622: real iPhone HEIC uploads hit Sharp's own metadata probe (its bundled libheif only supports AV1/AVIF) and got rejected before reaching the working `heif-convert`/`heif-dec` decode path already wired up downstream. One-line fix, add `"heif"` to that set, same as raw/psd/tga/bmp/etc.
- Reviewing the diff surfaced the same gap on erase-object's mask input: validated through the same function, no matching decode step, so a HEIC mask reached an unguarded `sharp()` call inside `inpaint()` and came back as a misclassified server error instead of a clean 422. Fixed the same way, mirroring the main image's existing decode branch.

## Test plan

- [x] Flipped the 6 assertions in `file-validation-mutation.test.ts` that had pinned the old (buggy) rejection as expected behavior; full file passes 167/167
- [x] New regression test in `erase-object-mask.test.ts` asserting `decodeHeic` fires for a HEIC mask
- [x] Full unit suite: 7455 passed
- [x] Integration: `image-depth` (real photo through a real route), the HEIC/HEIF slice of every `format-matrix*` file (263 tests), and the full `tests/integration/tools/image/` directory (2163 tests)
- [x] typecheck, lint clean

Didn't build a "realistic" multi-auxiliary-image HEIC fixture (depth map, gain map) to reproduce the exact production symptom. Verified `metadata()` succeeds on every real HEIC/HEIF fixture already in the repo regardless, since libheif reads box-level `ispe` data without touching the codec, so no existing or hand-authored real file reproduces the throw this fix guards against. Confirmed the new unit test is the only thing that would catch a regression here: stashed the fix and reran the existing 263 HEIC/HEIF integration tests, all passed even without it.

Two things worth a maintainer's eye, both pre-existing and out of scope for this PR:
- `format-decoders.ts` has its own independent `CLI_DECODED_FORMATS` set (backing `needsCliDecode()`), correctly left untouched here, but the two identically-named sets can drift with nothing to catch it.
- `fetch-urls.ts` and `user-files.ts` have the same shape of gap this PR fixes in erase-object (an undecoded CLI-format buffer reaching a raw `sharp()` call, or a `0x0` dimension written instead of unknown), already true today for PSD/RAW/etc. This PR just makes HEIC hit it more often, since it's a far more common upload than PSD.

Fixes #622
