### PR TITLE
fix(web,api): keep tracking a live job when the upload socket dies

### DIFF
--- a/apps/api/src/routes/progress.ts
+++ b/apps/api/src/routes/progress.ts
@@ -494,6 +494,32 @@ export async function registerProgressRoutes(app: FastifyInstance): Promise<void
       try {
         const [row] = await db.select().from(schema.jobs).where(eq(schema.jobs.id, jobId));
         if (ended) return;
+        // A live (queued/processing) single-file row replays a nonterminal
+        // frame: a reconnecting client must be able to tell "the job exists
+        // and is working" apart from "no such job", and heartbeats carry no
+        // evidence. Queued jobs publish nothing until the worker picks them
+        // up, so without this replay a busy pool looks identical to a job
+        // that never existed, and a client that degraded a dead upload
+        // socket to the async path gives up on it (#722).
+        if (
+          row &&
+          row.type !== "batch" &&
+          (row.status === "queued" || row.status === "processing")
+        ) {
+          const progress: Record<string, unknown> = isRecord(row.progress) ? row.progress : {};
+          const storedPercent = progress.percent;
+          const synthetic: SingleFileProgress = {
+            jobId,
+            type: "single",
+            phase: "processing",
+            percent:
+              typeof storedPercent === "number" && Number.isFinite(storedPercent)
+                ? storedPercent
+                : 0,
+            ...(typeof progress.stage === "string" ? { stage: progress.stage } : {}),
+          };
+          sendFrame(JSON.stringify(synthetic));
+        }
         if (
           row &&
           (row.status === "completed" || row.status === "failed" || row.status === "canceled")

--- a/apps/web/src/hooks/use-tool-processor.ts
+++ b/apps/web/src/hooks/use-tool-processor.ts
@@ -37,6 +37,12 @@ const LONG_RUNNING_TOOLS = new Set<string>(["content-aware-resize", "ai-canvas-e
 
 const UPLOAD_WEIGHT = 15;
 const SSE_STALL_TIMEOUT_MS = 300_000;
+// After degrading a dead POST to the async path (#722), how long to wait for
+// any SSE frame proving the job reached the server. The factory publishes its
+// first progress frame within milliseconds of the request ending, and the SSE
+// replay covers jobs that finished while disconnected, so a silent 30s means
+// the request tail never arrived and no job exists.
+const JOB_EVIDENCE_TIMEOUT_MS = 30_000;
 
 /** Extension to MIME type for batch ZIP blob construction. Falls back to undefined (generic). */
 const MIME_BY_EXT: Record<string, string> = {
@@ -136,6 +142,36 @@ export function useToolProcessor(toolId: string) {
     }, SSE_STALL_TIMEOUT_MS);
   }, [clearStallTimer]);
 
+  const jobEvidenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearJobEvidenceTimer = useCallback(() => {
+    if (jobEvidenceTimerRef.current) {
+      clearTimeout(jobEvidenceTimerRef.current);
+      jobEvidenceTimerRef.current = null;
+    }
+  }, []);
+
+  // Armed only when a dead POST degrades to the async path (#722): heartbeats
+  // alone must not keep the client in "processing" forever for a job the
+  // server never received.
+  const startJobEvidenceTimer = useCallback(() => {
+    clearJobEvidenceTimer();
+    jobEvidenceTimerRef.current = setTimeout(() => {
+      jobEvidenceTimerRef.current = null;
+      if (!activeJobIdRef.current) return;
+      clearStallTimer();
+      if (elapsedRef.current) clearInterval(elapsedRef.current);
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+      clearActiveJob();
+      setError("Processing was interrupted. Retry when reconnected.");
+      setProcessing(false);
+      setProgress(IDLE_PROGRESS);
+    }, JOB_EVIDENCE_TIMEOUT_MS);
+  }, [clearJobEvidenceTimer, clearStallTimer, clearActiveJob, setError, setProcessing]);
+
   const reconnectSSE = useCallback(
     (force = false) => {
       const jobId = activeJobIdRef.current;
@@ -168,6 +204,8 @@ export function useToolProcessor(toolId: string) {
             }
             if (data.type !== "single") return;
 
+            // Any single frame proves the job reached the server (#722).
+            clearJobEvidenceTimer();
             if (asyncModeRef.current) resetStallTimer();
 
             if (data.phase === "complete" && data.result) {
@@ -238,7 +276,14 @@ export function useToolProcessor(toolId: string) {
         // EventSource creation failed
       }
     },
-    [clearActiveJob, clearStallTimer, resetStallTimer, setError, setProcessing],
+    [
+      clearActiveJob,
+      clearStallTimer,
+      clearJobEvidenceTimer,
+      resetStallTimer,
+      setError,
+      setProcessing,
+    ],
   );
 
   useEffect(() => {
@@ -265,6 +310,7 @@ export function useToolProcessor(toolId: string) {
       if (xhrRef.current) xhrRef.current.abort();
       if (abortRef.current) abortRef.current.abort();
       if (stallTimerRef.current) clearTimeout(stallTimerRef.current);
+      if (jobEvidenceTimerRef.current) clearTimeout(jobEvidenceTimerRef.current);
     };
   }, [reconnectSSE]);
 
@@ -298,6 +344,9 @@ export function useToolProcessor(toolId: string) {
       });
       setProcessing(true);
       setProgress({ phase: "uploading", percent: 0, elapsed: 0 });
+      // A stale evidence timer from a previous degraded run must not fire
+      // into this run (#722).
+      clearJobEvidenceTimer();
 
       const startTime = Date.now();
       elapsedRef.current = setInterval(() => {
@@ -357,13 +406,36 @@ export function useToolProcessor(toolId: string) {
         }
       };
 
+      let uploadedFully = false;
       xhr.upload.onload = () => {
+        uploadedFully = true;
         setProgress((prev) => ({
           ...prev,
           phase: "processing",
           percent: UPLOAD_WEIGHT,
           stage: "Processing...",
         }));
+      };
+
+      // The POST socket died or timed out after the whole body left the
+      // browser: the job is running server-side under clientJobId (the sync
+      // wait is only an observer; BullMQ does not care about this socket) and
+      // SSE still delivers its result. Degrade to the async path exactly as a
+      // 202 would, instead of abandoning a live job (#722). A proxy idle
+      // timeout on the sync wait otherwise reproduces the failure on every
+      // retry while every "failed" job actually completes.
+      const degradeToAsync = () => {
+        if (!uploadedFully || activeJobIdRef.current !== clientJobId) return false;
+        asyncModeRef.current = true;
+        setActiveJob(clientJobId, cancelCurrentJob);
+        // If the drop also took the SSE, reopen it; the terminal replay
+        // cache covers a job that finished in between.
+        reconnectSSE();
+        resetStallTimer();
+        // Heartbeats alone must not hold "processing" forever if the
+        // request tail never reached the server.
+        startJobEvidenceTimer();
+        return true;
       };
 
       xhr.onload = () => {
@@ -424,6 +496,7 @@ export function useToolProcessor(toolId: string) {
       };
 
       xhr.onerror = () => {
+        if (degradeToAsync()) return;
         clearStallTimer();
         if (elapsedRef.current) clearInterval(elapsedRef.current);
         if (eventSourceRef.current) {
@@ -437,6 +510,7 @@ export function useToolProcessor(toolId: string) {
       };
 
       xhr.ontimeout = () => {
+        if (degradeToAsync()) return;
         clearStallTimer();
         if (elapsedRef.current) clearInterval(elapsedRef.current);
         if (eventSourceRef.current) {
@@ -466,6 +540,8 @@ export function useToolProcessor(toolId: string) {
       clearStallTimer,
       reconnectSSE,
       resetStallTimer,
+      clearJobEvidenceTimer,
+      startJobEvidenceTimer,
       toolName,
     ],
   );
@@ -509,6 +585,9 @@ export function useToolProcessor(toolId: string) {
       useFileStore.getState().setLastSavedLibraryFileId(null);
       setProcessing(true);
       setProgress({ phase: "uploading", percent: 0, elapsed: 0 });
+      // A stale evidence timer from a previous degraded run must not fire
+      // into this run (#722).
+      clearJobEvidenceTimer();
 
       const startTime = Date.now();
       elapsedRef.current = setInterval(() => {
@@ -646,7 +725,15 @@ export function useToolProcessor(toolId: string) {
         trackBatch("failed");
       }
     },
-    [toolId, processFiles, setProcessing, setError, clearActiveJob, toolName],
+    [
+      toolId,
+      processFiles,
+      setProcessing,
+      setError,
+      clearActiveJob,
+      clearJobEvidenceTimer,
+      toolName,
+    ],
   );
 
   return {

--- a/apps/web/src/hooks/use-tool-processor.ts
+++ b/apps/web/src/hooks/use-tool-processor.ts
@@ -38,10 +38,10 @@ const LONG_RUNNING_TOOLS = new Set<string>(["content-aware-resize", "ai-canvas-e
 const UPLOAD_WEIGHT = 15;
 const SSE_STALL_TIMEOUT_MS = 300_000;
 // After degrading a dead POST to the async path (#722), how long to wait for
-// any SSE frame proving the job reached the server. The factory publishes its
-// first progress frame within milliseconds of the request ending, and the SSE
-// replay covers jobs that finished while disconnected, so a silent 30s means
-// the request tail never arrived and no job exists.
+// any SSE frame proving the job reached the server. Only armed when no frame
+// arrived before the degrade; the progress route replays live queued and
+// processing rows on connect, so a silent 30s on a fresh SSE means the
+// request tail never arrived and no job exists.
 const JOB_EVIDENCE_TIMEOUT_MS = 30_000;
 
 /** Extension to MIME type for batch ZIP blob construction. Falls back to undefined (generic). */
@@ -103,6 +103,10 @@ export function useToolProcessor(toolId: string) {
   // serverFileId to the saved result, so "new" keeps deriving from the
   // original library file on re-runs.
   const saveModeRef = useRef<"new" | "overwrite">("new");
+  const jobEvidenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Whether any single-type SSE frame arrived for the current run: proof the
+  // job reached the server, consulted when a dead POST degrades (#722).
+  const sawJobEvidenceRef = useRef(false);
 
   const isAiTool = AI_PYTHON_TOOLS.has(toolId);
   const toolName = TOOLS.find((t) => t.id === toolId)?.name ?? toolId;
@@ -112,19 +116,6 @@ export function useToolProcessor(toolId: string) {
     activeEntryIndexRef.current = null;
     setActiveJob(null, null);
   }, [setActiveJob]);
-
-  const cancelCurrentJob = useCallback(async () => {
-    const jobId = activeJobIdRef.current;
-    if (!jobId) return;
-    try {
-      await fetch(`/api/v1/jobs/${jobId}/cancel`, {
-        method: "POST",
-        headers: formatHeaders(),
-      });
-    } catch {
-      // Cancel request failed; SSE handler will clean up
-    }
-  }, []);
 
   const clearStallTimer = useCallback(() => {
     if (stallTimerRef.current) {
@@ -141,8 +132,6 @@ export function useToolProcessor(toolId: string) {
       reconnectSSERef.current(true);
     }, SSE_STALL_TIMEOUT_MS);
   }, [clearStallTimer]);
-
-  const jobEvidenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clearJobEvidenceTimer = useCallback(() => {
     if (jobEvidenceTimerRef.current) {
@@ -166,10 +155,42 @@ export function useToolProcessor(toolId: string) {
         eventSourceRef.current = null;
       }
       clearActiveJob();
-      setError("Processing was interrupted. Retry when reconnected.");
+      setError(
+        "Processing was interrupted and the server never confirmed the job. Retry when reconnected.",
+      );
       setProcessing(false);
       setProgress(IDLE_PROGRESS);
     }, JOB_EVIDENCE_TIMEOUT_MS);
+  }, [clearJobEvidenceTimer, clearStallTimer, clearActiveJob, setError, setProcessing]);
+
+  const cancelCurrentJob = useCallback(async () => {
+    const jobId = activeJobIdRef.current;
+    if (!jobId) return;
+    try {
+      const res = await fetch(`/api/v1/jobs/${jobId}/cancel`, {
+        method: "POST",
+        headers: formatHeaders(),
+      });
+      // 404 means no job exists server-side (possible in the degraded #722
+      // state when the request tail never arrived). Nothing will ever emit a
+      // frame, so settle locally as canceled instead of blaming the network
+      // 30 seconds later.
+      if (res.status === 404 && activeJobIdRef.current === jobId) {
+        clearJobEvidenceTimer();
+        clearStallTimer();
+        if (elapsedRef.current) clearInterval(elapsedRef.current);
+        if (eventSourceRef.current) {
+          eventSourceRef.current.close();
+          eventSourceRef.current = null;
+        }
+        clearActiveJob();
+        setError("Canceled");
+        setProcessing(false);
+        setProgress(IDLE_PROGRESS);
+      }
+    } catch {
+      // Cancel request failed; SSE handler will clean up
+    }
   }, [clearJobEvidenceTimer, clearStallTimer, clearActiveJob, setError, setProcessing]);
 
   const reconnectSSE = useCallback(
@@ -205,6 +226,7 @@ export function useToolProcessor(toolId: string) {
             if (data.type !== "single") return;
 
             // Any single frame proves the job reached the server (#722).
+            sawJobEvidenceRef.current = true;
             clearJobEvidenceTimer();
             if (asyncModeRef.current) resetStallTimer();
 
@@ -213,6 +235,10 @@ export function useToolProcessor(toolId: string) {
               if (elapsedRef.current) clearInterval(elapsedRef.current);
               es.close();
               eventSourceRef.current = null;
+              // The SSE settles the run; a still-open sync POST (half-dead
+              // proxy, no RST) must not fire a late onerror/ontimeout over
+              // this result. abort() only emits onabort, which stays silent.
+              xhrRef.current?.abort();
               const idx = activeEntryIndexRef.current ?? useFileStore.getState().selectedIndex;
 
               const result = data.result as ProcessResult;
@@ -243,6 +269,9 @@ export function useToolProcessor(toolId: string) {
               if (elapsedRef.current) clearInterval(elapsedRef.current);
               es.close();
               eventSourceRef.current = null;
+              // Settle the still-open POST so its late onerror/ontimeout
+              // cannot replace this specific error with a generic one.
+              xhrRef.current?.abort();
               clearActiveJob();
               setError(data.error || "Processing failed");
               setProcessing(false);
@@ -345,8 +374,9 @@ export function useToolProcessor(toolId: string) {
       setProcessing(true);
       setProgress({ phase: "uploading", percent: 0, elapsed: 0 });
       // A stale evidence timer from a previous degraded run must not fire
-      // into this run (#722).
+      // into this run, and evidence never carries across runs (#722).
       clearJobEvidenceTimer();
+      sawJobEvidenceRef.current = false;
 
       const startTime = Date.now();
       elapsedRef.current = setInterval(() => {
@@ -428,13 +458,19 @@ export function useToolProcessor(toolId: string) {
         if (!uploadedFully || activeJobIdRef.current !== clientJobId) return false;
         asyncModeRef.current = true;
         setActiveJob(clientJobId, cancelCurrentJob);
-        // If the drop also took the SSE, reopen it; the terminal replay
-        // cache covers a job that finished in between.
-        reconnectSSE();
+        // Force a fresh SSE: the event that got us here says the network
+        // path just died, and a half-open source keeps readyState OPEN while
+        // delivering nothing. The server replays terminal state and live
+        // queued/processing rows on connect, so the swap loses nothing.
+        reconnectSSE(true);
         resetStallTimer();
-        // Heartbeats alone must not hold "processing" forever if the
-        // request tail never reached the server.
-        startJobEvidenceTimer();
+        // Heartbeats alone must not hold "processing" forever if the request
+        // tail never reached the server. A frame seen before the degrade
+        // already proves the job exists; queued jobs can then stay silent
+        // far longer than any timeout we could pick here.
+        if (!sawJobEvidenceRef.current) {
+          startJobEvidenceTimer();
+        }
         return true;
       };
 
@@ -496,6 +532,10 @@ export function useToolProcessor(toolId: string) {
       };
 
       xhr.onerror = () => {
+        // This run already settled (SSE delivered its terminal frame) or a
+        // newer run took over: a late socket event must neither error a
+        // finished result nor tear down the successor's state.
+        if (activeJobIdRef.current !== clientJobId) return;
         if (degradeToAsync()) return;
         clearStallTimer();
         if (elapsedRef.current) clearInterval(elapsedRef.current);
@@ -510,6 +550,7 @@ export function useToolProcessor(toolId: string) {
       };
 
       xhr.ontimeout = () => {
+        if (activeJobIdRef.current !== clientJobId) return;
         if (degradeToAsync()) return;
         clearStallTimer();
         if (elapsedRef.current) clearInterval(elapsedRef.current);
@@ -586,8 +627,9 @@ export function useToolProcessor(toolId: string) {
       setProcessing(true);
       setProgress({ phase: "uploading", percent: 0, elapsed: 0 });
       // A stale evidence timer from a previous degraded run must not fire
-      // into this run (#722).
+      // into this run, and evidence never carries across runs (#722).
       clearJobEvidenceTimer();
+      sawJobEvidenceRef.current = false;
 
       const startTime = Date.now();
       elapsedRef.current = setInterval(() => {

--- a/tests/integration/platform/job-survives-disconnect.test.ts
+++ b/tests/integration/platform/job-survives-disconnect.test.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../../apps/api/src/db/index.js";
+import { fixtures, readFixture } from "../../fixtures/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "../test-server.js";
+
+/**
+ * #722 contracts. The client now degrades a dead POST socket to the async
+ * path, which is only sound while two server behaviors hold:
+ *
+ * 1. A job whose upload request dies AFTER the body arrived keeps running
+ *    (the sync wait is an observer; nothing couples request close to job
+ *    cancellation) and its terminal frame is deliverable over SSE.
+ * 2. Connecting to the progress SSE for a queued or processing job replays a
+ *    nonterminal frame, so a reconnecting client gets evidence the job
+ *    exists instead of bare heartbeats.
+ *
+ * app.inject cannot express either (it buffers whole responses and cannot
+ * kill a socket mid-request), so both run over a real TCP socket.
+ */
+describe("job survival and progress replay across client disconnects (#722)", () => {
+  let testApp: TestApp;
+  let baseUrl: string;
+  let adminToken: string;
+
+  beforeAll(async () => {
+    testApp = await buildTestApp();
+    adminToken = await loginAsAdmin(testApp.app);
+    await testApp.app.listen({ port: 0, host: "127.0.0.1" });
+    const addr = testApp.app.server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  }, 30_000);
+
+  afterAll(async () => {
+    await testApp.cleanup();
+  }, 10_000);
+
+  /** Collect SSE frames for a job until the predicate matches or time runs out. */
+  function waitForFrame(
+    jobId: string,
+    match: (frame: Record<string, unknown>) => boolean,
+    timeoutMs: number,
+  ): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      const req = http.get(
+        `${baseUrl}/api/v1/jobs/${jobId}/progress`,
+        { headers: { authorization: `Bearer ${adminToken}`, accept: "text/event-stream" } },
+        (res) => {
+          let buf = "";
+          res.setEncoding("utf8");
+          res.on("data", (chunk: string) => {
+            buf += chunk;
+            let idx = buf.indexOf("\n\n");
+            while (idx !== -1) {
+              const frame = buf.slice(0, idx);
+              buf = buf.slice(idx + 2);
+              const line = frame.split("\n").find((l) => l.startsWith("data: "));
+              if (line) {
+                const data = JSON.parse(line.slice(6)) as Record<string, unknown>;
+                if (match(data)) {
+                  clearTimeout(deadline);
+                  req.destroy();
+                  resolve(data);
+                  return;
+                }
+              }
+              idx = buf.indexOf("\n\n");
+            }
+          });
+        },
+      );
+      const deadline = setTimeout(() => {
+        req.destroy();
+        reject(new Error("No matching SSE frame before the deadline"));
+      }, timeoutMs);
+      req.on("error", () => {
+        // Socket destroyed by resolve/timeout paths; errors there are expected.
+      });
+    });
+  }
+
+  it("keeps running a job whose upload socket died after the body was sent", async () => {
+    const clientJobId = randomUUID();
+    const png = readFixture(fixtures.image.base.png200);
+
+    const boundary = `----survive${Date.now()}`;
+    const parts: Buffer[] = [];
+    const push = (s: string) => parts.push(Buffer.from(s));
+    push(`--${boundary}\r\n`);
+    push(`Content-Disposition: form-data; name="file"; filename="input.png"\r\n`);
+    push(`Content-Type: image/png\r\n\r\n`);
+    parts.push(png);
+    push(`\r\n--${boundary}\r\n`);
+    push(`Content-Disposition: form-data; name="settings"\r\n\r\n`);
+    push(JSON.stringify({ angle: 90 }));
+    push(`\r\n--${boundary}\r\n`);
+    push(`Content-Disposition: form-data; name="clientJobId"\r\n\r\n`);
+    push(clientJobId);
+    push(`\r\n--${boundary}--\r\n`);
+    const body = Buffer.concat(parts);
+
+    const req = http.request(`${baseUrl}/api/v1/tools/image/rotate`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${adminToken}`,
+        "content-type": `multipart/form-data; boundary=${boundary}`,
+        "content-length": body.length,
+      },
+    });
+    req.on("error", () => {
+      // ECONNRESET from our own destroy is the point of the test.
+    });
+    await new Promise<void>((resolve) => {
+      req.end(body, () => {
+        // Body flushed to the kernel; give the server a beat to start the
+        // job, then kill the socket the way a proxy idle timeout would.
+        setTimeout(() => {
+          req.destroy();
+          resolve();
+        }, 150);
+      });
+    });
+
+    const terminal = await waitForFrame(
+      clientJobId,
+      (f) => f.type === "single" && (f.phase === "complete" || f.phase === "failed"),
+      20_000,
+    );
+    expect(terminal.phase).toBe("complete");
+    const result = terminal.result as Record<string, unknown>;
+    expect(String(result.downloadUrl)).toContain("/api/v1/download/");
+  }, 30_000);
+
+  it("replays a nonterminal frame for a processing job on SSE connect", async () => {
+    const jobId = `tp-live-${randomUUID()}`;
+    await db.insert(schema.jobs).values({
+      id: jobId,
+      type: "single",
+      status: "processing",
+      progress: { percent: 37, stage: "Processing" },
+      inputRefs: [],
+    });
+
+    try {
+      // Must arrive well before the 20s heartbeat cadence: it is a replay,
+      // not a live event.
+      const frame = await waitForFrame(
+        jobId,
+        (f) => f.type === "single" && f.phase === "processing",
+        5_000,
+      );
+      expect(frame.percent).toBe(37);
+      expect(frame.stage).toBe("Processing");
+    } finally {
+      await db.delete(schema.jobs).where(eq(schema.jobs.id, jobId));
+    }
+  }, 15_000);
+
+  it("replays a nonterminal frame for a queued job on SSE connect", async () => {
+    const jobId = `tp-queued-${randomUUID()}`;
+    await db.insert(schema.jobs).values({
+      id: jobId,
+      type: "single",
+      status: "queued",
+      progress: { percent: 0 },
+      inputRefs: [],
+    });
+
+    try {
+      const frame = await waitForFrame(
+        jobId,
+        (f) => f.type === "single" && f.phase === "processing",
+        5_000,
+      );
+      expect(frame.percent).toBe(0);
+    } finally {
+      await db.delete(schema.jobs).where(eq(schema.jobs.id, jobId));
+    }
+  }, 15_000);
+});

--- a/tests/unit/web/use-tool-processor-upload-interrupt.test.ts
+++ b/tests/unit/web/use-tool-processor-upload-interrupt.test.ts
@@ -193,7 +193,7 @@ describe("useToolProcessor upload interruption (#722)", () => {
     });
 
     expect(useFileStore.getState().error).toBe(
-      "Processing was interrupted. Retry when reconnected.",
+      "Processing was interrupted and the server never confirmed the job. Retry when reconnected.",
     );
     expect(useFileStore.getState().processing).toBe(false);
     expect(useFileStore.getState().activeJobId).toBeNull();
@@ -247,6 +247,177 @@ describe("useToolProcessor upload interruption (#722)", () => {
     expect(useFileStore.getState().error).toBeNull();
     expect(useFileStore.getState().processing).toBe(true);
     expect(useFileStore.getState().activeJobId).toBe(JOB_ID);
+
+    unmount();
+  });
+
+  it("skips the evidence timer when a frame already proved the job exists", () => {
+    const { unmount } = startRun();
+
+    // The factory's early progress frame arrives while the POST is still in
+    // flight; a queued job may then stay silent far longer than 30s.
+    act(() => {
+      sendSingleFrame({ phase: "processing", percent: 5, stage: "Validating..." });
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    unmount();
+  });
+
+  it("force-reopens the SSE on degrade even when the old one looks open", () => {
+    const { unmount } = startRun();
+
+    // A half-open connection keeps readyState OPEN while delivering nothing;
+    // the event that triggered the degrade says the network path just died.
+    expect(MockEventSource.instances).toHaveLength(1);
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(MockEventSource.instances[0].close).toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it("recovers when the drop killed the SSE along with the POST", () => {
+    const { unmount } = startRun();
+
+    act(() => {
+      // Sync-mode SSE error closes the source and nulls the ref.
+      MockEventSource.instances[0].onerror?.();
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    expect(MockEventSource.instances.length).toBeGreaterThan(1);
+    act(() => {
+      sendSingleFrame({
+        phase: "complete",
+        percent: 100,
+        result: {
+          jobId: "server-job",
+          downloadUrl: "/api/v1/download/server-job/clip_trimmed.mp4",
+          originalSize: 64,
+          processedSize: 32,
+        },
+      });
+    });
+
+    expect(useFileStore.getState().entries[0].status).toBe("completed");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("a degraded run's leftovers cannot touch the next run", () => {
+    const { result, unmount } = startRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    expect(useFileStore.getState().processing).toBe(true);
+
+    // Second run: the previous run's evidence timer must not fire into it.
+    const file = new File([new ArrayBuffer(64)], "clip2.mp4", { type: "video/mp4" });
+    act(() => {
+      useFileStore.getState().setFiles([file]);
+      result.current.processFiles([file], { startS: 0, endS: 2 });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    unmount();
+  });
+
+  it("keeps a failed frame's error over the evidence timeout", () => {
+    const { unmount } = startRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    act(() => {
+      sendSingleFrame({ phase: "failed", percent: 0, error: "Canceled" });
+    });
+    expect(useFileStore.getState().error).toBe("Canceled");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+    expect(useFileStore.getState().error).toBe("Canceled");
+
+    unmount();
+  });
+
+  it("a late client timeout cannot overwrite a result the SSE already delivered", () => {
+    const { unmount } = startRun();
+
+    // Sync flow, no degrade: the SSE settles the run first (half-dead proxy
+    // holds the POST open without an RST), then the XHR's own timer fires.
+    act(() => {
+      xhrs[0].upload.onload?.();
+      sendSingleFrame({
+        phase: "complete",
+        percent: 100,
+        result: {
+          jobId: "server-job",
+          downloadUrl: "/api/v1/download/server-job/clip_trimmed.mp4",
+          originalSize: 64,
+          processedSize: 32,
+        },
+      });
+    });
+    expect(useFileStore.getState().entries[0].status).toBe("completed");
+
+    act(() => {
+      xhrs[0].ontimeout?.();
+    });
+
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().entries[0].status).toBe("completed");
+
+    unmount();
+  });
+
+  it("cancel during degraded mode with an unknown job cleans up as canceled", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: false, status: 404 } as Response));
+    vi.stubGlobal("fetch", fetchMock);
+    const { unmount } = startRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    const cancel = useFileStore.getState().cancelCurrentJob;
+    expect(cancel).not.toBeNull();
+    await act(async () => {
+      await cancel?.();
+    });
+
+    // A 404 means no job exists server-side: nothing will ever emit a frame,
+    // so waiting (or blaming the network) misleads a user who clicked cancel.
+    expect(useFileStore.getState().error).toBe("Canceled");
+    expect(useFileStore.getState().processing).toBe(false);
+    expect(useFileStore.getState().activeJobId).toBeNull();
 
     unmount();
   });

--- a/tests/unit/web/use-tool-processor-upload-interrupt.test.ts
+++ b/tests/unit/web/use-tool-processor-upload-interrupt.test.ts
@@ -1,0 +1,253 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/image-preview", () => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  formatHeaders: () => new Map<string, string>(),
+  parseApiError: () => "error",
+}));
+
+vi.mock("@/lib/utils", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  return { ...actual, generateId: () => "22222222-2222-4222-8222-222222222222" };
+});
+
+import { useToolProcessor } from "@/hooks/use-tool-processor";
+import { useFileStore } from "@/stores/file-store";
+
+interface MockXhr {
+  status: number;
+  responseText: string;
+  timeout: number;
+  upload: { onprogress?: unknown; onload?: (() => void) | null };
+  onload?: () => void;
+  onerror?: (() => void) | null;
+  ontimeout?: (() => void) | null;
+  open: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  setRequestHeader: ReturnType<typeof vi.fn>;
+  abort: ReturnType<typeof vi.fn>;
+}
+
+class MockEventSource {
+  static OPEN = 1;
+  static instances: MockEventSource[] = [];
+
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = MockEventSource.OPEN;
+  close = vi.fn(() => {
+    this.readyState = 2;
+  });
+
+  constructor(readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+}
+
+let xhrs: MockXhr[];
+
+const JOB_ID = "22222222-2222-4222-8222-222222222222";
+
+function latestSse(): MockEventSource {
+  return MockEventSource.instances[MockEventSource.instances.length - 1];
+}
+
+function sendSingleFrame(frame: Record<string, unknown>) {
+  latestSse().onmessage?.({
+    data: JSON.stringify({ type: "single", jobId: JOB_ID, ...frame }),
+  } as MessageEvent);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal("URL", {
+    ...globalThis.URL,
+    createObjectURL: vi.fn(() => "blob:fake-url"),
+    revokeObjectURL: vi.fn(),
+  });
+  useFileStore.getState().reset();
+  xhrs = [];
+  MockEventSource.instances = [];
+  vi.stubGlobal("EventSource", MockEventSource);
+  vi.stubGlobal(
+    "XMLHttpRequest",
+    vi.fn(() => {
+      const xhr: MockXhr = {
+        status: 0,
+        responseText: "",
+        timeout: 0,
+        upload: {},
+        open: vi.fn(),
+        send: vi.fn(),
+        setRequestHeader: vi.fn(),
+        abort: vi.fn(),
+      };
+      xhrs.push(xhr);
+      return xhr;
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+/**
+ * #722: the POST socket dying AFTER the upload finished (proxy idle timeout
+ * on the sync wait, network blip) must not abandon the job. The server keeps
+ * running it under clientJobId and the SSE channel delivers the result; the
+ * client degrades to the async path exactly as if a 202 had arrived.
+ */
+describe("useToolProcessor upload interruption (#722)", () => {
+  function startRun() {
+    const file = new File([new ArrayBuffer(64)], "clip.mp4", { type: "video/mp4" });
+    useFileStore.getState().setFiles([file]);
+    const hook = renderHook(() => useToolProcessor("trim-video"));
+    act(() => {
+      hook.result.current.processFiles([file], { startS: 0, endS: 2 });
+    });
+    return hook;
+  }
+
+  it("degrades to the async path when the socket dies after the upload", () => {
+    const { unmount } = startRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    // Not an error: the job is live server-side and tracked via SSE.
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+    expect(useFileStore.getState().activeJobId).toBe(JOB_ID);
+
+    act(() => {
+      sendSingleFrame({
+        phase: "complete",
+        percent: 100,
+        result: {
+          jobId: "server-job",
+          downloadUrl: "/api/v1/download/server-job/clip_trimmed.mp4",
+          originalSize: 64,
+          processedSize: 32,
+        },
+      });
+    });
+
+    expect(useFileStore.getState().processing).toBe(false);
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().entries[0]).toMatchObject({
+      status: "completed",
+      processedUrl: "/api/v1/download/server-job/clip_trimmed.mp4",
+    });
+
+    unmount();
+  });
+
+  it("still fails when the socket dies mid-upload", () => {
+    const { unmount } = startRun();
+
+    act(() => {
+      // No upload.onload: the request body never fully left the browser, so
+      // no job can exist server-side.
+      xhrs[0].onerror?.();
+    });
+
+    expect(useFileStore.getState().error).toBe(
+      "Processing was interrupted. Retry when reconnected.",
+    );
+    expect(useFileStore.getState().processing).toBe(false);
+    expect(useFileStore.getState().activeJobId).toBeNull();
+
+    unmount();
+  });
+
+  it("surfaces the error when no job evidence ever arrives", () => {
+    const { unmount } = startRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    expect(useFileStore.getState().processing).toBe(true);
+
+    // Only heartbeats: the server never saw the request tail, no job exists.
+    act(() => {
+      latestSse().onmessage?.({
+        data: JSON.stringify({ type: "heartbeat" }),
+      } as MessageEvent);
+      vi.advanceTimersByTime(30_001);
+    });
+
+    expect(useFileStore.getState().error).toBe(
+      "Processing was interrupted. Retry when reconnected.",
+    );
+    expect(useFileStore.getState().processing).toBe(false);
+    expect(useFileStore.getState().activeJobId).toBeNull();
+
+    unmount();
+  });
+
+  it("keeps waiting once a progress frame proves the job exists", () => {
+    const { unmount } = startRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    act(() => {
+      sendSingleFrame({ phase: "processing", percent: 40, stage: "Processing" });
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    act(() => {
+      sendSingleFrame({
+        phase: "complete",
+        percent: 100,
+        result: {
+          jobId: "server-job",
+          downloadUrl: "/api/v1/download/server-job/clip_trimmed.mp4",
+          originalSize: 64,
+          processedSize: 32,
+        },
+      });
+    });
+
+    expect(useFileStore.getState().entries[0].status).toBe("completed");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("degrades on a client timeout after the upload as well", () => {
+    const { unmount } = startRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].ontimeout?.();
+    });
+
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+    expect(useFileStore.getState().activeJobId).toBe(JOB_ID);
+
+    unmount();
+  });
+});


### PR DESCRIPTION
Fixes #722. The repeated "Processing was interrupted. Retry when reconnected." on trim-video was the client abandoning jobs that finish.

**Root cause, proven against a live API.** The XHR onerror handler treated a dead POST socket as a dead job: it closed the SSE channel, cleared the active job, and errored, while the BullMQ job kept running under clientJobId. A repro script that destroys the POST socket right after the upload watched the SSE deliver the completed result 349ms later. Any proxy idle timeout on a "fast" tool's sync wait reproduces the failure on every retry, and every retry re-uploads the whole video and enqueues a duplicate.

**Fix.** When the upload has fully left the browser, onerror and ontimeout now degrade to the async path, the same state a 202 produces: async mode on, job kept, a fresh SSE forced open (a half-open one can look OPEN while delivering nothing). The SSE terminal replay then settles the run. Review hardened four premises:

- A 30s job-evidence timer restores a distinct error if no SSE frame ever proves the job reached the server, but only when no frame arrived before the degrade either; the factory publishes progress during the request, so the common case already has proof, and a queued job's later silence cannot be misread as nonexistence.
- The progress SSE now replays a nonterminal frame for live queued/processing rows on connect. Before, a queued job behind a busy pool was indistinguishable from a job that never existed; heartbeats carry no evidence.
- An SSE-delivered result settles the run for good: a late socket event from the still-open POST (half-dead proxy, no RST) can no longer paint a timeout error over a rendered success, and a stale run's events cannot tear down its successor.
- Cancel during the degraded window handles a 404 (job unknown server-side) by settling locally as Canceled instead of blaming the network 30 seconds later.

Mid-upload failures keep the immediate error: no job can exist server-side.

**Tests.** Twelve jsdom tests on the hook (eight watched failing first across the two rounds), plus three integration tests over a real TCP socket: the job-survives-POST-death contract (nothing couples request close to job cancellation; nothing enforced that before), and the nonterminal replay for processing and queued rows. Eight deliberate mutants, each killed by exactly the intended test: degrade removed, the uploadedFully guard dropped, evidence-clear removed, evidence timer removed, always-arm restored, the forced reconnect unforced, the run-identity guard dropped, and the cancel-404 status changed.

Verification: full unit suite green (8272), full integration suite and the real-processing e2e specs green, typecheck and Biome clean.

Out of scope, filed as #750: the batch path's identical abandonment (needs server-side ZIP persistence first), degrading on proxy 502/504 responses with a body, and a degrade analytics event for operator visibility.
