### PR TITLE
test: shard vitest by measured cost instead of path hash

### DIFF
--- a/tests/helpers/shard-partition.ts
+++ b/tests/helpers/shard-partition.ts
@@ -1,0 +1,100 @@
+/**
+ * Weight-aware partitioning for `vitest --shard`.
+ *
+ * Vitest's BaseSequencer shards by SHA1 of the file path, sorted, then sliced
+ * into equal FILE COUNTS (see `BaseSequencer.shard`). That is blind to how long
+ * a file takes, so the split is effectively a coin toss. Measured on CI run
+ * 30206780088 it put the four costliest generated matrix specs in one shard:
+ *
+ *   shard 1  3m47s   shard 2  5m13s   shard 3  16m04s   shard 4  24m47s
+ *
+ * The pipeline is gated by the slowest shard, so that cost the whole run ~20
+ * minutes of idle. Partitioning by measured cost instead lands every shard near
+ * the mean.
+ *
+ * A spec is never split across shards, so no shard can finish faster than the
+ * single costliest file (format-matrix-comprehensive, ~1365s of test time).
+ * That is the floor for any shard count.
+ */
+
+/**
+ * Total test time per spec in seconds, measured from CI run 30206780088
+ * (2026-07-26). Only the expensive tail is listed; everything else is close
+ * enough to the default that ranking it adds no value.
+ *
+ * These are load hints, not assertions. A stale number costs balance, never
+ * correctness: the partition stays total and disjoint whatever the weights say.
+ * Refresh by parsing per-test durations out of the Integration job logs.
+ */
+export const FILE_COST_SECONDS: Record<string, number> = {
+  "tests/integration/generated/format-matrix-comprehensive.test.ts": 1365,
+  "tests/integration/generated/format-matrix.test.ts": 1130,
+  "tests/integration/generated/format-matrix-generated.test.ts": 779,
+  "tests/integration/generated/format-matrix-exotic.test.ts": 370,
+  "tests/integration/generated/format-matrix-expanded.test.ts": 319,
+  "tests/integration/tools/image/image-enhancement.test.ts": 226,
+  "tests/integration/generated/new-formats.test.ts": 202,
+  "tests/integration/generated/format-matrix-multimodal.test.ts": 126,
+  "tests/integration/generated/settings-pairwise.test.ts": 109,
+  "tests/integration/generated/settings-matrix.test.ts": 99,
+  "tests/integration/security/hostile-inputs.test.ts": 72,
+  "tests/integration/tools/image/collage.test.ts": 52,
+  "tests/integration/security/adversarial-coverage-gaps.test.ts": 52,
+  "tests/integration/security/adversarial-extended.test.ts": 24,
+  "tests/integration/security/adversarial-matrix.test.ts": 19,
+  "tests/integration/tools/image/beautify.test.ts": 18,
+  "tests/integration/security/adversarial-final-gaps.test.ts": 18,
+  "tests/integration/platform/batch.test.ts": 17,
+  "tests/integration/tools/image/edit-metadata.test.ts": 17,
+  "tests/integration/tools/image/qr-generate.test.ts": 16,
+};
+
+/** Median-ish cost of an unlisted spec. Most sit well under a second. */
+const DEFAULT_COST_SECONDS = 2;
+
+/**
+ * Reduce an absolute moduleId, a leading-slash path, or an already-relative
+ * path down to the repo-relative form used as the cost-table key.
+ */
+function normalize(file: string): string {
+  const posix = file.replace(/\\/g, "/");
+  const idx = posix.indexOf("tests/");
+  return idx === -1 ? posix.replace(/^\/+/, "") : posix.slice(idx);
+}
+
+export function costOf(file: string): number {
+  return FILE_COST_SECONDS[normalize(file)] ?? DEFAULT_COST_SECONDS;
+}
+
+/**
+ * Longest-processing-time-first greedy bin packing: heaviest spec first, each
+ * one onto whichever bin is currently lightest.
+ *
+ * Every shard runs this in its own vitest process and then keeps only its own
+ * bin, so the result has to be identical everywhere. It is: the input is sorted
+ * before packing, and ties break on path, so filesystem enumeration order
+ * cannot change the answer.
+ */
+export function partitionByCost(files: string[], count: number): string[][] {
+  if (count <= 0) return [];
+
+  const bins: string[][] = Array.from({ length: count }, () => []);
+  const loads: number[] = new Array(count).fill(0);
+
+  const heaviestFirst = [...files].sort((a, b) => {
+    const byCost = costOf(b) - costOf(a);
+    if (byCost !== 0) return byCost;
+    return a < b ? -1 : a > b ? 1 : 0;
+  });
+
+  for (const file of heaviestFirst) {
+    let lightest = 0;
+    for (let i = 1; i < count; i++) {
+      if (loads[i] < loads[lightest]) lightest = i;
+    }
+    bins[lightest].push(file);
+    loads[lightest] += costOf(file);
+  }
+
+  return bins;
+}

