### PR TITLE
fix(ai): CPU-aware timeouts, abort propagation, and install liveness

### DIFF
--- a/apps/api/src/routes/tools/remove-background.ts
+++ b/apps/api/src/routes/tools/remove-background.ts
@@ -56,6 +56,7 @@ registerAiJobHandler("remove-background", async (input, data, ctx) => {
       model: settings.model,
       edgeRefine: settings.edgeRefine,
       decontaminate: settings.decontaminate,
+      signal: ctx.signal,
     },
     (percent, stage) => ctx.report(percent, stage),
   );
@@ -397,6 +398,7 @@ export function registerRemoveBackground(app: FastifyInstance) {
           model: s.model,
           edgeRefine: s.edgeRefine,
           decontaminate: s.decontaminate,
+          signal: ctx?.signal,
         });
 
         const fmt = (s.outputFormat ?? "png") as BgOutputFormat;

--- a/apps/api/src/routes/tools/upscale.ts
+++ b/apps/api/src/routes/tools/upscale.ts
@@ -54,7 +54,15 @@ registerAiJobHandler("upscale", async (input, data, ctx) => {
   const result = await upscale(
     input,
     ctx.scratchDir,
-    { scale, model, faceEnhance, denoise, format: pythonFormat, quality: outputQuality },
+    {
+      scale,
+      model,
+      faceEnhance,
+      denoise,
+      format: pythonFormat,
+      quality: outputQuality,
+      signal: ctx.signal,
+    },
     (percent, stage) => ctx.report(percent, stage),
   );
 
@@ -255,7 +263,7 @@ export function registerUpscale(app: FastifyInstance) {
       const needsCleanup = !ctx?.scratchDir;
       if (needsCleanup) await mkdir(scratchDir, { recursive: true });
       try {
-        const result = await upscale(orientedBuffer, scratchDir, { scale });
+        const result = await upscale(orientedBuffer, scratchDir, { scale, signal: ctx?.signal });
         const outputFormat = await resolveOutputFormat(inputBuffer, filename);
         let outputBuffer = result.buffer;
         if (outputFormat.format !== "png") {

--- a/packages/ai/python/gif_remove_bg.py
+++ b/packages/ai/python/gif_remove_bg.py
@@ -269,7 +269,10 @@ def main():
         from PIL import Image
 
         from gpu import onnx_providers
+        from model_paths import ensure_rembg_model_home
         from remove_bg import ALLOWED_MODELS
+
+        ensure_rembg_model_home()
 
         model = settings.get("model", "u2net")
         if model not in ALLOWED_MODELS:

--- a/packages/ai/python/install_feature.py
+++ b/packages/ai/python/install_feature.py
@@ -36,10 +36,25 @@ DOWNLOAD_META_BYTES = 64 * 1024 * 1024
 
 # -- Helpers --
 
+_progress_pipe_broken = [False]
+
+
 def emit_progress(percent: int, stage: str) -> None:
-    """Emit a progress update via stderr JSON line."""
-    sys.stderr.write(json.dumps({"progress": percent, "stage": stage}) + "\n")
-    sys.stderr.flush()
+    """Emit a progress update via stderr JSON line.
+
+    Progress frames are advisory liveness. If the parent died and stderr is a
+    broken pipe, the write raises BrokenPipeError (an OSError); letting that
+    escape from inside file_sha256/move_tree/safe_extract would be
+    misdiagnosed as a storage failure and could abort a working shared-venv
+    merge. Nobody is listening on a broken pipe, so swallow the error and
+    stop emitting instead."""
+    if _progress_pipe_broken[0]:
+        return
+    try:
+        sys.stderr.write(json.dumps({"progress": percent, "stage": stage}) + "\n")
+        sys.stderr.flush()
+    except OSError:
+        _progress_pipe_broken[0] = True
 
 
 def fail(message: str) -> None:
@@ -141,16 +156,75 @@ def get_site_packages_dir(venv_path: str) -> str:
 
 # -- SHA256 verification --
 
-def file_sha256(filepath: str) -> str:
-    """Stream-hash a file and return the hex digest."""
+def file_sha256(filepath: str, progress_cb=None) -> str:
+    """Stream-hash a file and return the hex digest.
+
+    progress_cb, when given, receives the cumulative bytes hashed so far. The
+    install watchdog treats stderr progress frames as the only liveness
+    signal, so callers hashing multi-GB archives report from inside the read
+    loop (real work, not a timer)."""
     h = hashlib.sha256()
+    done = 0
     with open(filepath, "rb") as f:
         while True:
             chunk = f.read(8192)
             if not chunk:
                 break
             h.update(chunk)
+            if progress_cb is not None:
+                done += len(chunk)
+                progress_cb(done)
     return h.hexdigest()
+
+
+def make_activity_reporter(percent: int, stage: str, min_delta_bytes: int = 512 * 1024 * 1024):
+    """Return a cumulative-bytes callback that emits a progress frame at most
+    every min_delta_bytes of new activity.
+
+    The percent stays fixed (the stage boundaries own the numbers); the frame
+    itself is what keeps the stall watchdog fed, and the stage text carries a
+    processed-bytes counter so a multi-GB stage visibly moves."""
+    last_emitted = [None]
+
+    def report(done_bytes: int) -> None:
+        if last_emitted[0] is not None and done_bytes - last_emitted[0] < min_delta_bytes:
+            return
+        last_emitted[0] = done_bytes
+        gb = done_bytes / (1024**3)
+        emit_progress(percent, f"{stage} ({gb:.1f} GB processed)")
+
+    return report
+
+
+def make_move_reporter(percent: int, stage: str, every: int = 500):
+    """Return a no-arg callback for move_tree that emits a progress frame
+    every `every` entries moved. Same watchdog-feeding role as
+    make_activity_reporter, keyed on entry count since moves have no byte
+    stream to measure."""
+    moved = [0]
+
+    def report() -> None:
+        moved[0] += 1
+        if moved[0] % every == 0:
+            emit_progress(percent, f"{stage} ({moved[0]} entries)")
+
+    return report
+
+
+def make_copy_activity_reporter(percent: int, stage: str):
+    """Return a byte-DELTA callback for move_tree's cross-filesystem copies.
+
+    Entry-count reporting goes silent for the whole duration of one huge
+    file; this accumulates chunk deltas into the cumulative total
+    make_activity_reporter expects, so a multi-GB copy emits every 512MB."""
+    reporter = make_activity_reporter(percent, stage)
+    total = [0]
+
+    def report(delta_bytes: int) -> None:
+        total[0] += delta_bytes
+        reporter(total[0])
+
+    return report
 
 
 def _unlink_quietly(path: str) -> None:
@@ -508,7 +582,10 @@ def download_and_verify(
         # the flaky mounts this retry exists for; it must surface as a JSON
         # error frame the Node bridge can parse, not a raw traceback.
         try:
-            return file_sha256(tar_path)
+            return file_sha256(
+                tar_path,
+                progress_cb=make_activity_reporter(86, "Verifying integrity..."),
+            )
         except OSError as e:
             fail(
                 f"Could not read back the downloaded archive to verify it "
@@ -562,28 +639,81 @@ def download_and_verify(
 
 # -- Safe tar extraction --
 
-def safe_extract(tar_path: str, staging_dir: str) -> None:
-    """Extract a tar.gz with security guards."""
+class _CountingReader:
+    """File wrapper that reports cumulative bytes read to a callback.
+
+    Extraction reads the compressed archive through this wrapper, so every
+    callback corresponds to real decompression work: the liveness signal the
+    install watchdog needs cannot outlive a genuinely wedged extract. The
+    count is cumulative across seeks (tarfile re-reads the gzip stream), so
+    reported values are always monotonic."""
+
+    def __init__(self, raw, progress_cb):
+        self._raw = raw
+        self._progress_cb = progress_cb
+        self._count = 0
+
+    def read(self, n=-1):
+        data = self._raw.read(n)
+        if data:
+            self._count += len(data)
+            self._progress_cb(self._count)
+        return data
+
+    def seek(self, *args):
+        return self._raw.seek(*args)
+
+    def tell(self):
+        return self._raw.tell()
+
+    def close(self):
+        return self._raw.close()
+
+
+def safe_extract(tar_path: str, staging_dir: str, progress_cb=None) -> None:
+    """Extract a tar.gz with security guards.
+
+    progress_cb, when given, receives cumulative compressed bytes read."""
     os.makedirs(staging_dir, exist_ok=True)
-    with tarfile.open(tar_path, "r:gz") as tf:
-        for member in tf.getmembers():
-            # Block symlinks, hardlinks, devices
-            if not member.isfile() and not member.isdir():
-                raise RuntimeError(f"Blocked unsafe tar entry type: {member.name}")
-            # Block absolute paths and traversal
-            if member.name.startswith("/") or ".." in member.name.split("/"):
-                raise RuntimeError(f"Blocked unsafe tar path: {member.name}")
-        # The filter= kwarg was added in Python 3.12; the manual guards above
-        # already block unsafe entries on older interpreters (e.g. 3.11).
-        if sys.version_info >= (3, 12):
-            tf.extractall(staging_dir, filter="data")
-        else:
-            tf.extractall(staging_dir)
+    with open(tar_path, "rb") as raw:
+        fileobj = _CountingReader(raw, progress_cb) if progress_cb is not None else raw
+        with tarfile.open(fileobj=fileobj, mode="r:gz") as tf:
+            for member in tf.getmembers():
+                # Block symlinks, hardlinks, devices
+                if not member.isfile() and not member.isdir():
+                    raise RuntimeError(f"Blocked unsafe tar entry type: {member.name}")
+                # Block absolute paths and traversal
+                if member.name.startswith("/") or ".." in member.name.split("/"):
+                    raise RuntimeError(f"Blocked unsafe tar path: {member.name}")
+            # The filter= kwarg was added in Python 3.12; the manual guards above
+            # already block unsafe entries on older interpreters (e.g. 3.11).
+            if sys.version_info >= (3, 12):
+                tf.extractall(staging_dir, filter="data")
+            else:
+                tf.extractall(staging_dir)
 
 
 # -- File move --
 
-def move_tree(src: str, dst: str) -> None:
+COPY_CHUNK_BYTES = 8 * 1024 * 1024
+
+
+def _copy_file_with_activity(src: str, dst: str, copy_activity_cb) -> None:
+    """shutil.copy2 equivalent (data + metadata) that reports byte deltas per
+    chunk, so a cross-filesystem copy of one multi-GB file still feeds the
+    stall watchdog."""
+    with open(src, "rb") as fsrc, open(dst, "wb") as fdst:
+        while True:
+            chunk = fsrc.read(COPY_CHUNK_BYTES)
+            if not chunk:
+                break
+            fdst.write(chunk)
+            if copy_activity_cb is not None:
+                copy_activity_cb(len(chunk))
+    shutil.copystat(src, dst)
+
+
+def move_tree(src: str, dst: str, progress_cb=None, copy_activity_cb=None) -> None:
     """Merge src into dst, replacing entries crash-atomically where possible.
 
     This writes into the SHARED /data/ai/venv site-packages, so a crash mid-move
@@ -592,7 +722,12 @@ def move_tree(src: str, dst: str) -> None:
     place with NO delete-then-write window, so an interruption leaves either the
     old or the new file intact, never a missing one. Cross-filesystem copies go
     through a temp sibling then an atomic rename for the same reason. Renames
-    (vs copytree) also avoid transiently doubling the payload on disk."""
+    (vs copytree) also avoid transiently doubling the payload on disk.
+
+    progress_cb, when given, is called once per entry moved; copy_activity_cb
+    receives byte deltas during cross-filesystem copies. Together they keep
+    liveness frames flowing whether the payload is many small entries or a
+    few huge ones."""
     if not os.path.isdir(src):
         return
     os.makedirs(dst, exist_ok=True)
@@ -601,7 +736,7 @@ def move_tree(src: str, dst: str) -> None:
         d = os.path.join(dst, name)
         if os.path.isdir(s) and os.path.isdir(d):
             # Both dirs exist: merge recursively rather than replace.
-            move_tree(s, d)
+            move_tree(s, d, progress_cb, copy_activity_cb)
             continue
         try:
             # A type mismatch (dir<->file) can't be atomically swapped by rename,
@@ -613,6 +748,8 @@ def move_tree(src: str, dst: str) -> None:
                 else:
                     os.remove(d)
             os.replace(s, d)
+            if progress_cb is not None:
+                progress_cb()
             continue
         except OSError as e:
             if getattr(e, "errno", None) != errno.EXDEV:
@@ -623,11 +760,17 @@ def move_tree(src: str, dst: str) -> None:
         if os.path.isdir(s):
             if os.path.exists(d):
                 shutil.rmtree(d)
-            shutil.copytree(s, d)
+            shutil.copytree(
+                s,
+                d,
+                copy_function=lambda cs, cd: _copy_file_with_activity(cs, cd, copy_activity_cb),
+            )
         else:
             tmp = d + ".part"
-            shutil.copy2(s, tmp)
+            _copy_file_with_activity(s, tmp, copy_activity_cb)
             os.replace(tmp, d)
+        if progress_cb is not None:
+            progress_cb()
     # Remove whatever remains of src (emptied by renames, or copied originals).
     shutil.rmtree(src, ignore_errors=True)
 
@@ -1138,9 +1281,19 @@ def _install() -> None:
         if not os.path.exists(tar_path):
             fail(f"Local bundle file not found: {tar_path}")
 
-        # Verify checksum
+        # Verify checksum, with the same liveness frames and readable read
+        # errors as the remote download path: the archive is just as large.
         emit_progress(10, "Verifying checksum...")
-        actual_sha256 = file_sha256(tar_path)
+        try:
+            actual_sha256 = file_sha256(
+                tar_path,
+                progress_cb=make_activity_reporter(10, "Verifying checksum..."),
+            )
+        except OSError as e:
+            fail(
+                f"Could not read the local bundle archive to verify it ({e}). "
+                f"Check the storage behind SNAPOTTER_BUNDLE_LOCAL_PATH."
+            )
         if actual_sha256 != expected_sha256:
             fail(
                 f"SHA256 checksum mismatch for local file.\n"
@@ -1182,7 +1335,11 @@ def _install() -> None:
     try:
         if os.path.exists(staging_dir):
             shutil.rmtree(staging_dir)
-        safe_extract(tar_path, staging_dir)
+        safe_extract(
+            tar_path,
+            staging_dir,
+            progress_cb=make_activity_reporter(88, "Extracting packages and models..."),
+        )
     except Exception as e:
         if os.path.exists(staging_dir):
             shutil.rmtree(staging_dir, ignore_errors=True)
@@ -1257,7 +1414,12 @@ def _install() -> None:
             reconcile_onnxruntime(staging_sp, site_packages_dir)
             reconciliation_plan = plan_reconciliation(staging_sp, site_packages_dir)
             supersede_distributions(site_packages_dir, reconciliation_plan, quarantine_dir)
-            move_tree(staging_sp, site_packages_dir)
+            move_tree(
+                staging_sp,
+                site_packages_dir,
+                progress_cb=make_move_reporter(92, "Installing packages..."),
+                copy_activity_cb=make_copy_activity_reporter(92, "Installing packages..."),
+            )
             clear_venv_writing(venv_writing_marker)
 
         # -- Move models --
@@ -1265,7 +1427,14 @@ def _install() -> None:
         staging_models = os.path.join(staging_dir, "models")
         if os.path.isdir(staging_models):
             os.makedirs(models_dir, exist_ok=True)
-            move_tree(staging_models, models_dir)
+            # Model bundles are a handful of multi-GB files, so report every
+            # entry; the byte reporter covers the inside of each copy.
+            move_tree(
+                staging_models,
+                models_dir,
+                progress_cb=make_move_reporter(95, "Installing models...", every=1),
+                copy_activity_cb=make_copy_activity_reporter(95, "Installing models..."),
+            )
     except OSError as e:
         shutil.rmtree(staging_dir, ignore_errors=True)
         abandon_merge(

--- a/packages/ai/python/model_paths.py
+++ b/packages/ai/python/model_paths.py
@@ -1,0 +1,34 @@
+"""Bundled-model location resolution for sidecar scripts."""
+import json
+import os
+import sys
+
+
+def ensure_rembg_model_home() -> None:
+    """Point rembg at the bundled models when U2NET_HOME is not already set.
+
+    The Docker image bakes U2NET_HOME and the dispatcher setdefaults it (from
+    DATA_DIR), but the per-request fallback on native installs has neither,
+    and rembg then falls back to ~/.u2net: unwritable (or plain wrong) for
+    service users and blind to the models the feature bundle installed
+    (Sentry NODE-4W). The Node bridge always provides MODELS_PATH, so
+    deriving the home here covers every bridge spawn path; all three
+    derivations use setdefault and agree on the default layout.
+
+    A missing MODELS_PATH means the ~/.u2net fallback is about to happen, so
+    warn instead of degrading silently.
+    """
+    models_path = os.getenv("MODELS_PATH")
+    if models_path:
+        os.environ.setdefault("U2NET_HOME", os.path.join(models_path, "rembg"))
+    elif "U2NET_HOME" not in os.environ:
+        sys.stderr.write(
+            json.dumps(
+                {
+                    "warning": "MODELS_PATH is not set; rembg will fall back to "
+                    "~/.u2net and cannot see bundle-installed models"
+                }
+            )
+            + "\n"
+        )
+        sys.stderr.flush()

--- a/packages/ai/python/remove_bg.py
+++ b/packages/ai/python/remove_bg.py
@@ -184,6 +184,9 @@ def main():
     output_path = sys.argv[2]
     settings = json.loads(sys.argv[3]) if len(sys.argv) > 3 else {}
 
+    from model_paths import ensure_rembg_model_home
+    ensure_rembg_model_home()
+
     model = settings.get("model", "birefnet-general-lite")
     if model not in ALLOWED_MODELS:
         model = "birefnet-general-lite"

--- a/packages/ai/python/tests/test_install_feature_download.py
+++ b/packages/ai/python/tests/test_install_feature_download.py
@@ -222,6 +222,36 @@ def test_download_and_verify_accepts_good_first_download(monkeypatch, tmp_path):
     assert dest.read_bytes() == GOOD_BYTES
 
 
+def test_download_and_verify_emits_liveness_frames_while_hashing(monkeypatch, tmp_path):
+    # The verify stage hashes a multi-GB file; the stall watchdog only counts
+    # progress frames, so verification must emit from inside the read loop.
+    installer = load_installer()
+    dest = tmp_path / "background-removal-amd64-gpu.tar.gz"
+    progress = []
+
+    def fake_hf(*args, **kwargs):
+        with open(args[2], "wb") as f:
+            f.write(GOOD_BYTES)
+        return True
+
+    monkeypatch.setattr(installer, "download_with_hf_hub", fake_hf)
+    monkeypatch.setattr(installer, "download_with_resume", lambda *a: None)
+    monkeypatch.setattr(installer, "emit_progress", lambda p, s: progress.append((p, s)))
+
+    installer.download_and_verify(
+        "deepsafe/feature-bundles",
+        "v2.0.0/background-removal-amd64-gpu.tar.gz",
+        str(dest),
+        _sha256(GOOD_BYTES),
+        len(GOOD_BYTES),
+    )
+
+    verify_frames = [
+        (p, s) for p, s in progress if p == 86 and "GB processed" in s
+    ]
+    assert verify_frames, "hashing must emit at least one in-loop liveness frame"
+
+
 def test_checksum_mismatch_retries_with_sequential_downloader(monkeypatch, tmp_path):
     """A corrupt accelerated download must be retried over the plain sequential
     downloader, not by re-running the transport that just produced bad bytes
@@ -401,7 +431,7 @@ def test_verify_read_error_fails_with_json_error(monkeypatch, tmp_path, capsys):
             f.write(GOOD_BYTES)
         return True
 
-    def broken_hash(path):
+    def broken_hash(path, progress_cb=None):
         raise OSError(5, "Input/output error")
 
     monkeypatch.setattr(installer, "download_with_hf_hub", fake_hf)
@@ -500,3 +530,71 @@ def test_local_bundle_checksum_error_reports_actual_hash(monkeypatch, tmp_path, 
     error = _last_error(capsys)
     assert _sha256(GOOD_BYTES) in error
     assert _sha256(BAD_BYTES) in error
+
+
+def _local_bundle_setup(monkeypatch, tmp_path, payload):
+    archive_entry = {
+        "file": "v2.0.0/background-removal.tar.gz",
+        "sha256": _sha256(GOOD_BYTES),
+        "compressedSize": len(GOOD_BYTES),
+        "extractedSize": 0,
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "bundles": {
+                    "background-removal": {
+                        "archives": {
+                            "amd64-gpu": archive_entry,
+                            "arm64-cpu": archive_entry,
+                        }
+                    }
+                }
+            }
+        )
+    )
+    models_dir = tmp_path / "ai" / "models"
+    models_dir.mkdir(parents=True)
+    local = tmp_path / "local.tar.gz"
+    local.write_bytes(payload)
+    monkeypatch.setenv("SNAPOTTER_BUNDLE_LOCAL_PATH", str(local))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["install_feature.py", "background-removal", str(manifest_path), str(models_dir)],
+    )
+
+
+def test_local_bundle_verify_emits_liveness_frames(monkeypatch, tmp_path):
+    # The local/offline path hashes the same multi-GB archives as the remote
+    # path and must feed the stall watchdog the same way.
+    installer = load_installer()
+    _local_bundle_setup(monkeypatch, tmp_path, BAD_BYTES)
+    progress = []
+    monkeypatch.setattr(installer, "emit_progress", lambda p, s: progress.append((p, s)))
+
+    with pytest.raises(SystemExit):
+        installer._install()
+
+    assert any("GB processed" in s for _, s in progress), (
+        "local verify must emit in-loop liveness frames"
+    )
+
+
+def test_local_bundle_verify_read_error_fails_with_json_error(monkeypatch, tmp_path, capsys):
+    installer = load_installer()
+    _local_bundle_setup(monkeypatch, tmp_path, GOOD_BYTES)
+    monkeypatch.setattr(installer, "emit_progress", lambda p, s: None)
+
+    def broken_hash(path, progress_cb=None):
+        raise OSError(5, "Input/output error")
+
+    monkeypatch.setattr(installer, "file_sha256", broken_hash)
+
+    with pytest.raises(SystemExit):
+        installer._install()
+
+    error = _last_error(capsys)
+    assert "Input/output error" in error
+    assert "SNAPOTTER_BUNDLE_LOCAL_PATH" in error

--- a/packages/ai/python/tests/test_install_feature_liveness.py
+++ b/packages/ai/python/tests/test_install_feature_liveness.py
@@ -1,0 +1,286 @@
+"""Liveness reporting for the long silent install stages.
+
+The install watchdog (INSTALL_STALL_MS, default 20 min) only counts JSON
+progress frames on stderr as liveness. Verify (86%), extract (88%) and the
+site-packages/models moves (92/95%) used to emit a single frame and then go
+silent through multi-GB work, so a legitimate install on a slow disk got
+killed as "stalled" (issue #505's second report). These tests pin the
+callback hooks that let the install loop emit frames from inside the real
+work, so a frame always means actual bytes moved, never a timer.
+"""
+
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tarfile
+
+import pytest
+
+
+def load_installer():
+    script_path = os.path.join(os.path.dirname(__file__), "..", "install_feature.py")
+    spec = importlib.util.spec_from_file_location(
+        "install_feature_liveness_under_test", script_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+# -- file_sha256 --
+
+
+def test_file_sha256_reports_cumulative_bytes(tmp_path):
+    installer = load_installer()
+    payload = b"x" * 100_000
+    blob = tmp_path / "blob.bin"
+    blob.write_bytes(payload)
+
+    seen = []
+    digest = installer.file_sha256(str(blob), progress_cb=seen.append)
+
+    assert digest == hashlib.sha256(payload).hexdigest()
+    assert seen, "expected at least one progress callback"
+    assert seen == sorted(seen), "reported byte counts must be monotonic"
+    assert seen[-1] == len(payload)
+
+
+def test_file_sha256_without_callback_is_unchanged(tmp_path):
+    installer = load_installer()
+    blob = tmp_path / "blob.bin"
+    blob.write_bytes(b"abc")
+
+    assert installer.file_sha256(str(blob)) == hashlib.sha256(b"abc").hexdigest()
+
+
+# -- safe_extract --
+
+
+def build_archive(tmp_path, file_count=5, file_size=10_000):
+    src = tmp_path / "content"
+    src.mkdir()
+    for i in range(file_count):
+        (src / f"f{i}.bin").write_bytes(os.urandom(file_size))
+    tar_path = tmp_path / "bundle.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tf:
+        for i in range(file_count):
+            tf.add(src / f"f{i}.bin", arcname=f"pkg/f{i}.bin")
+    return tar_path
+
+
+def test_safe_extract_reports_read_activity(tmp_path):
+    installer = load_installer()
+    tar_path = build_archive(tmp_path)
+    staging = tmp_path / "staging"
+
+    seen = []
+    installer.safe_extract(str(tar_path), str(staging), progress_cb=seen.append)
+
+    assert seen, "expected read-activity callbacks during extraction"
+    assert seen == sorted(seen), "cumulative bytes read must be monotonic"
+    # All files extracted intact
+    extracted = sorted(os.listdir(staging / "pkg"))
+    assert extracted == [f"f{i}.bin" for i in range(5)]
+
+
+def test_safe_extract_without_callback_is_unchanged(tmp_path):
+    installer = load_installer()
+    tar_path = build_archive(tmp_path, file_count=2)
+    staging = tmp_path / "staging"
+
+    installer.safe_extract(str(tar_path), str(staging))
+
+    assert sorted(os.listdir(staging / "pkg")) == ["f0.bin", "f1.bin"]
+
+
+def test_safe_extract_still_blocks_unsafe_entries_with_callback(tmp_path):
+    installer = load_installer()
+    tar_path = tmp_path / "evil.tar.gz"
+    data = b"gotcha"
+    with tarfile.open(tar_path, "w:gz") as tf:
+        info = tarfile.TarInfo(name="../escape.bin")
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+
+    with pytest.raises(RuntimeError, match="unsafe tar path"):
+        installer.safe_extract(str(tar_path), str(tmp_path / "staging"), progress_cb=lambda n: None)
+
+
+# -- move_tree --
+
+
+def test_move_tree_reports_each_moved_file(tmp_path):
+    installer = load_installer()
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    (src / "pkg" / "sub").mkdir(parents=True)
+    dst.mkdir()
+    (src / "top.py").write_text("a")
+    (src / "pkg" / "mod.py").write_text("b")
+    (src / "pkg" / "sub" / "deep.py").write_text("c")
+
+    ticks = []
+    installer.move_tree(str(src), str(dst), progress_cb=lambda: ticks.append(1))
+
+    assert (dst / "top.py").exists()
+    assert (dst / "pkg" / "mod.py").exists()
+    assert (dst / "pkg" / "sub" / "deep.py").exists()
+    # One tick per entry moved: whole-directory renames may count as a single
+    # move, but at least every top-level entry must tick.
+    assert len(ticks) >= 2
+
+
+def test_move_tree_reports_files_when_merging_into_existing_dirs(tmp_path):
+    installer = load_installer()
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    (src / "pkg").mkdir(parents=True)
+    (dst / "pkg").mkdir(parents=True)
+    (src / "pkg" / "new.py").write_text("n")
+    (dst / "pkg" / "old.py").write_text("o")
+
+    ticks = []
+    installer.move_tree(str(src), str(dst), progress_cb=lambda: ticks.append(1))
+
+    assert (dst / "pkg" / "new.py").exists()
+    assert (dst / "pkg" / "old.py").exists()
+    assert len(ticks) == 1
+
+
+# -- emit_progress broken-pipe guard --
+
+
+class _BrokenStderr:
+    def __init__(self):
+        self.write_attempts = 0
+
+    def write(self, _data):
+        self.write_attempts += 1
+        raise BrokenPipeError(32, "Broken pipe")
+
+    def flush(self):
+        raise BrokenPipeError(32, "Broken pipe")
+
+
+def test_emit_progress_swallows_broken_pipe_and_disables_itself(monkeypatch):
+    # Progress frames are advisory liveness. If the parent died and the pipe
+    # is broken, a frame raising BrokenPipeError (an OSError) into move_tree
+    # or file_sha256 would be misdiagnosed as a storage failure and could
+    # abort a working shared-venv merge. The emitter must swallow the error
+    # and stop trying instead.
+    installer = load_installer()
+    broken = _BrokenStderr()
+    monkeypatch.setattr(sys, "stderr", broken)
+
+    installer.emit_progress(50, "stage one")
+    installer.emit_progress(51, "stage two")
+
+    assert broken.write_attempts == 1, "emission must be disabled after the first failure"
+
+
+# -- throttled activity reporter --
+
+
+def test_counting_reader_stays_monotonic_across_seeks(tmp_path):
+    # tarfile re-reads the gzip stream after the guard scan (seek back to 0).
+    # The reader must count cumulative bytes READ, never file position, or the
+    # "GB processed" text runs backwards and throttling misbehaves.
+    installer = load_installer()
+    blob = tmp_path / "blob.bin"
+    blob.write_bytes(b"0123456789")
+
+    seen = []
+    with open(blob, "rb") as raw:
+        reader = installer._CountingReader(raw, seen.append)
+        reader.read(4)
+        reader.seek(0)
+        reader.read(4)
+
+    assert seen == [4, 8]
+
+
+def test_move_tree_reports_byte_activity_during_cross_fs_copies(tmp_path, monkeypatch):
+    # A single multi-GB model copied across filesystems (EXDEV) used to emit
+    # nothing until the whole file finished, which can exceed the 20-minute
+    # stall watchdog on slow disks. Chunked copies must report byte deltas.
+    installer = load_installer()
+    monkeypatch.setattr(installer, "COPY_CHUNK_BYTES", 4)
+
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    (src / "model.onnx").write_bytes(b"m" * 10)
+
+    real_replace = os.replace
+
+    def exdev_replace(a, b):
+        # Force the cross-filesystem path for the src->dst move, but let the
+        # temp-sibling promotion inside the copy path succeed.
+        if a.startswith(str(src)):
+            raise OSError(18, "Invalid cross-device link")
+        return real_replace(a, b)
+
+    monkeypatch.setattr(installer.os, "replace", exdev_replace)
+
+    deltas = []
+    installer.move_tree(
+        str(src), str(dst), progress_cb=lambda: None, copy_activity_cb=deltas.append
+    )
+
+    assert (dst / "model.onnx").read_bytes() == b"m" * 10
+    assert len(deltas) >= 2, "chunked copy must report more than once per file"
+    assert sum(deltas) == 10
+
+
+def test_install_flow_wires_liveness_reporters():
+    # Wiring guard: the primitives are useless if the install flow stops
+    # passing them. Delete any of these call-site arguments and the #505
+    # stall-kill quietly returns while every primitive test stays green.
+    base = os.path.join(os.path.dirname(__file__), "..")
+    with open(os.path.join(base, "install_feature.py")) as f:
+        source = f.read()
+
+    assert 'make_activity_reporter(86, "Verifying integrity...")' in source
+    assert 'make_activity_reporter(88, "Extracting packages and models...")' in source
+    assert 'make_move_reporter(92, "Installing packages...")' in source
+    # Model bundles are a handful of huge files, so the models move must
+    # report every entry, not every 500th.
+    assert 'make_move_reporter(95, "Installing models...", every=1)' in source
+
+
+def test_move_reporter_emits_every_nth_entry(capsys):
+    installer = load_installer()
+
+    cb = installer.make_move_reporter(92, "Installing packages...", every=3)
+    for _ in range(7):
+        cb()
+
+    lines = [line for line in capsys.readouterr().err.splitlines() if line.strip()]
+    frames = [json.loads(line) for line in lines]
+    # Entries 3 and 6 emit; 7 total calls -> 2 frames.
+    assert len(frames) == 2
+    assert all(f["progress"] == 92 for f in frames)
+    assert "3 entries" in frames[0]["stage"]
+    assert "6 entries" in frames[1]["stage"]
+
+
+def test_activity_reporter_throttles_and_emits_json_frames(capsys):
+    installer = load_installer()
+
+    cb = installer.make_activity_reporter(88, "Extracting packages and models...")
+    one_gb = 1024**3
+    cb(10)  # first activity emits immediately
+    cb(20)  # below the delta threshold: suppressed
+    cb(one_gb)  # past the threshold: emits
+
+    lines = [line for line in capsys.readouterr().err.splitlines() if line.strip()]
+    frames = [json.loads(line) for line in lines]
+    assert len(frames) == 2
+    assert all(f["progress"] == 88 for f in frames)
+    assert all(f["stage"].startswith("Extracting packages and models...") for f in frames)
+    assert "1.0 GB" in frames[1]["stage"]

--- a/packages/ai/python/tests/test_model_paths.py
+++ b/packages/ai/python/tests/test_model_paths.py
@@ -1,0 +1,97 @@
+"""U2NET_HOME resolution for rembg-based scripts (Sentry NODE-4W).
+
+The Docker image bakes U2NET_HOME and the dispatcher setdefaults it, but the
+per-request fallback on native installs has neither, so rembg fell back to
+~/.u2net: unwritable for service users (Errno 13 on /root/.u2net) and blind
+to the models the feature bundle installed. The scripts must derive the model
+home from MODELS_PATH (always set by the Node bridge) themselves.
+"""
+
+import ast
+import importlib.util
+import os
+
+
+def load_model_paths():
+    script_path = os.path.join(os.path.dirname(__file__), "..", "model_paths.py")
+    spec = importlib.util.spec_from_file_location("model_paths_under_test", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sets_u2net_home_from_models_path(monkeypatch):
+    module = load_model_paths()
+    monkeypatch.delenv("U2NET_HOME", raising=False)
+    monkeypatch.setenv("MODELS_PATH", "/data/ai/models")
+
+    module.ensure_rembg_model_home()
+
+    assert os.environ["U2NET_HOME"] == os.path.join("/data/ai/models", "rembg")
+
+
+def test_explicit_u2net_home_wins(monkeypatch):
+    module = load_model_paths()
+    monkeypatch.setenv("U2NET_HOME", "/custom/u2net")
+    monkeypatch.setenv("MODELS_PATH", "/data/ai/models")
+
+    module.ensure_rembg_model_home()
+
+    assert os.environ["U2NET_HOME"] == "/custom/u2net"
+
+
+def test_without_models_path_leaves_env_untouched_but_warns(monkeypatch, capsys):
+    # A missing MODELS_PATH means rembg will fall back to ~/.u2net, the exact
+    # NODE-4W failure. That must not happen silently.
+    module = load_model_paths()
+    monkeypatch.delenv("U2NET_HOME", raising=False)
+    monkeypatch.delenv("MODELS_PATH", raising=False)
+
+    module.ensure_rembg_model_home()
+
+    assert "U2NET_HOME" not in os.environ
+    err = capsys.readouterr().err
+    assert "MODELS_PATH" in err and "u2net" in err.lower()
+
+
+def test_with_models_path_set_no_warning(monkeypatch, capsys):
+    module = load_model_paths()
+    monkeypatch.delenv("U2NET_HOME", raising=False)
+    monkeypatch.setenv("MODELS_PATH", "/data/ai/models")
+
+    module.ensure_rembg_model_home()
+
+    assert capsys.readouterr().err == ""
+
+
+def _call_name(node):
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def test_remove_bg_and_gif_remove_bg_wire_the_helper():
+    # Wiring guard: both rembg entry points must call the helper inside main()
+    # before any rembg session resolution, otherwise the fallback-path bug
+    # returns. Checked via ast, scoped to main's body, because source position
+    # of helper definitions does not reflect execution order.
+    base = os.path.join(os.path.dirname(__file__), "..")
+    for script in ("remove_bg.py", "gif_remove_bg.py"):
+        with open(os.path.join(base, script)) as f:
+            tree = ast.parse(f.read())
+        main_fn = next(
+            n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "main"
+        )
+        calls = [n for n in ast.walk(main_fn) if isinstance(n, ast.Call)]
+        helper_lines = [c.lineno for c in calls if _call_name(c) == "ensure_rembg_model_home"]
+        session_lines = [
+            c.lineno for c in calls if _call_name(c) in ("new_session", "_create_session")
+        ]
+        assert helper_lines, f"{script} main() must call ensure_rembg_model_home"
+        assert not session_lines or min(helper_lines) < min(session_lines), (
+            f"{script} must call ensure_rembg_model_home before creating a rembg session"
+        )

--- a/packages/ai/src/background-removal.ts
+++ b/packages/ai/src/background-removal.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import sharp from "sharp";
 import {
+  isGpuAvailable,
   type ProgressCallback,
   parseStdoutJson,
   runPythonWithProgress,
@@ -69,8 +70,13 @@ export async function removeBackground(
 
   try {
     const megapixels = (origW * origH) / 1_000_000;
-    const baseTimeout = sidecarOptions.model?.startsWith("birefnet") ? 600000 : 300000;
-    const timeout = Math.max(baseTimeout, megapixels * 30 * 1000);
+    const gpu = isGpuAvailable();
+    // CPU inference is ~50-100x slower than GPU; mirror the upscaler's CPU
+    // rate, and give CPU runs a 10-minute floor since model load alone can
+    // exceed 5 minutes on NAS-class hardware.
+    const baseTimeout = sidecarOptions.model?.startsWith("birefnet") || !gpu ? 600_000 : 300_000;
+    const rateMs = gpu ? 30_000 : 180_000;
+    const timeout = Math.max(baseTimeout, megapixels * rateMs);
 
     const rawMask = await runAndParse(
       inputPath,
@@ -122,7 +128,7 @@ async function runAndParse(
     const { stdout } = await runPythonWithProgress(
       "remove_bg.py",
       [inputPath, outputPath, JSON.stringify(fallbackOpts)],
-      { onProgress, timeout: 300000, signal },
+      { onProgress, timeout, signal },
     );
     const result = parseStdoutJson(stdout);
     if (!result.success) {

--- a/packages/ai/src/upscaling.ts
+++ b/packages/ai/src/upscaling.ts
@@ -16,6 +16,7 @@ export interface UpscaleOptions {
   denoise?: number;
   format?: string;
   quality?: number;
+  signal?: AbortSignal;
 }
 
 export interface UpscaleResult {
@@ -32,6 +33,7 @@ export async function upscale(
   options: UpscaleOptions = {},
   onProgress?: ProgressCallback,
 ): Promise<UpscaleResult> {
+  const { signal, ...pythonOptions } = options;
   const inputPath = join(outputDir, "input_upscale.png");
   const outputPath = join(outputDir, "output_upscale.png");
 
@@ -40,7 +42,7 @@ export async function upscale(
 
   const meta = await sharp(pngBuffer).metadata();
   const megapixels = ((meta.width ?? 0) * (meta.height ?? 0)) / 1_000_000;
-  const scale = options.scale ?? 2;
+  const scale = pythonOptions.scale ?? 2;
   const effectiveMp = megapixels * scale ** 2;
   // CPU inference is ~50-100x slower than GPU; be generous for self-hosted NAS hardware
   const rateMs = isGpuAvailable() ? 30_000 : 180_000;
@@ -48,8 +50,8 @@ export async function upscale(
 
   const { stdout } = await runPythonWithProgress(
     "upscale.py",
-    [inputPath, outputPath, JSON.stringify(options)],
-    { onProgress, timeout },
+    [inputPath, outputPath, JSON.stringify(pythonOptions)],
+    { onProgress, timeout, signal },
   );
 
   const result = parseStdoutJson(stdout);

--- a/tests/unit/ai/background-removal.test.ts
+++ b/tests/unit/ai/background-removal.test.ts
@@ -21,11 +21,16 @@ vi.mock("../../../packages/ai/src/bridge.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../packages/ai/src/bridge.js")>()),
   runPythonWithProgress: vi.fn(),
   parseStdoutJson: vi.fn(),
+  isGpuAvailable: vi.fn(() => false),
 }));
 
 import sharp from "sharp";
 import { removeBackground } from "../../../packages/ai/src/background-removal.js";
-import { parseStdoutJson, runPythonWithProgress } from "../../../packages/ai/src/bridge.js";
+import {
+  isGpuAvailable,
+  parseStdoutJson,
+  runPythonWithProgress,
+} from "../../../packages/ai/src/bridge.js";
 
 const FAKE_INPUT = Buffer.from("fake-image-data");
 const FAKE_OUTPUT_DIR = "/tmp/test-output";
@@ -40,6 +45,7 @@ beforeEach(() => {
     stderr: "",
   });
   vi.mocked(parseStdoutJson).mockReturnValue({ success: true });
+  vi.mocked(isGpuAvailable).mockReturnValue(false);
   vi.mocked(sharp).mockImplementation(
     () =>
       ({
@@ -245,28 +251,7 @@ describe("removeBackground", () => {
   });
 
   describe("timeout calculation", () => {
-    it("uses 300000ms base timeout for non-birefnet models", async () => {
-      await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR, { model: "u2net" });
-
-      const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
-      expect(options.timeout).toBe(300000);
-    });
-
-    it("uses 600000ms base timeout for birefnet models", async () => {
-      await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR, { model: "birefnet-general" });
-
-      const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
-      expect(options.timeout).toBeGreaterThanOrEqual(600000);
-    });
-
-    it("uses 600000ms base timeout for birefnet-massive model", async () => {
-      await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR, { model: "birefnet-massive" });
-
-      const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
-      expect(options.timeout).toBeGreaterThanOrEqual(600000);
-    });
-
-    it("scales timeout with megapixels for large images", async () => {
+    const mock24MpImage = () => {
       vi.mocked(sharp).mockImplementation(
         () =>
           ({
@@ -276,19 +261,83 @@ describe("removeBackground", () => {
             metadata: vi.fn().mockResolvedValue({ width: 6000, height: 4000 }),
           }) as unknown as ReturnType<typeof sharp>,
       );
+    };
 
-      await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR);
+    describe("with a GPU", () => {
+      beforeEach(() => {
+        vi.mocked(isGpuAvailable).mockReturnValue(true);
+      });
 
-      // 24 MP * 30 * 1000 = 720000 > 300000
-      const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
-      expect(options.timeout).toBe(720000);
+      it("uses 300000ms base timeout for non-birefnet models", async () => {
+        await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR, { model: "u2net" });
+
+        const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
+        expect(options.timeout).toBe(300000);
+      });
+
+      it("uses 600000ms base timeout for birefnet models", async () => {
+        await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR, { model: "birefnet-general" });
+
+        const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
+        expect(options.timeout).toBeGreaterThanOrEqual(600000);
+      });
+
+      it("uses 600000ms base timeout for birefnet-massive model", async () => {
+        await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR, { model: "birefnet-massive" });
+
+        const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
+        expect(options.timeout).toBeGreaterThanOrEqual(600000);
+      });
+
+      it("scales timeout at 30s per megapixel for large images", async () => {
+        mock24MpImage();
+
+        await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR);
+
+        // 24 MP * 30 * 1000 = 720000 > 300000
+        const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
+        expect(options.timeout).toBe(720000);
+      });
+
+      it("uses default 300000ms base when model is not specified", async () => {
+        await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR);
+
+        const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
+        expect(options.timeout).toBe(300000);
+      });
     });
 
-    it("uses default 300000ms base when model is not specified", async () => {
-      await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR);
+    describe("CPU-only", () => {
+      it("raises the base timeout to 600000ms: model load alone can exceed 5 minutes", async () => {
+        await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR, { model: "u2net" });
 
-      const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
-      expect(options.timeout).toBe(300000);
+        const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
+        expect(options.timeout).toBe(600000);
+      });
+
+      it("keeps the 600000ms base for birefnet models", async () => {
+        await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR, { model: "birefnet-general" });
+
+        const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
+        expect(options.timeout).toBe(600000);
+      });
+
+      it("scales timeout at 180s per megapixel, matching the upscaler's CPU rate", async () => {
+        mock24MpImage();
+
+        await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR);
+
+        // 24 MP * 180 * 1000 = 4320000 > 600000
+        const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
+        expect(options.timeout).toBe(4320000);
+      });
+
+      it("uses the 600000ms base when model is not specified", async () => {
+        await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR);
+
+        const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
+        expect(options.timeout).toBe(600000);
+      });
     });
   });
 
@@ -492,15 +541,29 @@ describe("removeBackground", () => {
       expect(runPythonWithProgress).toHaveBeenCalledTimes(1);
     });
 
-    it("uses 300000ms timeout for the u2net fallback attempt", async () => {
+    it("gives the u2net fallback attempt the same adaptive timeout as the primary attempt", async () => {
+      // CPU-only large image: the fallback still runs on the same slow
+      // hardware, so a fixed 300s budget would kill it where the primary
+      // attempt was allowed 180s/MP.
+      vi.mocked(sharp).mockImplementation(
+        () =>
+          ({
+            png: vi.fn().mockReturnThis(),
+            resize: vi.fn().mockReturnThis(),
+            toBuffer: vi.fn().mockResolvedValue(Buffer.from("mock-png-data")),
+            metadata: vi.fn().mockResolvedValue({ width: 6000, height: 4000 }),
+          }) as unknown as ReturnType<typeof sharp>,
+      );
       vi.mocked(runPythonWithProgress)
         .mockRejectedValueOnce(new Error("Process killed (out of memory)"))
         .mockResolvedValueOnce({ stdout: '{"success": true}', stderr: "" });
 
       await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR, { model: "birefnet-general" });
 
+      const primaryOptions = vi.mocked(runPythonWithProgress).mock.calls[0][2];
       const fallbackOptions = vi.mocked(runPythonWithProgress).mock.calls[1][2];
-      expect(fallbackOptions.timeout).toBe(300000);
+      expect(fallbackOptions.timeout).toBe(primaryOptions.timeout);
+      expect(fallbackOptions.timeout).toBe(4320000);
     });
 
     it("propagates error if fallback also fails", async () => {

--- a/tests/unit/ai/tools.test.ts
+++ b/tests/unit/ai/tools.test.ts
@@ -1667,15 +1667,15 @@ describe("OCR dynamic timeout", () => {
 // ── removeBackground dynamic timeout ────────────────────────────────
 
 describe("removeBackground dynamic timeout", () => {
-  it("uses megapixel-based timeout for large images", async () => {
+  it("uses the CPU floor for small images when no GPU is available", async () => {
     vi.mocked(parseStdoutJson).mockReturnValue({ success: true });
 
     await removeBackground(FAKE_INPUT, FAKE_OUTPUT_DIR);
 
-    // sharp metadata returns 800x600 = 0.48MP
-    // baseTimeout = 300000, timeout = max(300000, 0.48 * 30 * 1000) = 300000
+    // sharp metadata returns 800x600 = 0.48MP; isGpuAvailable is mocked false
+    // baseTimeout = 600000 (CPU), timeout = max(600000, 0.48 * 180 * 1000)
     const options = vi.mocked(runPythonWithProgress).mock.calls[0][2];
-    expect(options.timeout).toBe(300000);
+    expect(options.timeout).toBe(600000);
   });
 });
 

--- a/tests/unit/ai/upscaling.test.ts
+++ b/tests/unit/ai/upscaling.test.ts
@@ -125,6 +125,16 @@ describe("upscale", () => {
       expect(JSON.parse(args[2])).toEqual(allOptions);
     });
 
+    it("forwards AbortSignal to the bridge without serializing it into the args JSON", async () => {
+      const controller = new AbortController();
+
+      await upscale(FAKE_INPUT, FAKE_OUTPUT_DIR, { scale: 2, signal: controller.signal });
+
+      const [, args, bridgeOptions] = vi.mocked(runPythonWithProgress).mock.calls[0];
+      expect(JSON.parse(args[2])).toEqual({ scale: 2 });
+      expect(bridgeOptions).toEqual(expect.objectContaining({ signal: controller.signal }));
+    });
+
     it("converts input to PNG before writing", async () => {
       await upscale(FAKE_INPUT, FAKE_OUTPUT_DIR);
 

--- a/tests/unit/api/ai-image-job-handlers.test.ts
+++ b/tests/unit/api/ai-image-job-handlers.test.ts
@@ -8,6 +8,7 @@ import {
   removeBackground,
   removeRedEye,
   restorePhoto,
+  upscale,
 } from "@snapotter/ai";
 import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -19,8 +20,10 @@ import { registerColorize } from "../../../apps/api/src/routes/tools/colorize.js
 import { registerEnhanceFaces } from "../../../apps/api/src/routes/tools/enhance-faces.js";
 import { registerNoiseRemoval } from "../../../apps/api/src/routes/tools/noise-removal.js";
 import { registerRedEyeRemoval } from "../../../apps/api/src/routes/tools/red-eye-removal.js";
+import { registerRemoveBackground } from "../../../apps/api/src/routes/tools/remove-background.js";
 import { registerRestorePhoto } from "../../../apps/api/src/routes/tools/restore-photo.js";
 import { registerTransparencyFixer } from "../../../apps/api/src/routes/tools/transparency-fixer.js";
+import { registerUpscale } from "../../../apps/api/src/routes/tools/upscale.js";
 import { fixtures, readFixture } from "../../fixtures/index.js";
 
 const aiMocks = vi.hoisted(() => ({
@@ -31,6 +34,7 @@ const aiMocks = vi.hoisted(() => ({
   removeBackground: vi.fn(),
   removeRedEye: vi.fn(),
   restorePhoto: vi.fn(),
+  upscale: vi.fn(),
 }));
 
 vi.mock("@snapotter/ai", () => ({
@@ -41,6 +45,7 @@ vi.mock("@snapotter/ai", () => ({
   removeBackground: aiMocks.removeBackground,
   removeRedEye: aiMocks.removeRedEye,
   restorePhoto: aiMocks.restorePhoto,
+  upscale: aiMocks.upscale,
 }));
 
 const PNG = readFixture(fixtures.image.base.png200);
@@ -102,6 +107,13 @@ function resetAiMocks() {
     eyesCorrected: 2,
   });
   vi.mocked(removeBackground).mockResolvedValue(PNG);
+  vi.mocked(upscale).mockResolvedValue({
+    buffer: PNG,
+    width: 400,
+    height: 300,
+    method: "realesrgan",
+    format: "png",
+  });
   vi.mocked(isMemoryAllocError).mockReturnValue(false);
 }
 
@@ -295,6 +307,64 @@ describe("AI image job handlers", () => {
       contentType: "image/png",
       resultPayload: { filename: "photo.png" },
     });
+  });
+});
+
+describe("worker abort signal pass-through", () => {
+  // A worker timeout or user cancel aborts ctx.signal; without forwarding it,
+  // the Python inference keeps burning CPU after the job is already dead.
+  it("remove-background forwards ctx.signal to the sidecar call", async () => {
+    registerRemoveBackground(fakeApp);
+
+    await runAiToolJob(job("remove-background", { model: "u2net" }), PNG, ctx);
+
+    expect(removeBackground).toHaveBeenCalledWith(
+      PNG,
+      SCRATCH_DIR,
+      expect.objectContaining({ model: "u2net", signal: ctx.signal }),
+      expect.any(Function),
+    );
+  });
+
+  it("upscale forwards ctx.signal to the sidecar call", async () => {
+    registerUpscale(fakeApp);
+
+    await runAiToolJob(job("upscale", { scale: 2, format: "png" }), PNG, ctx);
+
+    expect(upscale).toHaveBeenCalledWith(
+      PNG,
+      SCRATCH_DIR,
+      expect.objectContaining({ scale: 2, signal: ctx.signal }),
+      expect.any(Function),
+    );
+  });
+
+  it("remove-background pipeline processor forwards ctx.signal", async () => {
+    registerRemoveBackground(fakeApp);
+
+    const config = getToolConfig("remove-background");
+    expect(config).toBeDefined();
+    await config?.process(PNG, { model: "u2net" }, "photo.png", ctx);
+
+    expect(removeBackground).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      SCRATCH_DIR,
+      expect.objectContaining({ model: "u2net", signal: ctx.signal }),
+    );
+  });
+
+  it("upscale pipeline processor forwards ctx.signal", async () => {
+    registerUpscale(fakeApp);
+
+    const config = getToolConfig("upscale");
+    expect(config).toBeDefined();
+    await config?.process(PNG, { scale: 2 }, "photo.png", ctx);
+
+    expect(upscale).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      SCRATCH_DIR,
+      expect.objectContaining({ scale: 2, signal: ctx.signal }),
+    );
   });
 });
 


### PR DESCRIPTION
AI reliability fixes driven by user feedback (upscale and remove-background timing out on CPU-only hosts, bundle installs dying partway) and by Sentry NODE-4W.

**Timeouts.** remove-background allotted max(300s, 30s/MP) whatever the hardware, while upscale already ran 180s/MP on CPU. Model load alone can eat that 5-minute ceiling on a NUC. It now mirrors the upscaler: 600s floor and 180s/MP without a GPU, and the u2net OOM fallback reuses the computed budget instead of a hardcoded 300s.

**Aborts.** upscale and remove-background never passed ctx.signal to the sidecar, so a worker timeout or cancel left Python inference burning CPU to the end. Both job handlers and both pipeline processors forward it now.

**Install liveness.** The install watchdog counts only stderr progress frames. Verify (86), extract (88), and the site-packages/models moves (92/95) emitted one frame each, then went silent through multi-GB work, so INSTALL_STALL_MS killed legitimate slow-disk installs at 20 minutes (second report on #505, and inpaint-hq is now bigger than the bundle that hit it). Frames now come from inside the work loops: hashing reports every 512MB, extraction counts compressed bytes through a wrapping reader, moves tick per entry, and cross-filesystem copies report per chunk so a single multi-GB model no longer goes dark. Because the frames are tied to real bytes, a genuinely wedged install still stalls out and gets killed, which is the watchdog's job. emit_progress swallows a broken stderr pipe rather than letting BrokenPipeError impersonate a storage failure and roll back a working venv merge.

**NODE-4W.** The per-request fallback on native installs had no U2NET_HOME, so rembg looked in ~/.u2net (hence "/root/.u2net: permission denied" and "downloads disabled" for birefnet models the bundle had installed). remove_bg.py and gif_remove_bg.py derive the model home from MODELS_PATH themselves, warn when it's missing, and leave explicit overrides alone.

Verified: 282 Python tests pass (17 new across liveness, model paths, and local-archive verify), 1401 unit and 53 integration Node tests pass, typecheck and Biome clean. Pre-PR review by silent-failure-hunter and pr-test-analyzer; their findings (chunked-copy liveness for huge models, broken-pipe misattribution, pipeline-path signal coverage) are folded into the diff.