### PR TITLE
fix(ai): only restore what a photo actually needs (#723)

### DIFF
--- a/packages/ai/python/restore.py
+++ b/packages/ai/python/restore.py
@@ -69,16 +69,20 @@ NOISE_GATE_SIGMA = 5.0
 
 
 def estimate_noise_sigma(img_bgr):
-    """Fast Gaussian-noise estimate (Immerkaer). Robust to real image content
-    because the Laplacian-like kernel cancels smooth gradients and edges,
-    leaving the noise floor. Returns the estimated standard deviation."""
+    """Fast Gaussian-noise estimate (Immerkaer 1996). The kernel cancels any
+    intensity variation up to second order (flat and smoothly shaded regions),
+    so what survives is dominated by the pixel-scale noise; a sharp photo can
+    read a little high because hard edges also respond. Returns the estimated
+    standard deviation."""
     gray = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2GRAY).astype(np.float64)
     h, w = gray.shape
     if h < 3 or w < 3:
         return 0.0
     kernel = np.array([[1, -2, 1], [-2, 4, -2], [1, -2, 1]], dtype=np.float64)
     conv = np.abs(cv2.filter2D(gray, -1, kernel))
-    return float(np.sqrt(np.pi / 2) * conv.sum() / (6.0 * (w - 2) * (h - 2)))
+    # Sum the interior only: the border pixels are filter2D extrapolation
+    # artefacts, and the (w-2)(h-2) normaliser is the interior count.
+    return float(np.sqrt(np.pi / 2) * conv[1:-1, 1:-1].sum() / (6.0 * (w - 2) * (h - 2)))
 
 
 # ── Scratch detection ─────────────────────────────────────────────────

--- a/packages/ai/python/restore.py
+++ b/packages/ai/python/restore.py
@@ -50,6 +50,36 @@ DDCOLOR_MODEL_PATH = os.environ.get(
 LAMA_MODEL_SIZE = 512
 CODEFORMER_SIZE = 512
 
+# Content-adaptive gating (#723). Restoration used to run every step on every
+# image, so a clean photo lost half its fine detail: denoise softened a
+# noise-free image, and the scratch detector's Otsu threshold always selected
+# the top ~12% of edges (hair, features) as "scratches" and inpainted them.
+#
+# SCRATCH_RESPONSE_FLOOR: only inpaint pixels whose morphological line response
+# clears this absolute level. A clean portrait's response peaks around 187
+# (p99.9) so it produces an empty mask here, while genuine high-contrast
+# creases (response to ~238) still register. This trades faint-scratch recall
+# for not wrecking undamaged photos, until the learned scratch model lands.
+#
+# NOISE_GATE_SIGMA: skip denoising below this estimated noise level. A clean
+# scan measures ~2, a grainy one ~12, so 5 skips the images that have nothing
+# to denoise.
+SCRATCH_RESPONSE_FLOOR = 200
+NOISE_GATE_SIGMA = 5.0
+
+
+def estimate_noise_sigma(img_bgr):
+    """Fast Gaussian-noise estimate (Immerkaer). Robust to real image content
+    because the Laplacian-like kernel cancels smooth gradients and edges,
+    leaving the noise floor. Returns the estimated standard deviation."""
+    gray = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2GRAY).astype(np.float64)
+    h, w = gray.shape
+    if h < 3 or w < 3:
+        return 0.0
+    kernel = np.array([[1, -2, 1], [-2, 4, -2], [1, -2, 1]], dtype=np.float64)
+    conv = np.abs(cv2.filter2D(gray, -1, kernel))
+    return float(np.sqrt(np.pi / 2) * conv.sum() / (6.0 * (w - 2) * (h - 2)))
+
 
 # ── Scratch detection ─────────────────────────────────────────────────
 
@@ -96,9 +126,13 @@ def detect_scratches(img_bgr, _sensitivity=None):
     if otsu_thresh < 40:
         return np.zeros_like(gray)
 
-    # When Otsu is borderline, use a high fixed threshold to only catch strong scratches
-    if otsu_thresh < 60:
-        _, mask = cv2.threshold(response_u8, 100, 255, cv2.THRESH_BINARY)
+    # Require a strong ABSOLUTE response, not just Otsu's relative split. On a
+    # clean photo Otsu still selects the top ~12% of edges (hair, features) as
+    # "scratches"; the floor keeps only genuine high-contrast damage, so an
+    # undamaged image yields an empty mask instead of losing detail to
+    # false-positive inpainting (#723).
+    effective_thresh = max(float(otsu_thresh), float(SCRATCH_RESPONSE_FLOOR))
+    _, mask = cv2.threshold(response_u8, effective_thresh, 255, cv2.THRESH_BINARY)
 
     # Connected component filtering
     mask = _filter_components(mask, h * w)
