### PR TITLE
docs(deployment): troubleshoot the off-network EAI_AGAIN crash-loop

### DIFF
--- a/apps/docs/guide/deployment.md
+++ b/apps/docs/guide/deployment.md
@@ -561,6 +561,24 @@ cloudflared tunnel --url http://localhost:1349
 
 Note: Cloudflare has a 100 MB upload limit on free plans. Set `MAX_UPLOAD_SIZE_MB=100` to match.
 
+## Troubleshooting {#troubleshooting}
+
+### "Postgres not reachable: EAI_AGAIN" right after a failed first start {#eai-again-after-failed-first-start}
+
+If the very first `docker compose up -d` fails partway (a port already in use is the usual reason), a plain `up -d` retry can start the app container without attaching it to the compose network. The app then crash-loops with:
+
+```
+Postgres not reachable: EAI_AGAIN
+```
+
+while `docker ps` shows postgres healthy. The error is real but points at the wrong container: without the network, DNS for the `postgres` hostname cannot resolve at all, and the restart policy replays the same failure forever.
+
+Fix whatever broke the first start (usually: free the port), then force the app container to be recreated so it reattaches to the network:
+
+```bash
+docker compose up -d --force-recreate SnapOtter
+```
+
 ## CI/CD {#ci-cd}
 
 The GitHub repository has three workflows:


### PR DESCRIPTION
Fixes #675.

Adds a Troubleshooting section to the deployment guide with the EAI_AGAIN entry from the 2.2.0 fleet QA: a failed first `docker compose up -d` (port already held, in our case) followed by a plain `up -d` retry can start the app container without attaching it to the compose network. The app then crash-loops on `Postgres not reachable: EAI_AGAIN` while postgres sits healthy, and the restart policy replays it forever. Self-hosters read that as a database problem and debug the wrong container.

The entry names the real cause (no network, so the postgres hostname cannot resolve) and gives the one-line fix: `docker compose up -d --force-recreate SnapOtter`.

vitepress build passes on the branch (it includes the #687 anchor fix from main).
