### PR TITLE
feat(web): reorder files before running multi-file tools

### DIFF
--- a/apps/web/src/components/common/thumbnail-strip.tsx
+++ b/apps/web/src/components/common/thumbnail-strip.tsx
@@ -1,13 +1,32 @@
 import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  horizontalListSortingStrategy,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  ArrowLeftRight,
   CheckCircle2,
   File as FileIcon,
   FileText,
   Film,
+  GripVertical,
   Loader2,
   Music,
   XCircle,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "@/contexts/i18n-context";
 import type { FileEntry, PreviewKind } from "@/stores/file-store";
 
 const BROWSER_IMG_EXTS = new Set(["jpg", "jpeg", "png", "gif", "webp", "svg", "bmp", "avif"]);
@@ -176,14 +195,134 @@ function Thumb({ entry }: { entry: FileEntry }) {
   );
 }
 
+/** The selectable tile: thumbnail plus completed/failed status badge. */
+function ThumbTile({
+  entry,
+  index,
+  isSelected,
+  buttonRef,
+  onSelect,
+}: {
+  entry: FileEntry;
+  index: number;
+  isSelected: boolean;
+  buttonRef?: React.Ref<HTMLButtonElement>;
+  onSelect: (index: number) => void;
+}) {
+  const isCompleted = entry.status === "completed";
+  const isFailed = entry.status === "failed";
+  return (
+    <button
+      type="button"
+      ref={buttonRef}
+      onClick={() => onSelect(index)}
+      className={`relative shrink-0 rounded overflow-hidden transition-all ${
+        isSelected
+          ? "outline outline-2 outline-primary outline-offset-1"
+          : "hover:outline hover:outline-1 hover:outline-border"
+      }`}
+      style={{ width: 52, height: 38 }}
+      title={entry.file.name}
+    >
+      {entry.previewLoading ? (
+        <div className="w-full h-full flex items-center justify-center bg-muted">
+          <Loader2 className="h-3.5 w-3.5 text-muted-foreground animate-spin" />
+        </div>
+      ) : (
+        <Thumb entry={entry} />
+      )}
+      {isCompleted && (
+        <div className="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 bg-green-500 rounded-full flex items-center justify-center">
+          <CheckCircle2 className="h-2.5 w-2.5 text-white" />
+        </div>
+      )}
+      {isFailed && (
+        <div className="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 bg-red-500 rounded-full flex items-center justify-center">
+          <XCircle className="h-2.5 w-2.5 text-white" />
+        </div>
+      )}
+    </button>
+  );
+}
+
+/** A ThumbTile wrapped in a dnd-kit sortable, with a keyboard-reachable drag
+ *  handle. Tapping the tile still selects; the handle is the drag activator. */
+function SortableThumbTile({
+  entry,
+  index,
+  isSelected,
+  buttonRef,
+  onSelect,
+  dragLabel,
+}: {
+  entry: FileEntry;
+  index: number;
+  isSelected: boolean;
+  buttonRef?: React.Ref<HTMLButtonElement>;
+  onSelect: (index: number) => void;
+  dragLabel: string;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: entry.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  // dnd-kit sets role="button" on the handle; the native <button> already has
+  // that role, so drop it to avoid a redundant-role attribute.
+  const { role: _dragRole, ...dragAttributes } = attributes;
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`relative shrink-0 ${isDragging ? "z-10 opacity-50" : ""}`}
+    >
+      <ThumbTile
+        entry={entry}
+        index={index}
+        isSelected={isSelected}
+        buttonRef={buttonRef}
+        onSelect={onSelect}
+      />
+      <button
+        type="button"
+        {...dragAttributes}
+        {...listeners}
+        aria-label={dragLabel}
+        title={dragLabel}
+        className="absolute top-0 start-0 flex h-4 w-4 items-center justify-center rounded-ee bg-background/70 text-muted-foreground cursor-grab active:cursor-grabbing hover:bg-background hover:text-foreground focus:opacity-100"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <GripVertical className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
 interface ThumbnailStripProps {
   entries: FileEntry[];
   selectedIndex: number;
   onSelect: (index: number) => void;
+  /** When provided, tiles become drag-sortable; called with the moved indexes. */
+  onReorder?: (from: number, to: number) => void;
+  /** When provided, a reverse-order control is shown. */
+  onReverse?: () => void;
 }
 
-export function ThumbnailStrip({ entries, selectedIndex, onSelect }: ThumbnailStripProps) {
+export function ThumbnailStrip({
+  entries,
+  selectedIndex,
+  onSelect,
+  onReorder,
+  onReverse,
+}: ThumbnailStripProps) {
+  const { t } = useTranslation();
   const selectedRef = useRef<HTMLButtonElement>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   useEffect(() => {
     selectedRef.current?.scrollIntoView({
@@ -195,49 +334,77 @@ export function ThumbnailStrip({ entries, selectedIndex, onSelect }: ThumbnailSt
 
   if (entries.length <= 1) return null;
 
-  return (
+  function handleDragEnd(event: DragEndEvent) {
+    if (!onReorder) return;
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const from = entries.findIndex((e) => e.id === active.id);
+    const to = entries.findIndex((e) => e.id === over.id);
+    if (from !== -1 && to !== -1) onReorder(from, to);
+  }
+
+  const tiles = entries.map((entry, i) => {
+    const isSelected = i === selectedIndex;
+    const buttonRef = isSelected ? selectedRef : undefined;
+    if (!onReorder) {
+      return (
+        <ThumbTile
+          key={entry.id}
+          entry={entry}
+          index={i}
+          isSelected={isSelected}
+          buttonRef={buttonRef}
+          onSelect={onSelect}
+        />
+      );
+    }
+    return (
+      <SortableThumbTile
+        key={entry.id}
+        entry={entry}
+        index={i}
+        isSelected={isSelected}
+        buttonRef={buttonRef}
+        onSelect={onSelect}
+        dragLabel={t.a11y.dragToReorder}
+      />
+    );
+  });
+
+  const scroller = (
     <div
-      className="flex gap-1.5 px-3 py-2 overflow-x-auto border-t border-border bg-muted/30"
+      className="flex gap-1.5 px-3 py-2 overflow-x-auto grow"
       style={{ scrollBehavior: "smooth" }}
     >
-      {entries.map((entry, i) => {
-        const isSelected = i === selectedIndex;
-        const isCompleted = entry.status === "completed";
-        const isFailed = entry.status === "failed";
-        return (
-          <button
-            key={entry.file.name}
-            type="button"
-            ref={isSelected ? selectedRef : undefined}
-            onClick={() => onSelect(i)}
-            className={`relative shrink-0 rounded overflow-hidden transition-all ${
-              isSelected
-                ? "outline outline-2 outline-primary outline-offset-1"
-                : "hover:outline hover:outline-1 hover:outline-border"
-            }`}
-            style={{ width: 52, height: 38 }}
-            title={entry.file.name}
+      {onReorder ? (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext
+            items={entries.map((e) => e.id)}
+            strategy={horizontalListSortingStrategy}
           >
-            {entry.previewLoading ? (
-              <div className="w-full h-full flex items-center justify-center bg-muted">
-                <Loader2 className="h-3.5 w-3.5 text-muted-foreground animate-spin" />
-              </div>
-            ) : (
-              <Thumb entry={entry} />
-            )}
-            {isCompleted && (
-              <div className="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 bg-green-500 rounded-full flex items-center justify-center">
-                <CheckCircle2 className="h-2.5 w-2.5 text-white" />
-              </div>
-            )}
-            {isFailed && (
-              <div className="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 bg-red-500 rounded-full flex items-center justify-center">
-                <XCircle className="h-2.5 w-2.5 text-white" />
-              </div>
-            )}
-          </button>
-        );
-      })}
+            {tiles}
+          </SortableContext>
+        </DndContext>
+      ) : (
+        tiles
+      )}
+    </div>
+  );
+
+  return (
+    <div className="flex items-stretch border-t border-border bg-muted/30">
+      {onReverse && (
+        <button
+          type="button"
+          onClick={onReverse}
+          title={t.a11y.reverseOrder}
+          aria-label={t.a11y.reverseOrder}
+          className="shrink-0 px-2 flex items-center border-e border-border text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+        >
+          <ArrowLeftRight className="h-4 w-4" />
+        </button>
+      )}
+      {scroller}
     </div>
   );
 }

--- a/apps/web/src/lib/tool-display-modes.ts
+++ b/apps/web/src/lib/tool-display-modes.ts
@@ -255,6 +255,32 @@ for (const preset of CONVERSION_PRESETS) {
 export const MULTI_FILE_TOOLS: ReadonlySet<string> = multiFileTools;
 
 /**
+ * Multi-input tools where the ORDER of the files changes the result, so the
+ * user can drag to reorder them (and reverse the order) before running. This
+ * is the order-sensitive subset of multi-file tools: it adds the image tools
+ * that self-submit their files (stitch, collage) and drops the mixed-modality
+ * pairs (video+subtitle, video+audio) whose inputs are keyed by kind, not
+ * position, so reordering them would be meaningless.
+ */
+const reorderableTools = new Set<string>([
+  "merge-pdf",
+  "merge-audio",
+  "merge-videos",
+  "merge-csvs",
+  "images-to-video",
+  "sprite-sheet",
+  "stitch",
+  "collage",
+  "create-zip",
+]);
+for (const preset of CONVERSION_PRESETS) {
+  if (BASE_CONFIG[preset.base].group === "image-to-pdf") {
+    reorderableTools.add(preset.id);
+  }
+}
+export const REORDERABLE_TOOLS: ReadonlySet<string> = reorderableTools;
+
+/**
  * Live-preview tools whose imageWrapperStyle/children are an input control
  * (pixelate's selection box), not a CSS simulation of the result. After
  * processing, the viewer switches to the server result for these and keeps

--- a/apps/web/src/pages/tool-page.tsx
+++ b/apps/web/src/pages/tool-page.tsx
@@ -49,7 +49,11 @@ import { formatFileSize } from "@/lib/download";
 import { classifyFeedbackError } from "@/lib/feedback";
 import { format } from "@/lib/format";
 import { ICON_MAP } from "@/lib/icon-map";
-import { LIVE_PREVIEW_INPUT_OVERLAY_TOOLS, MULTI_FILE_TOOLS } from "@/lib/tool-display-modes";
+import {
+  LIVE_PREVIEW_INPUT_OVERLAY_TOOLS,
+  MULTI_FILE_TOOLS,
+  REORDERABLE_TOOLS,
+} from "@/lib/tool-display-modes";
 import { getToolName } from "@/lib/tool-i18n";
 import { getToolRegistryEntry } from "@/lib/tool-registry";
 import { useBase64Store } from "@/stores/base64-store";
@@ -301,6 +305,8 @@ export function ToolPage() {
     batchZipFilename,
     selectedIndex,
     setSelectedIndex,
+    reorderFiles,
+    reverseFiles,
     navigateNext,
     navigatePrev,
     currentEntry,
@@ -381,6 +387,7 @@ export function ToolPage() {
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const dragCounter = useRef(0);
   const isMultiFileTool = toolId ? MULTI_FILE_TOOLS.has(toolId) : false;
+  const canReorder = toolId ? REORDERABLE_TOOLS.has(toolId) : false;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: toolId triggers intentional reset on tool navigation
   useEffect(() => {
@@ -1283,6 +1290,8 @@ export function ToolPage() {
                 entries={entries}
                 selectedIndex={selectedIndex}
                 onSelect={setSelectedIndex}
+                onReorder={canReorder ? reorderFiles : undefined}
+                onReverse={canReorder ? reverseFiles : undefined}
               />
             )}
           </section>
@@ -1415,6 +1424,8 @@ export function ToolPage() {
               entries={entries}
               selectedIndex={selectedIndex}
               onSelect={setSelectedIndex}
+              onReorder={canReorder ? reorderFiles : undefined}
+              onReverse={canReorder ? reverseFiles : undefined}
             />
           )}
         </section>

--- a/apps/web/src/stores/file-store.ts
+++ b/apps/web/src/stores/file-store.ts
@@ -25,6 +25,8 @@ export function previewKindFor(modality: Modality): PreviewKind {
 }
 
 export interface FileEntry {
+  /** Stable identity for this entry, unchanged across reordering. */
+  id: string;
   file: File;
   blobUrl: string;
   previewLoading: boolean;
@@ -46,9 +48,12 @@ export interface FileEntry {
 // Helpers
 // ---------------------------------------------------------------------------
 
+let nextEntryId = 0;
+
 function createEntry(file: File): FileEntry {
   const modality = detectModalityFromMime(file.type);
   return {
+    id: `entry-${++nextEntryId}`,
     file,
     blobUrl: URL.createObjectURL(file),
     previewLoading: needsServerPreview(file),
@@ -143,6 +148,8 @@ interface FileState {
   setFiles: (files: File[]) => void;
   addFiles: (files: File[]) => void;
   removeFile: (index: number) => void;
+  reorderFiles: (from: number, to: number) => void;
+  reverseFiles: () => void;
   setSelectedIndex: (index: number) => void;
   navigateNext: () => void;
   navigatePrev: () => void;
@@ -276,6 +283,43 @@ export const useFileStore = create<FileState>((set, get) => ({
     } else if (newEntries.length === 0) {
       newIndex = 0;
     }
+    set({
+      entries: newEntries,
+      selectedIndex: newIndex,
+      files: deriveFiles(newEntries),
+      ...deriveSelected(newEntries, newIndex),
+    });
+  },
+
+  reorderFiles: (from, to) => {
+    const { entries, selectedIndex } = get();
+    if (from === to) return;
+    if (from < 0 || from >= entries.length || to < 0 || to >= entries.length) return;
+
+    const selectedId = entries[selectedIndex]?.id;
+    const newEntries = [...entries];
+    const [moved] = newEntries.splice(from, 1);
+    newEntries.splice(to, 0, moved);
+
+    const followed = selectedId ? newEntries.findIndex((e) => e.id === selectedId) : -1;
+    const newIndex = followed === -1 ? selectedIndex : followed;
+    set({
+      entries: newEntries,
+      selectedIndex: newIndex,
+      files: deriveFiles(newEntries),
+      ...deriveSelected(newEntries, newIndex),
+    });
+  },
+
+  reverseFiles: () => {
+    const { entries, selectedIndex } = get();
+    if (entries.length < 2) return;
+
+    const selectedId = entries[selectedIndex]?.id;
+    const newEntries = [...entries].reverse();
+
+    const followed = selectedId ? newEntries.findIndex((e) => e.id === selectedId) : -1;
+    const newIndex = followed === -1 ? selectedIndex : followed;
     set({
       entries: newEntries,
       selectedIndex: newIndex,

--- a/packages/shared/src/i18n/ar.ts
+++ b/packages/shared/src/i18n/ar.ts
@@ -4010,6 +4010,7 @@ export const ar: TranslationKeys = {
     imageControls: "عناصر تحكم المعاينة",
     zoomControls: "أدوات التكبير",
     dragToReorder: "اسحب لإعادة الترتيب",
+    reverseOrder: "عكس الترتيب",
     whiteBackground: "خلفية بيضاء",
     blackBackground: "خلفية سوداء",
     expandPanel: "توسيع اللوحة",

--- a/packages/shared/src/i18n/de.ts
+++ b/packages/shared/src/i18n/de.ts
@@ -4067,6 +4067,7 @@ export const de: TranslationKeys = {
     imageControls: "Vorschausteuerung",
     zoomControls: "Zoom-Steuerung",
     dragToReorder: "Ziehen zum Neuordnen",
+    reverseOrder: "Reihenfolge umkehren",
     whiteBackground: "Weißer Hintergrund",
     blackBackground: "Schwarzer Hintergrund",
     expandPanel: "Bereich erweitern",

--- a/packages/shared/src/i18n/en.ts
+++ b/packages/shared/src/i18n/en.ts
@@ -3983,6 +3983,7 @@ export const en = {
     imageControls: "Preview controls",
     zoomControls: "Zoom controls",
     dragToReorder: "Drag to reorder",
+    reverseOrder: "Reverse order",
     whiteBackground: "White background",
     blackBackground: "Black background",
     expandPanel: "Expand panel",

--- a/packages/shared/src/i18n/es.ts
+++ b/packages/shared/src/i18n/es.ts
@@ -4045,6 +4045,7 @@ export const es: TranslationKeys = {
     imageControls: "Controles de vista previa",
     zoomControls: "Controles de zoom",
     dragToReorder: "Arrastrar para reordenar",
+    reverseOrder: "Invertir orden",
     whiteBackground: "Fondo blanco",
     blackBackground: "Fondo negro",
     expandPanel: "Expandir panel",

--- a/packages/shared/src/i18n/fr.ts
+++ b/packages/shared/src/i18n/fr.ts
@@ -4070,6 +4070,7 @@ export const fr: TranslationKeys = {
     imageControls: "Contrôles d'aperçu",
     zoomControls: "Contrôles de zoom",
     dragToReorder: "Glisser pour réorganiser",
+    reverseOrder: "Inverser l'ordre",
     whiteBackground: "Arrière-plan blanc",
     blackBackground: "Arrière-plan noir",
     expandPanel: "Développer le panneau",

--- a/packages/shared/src/i18n/hi.ts
+++ b/packages/shared/src/i18n/hi.ts
@@ -3839,6 +3839,7 @@ export const hi: TranslationKeys = {
     imageControls: "पूर्वावलोकन नियंत्रण",
     zoomControls: "ज़ूम नियंत्रण",
     dragToReorder: "क्रम बदलने के लिए खींचें",
+    reverseOrder: "क्रम उलटें",
     whiteBackground: "सफ़ेद बैकग्राउंड",
     blackBackground: "काला बैकग्राउंड",
     expandPanel: "पैनल विस्तारित करें",

--- a/packages/shared/src/i18n/id.ts
+++ b/packages/shared/src/i18n/id.ts
@@ -4043,6 +4043,7 @@ export const id: TranslationKeys = {
     imageControls: "Image controls",
     zoomControls: "Kontrol zoom",
     dragToReorder: "Seret untuk mengurutkan ulang",
+    reverseOrder: "Balik urutan",
     whiteBackground: "Latar belakang putih",
     blackBackground: "Latar belakang hitam",
     expandPanel: "Perluas panel",

--- a/packages/shared/src/i18n/it.ts
+++ b/packages/shared/src/i18n/it.ts
@@ -4060,6 +4060,7 @@ export const it: TranslationKeys = {
     imageControls: "Controlli immagine",
     zoomControls: "Controlli zoom",
     dragToReorder: "Trascina per riordinare",
+    reverseOrder: "Inverti ordine",
     whiteBackground: "Sfondo bianco",
     blackBackground: "Sfondo nero",
     expandPanel: "Espandi pannello",

--- a/packages/shared/src/i18n/ja.ts
+++ b/packages/shared/src/i18n/ja.ts
@@ -3991,6 +3991,7 @@ export const ja: TranslationKeys = {
     imageControls: "Image controls",
     zoomControls: "ズームコントロール",
     dragToReorder: "ドラッグして並べ替え",
+    reverseOrder: "順序を逆にする",
     whiteBackground: "白背景",
     blackBackground: "黒背景",
     expandPanel: "パネルを展開",

--- a/packages/shared/src/i18n/ko.ts
+++ b/packages/shared/src/i18n/ko.ts
@@ -3969,6 +3969,7 @@ export const ko: TranslationKeys = {
     imageControls: "Image controls",
     zoomControls: "확대/축소 컨트롤",
     dragToReorder: "드래그하여 순서 변경",
+    reverseOrder: "순서 뒤집기",
     whiteBackground: "흰색 배경",
     blackBackground: "검은색 배경",
     expandPanel: "패널 펼치기",

--- a/packages/shared/src/i18n/nl.ts
+++ b/packages/shared/src/i18n/nl.ts
@@ -4052,6 +4052,7 @@ export const nl: TranslationKeys = {
     imageControls: "Image controls",
     zoomControls: "Zoombediening",
     dragToReorder: "Sleep om te herordenen",
+    reverseOrder: "Volgorde omkeren",
     whiteBackground: "Witte achtergrond",
     blackBackground: "Zwarte achtergrond",
     expandPanel: "Paneel uitvouwen",

--- a/packages/shared/src/i18n/pl.ts
+++ b/packages/shared/src/i18n/pl.ts
@@ -4056,6 +4056,7 @@ export const pl: TranslationKeys = {
     imageControls: "Sterowanie podglądem",
     zoomControls: "Kontrolki powiększenia",
     dragToReorder: "Przeciągnij, aby zmienić kolejność",
+    reverseOrder: "Odwróć kolejność",
     whiteBackground: "Białe tło",
     blackBackground: "Czarne tło",
     expandPanel: "Rozwiń panel",

--- a/packages/shared/src/i18n/pt-BR.ts
+++ b/packages/shared/src/i18n/pt-BR.ts
@@ -4051,6 +4051,7 @@ export const ptBR: TranslationKeys = {
     imageControls: "Controles de visualização",
     zoomControls: "Controles de zoom",
     dragToReorder: "Arraste para reordenar",
+    reverseOrder: "Inverter ordem",
     whiteBackground: "Fundo branco",
     blackBackground: "Fundo preto",
     expandPanel: "Expandir painel",

--- a/packages/shared/src/i18n/ru.ts
+++ b/packages/shared/src/i18n/ru.ts
@@ -4048,6 +4048,7 @@ export const ru: TranslationKeys = {
     imageControls: "Управление предпросмотром",
     zoomControls: "Управление масштабом",
     dragToReorder: "Перетащите для изменения порядка",
+    reverseOrder: "Обратить порядок",
     whiteBackground: "Белый фон",
     blackBackground: "Чёрный фон",
     expandPanel: "Развернуть панель",

--- a/packages/shared/src/i18n/sv.ts
+++ b/packages/shared/src/i18n/sv.ts
@@ -4039,6 +4039,7 @@ export const sv: TranslationKeys = {
     imageControls: "Förhandsvisningskontroller",
     zoomControls: "Zoomkontroller",
     dragToReorder: "Dra för att ändra ordning",
+    reverseOrder: "Omvänd ordning",
     whiteBackground: "Vit bakgrund",
     blackBackground: "Svart bakgrund",
     expandPanel: "Expandera panel",

--- a/packages/shared/src/i18n/th.ts
+++ b/packages/shared/src/i18n/th.ts
@@ -3988,6 +3988,7 @@ export const th: TranslationKeys = {
     imageControls: "การควบคุมการแสดงตัวอย่าง",
     zoomControls: "ตัวควบคุมการซูม",
     dragToReorder: "ลากเพื่อจัดเรียงใหม่",
+    reverseOrder: "กลับลำดับ",
     whiteBackground: "พื้นหลังสีขาว",
     blackBackground: "พื้นหลังสีดำ",
     expandPanel: "ขยายแผง",

--- a/packages/shared/src/i18n/tr.ts
+++ b/packages/shared/src/i18n/tr.ts
@@ -4051,6 +4051,7 @@ export const tr: TranslationKeys = {
     imageControls: "Önizleme kontrolleri",
     zoomControls: "Yakınlaştırma kontrolleri",
     dragToReorder: "Sıralamak için sürükleyin",
+    reverseOrder: "Sırayı tersine çevir",
     whiteBackground: "Beyaz arka plan",
     blackBackground: "Siyah arka plan",
     expandPanel: "Paneli genişlet",

--- a/packages/shared/src/i18n/uk.ts
+++ b/packages/shared/src/i18n/uk.ts
@@ -4046,6 +4046,7 @@ export const uk: TranslationKeys = {
     imageControls: "Елементи керування переглядом",
     zoomControls: "Керування масштабом",
     dragToReorder: "Перетягніть для зміни порядку",
+    reverseOrder: "Змінити порядок на зворотний",
     whiteBackground: "Біле тло",
     blackBackground: "Чорне тло",
     expandPanel: "Розгорнути панель",

--- a/packages/shared/src/i18n/vi.ts
+++ b/packages/shared/src/i18n/vi.ts
@@ -4035,6 +4035,7 @@ export const vi: TranslationKeys = {
     imageControls: "Điều khiển xem trước",
     zoomControls: "Điều khiển thu phóng",
     dragToReorder: "Kéo để sắp xếp lại",
+    reverseOrder: "Đảo ngược thứ tự",
     whiteBackground: "Nền trắng",
     blackBackground: "Nền đen",
     expandPanel: "Mở rộng bảng",

--- a/packages/shared/src/i18n/zh-CN.ts
+++ b/packages/shared/src/i18n/zh-CN.ts
@@ -3770,6 +3770,7 @@ export const zhCN: TranslationKeys = {
     imageControls: "预览控件",
     zoomControls: "缩放控件",
     dragToReorder: "拖动以重新排序",
+    reverseOrder: "反转顺序",
     whiteBackground: "白色背景",
     blackBackground: "黑色背景",
     expandPanel: "展开面板",

--- a/packages/shared/src/i18n/zh-TW.ts
+++ b/packages/shared/src/i18n/zh-TW.ts
@@ -3772,6 +3772,7 @@ export const zhTW: TranslationKeys = {
     imageControls: "預覽控制項",
     zoomControls: "縮放控制",
     dragToReorder: "拖曳以重新排序",
+    reverseOrder: "反轉順序",
     whiteBackground: "白色背景",
     blackBackground: "黑色背景",
     expandPanel: "展開面板",

--- a/tests/unit/web/reorderable-tools.test.ts
+++ b/tests/unit/web/reorderable-tools.test.ts
@@ -1,0 +1,43 @@
+import { TOOLS } from "@snapotter/shared";
+import { describe, expect, it } from "vitest";
+import { REORDERABLE_TOOLS } from "@/lib/tool-display-modes";
+
+describe("REORDERABLE_TOOLS", () => {
+  it("only references real tool ids (a typo would silently disable reorder)", () => {
+    const known = new Set(TOOLS.map((t) => t.id));
+    for (const id of REORDERABLE_TOOLS) {
+      expect(known.has(id), `REORDERABLE_TOOLS entry "${id}" is not a real tool`).toBe(true);
+    }
+  });
+
+  it("includes order-sensitive combine tools", () => {
+    for (const id of [
+      "merge-pdf",
+      "merge-audio",
+      "merge-videos",
+      "merge-csvs",
+      "images-to-video",
+      "sprite-sheet",
+      "stitch",
+      "collage",
+    ]) {
+      expect(REORDERABLE_TOOLS.has(id)).toBe(true);
+    }
+  });
+
+  it("includes image-to-pdf conversion presets whose page order matters", () => {
+    expect(REORDERABLE_TOOLS.has("jpg-to-pdf")).toBe(true);
+  });
+
+  it("excludes per-file batch tools where order is irrelevant", () => {
+    for (const id of ["compress", "convert", "content-aware-resize"]) {
+      expect(REORDERABLE_TOOLS.has(id)).toBe(false);
+    }
+  });
+
+  it("excludes mixed-modality pairs distinguished by kind, not position", () => {
+    for (const id of ["burn-subtitles", "embed-subtitles", "replace-audio"]) {
+      expect(REORDERABLE_TOOLS.has(id)).toBe(false);
+    }
+  });
+});

--- a/tests/unit/web/stores/file-store-reorder.test.ts
+++ b/tests/unit/web/stores/file-store-reorder.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const revokeObjectURL = vi.fn();
+const createObjectURL = vi.fn((_obj: Blob | MediaSource) => "blob:fake-url");
+
+vi.stubGlobal("URL", {
+  ...globalThis.URL,
+  createObjectURL,
+  revokeObjectURL,
+});
+
+const imagePreviewMock = vi.hoisted(() => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/image-preview", () => imagePreviewMock);
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+}));
+
+import { useFileStore } from "@/stores/file-store";
+
+function makeFile(name: string, size = 1024, type = "image/png"): File {
+  const buf = new ArrayBuffer(size);
+  return new File([buf], name, { type });
+}
+
+function names(): string[] {
+  return useFileStore.getState().files.map((f) => f.name);
+}
+
+describe("useFileStore reordering", () => {
+  beforeEach(() => {
+    useFileStore.getState().reset();
+    vi.clearAllMocks();
+    imagePreviewMock.needsServerPreview.mockReturnValue(false);
+    imagePreviewMock.fetchDecodedPreview.mockResolvedValue(null);
+  });
+
+  it("gives every entry a stable, unique id", () => {
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png"), makeFile("c.png")]);
+    const ids = useFileStore.getState().entries.map((e) => e.id);
+    expect(new Set(ids).size).toBe(3);
+    expect(ids.every((id) => typeof id === "string" && id.length > 0)).toBe(true);
+  });
+
+  it("reorderFiles moves an entry to a new position", () => {
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png"), makeFile("c.png")]);
+
+    useFileStore.getState().reorderFiles(0, 2);
+
+    expect(names()).toEqual(["b.png", "c.png", "a.png"]);
+  });
+
+  it("reorderFiles preserves each entry's id across the move", () => {
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png"), makeFile("c.png")]);
+    const idA = useFileStore.getState().entries[0].id;
+
+    useFileStore.getState().reorderFiles(0, 2);
+
+    const moved = useFileStore.getState().entries[2];
+    expect(moved.file.name).toBe("a.png");
+    expect(moved.id).toBe(idA);
+  });
+
+  it("reorderFiles keeps the selected entry selected", () => {
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png"), makeFile("c.png")]);
+    useFileStore.getState().setSelectedIndex(1); // select b.png
+
+    useFileStore.getState().reorderFiles(2, 0); // move c.png to front -> [c, a, b]
+
+    expect(names()).toEqual(["c.png", "a.png", "b.png"]);
+    expect(useFileStore.getState().selectedIndex).toBe(2); // b.png followed
+    expect(useFileStore.getState().selectedFileName).toBe("b.png");
+  });
+
+  it("reorderFiles is a no-op for out-of-range indexes", () => {
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png")]);
+    const before = useFileStore.getState().entries;
+
+    useFileStore.getState().reorderFiles(0, 5);
+    useFileStore.getState().reorderFiles(-1, 0);
+    useFileStore.getState().reorderFiles(1, 1);
+
+    expect(useFileStore.getState().entries).toBe(before);
+    expect(names()).toEqual(["a.png", "b.png"]);
+  });
+
+  it("reverseFiles reverses the order and keeps the selected entry selected", () => {
+    useFileStore
+      .getState()
+      .setFiles([makeFile("a.png"), makeFile("b.png"), makeFile("c.png"), makeFile("d.png")]);
+    useFileStore.getState().setSelectedIndex(0); // select a.png
+
+    useFileStore.getState().reverseFiles();
+
+    expect(names()).toEqual(["d.png", "c.png", "b.png", "a.png"]);
+    expect(useFileStore.getState().selectedIndex).toBe(3); // a.png followed to the end
+    expect(useFileStore.getState().selectedFileName).toBe("a.png");
+  });
+
+  it("reverseFiles is a no-op with fewer than two files", () => {
+    useFileStore.getState().setFiles([makeFile("only.png")]);
+    const before = useFileStore.getState().entries;
+
+    useFileStore.getState().reverseFiles();
+
+    expect(useFileStore.getState().entries).toBe(before);
+  });
+});

--- a/tests/unit/web/thumbnail-strip.test.tsx
+++ b/tests/unit/web/thumbnail-strip.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.stubGlobal("URL", {
+  ...globalThis.URL,
+  createObjectURL: vi.fn(() => "blob:fake-url"),
+  revokeObjectURL: vi.fn(),
+});
+
+vi.mock("@/lib/image-preview", () => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+}));
+
+// jsdom has no layout engine, so scrollIntoView is undefined.
+HTMLElement.prototype.scrollIntoView = vi.fn();
+
+import { ThumbnailStrip } from "@/components/common/thumbnail-strip";
+import { type FileEntry, useFileStore } from "@/stores/file-store";
+
+function stage(...fileNames: string[]): FileEntry[] {
+  const files = fileNames.map(
+    (name) => new File([new ArrayBuffer(64)], name, { type: "image/png" }),
+  );
+  useFileStore.getState().setFiles(files);
+  return useFileStore.getState().entries;
+}
+
+describe("ThumbnailStrip", () => {
+  beforeEach(() => {
+    useFileStore.getState().reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing with a single file", () => {
+    const entries = stage("only.png");
+    const { container } = render(
+      <ThumbnailStrip entries={entries} selectedIndex={0} onSelect={() => {}} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("selects a thumbnail on click", () => {
+    const entries = stage("a.png", "b.png", "c.png");
+    const onSelect = vi.fn();
+    render(<ThumbnailStrip entries={entries} selectedIndex={0} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "c.png" }));
+
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it("shows a reverse-order control that calls onReverse", () => {
+    const entries = stage("a.png", "b.png");
+    const onReverse = vi.fn();
+    render(
+      <ThumbnailStrip
+        entries={entries}
+        selectedIndex={0}
+        onSelect={() => {}}
+        onReverse={onReverse}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /reverse order/i }));
+
+    expect(onReverse).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the reverse control when onReverse is not provided", () => {
+    const entries = stage("a.png", "b.png");
+    render(<ThumbnailStrip entries={entries} selectedIndex={0} onSelect={() => {}} />);
+
+    expect(screen.queryByRole("button", { name: /reverse order/i })).toBeNull();
+  });
+
+  it("renders a drag handle per file when onReorder is provided", () => {
+    const entries = stage("a.png", "b.png", "c.png");
+    render(
+      <ThumbnailStrip
+        entries={entries}
+        selectedIndex={0}
+        onSelect={() => {}}
+        onReorder={() => {}}
+      />,
+    );
+
+    expect(screen.getAllByLabelText(/drag to reorder/i)).toHaveLength(3);
+  });
+
+  it("renders no drag handles when onReorder is absent", () => {
+    const entries = stage("a.png", "b.png", "c.png");
+    render(<ThumbnailStrip entries={entries} selectedIndex={0} onSelect={() => {}} />);
+
+    expect(screen.queryAllByLabelText(/drag to reorder/i)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Multi-file tools locked file order at add time, so changing the order meant removing and re-adding files. The thumbnail strip now supports drag-to-reorder plus a one-click reverse-order button.

It shows for the tools where order changes the result: merge-pdf, merge-audio, merge-videos, merge-csvs, images-to-video, sprite-sheet, stitch, collage, create-zip, and the image-to-pdf conversion presets. It stays off per-file batch tools, where order is irrelevant, and off the mixed-modality pairs like burn-subtitles and replace-audio, whose two inputs are keyed by kind rather than position.

The reverse button also covers the follow-up on the issue about multi-select imports landing in reverse. That ordering comes from the OS file picker, not our code, so a reverse control is the right lever regardless.

## How

- `file-store.ts`: new `reorderFiles(from, to)` and `reverseFiles()`. Every entry now carries a stable `id`, so a reorder keeps the same file selected and gives dnd-kit a real key.
- `thumbnail-strip.tsx`: sortable via the same `@dnd-kit` setup the pipeline builder already uses. Tap-to-select stays, each tile gets a keyboard-reachable drag handle, and the reverse button is pinned at the start. With the new props omitted it renders exactly as before.
- `REORDERABLE_TOOLS` in `tool-display-modes.ts` gates which tools get it; wired into both strip render paths in `tool-page.tsx`.
- One new i18n string, `a11y.reverseOrder`, added to all 21 locales (`dragToReorder` already existed).

Frontend only. The backend already merges in the order it receives.

## Tests

- `file-store-reorder` (7): move, id stability, selection-follows-the-file, out-of-range no-ops, reverse.
- `thumbnail-strip` (6): select still fires, reverse button calls back and is absent without the prop, drag handles appear per file only when reorder is enabled.
- `reorderable-tools` (5): membership, plus a drift guard so a typo'd id can't silently disable reorder.
- Full web unit suite: 1699 pass. Typecheck clean on web and shared. Biome clean.

Closes #729
