### PR TITLE
ci(nightly): bound Docker Container E2E memory (forks + tmpfs size)

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -62,9 +62,17 @@ services:
       - SYNC_WAIT_MS=120000
       - VITEST_TEST_TIMEOUT=180000
       - VITEST_HOOK_TIMEOUT=120000
+      # /tmp is tmpfs (RAM-backed) below, so each fork's scratch files count
+      # against RAM alongside the app plus Postgres and Redis. On a 7GB CI
+      # runner the default fork-per-core parallelism has correlated with the
+      # runner being killed mid-run (exit 137). One fork bounds the peak; the
+      # 90-minute job budget absorbs the slower serial run.
+      - VITEST_MAX_FORKS=1
     tmpfs:
-      - /tmp/test-workspace
-      - /tmp
+      # Cap the RAM-backed scratch mounts so a burst of large temp files (a
+      # multi-megapixel encode, a video transcode) cannot exhaust runner RAM.
+      - /tmp/test-workspace:size=1g
+      - /tmp:size=2g
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
After ruling out disk (#700 freed the runner to 110G/25%) and timeout (#698 gave 90 min; the job runs ~37 min), Docker Container E2E still gets terminated mid-run (exit 137, tests passing). The remaining pressure is RAM: test-unit mounts /tmp as tmpfs (RAM-backed), so each vitest fork's scratch files count against the 7GB runner alongside the app, Postgres, and Redis. Run a single fork and size-cap the scratch mounts (1g/2g) so a burst of large temp files cannot exhaust runner RAM. Every other nightly job is green.