### PR TITLE
fix(web): show the pixelate result on screen in selection mode

### DIFF
--- a/apps/web/src/lib/tool-display-modes.ts
+++ b/apps/web/src/lib/tool-display-modes.ts
@@ -253,3 +253,12 @@ for (const preset of CONVERSION_PRESETS) {
   }
 }
 export const MULTI_FILE_TOOLS: ReadonlySet<string> = multiFileTools;
+
+/**
+ * Live-preview tools whose imageWrapperStyle/children are an input control
+ * (pixelate's selection box), not a CSS simulation of the result. After
+ * processing, the viewer switches to the server result for these and keeps
+ * the overlay usable for the next round; simulation tools (vignette, duotone,
+ * beautify, ...) keep showing the styled original, which IS the result (#713).
+ */
+export const LIVE_PREVIEW_INPUT_OVERLAY_TOOLS: ReadonlySet<string> = new Set(["pixelate"]);

--- a/apps/web/src/pages/tool-page.tsx
+++ b/apps/web/src/pages/tool-page.tsx
@@ -49,7 +49,7 @@ import { formatFileSize } from "@/lib/download";
 import { classifyFeedbackError } from "@/lib/feedback";
 import { format } from "@/lib/format";
 import { ICON_MAP } from "@/lib/icon-map";
-import { MULTI_FILE_TOOLS } from "@/lib/tool-display-modes";
+import { LIVE_PREVIEW_INPUT_OVERLAY_TOOLS, MULTI_FILE_TOOLS } from "@/lib/tool-display-modes";
 import { getToolName } from "@/lib/tool-i18n";
 import { getToolRegistryEntry } from "@/lib/tool-registry";
 import { useBase64Store } from "@/stores/base64-store";
@@ -946,13 +946,17 @@ export function ToolPage() {
     }
 
     // For live-preview tools: keep showing the CSS-styled original so WYSIWYG.
