### PR TITLE
fix(telemetry): flatten python frames so they survive Sentry normalization

### DIFF
--- a/apps/api/src/lib/error-report.ts
+++ b/apps/api/src/lib/error-report.ts
@@ -198,7 +198,17 @@ export async function reportError(err: unknown, ctx: ReportContext): Promise<voi
       }
       const py = err as { pythonType?: string; pythonFrames?: unknown };
       if (Array.isArray(py.pythonFrames) && py.pythonFrames.length) {
-        scope.setContext("python", { type: py.pythonType, frames: py.pythonFrames });
+        // Flatten each frame to a short string. An array of frame OBJECTS sits
+        // deeper than Sentry's default normalizeDepth (3), so the SDK truncates
+        // each to "[Object]" before beforeSend runs and the context is lost.
+        // Strings are primitives and survive normalization at any depth.
+        const frames = py.pythonFrames
+          .map((f) => {
+            const o = (f ?? {}) as { file?: unknown; line?: unknown; func?: unknown };
+            return `${String(o.file)}:${String(o.line)} ${String(o.func)}`;
+          })
+          .slice(0, 20);
+        scope.setContext("python", { type: py.pythonType, frames });
       }
       Sentry.captureException(err instanceof Error ? err : new Error(String(err)));
     });

--- a/apps/api/src/lib/sentry-scrub.ts
+++ b/apps/api/src/lib/sentry-scrub.ts
@@ -182,15 +182,12 @@ export function buildBeforeSend(isActive: () => boolean, diagnostic = false) {
     const py = asObj(ctx?.python);
     if (py) {
       const type = typeof py.type === "string" ? py.type.slice(0, 64) : undefined;
+      // Frames arrive as flat strings ("file.py:12 func"); reportError flattens
+      // them so they survive Sentry's normalizeDepth. Keep strings only.
       const frames = Array.isArray(py.frames)
         ? py.frames
-            .map((f) => asObj(f))
-            .filter((f): f is AnyEvent => !!f)
-            .map((f) => ({
-              file: typeof f.file === "string" ? f.file.slice(0, 64) : "?",
-              line: typeof f.line === "number" ? f.line : 0,
-              func: typeof f.func === "string" ? f.func.slice(0, 64) : "?",
-            }))
+            .filter((f): f is string => typeof f === "string")
+            .map((f) => f.slice(0, 200))
             .slice(0, 20)
         : [];
       if (frames.length) keep.python = { type, frames };

--- a/tests/unit/api/sentry-scrub.test.ts
+++ b/tests/unit/api/sentry-scrub.test.ts
@@ -137,24 +137,21 @@ describe("buildBeforeSend (api)", () => {
     const out = send(evt({ contexts: { device: { hostname: "leak" } } }), {})!;
     expect(out.contexts).toBeUndefined();
   });
-  it("keeps a vetted python context and drops overlong fields", () => {
+  it("keeps a vetted python context of frame strings and drops overlong ones", () => {
     const event = {
       ...evt(),
       contexts: {
         python: {
           type: "RuntimeError",
-          frames: [
-            { file: "remove_bg.py", line: 88, func: "run" },
-            { file: "x".repeat(200), line: 1, func: "y".repeat(200) },
-          ],
+          frames: ["remove_bg.py:88 run", "x".repeat(500)],
         },
       },
     };
     const out = send(event, { originalException: new Error("x") })!;
     expect(out.contexts.python.type).toBe("RuntimeError");
     expect(out.contexts.python.frames).toHaveLength(2);
-    expect(out.contexts.python.frames[1].file.length).toBeLessThanOrEqual(64);
-    expect(out.contexts.python.frames[1].func.length).toBeLessThanOrEqual(64);
+    expect(out.contexts.python.frames[0]).toBe("remove_bg.py:88 run");
+    expect(out.contexts.python.frames[1].length).toBeLessThanOrEqual(200);
   });
   it("enforces the 500-events-per-hour ceiling", () => {
     for (let i = 0; i < 500; i++) expect(send(evt(), {})).not.toBeNull();

--- a/tests/unit/api/sentry-sdk-integration.test.ts
+++ b/tests/unit/api/sentry-sdk-integration.test.ts
@@ -1,0 +1,156 @@
+/**
+ * End-to-end check against the REAL @sentry/node SDK (not synthetic events):
+ * init Sentry with our buildBeforeSend + a capturing transport, push errors
+ * through reportError, and assert the actual outgoing event. This validates the
+ * SDK -> beforeSend integration the other unit tests stub, and that beforeSend
+ * never throws on a real SDK event (which would drop or leak an event).
+ */
+import * as Sentry from "@sentry/node";
+import { SafeError } from "@snapotter/shared";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  __resetGateForTests,
+  __setReaderForTests,
+  primeAnalyticsGate,
+} from "../../../apps/api/src/lib/analytics-gate.js";
+import { reportError, resetThrottleForTests } from "../../../apps/api/src/lib/error-report.js";
+import { buildBeforeSend } from "../../../apps/api/src/lib/sentry-scrub.js";
+
+interface Cap {
+  input: Record<string, unknown>;
+  output: Record<string, unknown> | null;
+  threw: unknown;
+}
+const captured: Cap[] = [];
+const clone = (v: unknown) => JSON.parse(JSON.stringify(v ?? null));
+
+beforeAll(async () => {
+  process.env.ANALYTICS_BAKED_OVERRIDE = "on"; // NODE_ENV=test lets the gate turn on
+  __setReaderForTests(async () => true);
+  await primeAnalyticsGate();
+  const real = buildBeforeSend(() => true);
+  Sentry.init({
+    dsn: "https://0123456789abcdef0123456789abcdef@o1.ingest.sentry.io/1",
+    defaultIntegrations: false,
+    // Deliberately NOT setting normalizeDepth: the real init uses the default (3),
+    // and the flattened string frames must survive that.
+    beforeSend: (event, hint) => {
+      const input = clone({
+        exception: event.exception,
+        message: event.message,
+        request: event.request,
+        tags: event.tags,
+        contexts: event.contexts,
+      });
+      let output: unknown;
+      let threw: unknown = null;
+      try {
+        output = real(event as never, hint as never);
+      } catch (e) {
+        threw = e;
+      }
+      captured.push({ input, output: output ? clone(output) : null, threw });
+      return output as never;
+    },
+    transport: () => ({ send: async () => ({}) as never, flush: async () => true }),
+  });
+});
+
+afterAll(async () => {
+  await Sentry.close(0);
+  __resetGateForTests();
+  delete process.env.ANALYTICS_BAKED_OVERRIDE;
+});
+
+async function capture(err: unknown, ctx: Parameters<typeof reportError>[1]): Promise<Cap> {
+  resetThrottleForTests();
+  captured.length = 0;
+  await reportError(err, ctx);
+  await Sentry.flush(2000);
+  expect(captured.length).toBeGreaterThan(0); // the SDK actually called our beforeSend
+  return captured.at(-1) as Cap;
+}
+
+const outStr = (c: Cap) => JSON.stringify(c.output);
+const lastValue = (c: Cap) =>
+  (c.output?.exception as { values?: Array<{ value?: string }> })?.values?.at(-1)?.value ?? "";
+
+describe("real @sentry/node integration", () => {
+  it("redacts a plain Error message and drops PII surfaces", async () => {
+    const c = await capture(new Error("open /data/uploads/9f/holiday_in_paris.jpg failed"), {
+      source: "worker",
+      pool: "image",
+      toolId: "rounded-crop",
+    });
+    expect(c.threw).toBeNull(); // beforeSend did not throw on a real SDK event
+    // the SDK built the raw event with the real message
+    expect(JSON.stringify(c.input.exception)).toContain("holiday_in_paris");
+    // the scrubbed, outgoing event does not leak it
+    expect(lastValue(c)).toBe("open <path> failed");
+    expect(outStr(c)).not.toContain("holiday_in_paris");
+    expect(outStr(c)).not.toContain("/data/uploads");
+    expect((c.output as { request?: unknown }).request).toBeUndefined();
+    expect((c.output as { tags: Record<string, string> }).tags.tool_id).toBe("rounded-crop");
+  });
+
+  it("keeps a vetted python context for a sidecar SafeError", async () => {
+    const e = new SafeError("Background removal failed", { kind: "bug" });
+    Object.assign(e, {
+      pythonType: "RuntimeError",
+      pythonFrames: [{ file: "remove_bg.py", line: 88, func: "run" }],
+    });
+    const c = await capture(e, { source: "worker", pool: "ai", toolId: "remove-background" });
+    expect(c.threw).toBeNull();
+    const py = (c.output?.contexts as { python?: { type?: string; frames?: unknown[] } })?.python;
+    expect(py?.type).toBe("RuntimeError");
+    // reportError flattens frame objects to strings so they survive normalizeDepth.
+    expect(py?.frames).toEqual(["remove_bg.py:88 run"]);
+    expect(lastValue(c)).toBe("Background removal failed");
+  });
+
+  it("rebuilds a pg error and redacts an IP in the message", async () => {
+    const pg = Object.assign(new Error("could not connect to 10.1.2.3"), {
+      code: "28P01",
+      routine: "auth_failed",
+    });
+    const c = await capture(pg, { source: "worker", pool: "system" });
+    expect(c.threw).toBeNull();
+    expect(lastValue(c)).toBe("pg 28P01 auth_failed");
+    expect((c.output as { tags: Record<string, string> }).tags.error_class).toBe("operational");
+  });
+
+  it("derives a frame title for an empty-message error", async () => {
+    const e = new Error("");
+    e.stack = "Error\n    at Object.process (/app/apps/api/src/routes/tools/rounded-crop.ts:96:10)";
+    const c = await capture(e, { source: "worker", pool: "image", toolId: "rounded-crop" });
+    expect(c.threw).toBeNull();
+    expect(lastValue(c)).toBe("at rounded-crop.ts:96");
+  });
+
+  it("only ships allowlisted tags (no stray keys)", async () => {
+    const c = await capture(new Error("boom"), {
+      source: "worker",
+      pool: "image",
+      toolId: "crop",
+    });
+    const allowed = new Set([
+      "source",
+      "tool_id",
+      "pool",
+      "route",
+      "method",
+      "error_class",
+      "error_code",
+      "deploy_mode",
+      "subsystem",
+      "status_code",
+      "input_format",
+      "job_id",
+      "instance_id",
+      "error_name",
+    ]);
+    for (const k of Object.keys((c.output as { tags: Record<string, string> }).tags ?? {})) {
+      expect(allowed.has(k)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The Python-traceback context from #741 never actually reached Sentry. `reportError` attached `contexts.python.frames` as an array of `{file, line, func}` objects, which sits deeper than Sentry's default `normalizeDepth` of 3, so the SDK truncated each frame to the literal string `"[Object]"` before `beforeSend` ran. The scrubber then saw non-object frames, vetted them to empty, and dropped the whole context. AI-tool failures shipped no Python stack, silently.

The existing unit tests missed it because they fed synthetic events straight to the scrubber and bypassed the SDK's normalization. A new real-SDK integration test catches it.

## Fix

Flatten each frame to a short string (`remove_bg.py:88 run`) in `reportError` before attaching the context. Strings are primitives, so they survive normalization at any depth. The scrubber now vets `python.frames` as capped strings.

## Test

`tests/unit/api/sentry-sdk-integration.test.ts` initializes the real `@sentry/node` with our `beforeSend` and a capturing transport, pushes a plain Error, a SafeError carrying python frames, a pg error, and an empty-message error through `reportError`, and asserts the actual outgoing event. It runs at the SDK's default `normalizeDepth`, so a regression to object frames fails it. It also asserts `beforeSend` never throws on a real SDK event.

## Test plan

- New integration test passes at default `normalizeDepth`; the python frames arrive as `["remove_bg.py:88 run"]`.
- Full api unit suite green (3272 tests); `@snapotter/api` typecheck clean.
