### PR TITLE
fix(ai): rebuild the amd64-gpu bundle closure and widen the compat gate

### DIFF
--- a/docker/feature-manifest.json
+++ b/docker/feature-manifest.json
@@ -29,10 +29,10 @@
       "estimatedSize": "4-5 GB",
       "archives": {
         "amd64-gpu": {
-          "file": "v2.0.0/background-removal-amd64-gpu.tar.gz",
-          "sha256": "a1dfbdd5862fd32c7719ca79b0c7e4b76a327330a5991ddad98a2761abca10cb",
-          "compressedSize": 4808242472,
-          "extractedSize": 0
+          "file": "v2.0.0/background-removal-amd64-gpu-r2.tar.gz",
+          "sha256": "61a7036d3c78a410b2237bd158b8f9d6ac51c38a623f3506243b608e62f92d33",
+          "compressedSize": 4826542966,
+          "extractedSize": 7177444273
         },
         "arm64-cpu": {
           "file": "v2.0.0/background-removal-arm64-cpu-r2.tar.gz",
@@ -43,7 +43,7 @@
       },
       "packages": {
         "common": ["rembg==2.0.62"],
-        "amd64": ["onnxruntime-gpu==1.20.1", "mediapipe>=0.10.21"],
+        "amd64": ["onnxruntime-gpu==1.20.2", "mediapipe>=0.10.21"],
         "arm64": ["onnxruntime==1.20.1", "mediapipe>=0.10.18"]
       },
       "pipFlags": {},
@@ -114,10 +114,10 @@
       "estimatedSize": "200-300 MB",
       "archives": {
         "amd64-gpu": {
-          "file": "v2.0.0/face-detection-amd64-gpu.tar.gz",
-          "sha256": "0ee28b86dac88c60e005604ba0595746f455ec97f08d0c8307ba9b57e131bc7f",
-          "compressedSize": 75358868,
-          "extractedSize": 209838080
+          "file": "v2.0.0/face-detection-amd64-gpu-r2.tar.gz",
+          "sha256": "ff242709bd03befe424fa5096a9d60c6b70f22fcef8af803a1c86838140832be",
+          "compressedSize": 88895081,
+          "extractedSize": 260502197
         },
         "arm64-cpu": {
           "file": "v2.0.0/face-detection-arm64-cpu-r2.tar.gz",
@@ -158,10 +158,10 @@
       "estimatedSize": "1-2 GB",
       "archives": {
         "amd64-gpu": {
-          "file": "v2.0.0/object-eraser-colorize-amd64-gpu.tar.gz",
-          "sha256": "a3f6cd2eca9e5dd907497d0d58ca5f6532887bb748e4062de0f4fb9815782c31",
-          "compressedSize": 1545472964,
-          "extractedSize": 2249379840
+          "file": "v2.0.0/object-eraser-colorize-amd64-gpu-r2.tar.gz",
+          "sha256": "0d858f287b9ab57a60e9e3209eae1c14a6a0792687f7105d40b1f4c2a19ef102",
+          "compressedSize": 1532343662,
+          "extractedSize": 2204704276
         },
         "arm64-cpu": {
           "file": "v2.0.0/object-eraser-colorize-arm64-cpu-r3.tar.gz",
@@ -172,7 +172,7 @@
       },
       "packages": {
         "common": ["huggingface-hub[hf_xet]==0.36.2"],
-        "amd64": ["onnxruntime-gpu==1.20.1"],
+        "amd64": ["onnxruntime-gpu==1.20.2"],
         "arm64": ["onnxruntime==1.20.1"]
       },
       "pipFlags": {},
@@ -279,10 +279,10 @@
       "estimatedSize": "4-5 GB",
       "archives": {
         "amd64-gpu": {
-          "file": "v2.0.0/upscale-enhance-amd64-gpu.tar.gz",
-          "sha256": "b725a0b18a8295cb87e15f79b31c294f1de98101dedd76389728300a8d377a15",
-          "compressedSize": 5358573124,
-          "extractedSize": 8406943960
+          "file": "v2.0.0/upscale-enhance-amd64-gpu-r2.tar.gz",
+          "sha256": "81f0c688abcdd277fbcdd5501aa22a4fe789e08fe9822811ea326a3de1a8b15d",
+          "compressedSize": 5371590150,
+          "extractedSize": 8454624391
         },
         "arm64-cpu": {
           "file": "v2.0.0/upscale-enhance-arm64-cpu-r2.tar.gz",
@@ -403,10 +403,10 @@
       "estimatedSize": "800 MB - 1 GB",
       "archives": {
         "amd64-gpu": {
-          "file": "v2.0.0/photo-restoration-amd64-gpu.tar.gz",
-          "sha256": "4747953db35c71b83db19ce12cc6c591730f0cb9f64621f239db17ae3e3563fd",
-          "compressedSize": 4680254837,
-          "extractedSize": 8172949791
+          "file": "v2.0.0/photo-restoration-amd64-gpu-r2.tar.gz",
+          "sha256": "38c82e61acf03980b97f6f2a4754dd7cdbc3d4d64f864bf2776168fc8fb91eea",
+          "compressedSize": 4693244387,
+          "extractedSize": 8220630756
         },
         "arm64-cpu": {
           "file": "v2.0.0/photo-restoration-arm64-cpu-r2.tar.gz",
@@ -418,7 +418,7 @@
       "packages": {
         "common": ["codeformer-pip==0.0.4", "huggingface-hub[hf_xet]==0.36.2", "setuptools<75"],
         "amd64": [
-          "onnxruntime-gpu==1.20.1",
+          "onnxruntime-gpu==1.20.2",
           "mediapipe>=0.10.21",
           "torch==2.7.0+cu126 torchvision==0.22.0+cu126 --index-url https://download.pytorch.org/whl/cu126",
           "lpips",
@@ -553,10 +553,10 @@
       "estimatedSize": "~600 MB",
       "archives": {
         "amd64-gpu": {
-          "file": "v2.0.0/transcription-amd64-gpu.tar.gz",
-          "sha256": "3033d480c6183df66855d78c355233dbc86a754d07414e544e1df1038337c9e1",
-          "compressedSize": 559189061,
-          "extractedSize": 845987840
+          "file": "v2.0.0/transcription-amd64-gpu-r2.tar.gz",
+          "sha256": "6229180f698d1ceb0866df4b1c091ed4a89f6324427d373dbbc13a763ae26ce2",
+          "compressedSize": 845757082,
+          "extractedSize": 1647328796
         },
         "arm64-cpu": {
           "file": "v2.0.0/transcription-arm64-cpu-r3.tar.gz",
@@ -567,8 +567,8 @@
       },
       "packages": {
         "common": ["faster-whisper>=1.0.0", "huggingface-hub[hf_xet]==0.36.2"],
-        "amd64": [],
-        "arm64": []
+        "amd64": ["onnxruntime-gpu==1.20.2"],
+        "arm64": ["onnxruntime==1.20.1"]
       },
       "pipFlags": {},
       "postInstall": [],

--- a/docker/verify-bundle-compatibility.sh
+++ b/docker/verify-bundle-compatibility.sh
@@ -187,6 +187,49 @@ if [[ $? -ne 0 ]]; then
   fail "Constrained-package consistency check failed -- see violations above" 2
 fi
 
+log "Scanning every package for multi-version disagreement (not just constrained)"
+
+# The tokenizers conflict behind #669 lived outside the constraints list, so
+# the constrained check above sailed past it. This scan reports ANY package
+# left at more than one version after layering. Default is a warning (patch
+# drift like filelock is normal); set COMPAT_STRICT_ANY=1 to make it fatal.
+set +e
+"${VENV}/bin/python3" - "${SITE_PACKAGES}" "${MANIFEST}" <<'PYANYVER'
+import json, os, re, sys
+
+sp, manifest_path = sys.argv[1], sys.argv[2]
+with open(manifest_path) as f:
+    constrained = {re.sub(r"[-_.]+", "_", c.split("==")[0]).lower()
+                   for c in json.load(f).get("constraints", [])}
+
+by_name = {}
+for entry in os.listdir(sp):
+    m = re.match(r"(.+)-([0-9][^-]*)\.dist-info$", entry)
+    if not m:
+        continue
+    key = re.sub(r"[-_.]+", "_", m.group(1)).lower()
+    by_name.setdefault(key, set()).add(m.group(2))
+
+offenders = {k: sorted(v) for k, v in by_name.items()
+             if len(v) > 1 and k not in constrained}
+if not offenders:
+    print("  No unconstrained package is present at more than one version.")
+    sys.exit(0)
+
+print("  WARNING: unconstrained packages at multiple versions after layering:")
+for pkg, vers in sorted(offenders.items()):
+    print(f"    {pkg}: {vers}")
+sys.exit(3)
+PYANYVER
+ANYVER_RC=$?
+set -e
+if [[ ${ANYVER_RC} -ne 0 ]]; then
+  if [[ "${COMPAT_STRICT_ANY:-0}" == "1" ]]; then
+    fail "Unconstrained multi-version packages present and COMPAT_STRICT_ANY=1" 2
+  fi
+  echo "  (warning only; triage each entry by consumer strictness before publishing)"
+fi
+
 log "Checking ONNX Runtime flavor consistency"
 
 "${VENV}/bin/python3" - "${SITE_PACKAGES}" <<'PYFLAVOR' || fail "ONNX Runtime flavor check failed" 2


### PR DESCRIPTION
Fixes #692.

The audit found the amd64-gpu set in worse shape than arm64 was. huggingface_hub sat at FOUR versions across bundles (0.36.2 / 1.19.0 / 1.22.0), so the #669 breakage exists on amd64 too and only survived QA because inpaint-hq happened to install last. transcription carried tokenizers 0.23.1 against transformers' hard `<0.21` check. background-removal carried the scipy 1.17.1 / scikit-image 0.26.0 strand (the exact pair from the GPU-box incident that produced test_upscale_failure_message.py). And transcription shipped plain CPU onnxruntime 1.27.0 into a set whose GPU bundles carry onnxruntime-gpu: the #490 flavor clobber, live in published artifacts, silently degrading GPU inference whenever transcription installs last.

Changes:

- Six bundles rebuilt under the constrained closure (inpaint-hq stays as the reference): none carries huggingface_hub, tokenizers is 0.20.3, scipy/scikit-image sit on the constrained versions, and mediapipe converges on 1.0.0 (same jump arm64 already shipped and proved).
- transcription's amd64 list pins `onnxruntime-gpu` so build-bundle.sh's flavor dedupe strips the transitive CPU build; its arm64 list pins the CPU flavor explicitly for parity (no artifact change, r3 already carries it).
- The gpu pins move from 1.20.1 to 1.20.2: PyPI no longer serves onnxruntime-gpu 1.20.1 at all, which made every gpu-pinning bundle unbuildable and would have bitten the next manual rebuild regardless.
- verify-bundle-compatibility.sh gains the any-package multi-version scan this issue asked for (warn by default, `COMPAT_STRICT_ANY=1` makes it fatal). It is the check that would have caught the tokenizers class before publish.

Verified on an amd64 host: all six bundles pass isolation verification including functional smokes; the layered closure gate passes with every constrained package at exactly one version; the new scan reports only loose-consumer patch drift (certifi, filelock, fsspec, setuptools, tqdm); the ONNX flavor check confirms GPU 1.20.2 with the CUDA provider library present in the merged venv. Manifest points at r2 paths; nothing published is overwritten, so baked manifests on shipped images keep working. The worst-order install plus the GPU AI matrix on the 4070 box runs as final acceptance once the artifacts are up, results on the issue.
