### PR TITLE
fix(ai): point every rebuilt arm64 bundle at its r2 archive

### DIFF
--- a/docker/feature-manifest.json
+++ b/docker/feature-manifest.json
@@ -33,10 +33,10 @@
           "extractedSize": 0
         },
         "arm64-cpu": {
-          "file": "v2.0.0/background-removal-arm64-cpu.tar.gz",
-          "sha256": "cbb570b81bfd740dd05e265dd8c93ade53a9f41fdd30cc8b3fbc47a8daa824af",
-          "compressedSize": 4631430295,
-          "extractedSize": 0
+          "file": "v2.0.0/background-removal-arm64-cpu-r2.tar.gz",
+          "sha256": "eb453211098ca6a90b23bae987c3be6873cf7f0f7d67e1855d34f335a2add076",
+          "compressedSize": 4535687017,
+          "extractedSize": 6375426284
         }
       },
       "packages": {
@@ -118,10 +118,10 @@
           "extractedSize": 209838080
         },
         "arm64-cpu": {
-          "file": "v2.0.0/face-detection-arm64-cpu.tar.gz",
-          "sha256": "8ad922514aba1721de154d370f9335f78c5ce5aceade5b19515e0192d4367909",
-          "compressedSize": 222878753,
-          "extractedSize": 704276480
+          "file": "v2.0.0/face-detection-arm64-cpu-r2.tar.gz",
+          "sha256": "c66d494c03beb3988decb2eea528ba4dced95956f337855ee6efee9b95f03720",
+          "compressedSize": 81361023,
+          "extractedSize": 232238876
         }
       },
       "packages": {
@@ -162,10 +162,10 @@
           "extractedSize": 2249379840
         },
         "arm64-cpu": {
-          "file": "v2.0.0/object-eraser-colorize-arm64-cpu.tar.gz",
-          "sha256": "252c0b4fc4ca6f807b2b93038a98469323d906d5c4d75df88e9f47497d30e67c",
-          "compressedSize": 1263259968,
-          "extractedSize": 1464884023
+          "file": "v2.0.0/object-eraser-colorize-arm64-cpu-r2.tar.gz",
+          "sha256": "6f9bd83c9791701dc95f62bc099eb5959be03adb84dd8793d7cae5c9d8f8e177",
+          "compressedSize": 1253858139,
+          "extractedSize": 1437089021
         }
       },
       "packages": {
@@ -283,10 +283,10 @@
           "extractedSize": 8406943960
         },
         "arm64-cpu": {
-          "file": "v2.0.0/upscale-enhance-arm64-cpu.tar.gz",
-          "sha256": "bfb25ff1468d426ba6a125632beabece11e1afebfa6a3adefc64f7b81d7bf469",
-          "compressedSize": 2319501276,
-          "extractedSize": 3661453942
+          "file": "v2.0.0/upscale-enhance-arm64-cpu-r2.tar.gz",
+          "sha256": "d2d9745d2ca1b546c4e5399d5bf8c024bad349135fdb1ad0e4da28b7ac19fc9e",
+          "compressedSize": 2209931629,
+          "extractedSize": 3246159800
         }
       },
       "packages": {
@@ -407,10 +407,10 @@
           "extractedSize": 8172949791
         },
         "arm64-cpu": {
-          "file": "v2.0.0/photo-restoration-arm64-cpu.tar.gz",
-          "sha256": "261a27a176b9f3e76d8cd92576b73a1c014b19e87b4f16e58ed46d17c77697c0",
-          "compressedSize": 1361837793,
-          "extractedSize": 2584214411
+          "file": "v2.0.0/photo-restoration-arm64-cpu-r2.tar.gz",
+          "sha256": "86f1b261314f9f66146c02fddcbeff1880da0b52716e21126c75c7eee00e445d",
+          "compressedSize": 1252233816,
+          "extractedSize": 2238681871
         }
       },
       "packages": {
@@ -557,10 +557,10 @@
           "extractedSize": 845987840
         },
         "arm64-cpu": {
-          "file": "v2.0.0/transcription-arm64-cpu.tar.gz",
-          "sha256": "07088951300dec14b80f4723a3d5bd968574ce2650259be3fd487e7abb47e120",
-          "compressedSize": 528491203,
-          "extractedSize": 741534382
+          "file": "v2.0.0/transcription-arm64-cpu-r2.tar.gz",
+          "sha256": "34a7e6de0d8c5954b2d84838db00b3fc6a1f05923fe4051fba28cd722e9b4379",
+          "compressedSize": 519782354,
+          "extractedSize": 715158338
         }
       },
       "packages": {

--- a/docker/verify-bundle.sh
+++ b/docker/verify-bundle.sh
@@ -165,7 +165,9 @@ case "${BUNDLE_ID}" in
     check_imports "onnxruntime cv2"
     ;;
   upscale-enhance)
-    check_imports "torch realesrgan onnxruntime"
+    # onnxruntime was only ever a transitive of an older dep tree here; no
+    # upscale-enhance script imports it and gpu.py degrades cleanly without it.
+    check_imports "torch realesrgan"
     ;;
   photo-restoration)
     check_imports "torch onnxruntime mediapipe"


### PR DESCRIPTION
Second half of #669, expanded after the closure gate caught the real blast radius.

Running verify-bundle-compatibility.sh over the published arm64 set (the gate that never ran pre-publish) showed the conflict was never transcription-specific: object-eraser-colorize, photo-restoration, and upscale-enhance also baked huggingface_hub 1.22.0, and background-removal plus face-detection carried a scipy 1.17.1 / scikit-image 0.26.0 strand against the constrained 1.12.0 / 0.24.0. Any hub carrier installed after inpaint-hq re-broke it, so shipping one rebuilt bundle would not have fixed the issue.

All six affected bundles are rebuilt in the official 2.2.0 image under the constrained closure (the legacy ocr archive is excluded: it is not in the current manifest, 2.2.0 installs OCR via the isolated v3 runtime, and only pre-inpaint images consume it). Results:

- No rebuilt bundle carries huggingface_hub at all; every one resolves to the base venv's 0.36.2, so no install order can strand hub again.
- The layered compatibility check now passes: exactly one version of every constrained package across all seven legacy bundles, ONNX flavor consistent.
- Each bundle passes verify-bundle.sh in isolation including its functional smoke (real remove_bg, detect_faces, colorize, restore, upscale, transcribe runs). upscale-enhance's check list drops onnxruntime: it was only ever a transitive of an older dep tree, no upscale script imports it, and gpu.py handles its absence.
- End-to-end on a throwaway arm64 container: offline-import of the rebuilt transcription, then inpaint-hq installed on top in 150s (the exact sequence that failed), transformers and faster-whisper import together, and the transcription artifact reads back correctly.

The manifest points each rebuilt bundle at a new `v2.0.0/<id>-arm64-cpu-r2.tar.gz` path. In-place overwrites would sha-break installs on every shipped image, since manifests are baked; the old artifacts stay untouched for them, and the next image release picks these up. amd64 likely has its own version strands (the master-QA scipy observation was on a GPU host); that audit is a follow-up, not this PR.

Artifacts are built and verified locally; the HF upload is the human-only step and happens alongside this PR.
