### PR TITLE
fix(image): validate caire settings as integers

### DIFF
--- a/apps/api/src/routes/tools/content-aware-resize.ts
+++ b/apps/api/src/routes/tools/content-aware-resize.ts
@@ -16,12 +16,14 @@ import { InputValidationError } from "../../modality/contract.js";
 import { inputHandlerFor } from "../../modality/input-handler.js";
 import { registerToolProcessFn } from "../tool-factory.js";
 
+// caire's -width/-height/-blur/-sobel flags are integer-only; a fractional
+// value makes the binary exit with a flag parse error.
 const settingsSchema = z.object({
-  width: z.number().positive().optional(),
-  height: z.number().positive().optional(),
+  width: z.number().int().positive().optional(),
+  height: z.number().int().positive().optional(),
   protectFaces: z.boolean().default(false),
-  blurRadius: z.number().min(0).max(20).default(4),
-  sobelThreshold: z.number().min(1).max(20).default(2),
+  blurRadius: z.number().int().min(0).max(20).default(4),
+  sobelThreshold: z.number().int().min(1).max(20).default(2),
   square: z.boolean().default(false),
 });
 

--- a/apps/api/src/routes/tools/trim-audio.ts
+++ b/apps/api/src/routes/tools/trim-audio.ts
@@ -5,12 +5,19 @@ import { audioContentType, formatFfmpegSeconds, runMediaTool } from "../../lib/m
 import { InputValidationError } from "../../modality/contract.js";
 import { createToolRoute } from "../tool-factory.js";
 
+// Stream copy cannot cut below one codec frame (mp3 ~26ms, flac up to ~93ms);
+// smaller windows produce a container with zero audio frames.
+const MIN_TRIM_WINDOW_S = 0.1;
+
 const settingsSchema = z
   .object({
     startS: z.number().finite().min(0).default(0),
     endS: z.number().finite().min(0.000001),
   })
-  .refine((s) => s.endS > s.startS, { message: "End must be after start" });
+  .refine((s) => s.endS > s.startS, { message: "End must be after start" })
+  .refine((s) => s.endS - s.startS >= MIN_TRIM_WINDOW_S, {
+    message: `Trim window must be at least ${MIN_TRIM_WINDOW_S} seconds`,
+  });
 
 export function registerTrimAudio(app: FastifyInstance) {
   createToolRoute(app, {
@@ -34,6 +41,11 @@ export function registerTrimAudio(app: FastifyInstance) {
           throw new InputValidationError("Start is beyond the end of the audio");
         }
         const endS = Math.min(settings.endS, info.durationS);
+        if (endS - settings.startS < MIN_TRIM_WINDOW_S) {
+          throw new InputValidationError(
+            `Trim window is shorter than ${MIN_TRIM_WINDOW_S} seconds after clamping to the audio duration`,
+          );
+        }
         // Fast seek with stream-copy for audio
         return [
           "-ss",

--- a/tests/integration/tools/audio/trim-audio.test.ts
+++ b/tests/integration/tools/audio/trim-audio.test.ts
@@ -67,4 +67,17 @@ describe.skipIf(!ffmpegAvailable())("trim-audio (requires ffmpeg)", () => {
     const res = await runTool({ startS: 0.5, endS: 0.2 });
     expect(res.statusCode).toBe(400);
   });
+
+  it("rejects a sub-frame trim window instead of returning an empty file", async () => {
+    const res = await runTool({ startS: 0, endS: 0.000001 });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects when clamping endS to the duration leaves a sub-frame window", async () => {
+    // tiny.mp3 is ~1.0-1.045s depending on the ffprobe build; endS clamps to
+    // the duration, leaving well under 0.1s either way.
+    const res = await runTool({ startS: 0.98, endS: 9 });
+    expect(res.statusCode).toBe(422);
+    expect(JSON.parse(res.body).details).toMatch(/Trim window/);
+  });
 });

--- a/tests/integration/tools/image/content-aware-resize.test.ts
+++ b/tests/integration/tools/image/content-aware-resize.test.ts
@@ -57,6 +57,27 @@ describe("Content-Aware Resize", () => {
     expect([200, 422]).toContain(res.statusCode);
   }, 60_000);
 
+  it("rejects fractional values for caire's integer-only flags", async () => {
+    for (const settings of [
+      { width: 100.5 },
+      { height: 80.25 },
+      { blurRadius: 2.5 },
+      { sobelThreshold: 10.5 },
+    ]) {
+      const { body, contentType } = createMultipartPayload([
+        { name: "file", filename: "test.png", contentType: "image/png", content: PNG_200x150 },
+        { name: "settings", content: JSON.stringify(settings) },
+      ]);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/tools/image/content-aware-resize",
+        headers: { authorization: `Bearer ${adminToken}`, "content-type": contentType },
+        body,
+      });
+      expect(res.statusCode, JSON.stringify(settings)).toBe(400);
+    }
+  }, 60_000);
+
   it("rejects requests without a file", async () => {
     const { body, contentType } = createMultipartPayload([
       { name: "settings", content: JSON.stringify({ width: 150 }) },

--- a/tests/unit/api/media-settings-schema.test.ts
+++ b/tests/unit/api/media-settings-schema.test.ts
@@ -41,6 +41,14 @@ describe("media time settings schemas", () => {
     expect(parses("trim-video", { startS: 0, endS: Number.MIN_VALUE })).toBe(false);
   });
 
+  it("rejects trim-audio windows shorter than the stream-copy floor", () => {
+    // Stream copy cannot cut below one codec frame (mp3 ~26ms, flac up to
+    // ~93ms), so windows under 0.1s ship a file with zero audio frames.
+    expect(parses("trim-audio", { startS: 0, endS: 0.000001 })).toBe(false);
+    expect(parses("trim-audio", { startS: 5, endS: 5.05 })).toBe(false);
+    expect(parses("trim-audio", { startS: 0, endS: 0.5 })).toBe(true);
+  });
+
   it("requires at least one representable fade duration", () => {
     expect(parses("fade-audio", { fadeInS: Number.MIN_VALUE, fadeOutS: 0 })).toBe(false);
     expect(parses("fade-audio", { fadeInS: 0, fadeOutS: 0.000001 })).toBe(true);


### PR DESCRIPTION
Fixes #672.

caire's `-width`, `-height`, `-blur`, and `-sobel` flags are integer-only, but the schema declared all four as plain numbers. A value like `sobelThreshold: 10.5` validated, crashed the binary with a flag parse error, and the user got 422 "The file may be in an unsupported or corrupted format" for a perfectly good PNG.

All four fields are now `.int()`, so fractional values get a 400 naming the actual field: `sobelThreshold: Expected integer, received float`. The UI only ever sends integers (range sliders with integer steps), so nothing legitimate breaks.

Verified: new integration test covering all four fields written first and watched fail, now green with the rest of the suite (27 tests). Patched the running v2.2.0 QA container: the original repro returns the settings-shaped 400, and integer settings still process to 200.

The catch-all corrupt-file message burying real tool errors is a broader pattern than this tool; not addressed here.
