### PR TITLE
fix(api): authorize the standalone upload and preview routes

### DIFF
--- a/apps/api/src/permissions.ts
+++ b/apps/api/src/permissions.ts
@@ -384,6 +384,44 @@ export async function requireToolAccess(
   return user;
 }
 
+/**
+ * Gate the file routes on the file permissions.
+ *
+ * Either grant is enough: `files:all` is the broader one, so a holder of it is
+ * never locked out for lacking `files:own`. This is the same rule
+ * `requireApiKeyManagement` in routes/api-keys.ts already applies to the
+ * identical apikeys:own / apikeys:all pair, and the roles editor presents Files
+ * and API Keys as the same shape of group.
+ *
+ * Runs before the resource is resolved so a caller without the permission gets
+ * 403 rather than a 404 that would confirm whether an id exists.
+ *
+ * Lives here rather than in routes/user-files.ts because /api/v1/upload needs the
+ * same gate and is registered outside that module.
+ *
+ * See SEC-20260726-C01.
+ */
+export async function requireFileAccess(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<AuthUser | null> {
+  const user = getAuthUser(request);
+  if (!user) {
+    reply.status(401).send({ error: "Authentication required", code: "AUTH_REQUIRED" });
+    return null;
+  }
+
+  if (
+    !(await hasEffectivePermission(user, "files:own")) &&
+    !(await hasEffectivePermission(user, "files:all"))
+  ) {
+    reply.status(403).send({ error: "Insufficient permissions", code: "FORBIDDEN" });
+    return null;
+  }
+
+  return user;
+}
+
 export async function requireOwnershipOrPermission(
   request: FastifyRequest,
   reply: FastifyReply,

--- a/apps/api/src/routes/file-preview.ts
+++ b/apps/api/src/routes/file-preview.ts
@@ -17,8 +17,8 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { getStoredFilePath } from "../lib/file-storage.js";
-import { hasEffectivePermission } from "../permissions.js";
-import { getAuthUser, requireAuth } from "../plugins/auth.js";
+import { hasEffectivePermission, requirePermission } from "../permissions.js";
+import { requireAuth } from "../plugins/auth.js";
 
 const PREVIEW_DIR = ".previews";
 let previewDirReady = false;
@@ -243,8 +243,11 @@ export async function filePreviewRoutes(app: FastifyInstance): Promise<void> {
       config: { rateLimit: { max: 60, timeWindow: "1 minute" } },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
-      // Optional auth -- the preview is for the user's own uploaded file
-      getAuthUser(request);
+      // Spawns FFmpeg over caller-supplied bytes for the tool workflow, so it takes
+      // the same grant as running a tool. This used to call getAuthUser and discard
+      // the result, leaving it open to any authenticated principal no matter what
+      // the operator had scoped them down to.
+      if (!(await requirePermission("tools:use")(request, reply))) return;
 
       const parts = request.parts();
       let fileBuffer: Buffer | null = null;

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -10,6 +10,7 @@ import { decodeToSharpCompat, needsCliDecode } from "../lib/format-decoders.js";
 import { decodeHeic } from "../lib/heic-converter.js";
 import { getObjectSize, getObjectStream, putObject } from "../lib/object-storage.js";
 import { isSvgBuffer, sanitizeSvg } from "../lib/svg-sanitize.js";
+import { requireFileAccess, requirePermission } from "../permissions.js";
 
 /**
  * Guard against path traversal in URL params.
@@ -85,6 +86,11 @@ export async function fileRoutes(app: FastifyInstance): Promise<void> {
     "/api/v1/upload",
     { config: { rateLimit: { max: 60, timeWindow: "1 minute" } } },
     async (request: FastifyRequest, reply: FastifyReply) => {
+      // Persists bytes that /api/v1/download then serves without auth, so this
+      // needs the same grant as the rest of the file surface. The tool-access
+      // middleware only covers /api/v1/tools/, and never reached this route.
+      if (!(await requireFileAccess(request, reply))) return;
+
       const jobId = randomUUID();
 
       const uploadedFiles: Array<{
@@ -231,6 +237,10 @@ export async function fileRoutes(app: FastifyInstance): Promise<void> {
   // ── POST /api/v1/preview ──────────────────────────────────────
   // Returns a WebP preview for formats browsers can't display (HEIC/HEIF).
   app.post("/api/v1/preview", async (request: FastifyRequest, reply: FastifyReply) => {
+    // Decodes attacker-supplied bytes through Sharp, libheif and LibRaw on behalf
+    // of the tool workflow, so it belongs behind the same grant as running a tool.
+    if (!(await requirePermission("tools:use")(request, reply))) return;
+
     const data = await request.file();
     if (!data) {
       return reply.status(400).send({ error: "No file provided" });

--- a/apps/api/src/routes/user-files.ts
+++ b/apps/api/src/routes/user-files.ts
@@ -33,8 +33,7 @@ import { decodeToSharpCompat, needsCliDecode } from "../lib/format-decoders.js";
 import { decodeHeic } from "../lib/heic-converter.js";
 import { isSvgBuffer, sanitizeSvg } from "../lib/svg-sanitize.js";
 import { pdfFirstPagePreview, videoPosterPreview } from "../modality/preview.js";
-import { hasEffectivePermission } from "../permissions.js";
-import { type AuthUser, requireAuth } from "../plugins/auth.js";
+import { hasEffectivePermission, requireFileAccess } from "../permissions.js";
 
 // ── Helpers ────────────────────────────────────────────────────────
 
@@ -115,38 +114,6 @@ function serializeFile(row: typeof schema.userFiles.$inferSelect) {
     toolChain: row.toolChain ?? [],
     createdAt: row.createdAt.toISOString(),
   };
-}
-
-/**
- * Gate the file-library routes on the file permissions.
- *
- * Either grant is enough: `files:all` is the broader one, so a holder of it is
- * never locked out for lacking `files:own`. This is the same rule
- * `requireApiKeyManagement` in routes/api-keys.ts already applies to the
- * identical apikeys:own / apikeys:all pair, and the roles editor presents Files
- * and API Keys as the same shape of group.
- *
- * Runs before the resource is resolved so a caller without the permission gets
- * 403 rather than a 404 that would confirm whether an id exists.
- *
- * See SEC-20260726-C01.
- */
-async function requireFileAccess(
-  request: FastifyRequest,
-  reply: FastifyReply,
-): Promise<AuthUser | null> {
-  const user = requireAuth(request, reply);
-  if (!user) return null;
-
-  if (
-    !(await hasEffectivePermission(user, "files:own")) &&
-    !(await hasEffectivePermission(user, "files:all"))
-  ) {
-    reply.status(403).send({ error: "Insufficient permissions", code: "FORBIDDEN" });
-    return null;
-  }
-
-  return user;
 }
 
 /**

--- a/tests/integration/security/upload-preview-authorization.test.ts
+++ b/tests/integration/security/upload-preview-authorization.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Authorization on the standalone upload and preview endpoints.
+ *
+ * These three routes sit outside both enforcement points the rest of the API
+ * relies on: `requireFileAccess`, which guards every route under /api/v1/files,
+ * and the tool-access middleware, which only fires for routes registered under
+ * /api/v1/tools/. Authentication alone used to be enough to reach them, so a
+ * principal an operator had scoped down to, say, settings:read could still stage
+ * bytes behind a public download URL and drive the image and media decoders.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { fixtures, readFixture } from "../../fixtures/index.js";
+import {
+  buildTestApp,
+  createMultipartPayload,
+  loginAsAdmin,
+  type TestApp,
+} from "../test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+/** Authenticates fine, holds neither tools:use nor files:own. */
+let scopedKey: string;
+/** The permissions a normal `user` role carries. */
+let capableKey: string;
+
+const PNG = readFixture(fixtures.image.base.png200);
+
+async function createKey(name: string, permissions: string[]): Promise<string> {
+  const res = await testApp.app.inject({
+    method: "POST",
+    url: "/api/v1/api-keys",
+    headers: { authorization: `Bearer ${adminToken}` },
+    payload: { name, permissions },
+  });
+  expect(res.statusCode).toBe(201);
+  return JSON.parse(res.body).key;
+}
+
+function pngUpload(fieldName: string) {
+  return createMultipartPayload([
+    { name: fieldName, filename: "probe.png", contentType: "image/png", content: PNG },
+  ]);
+}
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+  scopedKey = await createKey("no-file-rights", ["settings:read"]);
+  capableKey = await createKey("file-rights", ["tools:use", "files:own"]);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+describe("upload and preview authorization", () => {
+  it("refuses an upload from a principal without file permissions", async () => {
+    const { body, contentType } = pngUpload("file");
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/upload",
+      headers: { authorization: `Bearer ${scopedKey}`, "content-type": contentType },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(403);
+    // Nothing may be persisted, since /api/v1/download serves it without auth.
+    expect(JSON.parse(res.body)).not.toHaveProperty("jobId");
+  });
+
+  it("refuses an image preview from a principal without tool permissions", async () => {
+    const { body, contentType } = pngUpload("file");
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/preview",
+      headers: { authorization: `Bearer ${scopedKey}`, "content-type": contentType },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("refuses a media preview from a principal without tool permissions", async () => {
+    const { body, contentType } = pngUpload("file");
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/preview/generate",
+      headers: { authorization: `Bearer ${scopedKey}`, "content-type": contentType },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("still allows a principal that holds the permissions", async () => {
+    const upload = pngUpload("file");
+    const uploadRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/upload",
+      headers: { authorization: `Bearer ${capableKey}`, "content-type": upload.contentType },
+      payload: upload.body,
+    });
+    expect(uploadRes.statusCode).toBe(200);
+    expect(JSON.parse(uploadRes.body).jobId).toBeTruthy();
+
+    const preview = pngUpload("file");
+    const previewRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/preview",
+      headers: { authorization: `Bearer ${capableKey}`, "content-type": preview.contentType },
+      payload: preview.body,
+    });
+    expect(previewRes.statusCode).toBe(200);
+  });
+
+  it("still rejects anonymous callers with 401 rather than 403", async () => {
+    const { body, contentType } = pngUpload("file");
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/upload",
+      headers: { "content-type": contentType },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/tests/integration/test-server.ts
+++ b/tests/integration/test-server.ts
@@ -58,6 +58,7 @@ import { docsRoutes } from "../../apps/api/src/routes/docs.js";
 import { registerEnterpriseRoutes } from "../../apps/api/src/routes/enterprise/index.js";
 import { feedbackRoutes } from "../../apps/api/src/routes/feedback.js";
 import { registerFetchUrlsRoute } from "../../apps/api/src/routes/fetch-urls.js";
+import { filePreviewRoutes } from "../../apps/api/src/routes/file-preview.js";
 import { fileRoutes } from "../../apps/api/src/routes/files.js";
 import { registerJobRoutes } from "../../apps/api/src/routes/jobs.js";
 import { registerMemeTemplates } from "../../apps/api/src/routes/meme-templates.js";
@@ -191,6 +192,9 @@ export async function buildTestApp(): Promise<TestApp> {
 
   // User file library routes (persistent file management with versioning)
   await userFileRoutes(app);
+
+  // Library thumbnails plus the on-demand preview for uploaded media
+  await filePreviewRoutes(app);
 
   // Meme template routes
   await registerMemeTemplates(app);


### PR DESCRIPTION
Second of three fixes from a security review of the repo.

## What was wrong

`POST /api/v1/upload` (`routes/files.ts`), `POST /api/v1/preview` (same file) and `POST /api/v1/preview/generate` (`routes/file-preview.ts`) authenticated but never authorized. `routes/files.ts` imported no permission helper at all, and `file-preview.ts` called `getAuthUser(request)` and discarded the result under a comment describing the auth as optional.

Both enforcement points the codebase relies on miss these routes. `requireFileAccess` guards everything under `/api/v1/files`, and `toolAccessMiddleware` is scoped to the `/api/v1/tools/` prefix. These three sat in between.

This is invisible by default, because all three built-in roles hold `tools:use` and `files:own`. It bites once an operator uses custom roles or scoped API keys, both shipped features. A key issued for `settings:read` alone got 403 from `/api/v1/files` and 403 from the tool routes, then a 200 from `/api/v1/upload`, with the bytes readable at the unauthenticated `/api/v1/download/<uuid>/<name>` for up to `FILE_MAX_AGE_HOURS`. The same key drove Sharp, libheif and LibRaw through `/api/v1/preview`, and FFmpeg through `/api/v1/preview/generate`.

`Content-Disposition: attachment` plus the global `nosniff` means this is malware staging and domain-reputation abuse rather than stored XSS. The CPU cost of the decoders is denial of service and is not the point here.

## What changed

Upload takes `requireFileAccess`, because it persists bytes. Both preview routes take `tools:use`, because they decode on behalf of the tool workflow and keep nothing, so gating them on `files:own` would break an operator who deliberately granted tools without a library.

`requireFileAccess` moves from `routes/user-files.ts` into `permissions.ts` so both modules share one definition. The body is unchanged: `requireAuth` was already `getAuthUser` plus the identical 401.

## Verification

`tests/integration/security/upload-preview-authorization.test.ts` is new. It issues a real scoped API key through the API and asserts 403 on all three routes, 200 for a key holding `tools:use` and `files:own`, and 401 for an anonymous caller. Confirmed red first: upload and image preview both answered 200 for the scoped key.

`filePreviewRoutes` was never registered in the integration test server, so `/api/v1/preview/generate` returned 404 and that whole surface was unreachable from integration tests. Registering it is what made the media-preview case testable. With the gate removed again it answers 400 after reading the caller's bytes rather than 403, which is the regression this locks down.

Ran locally: full unit suite (449 files, 8217 tests) and the full integration suite (306 files, 9876 tests), both green. `pnpm typecheck` and `pnpm lint` clean.