### PR TITLE
ci(nightly): give Docker Container E2E a 90-minute budget

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -326,7 +326,9 @@ jobs:
   docker-e2e:
     name: Docker Container E2E
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # A from-scratch image build (~14 min) plus the full in-container suite runs
+    # ~65 min, so the old 60-minute budget cancelled the job before it finished.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Run container test suite


### PR DESCRIPTION
The nightly Docker Container E2E job cancelled at its 60-minute timeout on the last run (ran 00:20 to 01:25, killed at the 60-min mark) while every test was passing. A from-scratch 15GB image build (~14 min) plus the full in-container unit and integration suite legitimately runs ~65 minutes, and the job's own comment already flagged the 60-minute budget as tight. Raise it to 90 minutes.

This fixes the deterministic timeout-cancel. The separate exit-137 reclamations seen on earlier dispatches are GitHub runner-pool churn (external, tests passing throughout); a job that finishes in ~65 of 90 minutes also spends less of its life exposed to that.

Every other nightly job is green on the latest main run (E2E Full all four shards, Extended Matrix all four, Serial Bucket, Coverage, Cross-Browser, Docs, Landing).
