### PR TITLE
fix(files): store null instead of 0x0 for undecoded upload dimensions

### DIFF
--- a/apps/api/src/routes/user-files.ts
+++ b/apps/api/src/routes/user-files.ts
@@ -27,7 +27,7 @@ import {
   saveThumbnail,
   streamStoredFile,
 } from "../lib/file-storage.js";
-import { validateImageBuffer } from "../lib/file-validation.js";
+import { type ValidationResult, validateImageBuffer } from "../lib/file-validation.js";
 import { sanitizeFilename } from "../lib/filename.js";
 import { decodeToSharpCompat, needsCliDecode } from "../lib/format-decoders.js";
 import { decodeHeic } from "../lib/heic-converter.js";
@@ -79,6 +79,27 @@ function extToMime(ext: string): string {
     zip: "application/zip",
   };
   return map[clean] ?? "application/octet-stream";
+}
+
+/**
+ * The width/height to store for a validated image, or null if they weren't
+ * actually measured.
+ *
+ * validateImageBuffer() reports {width: 0, height: 0} by design for
+ * CLI_DECODED_FORMATS members (HEIC, RAW, PSD, TGA, ...): it intentionally
+ * skips decoding on upload, so 0 there means "unknown", not a real size.
+ * 0x0 is never a genuine image dimension, so treat it the same as an
+ * invalid/failed validation and store null instead of the literal 0.
+ */
+function measuredDimensions(validation: ValidationResult | null): {
+  width: number | null;
+  height: number | null;
+} {
+  if (!validation) return { width: null, height: null };
+  return {
+    width: validation.width > 0 ? validation.width : null,
+    height: validation.height > 0 ? validation.height : null,
+  };
 }
 
 function serializeFile(row: typeof schema.userFiles.$inferSelect) {
@@ -294,6 +315,7 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
         const mimeType = isValidImage
           ? formatToMime(validation.format)
           : part.mimetype || "application/octet-stream";
+        const dimensions = measuredDimensions(isValidImage ? validation : null);
 
         // Persist to disk
         const storedName = await saveFile(safeBuffer, safeName);
@@ -309,8 +331,8 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
             storedName,
             mimeType,
             size: fileSize,
-            width: isValidImage ? validation.width : null,
-            height: isValidImage ? validation.height : null,
+            width: dimensions.width,
+            height: dimensions.height,
             version: 1,
             parentId: null,
             toolChain: sourceToolId ? [sourceToolId] : null,
@@ -774,6 +796,7 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
     const resultName = `${baseName}${ext}`;
 
     const mimeType = isValidImage ? formatToMime(validation.format) : extToMime(ext);
+    const dimensions = measuredDimensions(isValidImage ? validation : null);
 
     // Sanitize SVG results to prevent XXE, SSRF, and script injection
     const safeResultBuffer = isSvgBuffer(fileBuffer) ? sanitizeSvg(fileBuffer) : fileBuffer;
@@ -800,8 +823,8 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
         storedName,
         mimeType,
         size: fileSize,
-        width: isValidImage ? validation.width : null,
-        height: isValidImage ? validation.height : null,
+        width: dimensions.width,
+        height: dimensions.height,
         version: nextVersion,
         parentId,
         toolChain: newChain,

--- a/tests/integration/platform/user-files.test.ts
+++ b/tests/integration/platform/user-files.test.ts
@@ -19,6 +19,10 @@ const PNG = readFixture(fixtures.image.base.png200);
 const JPG = readFixture(fixtures.image.base.jpg100);
 const _WEBP = readFixture(fixtures.image.base.webp50);
 const TINY_PNG = readFixture(fixtures.image.edge.px1);
+// BMP is a CLI_DECODED_FORMATS member (see file-validation.ts): validateImageBuffer()
+// intentionally returns {valid: true, width: 0, height: 0} for it without decoding,
+// since real decoding happens lazily elsewhere. Used to cover the 0x0-vs-null bug.
+const BMP = readFixture(fixtures.image.formats("bmp"));
 
 let testApp: TestApp;
 let app: TestApp["app"];
@@ -98,6 +102,31 @@ describe("File upload", () => {
     expect(res.statusCode).toBe(400);
     const result = JSON.parse(res.body);
     expect(result.error).toMatch(/no valid files/i);
+  });
+
+  // Regression test for #635: validateImageBuffer() reports {width: 0, height: 0}
+  // by design for CLI_DECODED_FORMATS members (never decoded on upload), and the
+  // route must treat that sentinel as "unknown" (null), not write the literal 0x0.
+  it("stores null dimensions (not 0x0) for a CLI-decoded format upload", async () => {
+    const { body, contentType } = createMultipartPayload([
+      { name: "file", filename: "photo.bmp", contentType: "image/bmp", content: BMP },
+    ]);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/files/upload",
+      headers: {
+        "content-type": contentType,
+        authorization: `Bearer ${adminToken}`,
+      },
+      body,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const result = JSON.parse(res.body);
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0].width).toBeNull();
+    expect(result.files[0].height).toBeNull();
   });
 });
 
