### PR TITLE
fix(ci): move docker-e2e test scratch off tmpfs to disk

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -62,17 +62,16 @@ services:
       - SYNC_WAIT_MS=120000
       - VITEST_TEST_TIMEOUT=180000
       - VITEST_HOOK_TIMEOUT=120000
-      # /tmp is tmpfs (RAM-backed) below, so each fork's scratch files count
-      # against RAM alongside the app plus Postgres and Redis. On a 7GB CI
-      # runner the default fork-per-core parallelism has correlated with the
-      # runner being killed mid-run (exit 137). One fork bounds the peak; the
-      # 90-minute job budget absorbs the slower serial run.
+      # One vitest fork bounds peak memory on a 7GB CI runner; the 90-minute
+      # job budget absorbs the slower serial run.
       - VITEST_MAX_FORKS=1
-    tmpfs:
-      # Cap the RAM-backed scratch mounts so a burst of large temp files (a
-      # multi-megapixel encode, a video transcode) cannot exhaust runner RAM.
-      - /tmp/test-workspace:size=1g
-      - /tmp:size=2g
+    # No tmpfs: the tools write multi-megapixel encodes and video transcodes to
+    # WORKSPACE_PATH and /tmp, and a RAM-backed mount made that scratch count
+    # against the 7GB runner alongside the app, Postgres, and Redis, which
+    # correlated with the runner being killed mid-run (exit 137). Sizing the
+    # tmpfs instead just moved the failure to ENOSPC. Let scratch land on the
+    # container's disk-backed layer, which has ample room once the job frees the
+    # preinstalled toolchains.
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## What

The scheduled Nightly workflow's `Docker Container E2E` job kept failing. This drops the RAM-backed tmpfs mounts on the `test-unit` service in `docker/docker-compose.test.yml` so the tools' scratch files land on the container's disk-backed layer instead.

## Why

The tools write multi-megapixel encodes and video transcodes into each vitest fork's workspace, which roots under `os.tmpdir()` (`/tmp`). Compose mounted `/tmp` as tmpfs, so all of that scratch counted against the 7GB runner's RAM alongside the app, Postgres, and Redis.

Two failure modes came out of that:

- Unbounded tmpfs: the runner was killed mid-run (`exit 137`), consistently around the 37-39 minute mark.
- tmpfs sized to cap RAM (an earlier attempt, #701): the cap was too small for the encode/transcode scratch, so the job hit ENOSPC and reported ~1100 test failures instead.

Removing the tmpfs fixes both: scratch goes to disk, which the job's "Free disk space" step already clears to ~110G, so there's no RAM pressure and no space ceiling. `VITEST_MAX_FORKS=1` stays as the memory ceiling. Postgres and Redis keep their small tmpfs data mounts (a single fork's schema clone and job state, tens of MB, not the multi-GB hog).

## Verification

- `docker-compose.test.yml` parses and `test-unit` no longer declares `tmpfs`; Postgres/Redis data mounts unchanged.
- Every other Nightly job (E2E Full x4, Extended Matrix x4, Serial, Surfaces, Device Matrix, Cross-Browser, Coverage, Schemathesis) is already green on main.
- A post-merge Nightly dispatch will confirm `Docker Container E2E` completes green.