### PR TITLE
test(web): stop the onboarding Escape test racing the passive effect

### DIFF
--- a/tests/unit/web/usage-survey-overlay.test.tsx
+++ b/tests/unit/web/usage-survey-overlay.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -265,10 +265,19 @@ describe("UsageSurveyOverlay", () => {
 
       renderOverlay();
       await screen.findByText("How are you using SnapOtter?");
+      await act(async () => {});
 
-      fireEvent.keyDown(document, { key: "Escape" });
-
+      // Escape is the one control here whose handler is a document listener
+      // registered by a passive effect; every other control is an onClick prop
+      // attached at commit. That makes it the only one that can miss an event
+      // dispatched too early, and it flaked exactly once on main: dialog fully
+      // rendered, handler never ran. Locally the listener is always attached by
+      // the time findByText resolves, so the window only opens under CI
+      // contention and cannot be reproduced here. Rather than bet on one
+      // mechanism, retry the dispatch until it lands. handleDismiss guards on
+      // `busy` and the settings write is idempotent, so repeats are harmless.
       await waitFor(() => {
+        fireEvent.keyDown(document, { key: "Escape" });
         expect(apiPut).toHaveBeenCalledWith("/v1/settings", {
           "onboarding.usageSurvey.dismissedAt": expect.any(String),
         });


### PR DESCRIPTION
`Unit Tests` went red on main right after #639 merged. One test, mine:

```
FAIL tests/unit/web/usage-survey-overlay.test.tsx
  > does not block the app > closes on Escape and records the dismissal
AssertionError: expected "spy" to be called with arguments: [ '/v1/settings', { …(1) } ]
Number of calls: 0
```

1 failed, 7473 passed. It passed on the PR run and passes locally.

## What it is

Not a product bug. The failure dump shows the dialog fully rendered while `apiPut` had zero calls, so the handler never ran. Escape is the only control in that file whose handler is a document listener registered by a passive effect. Every other control is an `onClick` prop attached at commit, which is why the sibling close-button test, with the same assertion, passed in the same run. `findByText` resolves at commit, so a keydown dispatched right after it can land before the listener exists.

I could not reproduce it: 50 runs isolated and whole-file, all green. A probe counting `document.addEventListener("keydown", ...)` shows the listener is already attached when `findByText` resolves on this machine, so the window only opens under CI contention.

## The fix

Since the mechanism cannot be confirmed directly, this does not bet on it. It settles effects, then retries the dispatch until the dismissal lands, which is robust to any timing cause. `handleDismiss` guards on `busy` and the settings write is idempotent, so repeated keydowns are harmless.

## Verification

- 30 consecutive whole-file runs, no failures.
- Still catches real breakage: flipping the handler to a key that never fires fails the test in about a second, so it has not been softened into always passing.
- Full unit suite green: 7,474 passed across 385 files.