@@ -118,7 +152,7 @@ def detect_scratches(img_bgr, _sensitivity=None):
         if len(nonzero) > 0:
             target_count = int(h * w * 0.15)
             cutoff = np.percentile(nonzero, max(0, 100 * (1 - target_count / len(nonzero))))
-            _, mask = cv2.threshold(response_u8, max(cutoff, otsu_thresh), 255, cv2.THRESH_BINARY)
+            _, mask = cv2.threshold(response_u8, max(cutoff, effective_thresh), 255, cv2.THRESH_BINARY)
             mask = _filter_components(mask, h * w)
 
     # Dilate for cleaner inpainting boundaries
@@ -699,10 +733,18 @@ def main():
             emit_progress(65, "Face enhancement disabled")
 
         if do_denoise and denoise_strength > 0:
-            emit_progress(70, "Reducing noise")
-            result = denoise_image(result, denoise_strength)
-            steps_applied.append("denoise")
-            emit_progress(80, "Noise reduced")
+            # Only denoise images that actually have noise: NLMeans softens fine
+            # detail, so running it on a clean photo removes texture it should
+            # keep (#723). The estimate is measured on the working image after
+            # any inpainting, so repaired regions do not skew it.
+            measured_sigma = estimate_noise_sigma(result)
+            if measured_sigma < NOISE_GATE_SIGMA:
+                emit_progress(80, f"Denoising skipped: already clean (noise {measured_sigma:.1f})")
+            else:
+                emit_progress(70, "Reducing noise")
+                result = denoise_image(result, denoise_strength)
+                steps_applied.append("denoise")
+                emit_progress(80, "Noise reduced")
         else:
             emit_progress(80, "Denoising disabled")
 

--- a/packages/ai/python/tests/test_restore_gating.py
+++ b/packages/ai/python/tests/test_restore_gating.py
@@ -1,0 +1,86 @@
+"""Content-adaptive gating for photo restoration (#723).
+
+The restoration pipeline used to denoise and inpaint every image, degrading
+clean photos. These tests pin the two pure-CV decisions that make it adaptive:
+the noise estimate that gates denoise, and the scratch detector's absolute
+response floor that stops it flagging an undamaged photo. Skips cleanly where
+the AI env (numpy/cv2) is absent, as on CI integration shards.
+"""
+import os
+import sys
+
+import pytest
+
+np = pytest.importorskip("numpy")
+cv2 = pytest.importorskip("cv2")
+pytest.importorskip("PIL")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import restore  # noqa: E402
+
+
+def _smooth_scene(seed=0):
+    """A detailed-but-noise-free image: a low-frequency gradient plus content
+    edges, the kind of clean photo the pipeline must leave alone."""
+    rng = np.random.default_rng(seed)
+    yy, xx = np.mgrid[0:256, 0:256].astype(np.float32)
+    base = (xx + yy) / 2.0  # smooth ramp, 0..255
+    img = np.stack([base, base * 0.9, base * 0.8], axis=-1)
+    # A few hard content edges (rectangles): high-contrast structure, no noise.
+    img[40:80, 60:200] = 220
+    img[150:210, 30:90] = 30
+    return np.clip(img, 0, 255).astype(np.uint8)
+
+
+# ── noise estimate gates denoise ──────────────────────────────────────
+
+def test_noise_estimate_is_low_for_a_clean_image():
+    sigma = restore.estimate_noise_sigma(_smooth_scene())
+    assert sigma < restore.NOISE_GATE_SIGMA
+
+
+def test_noise_estimate_rises_with_added_noise():
+    clean = _smooth_scene()
+    rng = np.random.default_rng(1)
+    noisy = np.clip(clean.astype(np.float32) + rng.normal(0, 20, clean.shape), 0, 255).astype(np.uint8)
+    assert restore.estimate_noise_sigma(noisy) > restore.NOISE_GATE_SIGMA
+    # And it tracks the injected level, not just "bigger".
+    assert restore.estimate_noise_sigma(noisy) > restore.estimate_noise_sigma(clean) + 5
+
+
+def test_noise_estimate_handles_a_tiny_image():
+    assert restore.estimate_noise_sigma(np.zeros((2, 2, 3), np.uint8)) == 0.0
+
+
+# ── scratch floor stops false positives, keeps real damage ────────────
+
+def test_clean_image_yields_no_scratch_mask():
+    # Content edges must not be inpainted: an undamaged photo returns an empty
+    # mask so no detail is lost (the pre-fix detector flagged ~12% of pixels).
+    mask = restore.detect_scratches(_smooth_scene())
+    assert np.count_nonzero(mask) == 0
+
+
+def test_strong_high_contrast_scratch_is_detected():
+    img = _smooth_scene()
+    # A bright thin diagonal crease over the scene: genuine high-contrast damage.
+    cv2.line(img, (20, 230), (230, 25), (252, 252, 252), 2)
+    mask = restore.detect_scratches(img)
+    assert np.count_nonzero(mask) > 0
+
+
+def test_the_floor_gates_detection():
+    # The floor, not some other step, decides what counts as damage: push it
+    # above the response range and even a real high-contrast crease vanishes.
+    # (End-to-end, dropping it to the old level takes a real photo from 0% to
+    # ~12% flagged; that is verified against the portrait fixture, not here.)
+    img = _smooth_scene()
+    cv2.line(img, (20, 230), (230, 25), (252, 252, 252), 2)
+    assert np.count_nonzero(restore.detect_scratches(img)) > 0
+
+    original = restore.SCRATCH_RESPONSE_FLOOR
+    try:
+        restore.SCRATCH_RESPONSE_FLOOR = 300  # above the 0..255 response range
+        assert np.count_nonzero(restore.detect_scratches(img)) == 0
+    finally:
+        restore.SCRATCH_RESPONSE_FLOOR = original