--- a/tests/unit/infra/shard-partition.test.ts
+++ b/tests/unit/infra/shard-partition.test.ts
@@ -1,0 +1,121 @@
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { costOf, FILE_COST_SECONDS, partitionByCost } from "../../helpers/shard-partition.js";
+
+const repoRoot = path.resolve(__dirname, "../../..");
+
+/** Every integration spec on disk, repo-relative, sorted. Mirrors the CI glob. */
+function integrationSpecs(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".test.ts")) out.push(path.relative(repoRoot, full));
+    }
+  };
+  walk(path.join(repoRoot, "tests/integration"));
+  return out.sort();
+}
+
+const HEAVYWEIGHTS = [
+  "tests/integration/generated/format-matrix-comprehensive.test.ts",
+  "tests/integration/generated/format-matrix.test.ts",
+  "tests/integration/generated/format-matrix-generated.test.ts",
+  "tests/integration/generated/format-matrix-exotic.test.ts",
+];
+
+describe("partitionByCost", () => {
+  // The whole point of the helper: a shard must never silently drop a spec.
+  // These two invariants are what make the CI change coverage-neutral.
+  describe("partition is total and disjoint", () => {
+    it("places every input file in exactly one bin", () => {
+      const files = integrationSpecs();
+      const bins = partitionByCost(files, 4);
+      const flat = bins.flat();
+
+      expect(flat.slice().sort()).toEqual(files.slice().sort());
+      expect(new Set(flat).size).toBe(files.length);
+    });
+
+    it("holds for shard counts 1 through 8", () => {
+      const files = integrationSpecs();
+      for (let count = 1; count <= 8; count++) {
+        const flat = partitionByCost(files, count).flat();
+        expect(new Set(flat).size, `count=${count} lost or duplicated a file`).toBe(files.length);
+        expect(flat.slice().sort(), `count=${count} changed the file set`).toEqual(
+          files.slice().sort(),
+        );
+      }
+    });
+
+    it("returns exactly `count` bins even when files are scarce", () => {
+      expect(partitionByCost(["a.test.ts", "b.test.ts"], 4)).toHaveLength(4);
+      expect(partitionByCost([], 4)).toHaveLength(4);
+      expect(partitionByCost([], 4).flat()).toEqual([]);
+    });
+  });
+
+  // Each shard is a separate vitest process computing the partition
+  // independently, so all of them must agree or specs get run twice or never.
+  describe("determinism across processes", () => {
+    it("is stable across repeated calls", () => {
+      const files = integrationSpecs();
+      expect(partitionByCost(files, 4)).toEqual(partitionByCost(files, 4));
+    });
+
+    it("ignores input ordering", () => {
+      const files = integrationSpecs();
+      const shuffled = files.slice().reverse();
+      expect(partitionByCost(shuffled, 4)).toEqual(partitionByCost(files, 4));
+    });
+  });
+
+  describe("balance", () => {
+    it("splits the four heavyweight matrix specs across different bins", () => {
+      const bins = partitionByCost(integrationSpecs(), 4);
+      const landedIn = HEAVYWEIGHTS.map((h) => bins.findIndex((b) => b.includes(h)));
+
+      expect(landedIn).not.toContain(-1);
+      expect(new Set(landedIn).size).toBe(HEAVYWEIGHTS.length);
+    });
+
+    it("keeps the costliest bin within 25% of the ideal share", () => {
+      const files = integrationSpecs();
+      const bins = partitionByCost(files, 4);
+      const cost = (b: string[]) => b.reduce((sum, f) => sum + costOf(f), 0);
+      const ideal = cost(files) / 4;
+      const heaviest = Math.max(...bins.map(cost));
+
+      // A spec is never split, so the floor is the single costliest file.
+      const floor = Math.max(ideal, ...files.map(costOf));
+      expect(heaviest).toBeLessThanOrEqual(floor * 1.25);
+    });
+  });
+
+  describe("costOf", () => {
+    it("returns the measured cost for a known-heavy spec", () => {
+      const known = "tests/integration/generated/format-matrix-comprehensive.test.ts";
+      expect(costOf(known)).toBe(FILE_COST_SECONDS[known]);
+    });
+
+    it("falls back to a default for unmeasured specs", () => {
+      expect(costOf("tests/integration/does/not/exist.test.ts")).toBeGreaterThan(0);
+    });
+
+    it("matches regardless of leading slash or absolute prefix", () => {
+      const known = "tests/integration/generated/format-matrix.test.ts";
+      expect(costOf(`/${known}`)).toBe(costOf(known));
+      expect(costOf(path.join(repoRoot, known))).toBe(costOf(known));
+    });
+  });
+
+  describe("cost table hygiene", () => {
+    it("only lists specs that still exist", () => {
+      const onDisk = new Set(integrationSpecs());
+      const stale = Object.keys(FILE_COST_SECONDS).filter((f) => !onDisk.has(f));
+      expect(stale, `cost table references deleted specs: ${stale.join(", ")}`).toEqual([]);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,8 @@ import { readdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { defineConfig } from "vitest/config";
+import { BaseSequencer } from "vitest/node";
+import { partitionByCost } from "./tests/helpers/shard-partition.js";
 
 // Resolve api-workspace packages that pnpm only exposes under apps/api/node_modules.
 const apiNodeModules = path.resolve(__dirname, "apps/api/node_modules");
@@ -24,6 +26,29 @@ function findPnpmPackage(scope: string, name: string): string {
     throw new Error(`${scope}/${name} not found in pnpm store`);
   }
   return path.join(pnpmDir, entries[entries.length - 1], "node_modules", scope, name);
+}
+
+/**
+ * Shards by measured cost instead of by SHA1 of the file path.
+ *
+ * The stock BaseSequencer slices an equal number of FILES per shard, which took
+ * no account of the fact that four generated matrix specs carry most of the
+ * suite's runtime. See tests/helpers/shard-partition.ts for the measurements.
+ *
+ * `sort` is inherited untouched, and vitest only calls `shard` when --shard is
+ * passed, so unsharded runs (local, nightly full matrix) behave exactly as before.
+ */
+class CostAwareSequencer extends BaseSequencer {
+  async shard(specs: Parameters<BaseSequencer["shard"]>[0]) {
+    const shardConfig = this.ctx.config.shard;
+    if (!shardConfig) return specs;
+
+    const { index, count } = shardConfig;
+    const byModuleId = new Map(specs.map((spec) => [spec.moduleId, spec]));
+    const bin = partitionByCost([...byModuleId.keys()], count)[index - 1] ?? [];
+
+    return bin.map((moduleId) => byModuleId.get(moduleId)).filter((spec) => spec !== undefined);
+  }
 }
 
 export default defineConfig({
@@ -49,6 +74,9 @@ export default defineConfig({
           Number(process.env.VITEST_MAX_FORKS) ||
           (process.env.CI ? 4 : Math.max(2, Math.floor(os.availableParallelism() / 2))),
       },
+    },
+    sequence: {
+      sequencer: CostAwareSequencer,
     },
     globalSetup: ["tests/global-setup.ts"],
     setupFiles: ["tests/setup/per-fork-env.ts"],


### PR DESCRIPTION
Integration shards ran 3m47s, 5m13s, 16m04s and 24m47s on the last main run. Same file count each, wildly different runtimes, and the pipeline waits on the slowest. This balances them to within 2 seconds of each other.

## Cause

`BaseSequencer.shard` sorts specs by SHA1 of their path and slices an equal number of *files* per shard (`node_modules/vitest/dist/chunks/coverage.DfSpMS-b.js:3457`). Nothing in that considers runtime, so which shard gets the expensive specs is a coin toss that reshuffles whenever a file is added or renamed.

Re-running that hash over the 297 integration specs put all four heavyweight generated matrix files in shard 4. They were 94% of its test time.

## Change

`CostAwareSequencer` in `vitest.config.ts` overrides `shard` with greedy longest-processing-time-first bin packing over measured per-spec cost. `sort` is inherited untouched, and vitest only calls `shard` when `--shard` is passed, so unsharded runs (local, nightly full matrix) are unaffected.

Weights came from parsing per-test durations out of the four Integration job logs on run 30206780088. Only the expensive tail is listed; everything else defaults. They're load hints, not assertions: a stale number costs balance, never correctness.

Worth noting `format-matrix-generated.test.ts` is 779s despite being 169 lines. Ranking by file size would have missed it, which is why these are measured rather than estimated.

## Projection

| shard | files | cost |
|---|---|---|
| 1 | 17 | 1397s |
| 2 | 93 | 1396s |
| 3 | 94 | 1395s |
| 4 | 93 | 1396s |

Ideal is 1396s. The floor is 1365s, because `format-matrix-comprehensive` is a single spec and a spec can't split across shards. That's why shard 1 holds 17 files and still pulls its weight.

### Correction: measured, not 12 min

That 12 min was wrong, and the run on this PR shows why. Wall time per shard:

| shard | before | after |
|---|---|---|
| 1 | 3m47s | 20m59s |
| 2 | 5m13s | 17m55s |
| 3 | 16m04s | 16m33s |
| 4 | 24m47s | 9m19s |

CI total goes 25 min to 21.3 min. Real, but a quarter of what the cost table suggested.

The cost model predicts balance, not wall time. Tests inside one spec file run sequentially in a single fork, so a shard can never finish faster than its largest file no matter how many forks it has. Shard 1's log makes it plain: `Duration 1175.70s ... tests 1217.79s`, a ratio of 1.04, three forks idle while `format-matrix-comprehensive` ground through alone.

Every shard's wall now tracks its largest single spec (1130s gives 17m55s, 779s gives 16m33s), not its total cost. So the ceiling is set by `format-matrix-comprehensive` and `format-matrix` each being one indivisible file.

Splitting those is the follow-up. It needs this PR first: under SHA1 the pieces would just re-scatter at random.

## Coverage is unchanged, and here's the proof

The property that matters is that the partition stays total and disjoint. `tests/unit/infra/shard-partition.test.ts` asserts exactly that against the real on-disk spec list, for shard counts 1 through 8, plus determinism and order-independence (each shard is a separate vitest process computing the partition independently, so they have to agree or specs run twice or never).

Verified beyond the unit test:

- **Sequencer is actually invoked.** Ran `tests/unit/infra` sharded 4 ways for real. Observed assignment matches the cost-aware prediction exactly and differs completely from what SHA1 would produce, so it isn't silently falling back.
- **Real sharded integration run.** `tests/integration/platform` split 2 ways gave 42 + 50 = 92 files, matching disk. 786 and 817 tests passed.
- **Full unit suite.** 391 files, 7606 passed, 1 skipped.
- Typecheck and lint clean.

The end-to-end check is the Integration jobs on this PR. Per-shard test counts must still sum to the baseline from run 30206780088: **297 files, 9903 tests, 9435 passed, 468 skipped.** If the totals move, the partition dropped something and this should not merge.

One gap worth naming: a new expensive spec won't be in the cost table and gets the default weight, so it lands wherever the packing puts it. That's no worse than today's coin toss, and the hygiene test catches table entries that point at deleted specs.
