### PR TITLE
fix(search): surface PDF editing tools for 'edit pdf' and 'annotate'

### DIFF
--- a/apps/web/src/hooks/use-fuse-search.ts
+++ b/apps/web/src/hooks/use-fuse-search.ts
@@ -4,7 +4,9 @@ import type { IFuseOptions } from "fuse.js";
 import Fuse from "fuse.js";
 import { useMemo } from "react";
 
-const FUSE_OPTIONS: IFuseOptions<Tool> = {
+// Exported so tests exercise the real ranking config instead of a copy that
+// can drift out of sync with production (which would give false green).
+export const FUSE_OPTIONS: IFuseOptions<Tool> = {
   keys: [
     { name: "name", weight: 0.35 },
     { name: "keywords", weight: 0.3 },

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1395,6 +1395,7 @@ const BASE_TOOLS: Tool[] = [
     modality: "document",
     acceptedInputs: [".pdf"],
     executionHint: "fast",
+    keywords: ["edit pdf", "modify pdf"],
   },
   {
     id: "convert-document",
@@ -1596,6 +1597,7 @@ const BASE_TOOLS: Tool[] = [
     modality: "document",
     acceptedInputs: [".pdf"],
     executionHint: "fast",
+    keywords: ["edit pdf", "modify pdf"],
   },
   {
     id: "pdf-page-numbers",
@@ -1607,6 +1609,7 @@ const BASE_TOOLS: Tool[] = [
     modality: "document",
     acceptedInputs: [".pdf"],
     executionHint: "fast",
+    keywords: ["edit pdf", "modify pdf"],
   },
   {
     id: "flatten-pdf",
@@ -1629,6 +1632,7 @@ const BASE_TOOLS: Tool[] = [
     modality: "document",
     acceptedInputs: [".pdf"],
     executionHint: "fast",
+    keywords: ["edit pdf", "modify pdf"],
   },
   {
     id: "sign-pdf",
@@ -1640,7 +1644,20 @@ const BASE_TOOLS: Tool[] = [
     modality: "document",
     acceptedInputs: [".pdf"],
     executionHint: "fast",
-    keywords: ["sign", "signature", "e-sign", "esign", "fill and sign", "autograph"],
+    keywords: [
+      "sign",
+      "signature",
+      "e-sign",
+      "esign",
+      "fill and sign",
+      "autograph",
+      "annotate",
+      "annotate pdf",
+      "markup",
+      "pdf editor",
+      "edit pdf",
+      "modify pdf",
+    ],
   },
   {
     id: "pdf-to-text",

--- a/tests/unit/web/fuse-search.test.ts
+++ b/tests/unit/web/fuse-search.test.ts
@@ -1,23 +1,10 @@
 import { normalizeSearchQuery, TOOLS } from "@snapotter/shared";
 import Fuse from "fuse.js";
 import { describe, expect, it } from "vitest";
-
-const OPTS = {
-  keys: [
-    { name: "name", weight: 0.35 },
-    { name: "description", weight: 0.25 },
-    { name: "keywords", weight: 0.3 },
-    { name: "modality", weight: 0.15 },
-    { name: "id", weight: 0.15 },
-    { name: "category", weight: 0.1 },
-  ],
-  threshold: 0.45,
-  ignoreLocation: true,
-  minMatchCharLength: 2,
-};
+import { FUSE_OPTIONS } from "@/hooks/use-fuse-search";
 
 function search(q: string) {
-  const fuse = new Fuse(TOOLS, OPTS as never);
+  const fuse = new Fuse(TOOLS, FUSE_OPTIONS);
   return fuse.search(normalizeSearchQuery(q)).map((r) => r.item.id);
 }
 

--- a/tests/unit/web/pdf-edit-search.test.ts
+++ b/tests/unit/web/pdf-edit-search.test.ts
@@ -1,0 +1,67 @@
+import { normalizeSearchQuery, TOOLS } from "@snapotter/shared";
+import Fuse from "fuse.js";
+import { describe, expect, it } from "vitest";
+import { FUSE_OPTIONS } from "@/hooks/use-fuse-search";
+
+// Uses the same FUSE_OPTIONS the app ships, imported rather than copied, so a
+// ranking change in production cannot pass here on a stale config.
+function search(q: string): string[] {
+  const fuse = new Fuse(TOOLS, FUSE_OPTIONS);
+  const n = normalizeSearchQuery(q);
+  return fuse.search(n || q).map((r) => r.item.id);
+}
+
+const PDF_EDIT_TOOLS = new Set(TOOLS.filter((t) => t.category === "pdf-edit").map((t) => t.id));
+
+describe("PDF editing discoverability (#733)", () => {
+  it("'edit pdf' surfaces the PDF editing suite", () => {
+    const results = search("edit pdf");
+    // Reported symptom: this returned nothing, so the user concluded the
+    // feature did not exist.
+    expect(results.length).toBeGreaterThanOrEqual(3);
+    // The top few hits are all genuine PDF editing tools, not converters that
+    // merely end in "-pdf".
+    for (const id of results.slice(0, 3)) {
+      expect(PDF_EDIT_TOOLS.has(id)).toBe(true);
+    }
+    expect(results).toContain("sign-pdf");
+  });
+
+  it("'modify pdf' surfaces the PDF editing suite", () => {
+    const results = search("modify pdf");
+    expect(results.slice(0, 3).some((id) => PDF_EDIT_TOOLS.has(id))).toBe(true);
+  });
+
+  it("'annotate pdf' leads to the annotate/sign tool", () => {
+    expect(search("annotate pdf").slice(0, 3)).toContain("sign-pdf");
+  });
+
+  it("'annotate' leads to the annotate/sign tool", () => {
+    expect(search("annotate").slice(0, 5)).toContain("sign-pdf");
+  });
+
+  it("'pdf editor' leads to the annotate/sign tool", () => {
+    expect(search("pdf editor").slice(0, 5)).toContain("sign-pdf");
+  });
+
+  // Regression guards: the generic edit keywords must not steal more specific
+  // PDF searches.
+  it.each([
+    ["rotate pdf", "rotate-pdf"],
+    ["sign pdf", "sign-pdf"],
+    ["watermark pdf", "watermark-pdf"],
+    ["redact pdf", "redact-pdf"],
+    ["compress pdf", "compress-pdf"],
+  ])("'%s' still ranks %s first", (q, id) => {
+    expect(search(q)[0]).toBe(id);
+  });
+
+  it("'edit metadata' still resolves to a metadata tool, not a PDF editor", () => {
+    // The generic "edit pdf" keyword must not hijack a metadata search: the
+    // top hit stays a metadata tool (the specific one is a pre-existing
+    // ranking detail this fix must not change).
+    const top = search("edit metadata")[0];
+    expect(top).toMatch(/metadata/);
+    expect(PDF_EDIT_TOOLS.has(top)).toBe(false);
+  });
+});

--- a/tests/unit/web/pdf-edit-search.test.ts
+++ b/tests/unit/web/pdf-edit-search.test.ts
@@ -16,8 +16,8 @@ const PDF_EDIT_TOOLS = new Set(TOOLS.filter((t) => t.category === "pdf-edit").ma
 describe("PDF editing discoverability (#733)", () => {
   it("'edit pdf' surfaces the PDF editing suite", () => {
     const results = search("edit pdf");
-    // Reported symptom: this returned nothing, so the user concluded the
-    // feature did not exist.
+    // Reported symptom: this returned no useful results (only converters that
+    // end in "-pdf"), so the user concluded the feature did not exist.
     expect(results.length).toBeGreaterThanOrEqual(3);
     // The top few hits are all genuine PDF editing tools, not converters that
     // merely end in "-pdf".


### PR DESCRIPTION
Fixes #733. Searching "edit pdf", "annotate pdf", "annotate", or "pdf editor" returned no useful results (only converters that end in "-pdf"), so the reporter concluded the feature didn't exist. It does: the editing tools live in the pdf-edit category ("Edit & Annotate").

**Cause.** None of those tools carried the generic editing verbs as search keywords, and the category id "pdf-edit" does not fuzzy-match the reversed phrase "edit pdf" (different word order, at Fuse threshold 0.45). So the queries matched nothing useful ("modify pdf" returned only converters that happen to end in "-pdf").

**Fix.** Keywords, the lever the issue itself suggested. "edit pdf"/"modify pdf" go on the editing tools (rotate, watermark, page-numbers, redact), and sign-pdf, the interactive placement surface, gets the annotate/markup/pdf-editor vocabulary so it leads for "annotate pdf" and "pdf editor". These are English-only search aliases in shared constants, not display strings, so no locale work.

Two deliberate omissions: flatten-pdf (a technical bake-forms op, not a user "edit" verb) and "add text to pdf" as a keyword, which collided with the landing site's "add text to image" -> text-overlay invariant.

**Verification.** New test asserts "edit pdf" now surfaces the editing suite (top hits all pdf-edit tools, sign-pdf included) and annotate/editor queries lead to sign-pdf, watched failing first. Regression guards pin that specific searches keep their top hit (rotate pdf -> rotate-pdf, sign pdf -> sign-pdf, compress pdf -> compress-pdf) and that "edit metadata" still resolves to a metadata tool, not a PDF editor. Two mutants, each killed by exactly its test. The landing tool-search invariants still pass, and the full unit suite is green (8288).

The test imports the real FUSE_OPTIONS (now exported) rather than a copy, so a future ranking change can't pass here on a stale config. The pre-existing fuse-search.test.ts copy was migrated to the same import in review, so both search tests now share one config.
