### PR TITLE
docs(env): show the real default for SNAPOTTER_ALLOW_MODEL_DOWNLOAD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,10 +50,12 @@ LIBREOFFICE_TIMEOUT_S=120
 # PDFCPU_PATH=
 # SNAPOTTER_HW_ACCEL=  # nvenc|vaapi: hardware encoder family (default software)
 
-# AI tools fetch missing model files automatically (public model weights only,
-# never user data). Set 0 for airgapped deployments to guarantee zero outbound
-# fetches; missing models then produce actionable errors instead of downloads.
-SNAPOTTER_ALLOW_MODEL_DOWNLOAD=1
+# Runtime fallback downloads for AI model files, off by default. Bundle installs
+# are unaffected: they verify a pinned sha256 either way. Set 1 to let a tool
+# fetch a model file that is missing from its bundle (public model weights only,
+# never user data) instead of failing with an actionable error. Those fallback
+# fetches are not digest-checked, and some come from third-party model hosts.
+SNAPOTTER_ALLOW_MODEL_DOWNLOAD=0
 
 SESSION_DURATION_HOURS=168
 LOGIN_ATTEMPT_LIMIT=10


### PR DESCRIPTION
Follow-up from the security review. Not a vulnerability, an accuracy fix.

`.env.example` shipped `SNAPOTTER_ALLOW_MODEL_DOWNLOAD=1`, but:

- the code defaults to `0` and fails closed (`offline_guard.py:18`, and `bridge.ts:74-80` normalises the value and adds `HF_HUB_OFFLINE=1` when it is off)
- `apps/docs/guide/security.md:33` says "Runtime model downloads are disabled by default. Set `SNAPOTTER_ALLOW_MODEL_DOWNLOAD=1` only to explicitly opt into automatic fallback downloads"
- every other reference in the repo uses `0`, including `docker/build-ocr-runtime.sh` and `docker/verify-ocr-runtime.sh`

The rest of `.env.example` mirrors code defaults (`PORT=1349`, `AUTH_ENABLED=true`, `FILE_MAX_AGE_HOURS=72`), so this line read as "the shipped default is on" to anyone using the file as the reference it otherwise is. That matters because the fallback fetches it enables are exactly the ones with no digest verification, several against third-party model hosts, while the primary bundle install path verifies a pinned sha256 either way.

No runtime behaviour changes. No compose file or Dockerfile sets the variable, so the code default already governed real deployments; this only stops the example from contradicting the code and the security guide. Comment reworded around opting in.

Ran the AI unit tests (1055 passing) and `pnpm lint`.