### PR TITLE
test: correct the SYNC_WAIT_MS comment and guard six 202 branches

### DIFF
--- a/tests/integration/generated/format-matrix-3.test.ts
+++ b/tests/integration/generated/format-matrix-3.test.ts
@@ -60,6 +60,7 @@ describe("Multipage TIFF handling", () => {
       // Multipage TIFF should either succeed or return a clean error
       expect([200, 202, 400, 422]).toContain(res.statusCode);
 
+      if (await settleAsyncFallback(res)) return;
       if (res.statusCode === 200) {
         const body = JSON.parse(res.body);
 

--- a/tests/integration/generated/format-matrix-4.test.ts
+++ b/tests/integration/generated/format-matrix-4.test.ts
@@ -507,6 +507,7 @@ describe("Image-to-PDF cross-format matrix", () => {
 
       expect([200, 202, 400, 422]).toContain(res.statusCode);
 
+      if (await settleAsyncFallback(res)) return;
       if (res.statusCode === 200) {
         const body = JSON.parse(res.body);
         expect(body.downloadUrl).toBeDefined();

--- a/tests/integration/generated/format-matrix-comprehensive-1.test.ts
+++ b/tests/integration/generated/format-matrix-comprehensive-1.test.ts
@@ -10,6 +10,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { fixtureDir } from "../../fixtures/index.js";
+import { settleAsyncFallback } from "../settle-job.js";
 import { createMultipartPayload } from "../test-server.js";
 import {
   ACCEPTABLE_FALLBACK_CODES,
@@ -147,6 +148,7 @@ describe("Image enhancement across all 16 primary formats", () => {
             expect(res.statusCode).toBe(200);
           }
 
+          if (await settleAsyncFallback(res)) return;
           if (res.statusCode === 200) {
             const body = JSON.parse(res.body);
             expect(body.corrections).toBeDefined();

--- a/tests/integration/generated/format-matrix-comprehensive-3.test.ts
+++ b/tests/integration/generated/format-matrix-comprehensive-3.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
+import { settleAsyncFallback } from "../settle-job.js";
 import { createMultipartPayload } from "../test-server.js";
 import {
   ACCEPTABLE_FALLBACK_CODES,
@@ -327,6 +328,7 @@ describe("SVG through raster tools", () => {
       expect([200, 202, 400, 422]).toContain(res.statusCode);
 
       const body = JSON.parse(res.body);
+      if (await settleAsyncFallback(res)) return;
       if (res.statusCode === 200) {
         if (tool.id === "info") {
           expect(body.width).toBeGreaterThan(0);

--- a/tests/integration/generated/format-matrix-expanded.test.ts
+++ b/tests/integration/generated/format-matrix-expanded.test.ts
@@ -35,6 +35,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { fixtureDir, fixtures } from "../../fixtures/index.js";
+import { settleAsyncFallback } from "../settle-job.js";
 import {
   buildTestApp,
   createMultipartPayload,
@@ -414,6 +415,7 @@ describe("Edit-metadata cross-format", () => {
             expect([200, 202, 400, 422]).toContain(res.statusCode);
           }
 
+          if (await settleAsyncFallback(res)) return;
           if (res.statusCode === 200) {
             const body = JSON.parse(res.body);
             expect(body.downloadUrl).toBeDefined();
@@ -465,6 +467,7 @@ describe("Edit-metadata cross-format", () => {
           expect([200, 202, 400, 422]).toContain(res.statusCode);
 
           const body = JSON.parse(res.body);
+          if (await settleAsyncFallback(res)) return;
           if (res.statusCode === 200) {
             // inspect returns metadata fields; at minimum it is an object
             expect(typeof body).toBe("object");

--- a/tests/setup/per-fork-env.ts
+++ b/tests/setup/per-fork-env.ts
@@ -27,11 +27,17 @@ process.env.BULLMQ_PREFIX = `snapotter_test_${suffix}`;
 // test forks; 30s keeps tool routes synchronous (200) in tests while production
 // stays at 8s.
 //
-// An explicit SYNC_WAIT_MS is now honored verbatim rather than floored. The
+// An explicit SYNC_WAIT_MS is honored verbatim rather than floored, so the
 // constrained docker test image (macOS Docker VM, where Sharp and FFmpeg run
-// ~2-3x slower) still widens the window, and forcing it *down* (SYNC_WAIT_MS=0)
-// drives every tool through its 202 path, which is the only way to exercise
-// that branch on a machine fast enough to never hit it naturally.
+// ~2-3x slower) can widen the window.
+//
+// Careful with 0: per the repo-wide convention it means unlimited, not
+// instant. BullMQ's waitUntilFinished only arms its timer under `if (ttl)`, so
+// 0 waits forever and every route answers 200. To force the 202 path (the only
+// way to exercise it on a machine fast enough never to hit it naturally), pass
+// a small positive value such as SYNC_WAIT_MS=1. Note that most specs assert a
+// bare 200 and will fail under it; only the ones that call
+// settleAsyncFallback are written to survive.
 const requestedSyncWait = process.env.SYNC_WAIT_MS?.trim();
 const hasExplicitSyncWait =
   Boolean(requestedSyncWait) && Number.isFinite(Number(requestedSyncWait));


### PR DESCRIPTION
Fixes a wrong comment I added in #652, and the six latent flakes that correcting it uncovered.

## The comment was backwards

#652 left this in `tests/setup/per-fork-env.ts`:

> forcing it *down* (SYNC_WAIT_MS=0) drives every tool through its 202 path

It does the opposite. BullMQ's `waitUntilFinished` arms its timeout under `if (ttl)`, so 0 is falsy, no timer is set, it waits forever and every route answers 200. That is also the documented repo-wide convention: `0` means unlimited. A small positive value such as `SYNC_WAIT_MS=1` is what actually forces the async path.

Left alone, that comment would send the next person straight into building something on a flag that does the reverse of what it claims.

It also means the local validation quoted on #652 was worthless. Those runs pushed every request through the *synchronous* path and never once reached `settleAsyncFallback`. The merged helper is fine, but the evidence given for it did not show that. What actually demonstrates it is the CI run: the 29-34s band dropped from 44 tests to 6, which only happens if the helper is doing its job.

## Six specs that mishandle a 202 they claim to accept

Redoing the validation properly with `SYNC_WAIT_MS=1` surfaced a real pattern:

```ts
expect([200, 202, 400, 422]).toContain(res.statusCode);

if (res.statusCode === 200) {
  ...
} else {
  const body = JSON.parse(res.body);
  expect(body.error).toBeDefined();   // a 202 body is {jobId, async}
}
```

The gate admits 202, then the `else` demands an error body that a 202 never has. These pass today only because the window is wide enough that the job usually finishes first. On a slow enough runner they fail. Six sites, in `format-matrix-3`, `format-matrix-4`, `format-matrix-expanded` (x2), `format-matrix-comprehensive-1` and `format-matrix-comprehensive-3`.

Each now settles the job before branching, the same pattern #652 established.

## Verification

| | before | after |
|---|---|---|
| `expected undefined to be defined` under `SYNC_WAIT_MS=1` | 55 | **0** |
| normal 30s window, the 5 changed specs | 1183 passed | **1183 passed** |

The 1183 matches the collected test count exactly, so nothing was dropped. Remaining forced-async failures are all `expected 202 to be 200`, which are bare sync-contract assertions failing by design under an artificial 1ms window.

## Deliberately not fixed

Specs asserting a bare `toBe(200)` without listing 202. They own the synchronous contract on purpose and widening them would weaken what they verify. Two other candidates my first pass flagged turned out to be correct already and were left alone: `format-matrix-expanded:287` uses `else if (res.statusCode >= 400)`, and `format-matrix-ai:494` has an explicit `else if (res.statusCode === 202)` branch above it.

Also worth recording: a nightly forced-async job is not viable. 186 specs assert a bare 200 with no 202 branch, so `resize.test.ts` alone fails 13 of 17. It would be permanently red.
