### PR TITLE
ci(ocr): verify the baked trust file, not unset image env vars

### DIFF
--- a/.github/workflows/ai-bundles.yml
+++ b/.github/workflows/ai-bundles.yml
@@ -358,18 +358,25 @@ jobs:
         run: |
           : "${OCR_RUNTIME_INDEX_KEY_ID:?Set repository variable OCR_RUNTIME_INDEX_KEY_ID}"
           : "${OCR_RUNTIME_INDEX_PUBLIC_KEY_PEM_B64:?Set repository variable OCR_RUNTIME_INDEX_PUBLIC_KEY_PEM_B64}"
-          actual_key_id="$(docker run --rm --entrypoint sh "${SNAPOTTER_BUNDLE_IMAGE}" \
-            -c 'printf %s "$OCR_RUNTIME_INDEX_KEY_ID"')"
-          actual_public_key="$(docker run --rm --entrypoint sh "${SNAPOTTER_BUNDLE_IMAGE}" \
-            -c 'printf %s "$OCR_RUNTIME_INDEX_PUBLIC_KEY_PEM_B64"')"
+          # The official image bakes the trust store as a FILE
+          # (/app/docker/ocr-runtime-trust.json, written by write-ocr-runtime-trust.mjs)
+          # and deliberately leaves OCR_RUNTIME_INDEX_* unset in the image env: those
+          # are the operator-override path, and loadOcrRuntimeTrustKeys
+          # (packages/ai/src/runtime-index.ts:52-71) reads env only when set, else the
+          # baked file. So verify the file the runtime actually trusts, not the env.
+          trust_json="$(docker run --rm --entrypoint sh "${SNAPOTTER_BUNDLE_IMAGE}" \
+            -c 'cat /app/docker/ocr-runtime-trust.json')"
+          actual_key_id="$(printf '%s' "${trust_json}" | jq -r '.keys[0].keyId')"
+          actual_public_key="$(printf '%s' "${trust_json}" | jq -r '.keys[0].publicKey')"
+          expected_public_key="$(printf '%s' "${OCR_RUNTIME_INDEX_PUBLIC_KEY_PEM_B64}" | base64 --decode)"
           actual_official_container="$(docker run --rm --entrypoint sh "${SNAPOTTER_BUNDLE_IMAGE}" \
             -c 'printf %s "$SNAPOTTER_OFFICIAL_CONTAINER"')"
           [[ "${actual_key_id}" == "${OCR_RUNTIME_INDEX_KEY_ID}" ]] || {
-            echo "::error::Verification image OCR key ID does not match the release identity"
+            echo "::error::Baked OCR trust key ID (${actual_key_id}) does not match the release identity"
             exit 1
           }
-          [[ "${actual_public_key}" == "${OCR_RUNTIME_INDEX_PUBLIC_KEY_PEM_B64}" ]] || {
-            echo "::error::Verification image OCR public key does not match the release identity"
+          [[ "${actual_public_key}" == "${expected_public_key}" ]] || {
+            echo "::error::Baked OCR trust public key does not match the release identity"
             exit 1
           }
           [[ "${actual_official_container}" == "1" ]] || {

--- a/tests/unit/infra/ocr-release-workflow.test.ts
+++ b/tests/unit/infra/ocr-release-workflow.test.ts
@@ -203,8 +203,14 @@ describe("OCR v3 bundle release workflow", () => {
     expect(verifyJob).toContain("timeout-minutes: 90");
     expect(verifyJob).toContain("docker/verify-ocr-runtime.sh");
     expect(verifyJob).toContain("Verify image has the release trust identity");
-    expect(verifyJob).toContain("Verification image OCR key ID does not match");
-    expect(verifyJob).toContain("Verification image OCR public key does not match");
+    // The identity is verified against the baked trust FILE, which the runtime
+    // reads, not the OCR_RUNTIME_INDEX_* env vars, which the official image leaves
+    // unset by design. Reading the env compared "" and failed a correct image.
+    expect(verifyJob).toContain("cat /app/docker/ocr-runtime-trust.json");
+    expect(verifyJob).toContain(".keys[0].keyId");
+    expect(verifyJob).toContain("Baked OCR trust key ID");
+    expect(verifyJob).toContain("Baked OCR trust public key does not match");
+    expect(verifyJob).not.toContain('printf %s "$OCR_RUNTIME_INDEX_KEY_ID"');
     expect(verifyJob).toContain(
       'actual_official_container="$(docker run --rm --entrypoint sh "${SNAPOTTER_BUNDLE_IMAGE}"',
     );


### PR DESCRIPTION
Fourth latent bug in the OCR publish chain that #649/#519 added but never ran
end-to-end. Found on the v2.2.0 release run (verify-ocr failed on both arches).

## The bug

`verify-ocr`'s "Verify image has the release trust identity" step read
`OCR_RUNTIME_INDEX_KEY_ID` from inside the release image. The official image
leaves that env unset by design: it's the operator-override path, and
`loadOcrRuntimeTrustKeys` (`packages/ai/src/runtime-index.ts:52-71`) reads env
only when set, else the baked file. So the check compared `""` against
`snapotter-ocr-2026-07` and failed a correct image.

## The fix

The image bakes `/app/docker/ocr-runtime-trust.json` (correct keyId + Ed25519
PEM, from the same var at build time), and the runtime reads that file. Verify
the file: extract keyId + publicKey and compare to the release identity, keeping
the `SNAPOTTER_OFFICIAL_CONTAINER==1` check (that env IS set).

Verified against the freshly built release image `sha256:2ab2500`: keyId,
publicKey, official-marker all PASS.

## Full-chain audit

Because this was the fourth serial failure, I audited the entire remaining chain
(verify, verify-ocr-nvidia, sign, verify-signed, publish) against the real image
and the runtime code, and **reproduced the sign+verify path end-to-end inside the
image** on the actual ASCII index: PASS. Every path/binary/secret/artifact shape
checks out. Nothing else breaks for v2.2.0.

## Known latent (deferred, filed separately)

The Python signer canonicalizes with `ensure_ascii=True` while the JS verifier
`canonicalRuntimeJson` emits raw UTF-8. They diverge on any non-ASCII codepoint,
which would make a published index un-installable while the workflow stays green.
It **cannot fire on v2.2.0** (all model metadata is ASCII), so it's deferred to a
follow-up rather than expanding this release fix. Filed as an issue.

Non-releasable type so the re-dispatch re-runs 2.2.0.
