### PR TITLE
fix(web): honor WebP/AVIF output for remove-background transparent case

### DIFF
--- a/apps/web/src/components/tools/remove-bg-settings.tsx
+++ b/apps/web/src/components/tools/remove-bg-settings.tsx
@@ -739,7 +739,12 @@ export function RemoveBgSettings({ onBgPreview }: RemoveBgSettingsProps = {}) {
   // keeps the skip and save decisions reading the same live state at one point,
   // so toggling effects after Phase 1 can neither drop nor double the save.
   const fromLibrary = Boolean(currentEntry?.serverFileId);
-  const needsEffectsRequest = Boolean(hasEffectsToApply) || fromLibrary;
+  // WebP/AVIF output is only produced by the Phase 2 effects request; Phase 1
+  // always writes a PNG. Without this, choosing a non-PNG format with a
+  // transparent background and no effects fell through to the plain download
+  // of the Phase 1 PNG, so the chosen format was silently ignored (#720).
+  const wantsNonPngOutput = ((settings.outputFormat as string) ?? "png") !== "png";
+  const needsEffectsRequest = Boolean(hasEffectsToApply) || fromLibrary || wantsNonPngOutput;
 
   // Build CSS preview state from current settings and send to tool-page
   useEffect(() => {

--- a/tests/unit/web/remove-bg-output-format.test.tsx
+++ b/tests/unit/web/remove-bg-output-format.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Phase 1 (background removal) is "done": the processor exposes a mask PNG
+// download URL and is no longer processing, so the wrapper renders its
+// download controls. Only Phase 2 (the effects request) re-encodes to the
+// chosen output format; Phase 1 always emits PNG.
+vi.mock("@/hooks/use-tool-processor", () => ({
+  useToolProcessor: () => ({
+    processFiles: vi.fn(),
+    processAllFiles: vi.fn(),
+    processing: false,
+    error: null,
+    downloadUrl: "/api/v1/download/JOB123/pic_mask.png",
+    originalSize: 1000,
+    processedSize: 500,
+    progress: { phase: "idle", percent: 0, stage: "", elapsed: 0 },
+  }),
+}));
+
+import { RemoveBgSettings } from "@/components/tools/remove-bg-settings";
+import { useFileStore } from "@/stores/file-store";
+
+beforeEach(() => {
+  // jsdom has no object-URL support; the file store mints preview URLs.
+  URL.createObjectURL = vi.fn(() => "blob:mock");
+  URL.revokeObjectURL = vi.fn();
+  // One local (non-library) file, so fromLibrary is false and the output
+  // format is the only thing that can route the download through Phase 2.
+  useFileStore
+    .getState()
+    .setFiles([new File([new Uint8Array([1, 2, 3])], "pic.png", { type: "image/png" })]);
+});
+
+afterEach(() => {
+  cleanup();
+  useFileStore.getState().setFiles([]);
+});
+
+describe("remove-background output format routing (#720)", () => {
+  it("uses the plain (Phase 1) download for the default PNG output", async () => {
+    render(<RemoveBgSettings />);
+
+    // Download controls appear once the Phase 1 result is picked up.
+    expect(await screen.findByTestId("remove-background-download")).toBeInTheDocument();
+    expect(screen.queryByTestId("remove-background-download-effects")).not.toBeInTheDocument();
+  });
+
+  it("routes the download through the effects request when WebP is chosen", async () => {
+    render(<RemoveBgSettings />);
+
+    // Default PNG: plain download.
+    await screen.findByTestId("remove-background-download");
+
+    // Choose WebP output (transparent background, no effects).
+    fireEvent.click(screen.getByTestId("remove-background-format-webp"));
+
+    // The download must now go through Phase 2, the only path that re-encodes,
+    // instead of handing back the Phase 1 PNG.
+    await waitFor(() => {
+      expect(screen.getByTestId("remove-background-download-effects")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("remove-background-download")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What
remove-background exposes a WebP/AVIF output option, but selecting it returned a PNG when the background was transparent with no effects. The chosen format was silently dropped.

## Why
The tool runs two phases. Phase 1 removes the background and always writes a PNG (the cached mask). Phase 2 (`/effects`) is the only path that re-encodes to the chosen format. The download button only routed through Phase 2 when effects applied or the file came from the library, so the transparent, no-effects case handed back the Phase 1 PNG regardless of the format picked.

## Fix
Treat a non-PNG output format as a reason to route the download through Phase 2, alongside the existing effects/library conditions. One line in `remove-bg-settings.tsx`. The multi-file batch path and the pipeline process fn already honored the format.

## Testing
Added `tests/unit/web/remove-bg-output-format.test.tsx`: after Phase 1 completes, the default PNG keeps the plain download, and selecting WebP switches the control to the Phase 2 effects download. Confirmed the WebP case fails without the fix.

- `pnpm vitest run tests/unit/web/remove-bg-output-format.test.tsx` -> 2 passed
- `pnpm --filter @snapotter/web typecheck` clean

Fixes #720