@@ -475,6 +504,48 @@ describe("Save result", () => {
     });
 
     expect(res.statusCode).toBe(404);
+  });
+
+  // Regression test for #635: same 0x0-vs-null bug as the upload endpoint, but on
+  // the separate save-result write path (a tool result saved as a new version).
+  it("stores null dimensions (not 0x0) for a CLI-decoded format result", async () => {
+    // Upload the parent file
+    const { body: uploadBody, contentType: uploadCt } = createMultipartPayload([
+      {
+        name: "file",
+        filename: "parent-for-bmp-result.png",
+        contentType: "image/png",
+        content: PNG,
+      },
+    ]);
+
+    const uploadRes = await app.inject({
+      method: "POST",
+      url: "/api/v1/files/upload",
+      headers: { "content-type": uploadCt, authorization: `Bearer ${adminToken}` },
+      body: uploadBody,
+    });
+
+    const parentId = JSON.parse(uploadRes.body).files[0].id;
+
+    // Save a BMP "processed" result as a new version
+    const { body: saveBody, contentType: saveCt } = createMultipartPayload([
+      { name: "file", filename: "result.bmp", contentType: "image/bmp", content: BMP },
+      { name: "parentId", content: parentId },
+      { name: "toolId", content: "convert" },
+    ]);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/files/save-result",
+      headers: { "content-type": saveCt, authorization: `Bearer ${adminToken}` },
+      body: saveBody,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const result = JSON.parse(res.body);
+    expect(result.file.width).toBeNull();
+    expect(result.file.height).toBeNull();
   });
 
   it("builds version chain correctly across multiple saves", async () => {


### PR DESCRIPTION
## Summary

`validateImageBuffer()` intentionally reports `{width: 0, height: 0}` for every `CLI_DECODED_FORMATS` member (HEIC, RAW, PSD, TGA, ...), it skips decoding on upload by design and defers real dimension measurement to the thumbnail endpoint, which already decodes lazily. The file library's upload and save-result endpoints treated that `0` as a real measurement and wrote it straight into the DB. A library UI showing file dimensions would render a bogus "0 x 0" for a HEIC photo (or RAW, PSD, ...) instead of just not showing a size.

Adds a small `measuredDimensions()` helper next to the file's existing `formatToMime`/`extToMime` helpers, treats non-positive width/height as unmeasured, stores `null` at both write sites.

Filed as #635 while fixing #622 (HEIC validation), heif joining `CLI_DECODED_FORMATS` is what made this hit real, common uploads instead of just RAW/PSD.

## Test plan

- [x] Two new regression tests (upload + save-result endpoints), using a real BMP fixture since it already sits in `CLI_DECODED_FORMATS` today, independent of the HEIC fix in #631, so they reproduce the bug on current `main` without depending on an unmerged PR
- [x] Existing PNG upload test still asserts real, non-null dimensions unchanged, confirming the fix only touches the `0`/`0` sentinel case
- [x] `tests/integration/platform/user-files.test.ts`: 24 passed
- [x] `tests/unit/api/user-files-route.test.ts`: 42 passed
- [x] `ownership-enforcement.test.ts` + `library-save-mode.test.ts` (other suites hitting the same routes): 22 passed
- [x] typecheck, lint clean

Fixes #635
