### PR TITLE
test(qa): decode subtitle output as text in the sweep oracle

### DIFF
--- a/tests/qa/lib/oracles.ts
+++ b/tests/qa/lib/oracles.ts
@@ -100,6 +100,14 @@ export function detectSignature(data: Buffer): string | null {
 const IMAGE_SIGNATURES = new Set(["PNG", "JPEG", "GIF", "BMP", "TIFF-LE", "TIFF-BE", "ICO", "PSD"]);
 const MEDIA_SIGNATURES = new Set(["ISOBMFF", "MATROSKA", "OGG", "FLAC", "ID3", "MP3", "RIFF"]);
 
+/**
+ * Plain-text formats a tool may serve as application/octet-stream, so the
+ * content-type check below misses them and they fall through to "binary".
+ * Subtitles are the ones that reach here without a text/* type; decoding them
+ * as text asserts real content instead of passing on a byte-count floor.
+ */
+const TEXT_EXTS = new Set([".srt", ".vtt", ".ass", ".txt"]);
+
 function classify(data: Buffer, filename: string, contentType: string): OutputKind {
   if (data.length === 0) return "empty";
   const ct = contentType.split(";")[0].trim().toLowerCase();
@@ -120,6 +128,7 @@ function classify(data: Buffer, filename: string, contentType: string): OutputKi
   if (signature === "ISOBMFF" || signature === "MATROSKA") return "video";
   if (signature && MEDIA_SIGNATURES.has(signature)) return "audio";
   if (ct.startsWith("text/") || ct.includes("xml") || ct.includes("markdown")) return "text";
+  if (TEXT_EXTS.has(ext)) return "text";
   return "binary";
 }
 


### PR DESCRIPTION
## What

Follow-up to #703 (#690). The canonical lane's decode oracle keyed "text" off the HTTP content-type only, so `.srt`/`.vtt`/`.ass` artifacts served as `application/octet-stream` classified as "binary" and passed on a 16-byte floor. That meant auto-subtitles and extract-subtitles only proved their output was non-trivial, not that it was a real subtitle.

`classify()` already keys zip/svg/json/csv off the filename extension; this extends the text branch the same way with a small `TEXT_EXTS` set (`.srt`, `.vtt`, `.ass`, `.txt`).

## Effect

The output now decodes as text, so the oracle asserts real content and an empty or whitespace-only subtitle fails as "whitespace only" instead of sliding through on byte count.

## Verification

On a live v2.2.0 container with bundles installed:

- auto-subtitles: was `binary no-signature 180B`, now **`text 180chars 8lines`** (still PASS).
- extract-subtitles: now **`text 101chars 9lines`** (still PASS).

`biome check` clean. No product code touched; this only sharpens the QA sweep's assertion for subtitle-producing tools.