### PR TITLE
test(e2e): make the pin-tools spec idempotent across retries

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -211,6 +211,19 @@ export async function putSettings(
   return { ok: res.ok(), status: res.status() };
 }
 
+/** Upsert the current user's preferences (e.g. reset shared state a spec mutates). */
+export async function putPreferences(
+  page: Page,
+  data: Record<string, unknown>,
+): Promise<{ ok: boolean; status: number }> {
+  const token = await getAuthToken(page);
+  const res = await page.request.put("/api/v1/preferences", {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    data,
+  });
+  return { ok: res.ok(), status: res.status() };
+}
+
 /**
  * changePasswordViaApi() — revert a password change without driving the UI.
  * The current session token survives a password change (the API only revokes

--- a/tests/e2e/pin-tools.spec.ts
+++ b/tests/e2e/pin-tools.spec.ts
@@ -1,9 +1,15 @@
-import { expect, test } from "./helpers";
+import { expect, putPreferences, test } from "./helpers";
 
 // Mutates the shared per-user `pinnedTools` preference on the server, so it
 // pins and then unpins within the single test to leave state clean.
 test.describe("Pin tools", () => {
   test("pin a tool, persist across reload, then unpin", async ({ loggedInPage: page }) => {
+    // Start from a known-empty pin state. CI retries once, and a prior attempt
+    // that failed after pinning but before unpinning leaves a server-side pin,
+    // which would fail the "not pinned yet" assertion below on the retry.
+    expect((await putPreferences(page, { pinnedTools: [] })).ok).toBeTruthy();
+    await page.reload();
+
     // Resize lives under Image > Essentials on the All tab (default).
     const pinToggle = page.getByTestId("pin-toggle-resize").first();
     await expect(pinToggle).toBeVisible();


### PR DESCRIPTION
The main nightly's E2E Full (4/4) failed on pin-tools at its opening assertion ("no Pinned section yet"), finding one where it expected none. The spec mutates the shared per-user pinnedTools preference and pins then unpins to self-clean, but CI runs retries: 1, so an attempt that fails after pinning and before the unpin (a reload flake, say) leaves a server-side pin. The retry then starts with that pin present and fails line 12. It passed on the five prior nightly runs, so it is an intermittent self-inflicted retry leak, not a regression.

Reset pinnedTools to empty via the preferences API at the start of the test (new putPreferences helper, mirroring putSettings), then reload, so the test starts from a known-empty state regardless of what a prior attempt left behind. The pin/reload/unpin assertions are unchanged.
