### PR TITLE
fix(api): stop claiming no GPU exists before the first AI bundle install

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -27,7 +27,7 @@ Emitted from `apps/api` through `trackEvent()`; properties are filtered by `anal
 
 | Event | Fires when | Key properties |
 | --- | --- | --- |
-| `instance_started` | Once per boot | `arch`, `os_platform`, `deploy_mode`, `gpu_present` |
+| `instance_started` | Once per boot | `arch`, `os_platform`, `deploy_mode`, `gpu_present`, `app_version` |
 | `auth_login` | A login succeeds | `method` (`password` or `oidc`) |
 | `auth_login_failed` | A login attempt fails | `method` (`password` or `oidc`) |
 | `tool_used` | A tool job finishes | `tool_id`, `status`, `duration_ms`, `category`, `is_ai_tool`, `is_batch`, `input_format`, `output_format`, `bytes_in`, `bytes_out`, `execution_hint`, `error_code`, `error_kind` |

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,6 +33,7 @@ import {
   startInterruptedInstallRecovery,
   stopInterruptedInstallRecovery,
 } from "./lib/feature-status.js";
+import { gpuBootLine } from "./lib/gpu-boot-line.js";
 import { logger } from "./lib/logger.js";
 import { requestDuration } from "./lib/metrics.js";
 import { purgeOcrRuntimeDownloads, runOcrRuntimeMaintenance } from "./lib/ocr-runtime-install.js";
@@ -771,11 +772,7 @@ try {
   await app.listen({ port: env.PORT, host: "0.0.0.0" });
 
   const dispatcherResult = await initDispatcher();
-  const gpuLine = dispatcherResult.ready
-    ? dispatcherResult.gpu
-      ? "[INFO] GPU detected -- AI tools will use CUDA acceleration"
-      : "[WARN] No GPU detected -- AI tools will use CPU (slower)"
-    : "[WARN] AI sidecar did not start -- AI tools will use per-request Python (slower)";
+  const gpuLine = gpuBootLine(dispatcherResult, gatherSystemProperties().gpu_present);
   console.log(
     [
       `SnapOtter v${APP_VERSION} running on port ${env.PORT}`,

--- a/apps/api/src/lib/analytics-allowlist.ts
+++ b/apps/api/src/lib/analytics-allowlist.ts
@@ -26,7 +26,7 @@ const ALLOWED: Record<string, ReadonlySet<string>> = {
     "status",
   ]),
   ai_bundle_action: new Set(["bundle_id", "action", "duration_ms"]),
-  instance_started: new Set(["arch", "os_platform", "deploy_mode", "gpu_present"]),
+  instance_started: new Set(["arch", "os_platform", "deploy_mode", "gpu_present", "app_version"]),
   auth_login: new Set(["method"]),
   auth_login_failed: new Set(["method"]),
 };

--- a/apps/api/src/lib/gpu-boot-line.ts
+++ b/apps/api/src/lib/gpu-boot-line.ts
@@ -1,0 +1,26 @@
+interface DispatcherStartState {
+  ready: boolean;
+  gpu: boolean;
+}
+
+/**
+ * One boot-banner line describing the AI acceleration state.
+ *
+ * The hardware-present-but-unusable branch exists because a fresh GPU
+ * deployment has working passthrough but no torch/ONNX runtime until the
+ * first AI bundle installs, so the dispatcher reports gpu=false. Logging
+ * "No GPU detected" there sends GPU users off to debug their container
+ * toolkit (#673).
+ */
+export function gpuBootLine(dispatcher: DispatcherStartState, gpuHardwarePresent: boolean): string {
+  if (!dispatcher.ready) {
+    return "[WARN] AI sidecar did not start -- AI tools will use per-request Python (slower)";
+  }
+  if (dispatcher.gpu) {
+    return "[INFO] GPU detected -- AI tools will use CUDA acceleration";
+  }
+  if (gpuHardwarePresent) {
+    return "[INFO] GPU hardware detected -- AI frameworks install with the first AI bundle; AI tools use CPU until then";
+  }
+  return "[WARN] No GPU detected -- AI tools will use CPU (slower)";
+}

--- a/apps/api/src/lib/system-info.ts
+++ b/apps/api/src/lib/system-info.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import os from "node:os";
-import type { InstanceStartedProperties } from "@snapotter/shared";
+import { APP_VERSION, type InstanceStartedProperties } from "@snapotter/shared";
 import { deployMode } from "./deploy-mode.js";
 
 // Facts about the running instance, shipped once at boot as the
@@ -19,5 +19,6 @@ export function gatherSystemProperties(): InstanceStartedProperties {
     os_platform: os.platform(),
     deploy_mode: deployMode(),
     gpu_present: existsSync("/dev/nvidia0"),
+    app_version: APP_VERSION,
   };
 }

--- a/packages/shared/src/analytics/events.ts
+++ b/packages/shared/src/analytics/events.ts
@@ -79,6 +79,8 @@ export interface InstanceStartedProperties {
   os_platform: string;
   deploy_mode: "embedded" | "external" | "native";
   gpu_present: boolean;
+  /** APP_VERSION at boot; the only event property that segments the install base by release. */
+  app_version: string;
 }
 
 export interface EditorToolUsedProperties {

--- a/tests/unit/api/analytics-allowlist.test.ts
+++ b/tests/unit/api/analytics-allowlist.test.ts
@@ -59,6 +59,7 @@ describe("sanitizeEventProperties", () => {
       os_platform: "linux",
       deploy_mode: "embedded",
       gpu_present: false,
+      app_version: "2.2.0",
       hostname: "leaked-hostname",
     });
     expect(out).toEqual({
@@ -66,6 +67,7 @@ describe("sanitizeEventProperties", () => {
       os_platform: "linux",
       deploy_mode: "embedded",
       gpu_present: false,
+      app_version: "2.2.0",
     });
     expect(out).not.toHaveProperty("hostname");
   });

--- a/tests/unit/api/gpu-boot-line.test.ts
+++ b/tests/unit/api/gpu-boot-line.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { gpuBootLine } from "../../../apps/api/src/lib/gpu-boot-line.js";
+
+describe("gpuBootLine", () => {
+  it("announces CUDA when the dispatcher can use the GPU", () => {
+    expect(gpuBootLine({ ready: true, gpu: true }, true)).toBe(
+      "[INFO] GPU detected -- AI tools will use CUDA acceleration",
+    );
+  });
+
+  it("explains the pending-bundle state instead of claiming no GPU exists", () => {
+    // Fresh GPU deployment: passthrough works, but no torch/ONNX runtime is
+    // installed until the first AI bundle, so the dispatcher reports gpu=false.
+    const line = gpuBootLine({ ready: true, gpu: false }, true);
+    expect(line).toContain("GPU hardware detected");
+    expect(line).toContain("AI bundle");
+    expect(line).not.toContain("No GPU detected");
+  });
+
+  it("keeps the plain no-GPU warning for hosts without a GPU", () => {
+    expect(gpuBootLine({ ready: true, gpu: false }, false)).toBe(
+      "[WARN] No GPU detected -- AI tools will use CPU (slower)",
+    );
+  });
+
+  it("keeps the sidecar warning when the dispatcher did not start", () => {
+    expect(gpuBootLine({ ready: false, gpu: false }, true)).toBe(
+      "[WARN] AI sidecar did not start -- AI tools will use per-request Python (slower)",
+    );
+  });
+});

--- a/tests/unit/api/system-info.test.ts
+++ b/tests/unit/api/system-info.test.ts
@@ -10,6 +10,7 @@ vi.mock("../../../apps/api/src/lib/deploy-mode.js", () => ({
   deployMode: mockDeployMode,
 }));
 
+import { APP_VERSION } from "@snapotter/shared";
 import { gatherSystemProperties } from "../../../apps/api/src/lib/system-info.js";
 
 describe("gatherSystemProperties", () => {
@@ -45,6 +46,12 @@ describe("gatherSystemProperties", () => {
     mockExistsSync.mockReturnValue(false);
     mockDeployMode.mockReturnValue("external");
     expect(gatherSystemProperties().gpu_present).toBe(false);
+  });
+
+  it("carries the app version so release adoption is measurable", () => {
+    mockDeployMode.mockReturnValue("embedded");
+    mockExistsSync.mockReturnValue(false);
+    expect(gatherSystemProperties().app_version).toBe(APP_VERSION);
   });
 
   it("passes through deploy mode and os platform", () => {


### PR DESCRIPTION
Fixes #673.

On a correctly configured NVIDIA host, first boot logged `[WARN] No GPU detected -- AI tools will use CPU (slower)` because the GPU probe needs torch or ONNX Runtime and neither exists until the first AI bundle installs. The python line directly above it even said the opposite ("nvidia-smi found GPU ... but neither torch nor ONNX Runtime can use it"). A GPU user following the README's verify step reads the WARN, concludes passthrough is broken, and starts debugging the container toolkit.

The banner logic moved into a small pure helper with the missing state added: dispatcher ready, gpu unusable, but GPU hardware present (same `/dev/nvidia0` check the instance census uses). That state now logs:

```
[INFO] GPU hardware detected -- AI frameworks install with the first AI bundle; AI tools use CPU until then
```

Hosts without a GPU keep the old WARN, working CUDA keeps the old INFO, and the sidecar-failed branch is untouched.

Verified: four-state unit test written first and watched fail. Then a throwaway container from the published 2.2.0 image with a fresh /data on the RTX 4070 box, patched with this change: the boot banner shows the new line right under the accurate python probe output. The long-lived GPU stack there (bundles installed, dispatcher gpu=true) still gets the CUDA line.
