### PR TITLE
ci(nightly): free disk before the Docker Container E2E build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -331,6 +331,16 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Free disk space
+        # The from-scratch image is ~15 GB and the build layers add more on top
+        # of three running containers, which crowds a standard runner and has
+        # correlated with the VM being terminated mid-run (exit 137). Reclaim the
+        # preinstalled toolchains this job never uses before building.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker image prune -af || true
+          df -h /
       - name: Run container test suite
         # Attribute the job to test-unit: it runs the full integration suite
         # against the container's real binaries (ffmpeg/qpdf/tesseract/...), which


### PR DESCRIPTION
The Docker Container E2E job builds a ~15GB image on top of three running containers, the heaviest footprint in the nightly, and has been terminated mid-run (exit 137, tests passing each time) across several dispatches. Every other nightly job is green. Reclaim the preinstalled toolchains this job never uses (dotnet, android, ghc, boost, CodeQL, the tool cache) before building, which is the standard disk-freeing heavy docker-build jobs use, to reduce the resource pressure correlated with the mid-run terminations. If terminations persist after this, the job likely needs a larger runner, which is a cost decision.