### PR TITLE
fix(ai): constrain tokenizers and onnxruntime, drop obsolete arm64 protobuf pins

### DIFF
--- a/docker/feature-manifest.json
+++ b/docker/feature-manifest.json
@@ -17,7 +17,9 @@
     "scikit-learn==1.4.2",
     "scikit-image==0.24.0",
     "pandas==2.2.2",
-    "huggingface-hub==0.36.2"
+    "huggingface-hub==0.36.2",
+    "tokenizers==0.20.3",
+    "onnxruntime==1.20.1"
   ],
   "bundleRepo": "deepsafe/feature-bundles",
   "bundles": {
@@ -162,16 +164,16 @@
           "extractedSize": 2249379840
         },
         "arm64-cpu": {
-          "file": "v2.0.0/object-eraser-colorize-arm64-cpu-r2.tar.gz",
-          "sha256": "6f9bd83c9791701dc95f62bc099eb5959be03adb84dd8793d7cae5c9d8f8e177",
-          "compressedSize": 1253858139,
-          "extractedSize": 1437089021
+          "file": "v2.0.0/object-eraser-colorize-arm64-cpu-r3.tar.gz",
+          "sha256": "18aaf0bc507e94e248296f3092e625ff6339365b6df7030439c4ec9465098bfa",
+          "compressedSize": 1253914457,
+          "extractedSize": 1437568952
         }
       },
       "packages": {
         "common": ["huggingface-hub[hf_xet]==0.36.2"],
         "amd64": ["onnxruntime-gpu==1.20.1"],
-        "arm64": ["onnxruntime==1.20.1", "protobuf>=4.25.3,<5"]
+        "arm64": ["onnxruntime==1.20.1"]
       },
       "pipFlags": {},
       "postInstall": [],
@@ -557,16 +559,16 @@
           "extractedSize": 845987840
         },
         "arm64-cpu": {
-          "file": "v2.0.0/transcription-arm64-cpu-r2.tar.gz",
-          "sha256": "34a7e6de0d8c5954b2d84838db00b3fc6a1f05923fe4051fba28cd722e9b4379",
-          "compressedSize": 519782354,
-          "extractedSize": 715158338
+          "file": "v2.0.0/transcription-arm64-cpu-r3.tar.gz",
+          "sha256": "19938e1220bdcfdbdb0e6c5019971b38b4a519f818d9cd29b789bc19de661485",
+          "compressedSize": 536230905,
+          "extractedSize": 781074121
         }
       },
       "packages": {
         "common": ["faster-whisper>=1.0.0", "huggingface-hub[hf_xet]==0.36.2"],
         "amd64": [],
-        "arm64": ["protobuf>=4.25.3,<5"]
+        "arm64": []
       },
       "pipFlags": {},
       "postInstall": [],


### PR DESCRIPTION
Round two of the #669 closure, driven by what the worst-order end-to-end caught after #691.

Installing the r2 transcription AFTER inpaint-hq broke transformers again, one dependency over from the original bug: the rebuild had picked up tokenizers 0.23.1 (today's transitive of faster-whisper) against transformers' hard `>=0.20,<0.21` check. A full multi-version scan across all seven bundles then showed the r2 rebuilds had also drifted onnxruntime to 1.28.0 and, more interestingly, that the arm64 protobuf story changed underneath us: arm64 now resolves mediapipe 1.0.0 (aarch64 wheels exist above the old 0.10.18 ceiling), which drops the python protobuf dependency entirely. The `protobuf>=4.25.3,<5` arm64 pins from the 2.0.0 era were no longer protecting anything; they were the last remaining source of cross-bundle disagreement.

Changes:

- `constraints` gains `tokenizers==0.20.3` and `onnxruntime==1.20.1`, matching the versions the rest of the set already agrees on. The compatibility gate now enforces both.
- The obsolete protobuf pins are removed from the two arm64 package lists that still had them.
- transcription and object-eraser-colorize point at rebuilt `-r3` archives (uploaded, sha-verified). The other four r2 archives from #691 are internally consistent and stay.

Verified: 41 manifest tests green; both r3 bundles pass isolation verification including functional smokes; the layered compatibility check passes with every constrained package at exactly one version; a full multi-version scan across all seven bundles plus the base venv shows only filelock patch drift remaining, which nothing strict consumes. The all-seven worst-order install from HF plus the full installed AI matrix runs against this manifest as the final acceptance gate, results on #669.
