### PR TITLE
fix(web): give iOS users a way out of the editor warning and clear the bottom nav

### DIFF
--- a/apps/web/src/components/layout/app-layout.tsx
+++ b/apps/web/src/components/layout/app-layout.tsx
@@ -67,7 +67,16 @@ export function AppLayout({ children, breadcrumb, navVariant }: AppLayoutProps) 
       <main
         id="main-content"
         tabIndex={-1}
-        className={cn("flex-1 overflow-y-auto", isMobile && "pb-20")}
+        className="flex-1 overflow-y-auto"
+        // The fixed bottom nav grows by the home-indicator inset on iOS
+        // (its own paddingBottom is max(0.5rem, safe-area-inset-bottom)), so
+        // a fixed 5rem reservation leaves the last row underneath it on
+        // notched devices (#736).
+        style={
+          isMobile
+            ? { paddingBottom: "calc(4.5rem + max(0.5rem, env(safe-area-inset-bottom)))" }
+            : undefined
+        }
       >
         {children}
       </main>

--- a/apps/web/src/pages/editor-page.tsx
+++ b/apps/web/src/pages/editor-page.tsx
@@ -2,6 +2,7 @@
 import { ANALYTICS_EVENTS, apiToolPath } from "@snapotter/shared";
 import { Monitor } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router";
 import { CanvasResizeDialog } from "@/components/editor/common/canvas-resize-dialog";
 import {
   AutosaveRecoveryBanner,
@@ -157,6 +158,15 @@ export function EditorPage() {
         <Monitor size={48} className="text-muted-foreground mb-4" />
         <h2 className="text-lg font-semibold text-foreground mb-2">{t.editor.mobile.heading}</h2>
         <p className="text-sm text-muted-foreground max-w-sm">{t.editor.mobile.description}</p>
+        {/* A home-screen web app has no browser chrome, so this screen needs
+            its own way back or it is a dead end (#735). */}
+        <Link
+          to="/"
+          data-testid="editor-mobile-back"
+          className="mt-6 px-5 py-2.5 rounded-lg bg-primary text-primary-foreground font-medium"
+        >
+          {t.toolPage.backToTools}
+        </Link>
       </main>
     );
   }

--- a/tests/e2e/device-mobile.spec.ts
+++ b/tests/e2e/device-mobile.spec.ts
@@ -294,3 +294,50 @@ test.describe("@mobile RTL responsive", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// iOS navigation dead ends (#735, #736)
+// ---------------------------------------------------------------------------
+test.describe("@mobile iOS navigation", () => {
+  test("editor desktop-only warning offers a way back (#735)", async ({ loggedInPage: page }) => {
+    // A home-screen web app runs with no browser chrome, so without an
+    // in-page control the editor's desktop-only warning is a dead end.
+    await page.goto("/editor");
+    await expect(page.getByText("Desktop Recommended")).toBeVisible({ timeout: 10_000 });
+
+    const back = page.getByTestId("editor-mobile-back");
+    await expect(back).toBeVisible();
+    await back.click();
+    await page.waitForURL(/\/$/, { timeout: 10_000 });
+  });
+
+  test("last tool clears the fixed bottom nav (#736)", async ({ loggedInPage: page }) => {
+    await page.goto("/");
+    const main = page.locator("#main-content");
+    await expect(main).toBeVisible();
+
+    // The scroller must reserve the nav height plus the home-indicator
+    // inset. Device emulation reports a zero inset, so the inset's
+    // participation is pinned on the style; the geometry check below runs
+    // at inset zero.
+    expect(await main.evaluate((el) => (el as HTMLElement).style.paddingBottom)).toContain(
+      "safe-area-inset-bottom",
+    );
+
+    await main.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+    // The pin toggle is a sibling of the card link inside a relative
+    // wrapper, so the wrapper (its parent) is the card's true bounding box.
+    const lastCard = page
+      .getByTestId(/^pin-toggle-/)
+      .last()
+      .locator("xpath=..");
+    const nav = page.locator("nav.fixed");
+    const [cardBox, navBox] = await Promise.all([lastCard.boundingBox(), nav.boundingBox()]);
+    expect(cardBox).not.toBeNull();
+    expect(navBox).not.toBeNull();
+    if (!cardBox || !navBox) return;
+    expect(cardBox.y + cardBox.height).toBeLessThanOrEqual(navBox.y + 1);
+  });
+});

--- a/tests/e2e/device-mobile.spec.ts
+++ b/tests/e2e/device-mobile.spec.ts
@@ -308,7 +308,7 @@ test.describe("@mobile iOS navigation", () => {
     const back = page.getByTestId("editor-mobile-back");
     await expect(back).toBeVisible();
     await back.click();
-    await page.waitForURL(/\/$/, { timeout: 10_000 });
+    await expect(page).toHaveURL("/", { timeout: 10_000 });
   });
 
   test("last tool clears the fixed bottom nav (#736)", async ({ loggedInPage: page }) => {

--- a/tests/e2e/gui-navigation.spec.ts
+++ b/tests/e2e/gui-navigation.spec.ts
@@ -148,6 +148,15 @@ test.describe("Home Page - Before Upload", () => {
     await expect(page.getByText("Essentials").first()).toBeVisible();
   });
 
+  test("desktop scroller carries no mobile nav reservation", async ({ loggedInPage: page }) => {
+    // The mobile-only bottom padding (#736) must not leak to desktop; an
+    // unconditional reservation would leave 80px of dead space at the end
+    // of every page's scroll.
+    expect(
+      await page.locator("#main-content").evaluate((el) => (el as HTMLElement).style.paddingBottom),
+    ).toBe("");
+  });
+
   test("each tool category header is visible in tool panel", async ({ loggedInPage: page }) => {
     const toolPanel = page.locator("aside, [class*='tool-panel'], section").filter({
       hasText: "Essentials",


### PR DESCRIPTION
Fixes #735 and #736, both iPhone reports from in-app feedback.

**#735, the editor warning dead end.** A home-screen web app has no Safari chrome, so the editor's desktop-only warning had no way out. It now carries a Back to Tools link, reusing the existing toolPage string, so no locale churn across the 21 languages.

**#736, the hidden last tool row.** The mobile scroller reserved a flat 5rem for the fixed bottom nav, but the nav's own padding is max(0.5rem, env(safe-area-inset-bottom)): on a notched iPhone the nav grows past the reservation and the last row slides underneath. The scroller now reserves calc(4.5rem + max(0.5rem, env(safe-area-inset-bottom))), the same formula the nav grows by. At inset zero that computes to exactly the old 5rem, so nothing moves on inset-less devices and every emulated screenshot stays pixel-identical.

**Tests.** Two new @mobile tests in device-mobile.spec.ts, running on the Pixel 7 chromium and iPhone 14 webkit projects and in the PR mobile-smoke job. Both watched failing first. Playwright cannot fake a nonzero safe-area inset, so the inset's participation is pinned on the style string and the geometry is asserted at inset zero, where a zero-padding mutant dies to exactly the overlap check. The notched-device arithmetic is verified by derivation, the same trade the dvh viewport fix made in #559.

Verification: full device-mobile spec green on both mobile projects (33 tests), full unit suite green (8260), typecheck and Biome clean. No error paths are touched (a link and a padding), so the silent-failure pass was skipped; code-reviewer and pr-test-analyzer ran on the diff.