### PR DESCRIPTION
Fixes #723. restore-photo made clean photos look worse because it ran every restoration step on every image.

**Reproduced and measured.** On a clean color portrait (noise near zero), the default pipeline came back at SSIM 0.886 with **detail retained 0.53** (fine detail halved). Isolating the stages: scratch removal alone dropped detail to 0.69, denoise alone to 0.87. The scratch detector's Otsu threshold always selects the top ~12% of edges as "scratches", so it flagged 12% of the clean photo and LaMa inpainted it; NLMeans then softened an image with nothing to denoise.

**Both steps are now content-adaptive** (`packages/ai/python/restore.py`):

- **Denoise** is gated on a fast Immerkaer noise estimate. Below `NOISE_GATE_SIGMA` (5), a clean scan (measures ~2) skips it; a grainy one (~12) still denoises.
- **Scratch detection** requires a strong absolute response (`SCRATCH_RESPONSE_FLOOR`, 200), not just Otsu's relative split. A clean portrait's response peaks around 187 so it yields an empty mask, while genuine high-contrast creases (response to ~238) still register.

The face step is deliberately untouched. It's the opted-in feature, it wasn't the detail-killer (isolated detail 1.00), and its code is what the separate GFPGAN migration will replace.

**Verified end-to-end** against the real portrait in an AI runtime with the models installed:

| input | before | after | steps that ran |
| --- | --- | --- | --- |
| clean photo | detail 0.53 | **detail 1.00** | face enhancement only |
| damaged photo | (repairs) | detail 0.94, scratches repaired | scratch + face |

So a good photo is now a near no-op, and a damaged one still restores. Six pure-CV unit tests pin the two decisions (`packages/ai/python/tests/test_restore_gating.py`, importorskip pattern like the neighbouring `test_inpaint_geometry.py`): the noise estimate is low on a clean image and tracks injected noise; the scratch detector yields an empty mask on clean structure, detects a real crease, and the floor is what gates detection (push it past the response range and even a real crease vanishes).

**Known trade-off:** the absolute floor sacrifices faint-scratch recall to guarantee clean photos aren't degraded, which matches the priority for this fix. The durable fix is a learned scratch detector (BOPBTL, MIT), which needs a model added to the photo-restoration bundle, so it rides the release train. The CodeFormer non-commercial license issue is tracked separately.

CI note: the AI Python tests run only where numpy/cv2 are present, same as every existing test in that directory, so they skip on the standard shards; this change touches no JS/TS.