-    // The server-rendered result is available via download.
+    // The server-rendered result is available via download. Tools whose
+    // overlay is an input control (pixelate's selection box) get the opposite
+    // treatment: the style simulates nothing, so show the server result and
+    // keep the overlay on top for the next region (#713).
     if (hasProcessed && originalBlobUrl && displayMode === "live-preview" && imageWrapperStyle) {
+      const overlayIsInput = toolId ? LIVE_PREVIEW_INPUT_OVERLAY_TOOLS.has(toolId) : false;
       return (
         <ImageViewer
-          src={originalBlobUrl}
-          filename={selectedFileName ?? files[0].name}
-          fileSize={selectedFileSize ?? files[0].size}
+          src={overlayIsInput ? displayUrl : originalBlobUrl}
+          filename={overlayIsInput ? processedFileName : (selectedFileName ?? files[0].name)}
+          fileSize={overlayIsInput ? (processedSize ?? 0) : (selectedFileSize ?? files[0].size)}
           imageWrapperStyle={imageWrapperStyle}
           imageWrapperChildren={imageWrapperChildren}
         />

--- a/apps/web/src/pages/tool-page.tsx
+++ b/apps/web/src/pages/tool-page.tsx
@@ -904,24 +904,26 @@ export function ToolPage() {
       }
     }
 
+    const conversionCompleteCard = (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="text-center p-8 max-w-xs">
+          <div className="mx-auto w-16 h-16 rounded-2xl bg-emerald-50 dark:bg-emerald-950/30 flex items-center justify-center mb-4">
+            <CheckCircle2 className="h-8 w-8 text-success-ink" />
+          </div>
+          <p className="font-medium text-foreground mb-1">{t.toolPage.conversionComplete}</p>
+          <p className="text-sm text-muted-foreground mb-1">{processedFileName}</p>
+          {processedSize != null && (
+            <p className="text-xs text-muted-foreground">
+              {processedFileType} &middot; {formatFileSize(processedSize)}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+
     // Non-previewable format with no fallback at all - show success card
     if (hasProcessed && !isProcessedPreviewable && !processedPreviewUrl && !originalBlobUrl) {
-      return (
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center p-8 max-w-xs">
-            <div className="mx-auto w-16 h-16 rounded-2xl bg-emerald-50 dark:bg-emerald-950/30 flex items-center justify-center mb-4">
-              <CheckCircle2 className="h-8 w-8 text-success-ink" />
-            </div>
-            <p className="font-medium text-foreground mb-1">{t.toolPage.conversionComplete}</p>
-            <p className="text-sm text-muted-foreground mb-1">{processedFileName}</p>
-            {processedSize != null && (
-              <p className="text-xs text-muted-foreground">
-                {processedFileType} &middot; {formatFileSize(processedSize)}
-              </p>
-            )}
-          </div>
-        </div>
-      );
+      return conversionCompleteCard;
     }
 
     if (
@@ -952,11 +954,30 @@ export function ToolPage() {
     // keep the overlay on top for the next region (#713).
     if (hasProcessed && originalBlobUrl && displayMode === "live-preview" && imageWrapperStyle) {
       const overlayIsInput = toolId ? LIVE_PREVIEW_INPUT_OVERLAY_TOOLS.has(toolId) : false;
+      if (overlayIsInput) {
+        // Never substitute the original for the result here: pixelate
+        // redacts, and a missing result preview rendered as the untouched
+        // original would show unredacted content under the processed
+        // filename. Without a renderable result, show the success card.
+        const resultSrc = processedPreviewUrl ?? (isProcessedPreviewable ? processedUrl : null);
+        if (!resultSrc) {
+          return conversionCompleteCard;
+        }
+        return (
+          <ImageViewer
+            src={resultSrc}
+            filename={processedFileName}
+            fileSize={processedSize ?? 0}
+            imageWrapperStyle={imageWrapperStyle}
+            imageWrapperChildren={imageWrapperChildren}
+          />
+        );
+      }
       return (
         <ImageViewer
-          src={overlayIsInput ? displayUrl : originalBlobUrl}
-          filename={overlayIsInput ? processedFileName : (selectedFileName ?? files[0].name)}
-          fileSize={overlayIsInput ? (processedSize ?? 0) : (selectedFileSize ?? files[0].size)}
+          src={originalBlobUrl}
+          filename={selectedFileName ?? files[0].name}
+          fileSize={selectedFileSize ?? files[0].size}
           imageWrapperStyle={imageWrapperStyle}
           imageWrapperChildren={imageWrapperChildren}
         />

--- a/tests/e2e/pixelate-display.spec.ts
+++ b/tests/e2e/pixelate-display.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test, uploadTestImage } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// What is on screen AFTER processing, for live-preview tools (#713).
+//
+// Live-preview tools whose wrapper style simulates the result (vignette,
+// duotone, beautify, ...) keep showing the styled original: WYSIWYG. Pixelate
+// is different: its overlay is the selection box, an input control, so after
+// processing the viewer must switch to the server-rendered result. Before the
+// fix, selection mode kept showing the untouched original forever while the
+// download link quietly carried the real result.
+// ---------------------------------------------------------------------------
+
+test.describe("Pixelate result display (#713)", () => {
+  test("whole-image mode shows the processed image", async ({ loggedInPage: page }) => {
+    await page.goto("/image/pixelate");
+    await uploadTestImage(page);
+
+    const submit = page.getByTestId("pixelate-submit");
+    await expect(submit).toBeEnabled({ timeout: 5000 });
+    await submit.click();
+    await expect(page.getByTestId("pixelate-download")).toBeVisible({ timeout: 30_000 });
+
+    const result = page.locator('img[alt="test-image_pixelated.png"]');
+    await expect(result).toBeVisible({ timeout: 10_000 });
+    expect(await result.getAttribute("src")).toContain("/api/v1/download/");
+  });
+
+  test("selection mode shows the processed image and keeps the box", async ({
+    loggedInPage: page,
+  }) => {
+    await page.goto("/image/pixelate");
+    await uploadTestImage(page);
+
+    await page.getByTestId("pixelate-mode-selection").click();
+    await expect(page.getByTestId("pixelate-selection-box")).toBeVisible({ timeout: 5000 });
+
+    const submit = page.getByTestId("pixelate-submit");
+    await expect(submit).toBeEnabled({ timeout: 5000 });
+    await submit.click();
+    await expect(page.getByTestId("pixelate-download")).toBeVisible({ timeout: 30_000 });
+
+    // The viewer must switch to the server result, not keep the original.
+    const result = page.locator('img[alt="test-image_pixelated.png"]');
+    await expect(result).toBeVisible({ timeout: 10_000 });
+    expect(await result.getAttribute("src")).toContain("/api/v1/download/");
+
+    // The selection box is an input control and stays available for the
+    // next region, rendered over the result.
+    await expect(page.getByTestId("pixelate-selection-box")).toBeVisible();
+  });
+
+  test("beautify keeps the styled original after processing (WYSIWYG pin)", async ({
+    loggedInPage: page,
+  }) => {
+    // The other side of the contract: for tools whose wrapper style simulates
+    // the result, processing must NOT switch the viewer away from the styled
+    // original. Guards against "fixing" #713 by dropping that branch.
+    await page.goto("/image/beautify");
+    await uploadTestImage(page);
+
+    const submit = page.getByTestId("beautify-submit");
+    await expect(submit).toBeEnabled({ timeout: 5000 });
+    await submit.click();
+    await expect(page.getByTestId("beautify-download")).toBeVisible({ timeout: 30_000 });
+
+    const original = page.locator('img[alt="test-image.png"]');
+    await expect(original).toBeVisible({ timeout: 10_000 });
+    expect(await original.getAttribute("src")).toContain("blob:");
+  });
+});

--- a/tests/e2e/pixelate-display.spec.ts
+++ b/tests/e2e/pixelate-display.spec.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { expect, test, uploadTestImage } from "./helpers";
 
 // ---------------------------------------------------------------------------
@@ -43,11 +44,68 @@ test.describe("Pixelate result display (#713)", () => {
     // The viewer must switch to the server result, not keep the original.
     const result = page.locator('img[alt="test-image_pixelated.png"]');
     await expect(result).toBeVisible({ timeout: 10_000 });
-    expect(await result.getAttribute("src")).toContain("/api/v1/download/");
+    const round1Src = await result.getAttribute("src");
+    expect(round1Src).toContain("/api/v1/download/");
 
     // The selection box is an input control and stays available for the
     // next region, rendered over the result.
-    await expect(page.getByTestId("pixelate-selection-box")).toBeVisible();
+    const box = page.getByTestId("pixelate-selection-box");
+    await expect(box).toBeVisible();
+
+    // Round 2: the box must still be draggable over the result, and
+    // re-applying must put a NEW result on screen, not the stale one.
+    const beforeLeft = await box.evaluate((el) => (el as HTMLElement).style.left);
+    const bb = await box.boundingBox();
+    expect(bb).not.toBeNull();
+    if (!bb) return;
+    await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(bb.x + bb.width / 2 - 80, bb.y + bb.height / 2 - 60, { steps: 5 });
+    await page.mouse.up();
+    await expect
+      .poll(async () => box.evaluate((el) => (el as HTMLElement).style.left))
+      .not.toBe(beforeLeft);
+
+    await submit.click();
+    await expect(page.getByTestId("pixelate-download")).toBeVisible({ timeout: 30_000 });
+    await expect
+      .poll(async () => result.getAttribute("src"), { timeout: 15_000 })
+      .not.toBe(round1Src);
+    expect(await result.getAttribute("src")).toContain("/api/v1/download/");
+  });
+
+  test("selection mode shows the decoded result preview for TIFF output", async ({
+    loggedInPage: page,
+  }) => {
+    // Pixelate mirrors the input format, so a TIFF input produces a TIFF
+    // result the browser cannot render in <img>. The server-generated
+    // preview must be shown; falling back to the original blob would show
+    // unredacted content labeled as the result.
+    await page.goto("/image/pixelate");
+
+    const fileChooserPromise = page.waitForEvent("filechooser");
+    await page
+      .getByRole("button", { name: /upload from computer/i })
+      .first()
+      .click();
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(
+      path.join(process.cwd(), "tests", "fixtures", "image", "formats", "sample.tiff"),
+    );
+
+    await page.getByTestId("pixelate-mode-selection").click();
+    await expect(page.getByTestId("pixelate-selection-box")).toBeVisible({ timeout: 10_000 });
+
+    const submit = page.getByTestId("pixelate-submit");
+    await expect(submit).toBeEnabled({ timeout: 5000 });
+    await submit.click();
+    await expect(page.getByTestId("pixelate-download")).toBeVisible({ timeout: 30_000 });
+
+    const result = page.locator('img[alt="sample_pixelated.tiff"]');
+    await expect(result).toBeVisible({ timeout: 10_000 });
+    const src = await result.getAttribute("src");
+    expect(src).not.toContain("blob:");
+    expect(src).toContain("/api/v1/download/");
   });
 
   test("beautify keeps the styled original after processing (WYSIWYG pin)", async ({

--- a/tests/unit/web/live-preview-input-overlay-drift.test.ts
+++ b/tests/unit/web/live-preview-input-overlay-drift.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { LIVE_PREVIEW_INPUT_OVERLAY_TOOLS, TOOL_DISPLAY_MODES } from "@/lib/tool-display-modes";
+
+/**
+ * Issue #713: LIVE_PREVIEW_INPUT_OVERLAY_TOOLS switches the post-processing
+ * viewer to the server result for live-preview tools whose overlay is an
+ * input control. A member that is not actually a live-preview tool never
+ * reaches the branch that reads the set, so a typo'd id silently
+ * reintroduces the bug for that tool.
+ */
+describe("LIVE_PREVIEW_INPUT_OVERLAY_TOOLS drift (issue #713)", () => {
+  it("contains only ids registered as live-preview tools", () => {
+    expect(LIVE_PREVIEW_INPUT_OVERLAY_TOOLS.size).toBeGreaterThan(0);
+    for (const id of LIVE_PREVIEW_INPUT_OVERLAY_TOOLS) {
+      expect(
+        TOOL_DISPLAY_MODES[id],
+        `"${id}" is in LIVE_PREVIEW_INPUT_OVERLAY_TOOLS but is not a live-preview tool`,
+      ).toBe("live-preview");
+    }
+  });
+});


### PR DESCRIPTION
Closes #713, the unfinished half of #678: selection-mode pixelate produced a correct file you could download while the viewer kept showing the untouched original, indefinitely.

**Cause.** The live-preview display branch keeps showing the CSS-styled original whenever a tool has set imageWrapperStyle, on the assumption the style simulates the result. Right for vignette, duotone, beautify, border, and image-pad. Wrong for pixelate, which sets the style only to host its selection box: an input control.

**Fix.** A React-free `LIVE_PREVIEW_INPUT_OVERLAY_TOOLS` set in tool-display-modes.ts (the repo's single source for per-tool display facts) marks pixelate's overlay as input. After processing, those tools switch the viewer to the server result and keep the overlay on top, so the box is still there for the next region. Simulation tools are untouched. One guard came out of review: on this path a missing result preview (TIFF/JXL output whose server preview generation failed) renders the success card instead of falling back to the original blob, because a redaction tool must never display unredacted content under the processed filename.

**Tests.** No e2e ever asserted what is on screen after processing for any live-preview tool, which is how six green tests sat on top of this bug. The new spec pins both sides of the contract:

- whole-image mode shows the processed image
- selection mode shows the processed image, keeps the box draggable, and a second Apply replaces the on-screen result (watched failing before the fix, exactly at "result image never appears")
- TIFF output shows the server preview, never the original blob
- beautify keeps the styled original after processing (WYSIWYG pin)

Plus a drift unit test locking every set member to a live-preview registration.

Mutants, each killed by exactly the intended assertion: overlayIsInput forced true for all tools (beautify pin), pointerEvents dead on the box (round-2 drag), resultSrc forced null (selection and TIFF tests), a bogus set member (drift test).

Verification: new spec green, full beautify spec green, the two catalog-wide specs that render every tool page green (291 tests), full unit suite green (8251), typecheck and Biome clean.

Review also found three pre-existing adjacent defects that stay out of this PR, filed as #746: the same original-blob fallback in the sibling display branches, batch runs leaking stale processed state, and the viewer's silent load-error path.
