### PR TITLE
ci: take Build off the integration shard critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,16 +414,12 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs:
-      [
-        changes,
-        lint,
-        typecheck,
-        test-unit,
-        test-integration,
-        test-e2e-smoke,
-        test-e2e-mobile-smoke,
-      ]
+    # Only `changes` is a real dependency (its output gates the `if` below).
+    # Gating on the test jobs used to save a runner minute on red PRs, but it
+    # put a 55s job behind the slowest integration shard and added that time to
+    # every green run. Build and the test jobs are independent required checks,
+    # so a green Build still can't merge past a red shard.
+    needs: [changes]
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Build was queued behind all four integration shards but only reads `needs.changes.outputs.code`. Everything else in its `needs` was ordering, not a data dependency. Dropping them takes ~55s off every green run.

Upfront: that's 3.5% of a 26 minute pipeline. It's the slice that was safe to land without touching branch protection or test semantics.

## Why it's safe

Build and the test jobs are independent required status checks, so a green Build cannot merge past a red shard. Nothing gets renamed. All 16 required contexts still report and `Integration (1/4)` through `(4/4)` are untouched, so branch protection needs no edit.

Verified the graph parses and still emits every context:

```
Build    needs=['changes']
missing required contexts: none
shard contexts: Integration (1/4), (2/4), (3/4), (4/4)
```

The only thing given up is a runner minute on already-red PRs.

## What's actually eating the 26 minutes

Not this. Two things, neither touched here.

Vitest `--shard` partitions by SHA1 of the file path into equal *file counts*, blind to duration (`node_modules/vitest/dist/chunks/coverage.DfSpMS-b.js:3457`). Re-running that hash over the 294 integration files puts all four heavyweight generated matrix files (`format-matrix`, `format-matrix-comprehensive`, `format-matrix-exotic`, `new-formats`) in shard 4. They're 94% of its test time, which is why it runs 25 minutes against shard 1's 4.

Then 31 tests sit pinned at 29-33s against the 30s `SYNC_WAIT_MS` floor in `tests/setup/per-fork-env.ts:32`, hit `if (isAsyncFallback(res)) return;` and early-exit having asserted only `async === true` and that a jobId exists. That's 29% of shard 4's test time buying two assertions. Worth flagging separately: it means coverage silently varies run to run, since a job landing at 29s validates the full response shape and the same job at 31s validates nothing and still goes green.

Follow-up is a weight-aware `sequence.sequencer` in `vitest.config.ts`. That keeps the four shard job names, so it also needs no branch-protection edit.
