### PR TITLE
docs(deployment): note the WSL2 Windows-host loopback gap

### DIFF
--- a/apps/docs/guide/deployment.md
+++ b/apps/docs/guide/deployment.md
@@ -579,6 +579,12 @@ Fix whatever broke the first start (usually: free the port), then force the app 
 docker compose up -d --force-recreate SnapOtter
 ```
 
+### Windows: reachable from other devices, not from the PC itself {#windows-wsl2-loopback}
+
+With Docker running inside WSL2 (the usual Windows setup), the stack can be reachable from every other machine on your network while `http://localhost:1349` times out on the Windows host itself, even with WSL's mirrored networking mode enabled. The port never shows up in Windows `netstat`, and nothing is wrong with the containers.
+
+Open the app from another device, or from inside the distro using its own address (`hostname -I` in the WSL shell). If localhost forwarding happens to work on your WSL version, treat it as a bonus rather than something to depend on.
+
 ## CI/CD {#ci-cd}
 
 The GitHub repository has three workflows:


### PR DESCRIPTION
Fixes #676.

Adds the Windows entry to the Troubleshooting section: with Docker inside WSL2, the stack can be reachable from every other machine on the network while localhost times out on the Windows host itself, even with mirrored networking enabled. The port never appears in Windows netstat and the containers are fine, which is exactly backwards from what the person at the keyboard expects.

The note says to reach the app from another device or via the distro's own address (`hostname -I`), and not to depend on Windows-host loopback forwarding.

Observed on Windows 11 + WSL 2.7.8.0 during the 2.2.0 fleet QA. vitepress build passes.
