### PR TITLE
fix(ai): align offline bundle import entry cap with the installer

### DIFF
--- a/apps/api/src/lib/feature-status.ts
+++ b/apps/api/src/lib/feature-status.ts
@@ -1479,7 +1479,13 @@ interface BundleDescriptor {
 }
 
 const IMPORT_MAX_BYTES = 20 * 1024 * 1024 * 1024; // 20 GB cumulative
-const IMPORT_MAX_ENTRIES = 10_000;
+// Matches the installer's own cap (max_entries in
+// packages/ai/python/install_runtime.py) so any bundle that installs online
+// also imports offline. OCR ships thousands of small files and blew the old
+// 10k cap while staying well under the installer's, so the same bundle
+// installed via the app but failed a manual import (#719). The 20 GB byte cap
+// and the entry-type/traversal guards remain the real DoS backstops.
+const IMPORT_MAX_ENTRIES = 100_000;
 
 export async function importBundleArchive(
   stream: Readable,

--- a/tests/integration/platform/feature-import.test.ts
+++ b/tests/integration/platform/feature-import.test.ts
@@ -260,6 +260,34 @@ describe("importBundleArchive", () => {
     expect(readFileSync(modelPath)).toEqual(fakeModel);
   });
 
+  it("imports a bundle whose file count exceeds the legacy 10k entry cap (#719)", async () => {
+    // OCR-style bundle: thousands of small files. The old 10k manual-import
+    // cap rejected these ("Archive exceeds 10000 entry limit") even though the
+    // installer accepts them, so the same bundle installed via the app but
+    // failed an offline import. Entry count here (~10,052 incl. bundle.json
+    // and the models/ dir) is above the old cap and well under the new one.
+    const count = 10_050;
+    const modelFiles = Array.from({ length: count }, (_, i) => ({
+      path: `f${i}.bin`,
+      content: Buffer.from([i & 0xff]),
+    }));
+    const archivePath = await buildArchive(
+      {
+        bundleId: testBundleId,
+        version: testVersion,
+        models: modelFiles.map((m) => m.path),
+      },
+      modelFiles,
+    );
+
+    const result = await importBundleArchive(createReadStream(archivePath));
+
+    expect(result.bundleId).toBe(testBundleId);
+    expect(result.models).toHaveLength(count);
+    expect(existsSync(join(modelsDir, "f0.bin"))).toBe(true);
+    expect(existsSync(join(modelsDir, `f${count - 1}.bin`))).toBe(true);
+  }, 60_000);
+
   it("rejects archive with path traversal", async () => {
     const traversalPath = await buildTraversalArchive();
     const stream = createReadStream(traversalPath);


### PR DESCRIPTION
## What
Manual AI bundle import rejected archives over 10,000 entries (`IMPORT_MAX_ENTRIES` in `feature-status.ts`), while the installer allows 100,000 (`max_entries` in `install_runtime.py`). The OCR bundle ships thousands of small files, so it installed fine through the app yet failed an offline import with `Archive exceeds 10000 entry limit`. This raises the manual cap to match the installer.

## Why
Reported through in-app feedback several times across languages (#719). Two code paths handling the same bundles disagreed on the entry cap.

## Risk
Low. The 20 GB cumulative byte cap and the entry-type and path-traversal guards are the real DoS backstops and are untouched. Only the entry count aligns with what the installer already accepts for the identical bundles.

## Testing
Added an integration case in `feature-import.test.ts` that imports a ~10,050-file bundle (above the old cap, under the new one) and confirms the files land in the models dir.

- `pnpm vitest run tests/integration/platform/feature-import.test.ts` -> 21 passed
- `pnpm --filter @snapotter/api typecheck` clean

Fixes #719