### PR TITLE
fix(qa): give the canonical lane meaningful inputs for six tools

### DIFF
--- a/tests/qa/api-sweep.mts
+++ b/tests/qa/api-sweep.mts
@@ -146,6 +146,10 @@ interface SecondarySpec {
 const SECONDARY_INPUTS: Record<string, SecondarySpec[]> = {
   "watermark-image": [{ field: "watermark", ext: ".png", modality: "image" }],
   compose: [{ field: "overlay", ext: ".png", modality: "image" }],
+  // erase-object needs a mask image as a discrete second file; without it the
+  // route refuses with 400. The worker resizes the mask to the image, so any
+  // valid PNG works.
+  "erase-object": [{ field: "mask", ext: ".png", modality: "image" }],
   compare: [{ field: "file", sameAsPrimary: true }],
   "find-duplicates": [{ field: "file", sameAsPrimary: true }],
   collage: [{ field: "file", sameAsPrimary: true }],
@@ -175,6 +179,16 @@ const EXTRA_FIELDS: Record<string, Record<string, string>> = {
 const TOOL_FIXTURES: Record<string, Record<string, string>> = {
   "chart-maker": { ".json": join(REPO, "tests/fixtures/data/valid/chart.json") },
   "extract-subtitles": { ".mkv": join(REPO, "tests/fixtures/video/formats/tiny-subs.mkv") },
+  // remove-gif-background rejects a still GIF by design; it needs an animated one.
+  "remove-gif-background": {
+    ".gif": join(REPO, "tests/fixtures/image/valid/animated-simpsons.gif"),
+  },
+  // Extraction tools emit an empty (but valid) artifact when the input has none
+  // of the thing they extract, which the decodable-output oracle then reads as a
+  // zero-byte failure. Pin fixtures that actually carry text and speech.
+  ocr: { ".png": join(REPO, "tests/fixtures/image/valid/ocr-clean.png") },
+  "transcribe-audio": { ".wav": join(REPO, "tests/fixtures/audio/valid/speech-10s.wav") },
+  "auto-subtitles": { ".mp4": join(REPO, "tests/fixtures/video/valid/speech-10s.mp4") },
 };
 
 /**
@@ -184,6 +198,11 @@ const TOOL_FIXTURES: Record<string, Record<string, string>> = {
  */
 const CANONICAL_EXT: Record<string, string> = {
   "extract-subtitles": ".mkv",
+  // ocr and transcribe-audio declare several formats but only the pinned
+  // content fixture above exercises them, so force its extension over the
+  // earlier-declared .jpg / .mp3 that would resolve to a content-free file.
+  ocr: ".png",
+  "transcribe-audio": ".wav",
 };
 
 /** Formats a multi-input tool only accepts on its SECONDARY field. */
@@ -231,6 +250,9 @@ const EXPECTED_SELF_REJECT: Record<string, RegExp[]> = {
   "remove-pages": [/out of range/i, /only \d+ page/i],
   "extract-pages": [/out of range/i, /only \d+ page/i],
   "split-pdf": [/out of range/i, /only \d+ page/i, /single page/i],
+  // The base passport-photo route is a dispatcher; the real work lives on its
+  // /analyze and /generate sub-routes, so the bare tool path refuses by design.
+  "passport-photo": [/\/analyze or \/generate/i],
 };
 
 /** High-risk axis triples worth explicit three-way coverage. */


### PR DESCRIPTION
## What

Closes #690. On a bundles-installed container the API sweep's canonical lane reported six false failures. All six are harness gaps (wrong or content-free fixtures, a missing mask part, and one by-design refusal), not product bugs. This gives each of the six the input it needs so the lane becomes a clean regression gate for AI-installed deployments too.

Change is four keyed additions to existing lookup tables in `tests/qa/api-sweep.mts`:

| Tool | Fix |
|------|-----|
| remove-gif-background | `TOOL_FIXTURES` pin to `animated-simpsons.gif` (the tool refuses a still GIF by design) |
| erase-object | add to `SECONDARY_INPUTS` with a `mask` PNG field (the route 400s without a mask; the worker resizes any mask to the image) |
| passport-photo | add to `EXPECTED_SELF_REJECT` (the base route is a dispatcher that refuses with "use /analyze or /generate") |
| ocr, transcribe-audio, auto-subtitles | `TOOL_FIXTURES` + `CANONICAL_EXT` pin to content-bearing `ocr-clean.png` / `speech-10s.wav` / `speech-10s.mp4` |

## Root cause

The issue suspected the download or preview-URL resolution for ai-pool jobs. A direct probe ruled that out: the download path is correct. OCR of the content-free fixture the lane was feeding returns `downloadUrl=.../sample_ocr.txt` with a genuinely empty (0-byte) artifact, because the image has no text. The same OCR on `ocr-clean.png` returns `ocr-clean_ocr.txt` with "The quick brown fox 12345". So the tools were correct all along; the lane was feeding them inputs with none of the content they extract, and the decodable-output oracle read the empty result as a failure. Same fixture-mismatch class as remove-gif-background.

## Verification

Red to green against a live v2.2.0 container with every AI bundle installed (background-removal, object-eraser-colorize, inpaint-hq, ocr, transcription):

- Canonical lane, the six tools: **6 fail -> 5 pass + 1 expected-reject**.
- Multi lane (regression for the new `erase-object` SECONDARY_INPUTS entry): **0 fail across 20 tools**, erase-object produces a valid inpainted PNG.
- auto-subtitles output confirmed a real SRT with transcribed speech, not a placeholder.
- `biome check` clean; targeted `tsc --noEmit` reports no errors in the file.

Fixes #690