### PR TITLE
feat(web): hint that files can be reordered before running

### DIFF
--- a/apps/web/src/pages/tool-page.tsx
+++ b/apps/web/src/pages/tool-page.tsx
@@ -1155,6 +1155,9 @@ export function ToolPage() {
 
         <div className="space-y-2">
           <h3 className="text-sm font-medium text-muted-foreground">{t.common.settings}</h3>
+          {canReorder && hasMultiple && (
+            <p className="text-xs text-muted-foreground">{t.dropzone.reorderHint}</p>
+          )}
           <Suspense fallback={<div className="text-xs text-muted-foreground">Loading...</div>}>
             <ToolSettings {...settingsProps} />
           </Suspense>

--- a/packages/shared/src/i18n/ar.ts
+++ b/packages/shared/src/i18n/ar.ts
@@ -3864,6 +3864,7 @@ export const ar: TranslationKeys = {
     filesSelected: "تم اختيار {count} ملف",
     dropToAdd: "أفلت لإضافة ملفات",
     dropToReplace: "أفلت لاستبدال الملف",
+    reorderHint: "اسحب الصور المصغّرة لإعادة الترتيب، أو اعكس الترتيب، قبل التشغيل.",
   },
   reviewPanel: {
     processedResultAlt: "النتيجة المعالجة",

--- a/packages/shared/src/i18n/de.ts
+++ b/packages/shared/src/i18n/de.ts
@@ -3918,6 +3918,8 @@ export const de: TranslationKeys = {
     filesSelected: "{count} Dateien ausgewählt",
     dropToAdd: "Ablegen, um Dateien hinzuzufügen",
     dropToReplace: "Ablegen, um Datei zu ersetzen",
+    reorderHint:
+      "Miniaturen zum Neuordnen ziehen oder die Reihenfolge umkehren, bevor du startest.",
   },
   reviewPanel: {
     processedResultAlt: "Verarbeitetes Ergebnis",

--- a/packages/shared/src/i18n/en.ts
+++ b/packages/shared/src/i18n/en.ts
@@ -3837,6 +3837,7 @@ export const en = {
     filesSelected: "{count} files selected",
     dropToAdd: "Drop to add files",
     dropToReplace: "Drop to replace file",
+    reorderHint: "Drag the thumbnails to reorder, or reverse the order, before running.",
   },
   reviewPanel: {
     processedResultAlt: "Processed result",

--- a/packages/shared/src/i18n/es.ts
+++ b/packages/shared/src/i18n/es.ts
@@ -3896,6 +3896,7 @@ export const es: TranslationKeys = {
     filesSelected: "{count} archivos seleccionados",
     dropToAdd: "Suelta para agregar archivos",
     dropToReplace: "Suelta para reemplazar archivo",
+    reorderHint: "Arrastra las miniaturas para reordenar, o invierte el orden, antes de ejecutar.",
   },
   reviewPanel: {
     processedResultAlt: "Resultado procesado",

--- a/packages/shared/src/i18n/fr.ts
+++ b/packages/shared/src/i18n/fr.ts
@@ -3922,6 +3922,8 @@ export const fr: TranslationKeys = {
     filesSelected: "{count} fichiers sélectionnés",
     dropToAdd: "Déposer pour ajouter des fichiers",
     dropToReplace: "Déposer pour remplacer le fichier",
+    reorderHint:
+      "Faites glisser les miniatures pour les réorganiser, ou inversez l'ordre, avant de lancer.",
   },
   reviewPanel: {
     processedResultAlt: "Résultat traité",

--- a/packages/shared/src/i18n/hi.ts
+++ b/packages/shared/src/i18n/hi.ts
@@ -3693,6 +3693,7 @@ export const hi: TranslationKeys = {
     filesSelected: "{count} फाइलें चुनी गईं",
     dropToAdd: "फाइलें जोड़ने के लिए छोड़ें",
     dropToReplace: "फाइल बदलने के लिए छोड़ें",
+    reorderHint: "चलाने से पहले क्रम बदलने के लिए थंबनेल खींचें, या क्रम उलटें।",
   },
   reviewPanel: {
     processedResultAlt: "प्रोसेस्ड परिणाम",

--- a/packages/shared/src/i18n/id.ts
+++ b/packages/shared/src/i18n/id.ts
@@ -3895,6 +3895,8 @@ export const id: TranslationKeys = {
     filesSelected: "{count} file dipilih",
     dropToAdd: "Lepas untuk menambahkan file",
     dropToReplace: "Lepas untuk mengganti file",
+    reorderHint:
+      "Seret gambar mini untuk mengurutkan ulang, atau balik urutannya, sebelum menjalankan.",
   },
   reviewPanel: {
     processedResultAlt: "Hasil yang diproses",

--- a/packages/shared/src/i18n/it.ts
+++ b/packages/shared/src/i18n/it.ts
@@ -3912,6 +3912,7 @@ export const it: TranslationKeys = {
     filesSelected: "{count} file selezionati",
     dropToAdd: "Rilascia per aggiungere file",
     dropToReplace: "Rilascia per sostituire il file",
+    reorderHint: "Trascina le miniature per riordinarle, o inverti l'ordine, prima di eseguire.",
   },
   reviewPanel: {
     processedResultAlt: "Risultato elaborato",

--- a/packages/shared/src/i18n/ja.ts
+++ b/packages/shared/src/i18n/ja.ts
@@ -3842,6 +3842,7 @@ export const ja: TranslationKeys = {
     filesSelected: "{count}ファイルを選択済み",
     dropToAdd: "ファイルを追加するにはドロップ",
     dropToReplace: "ファイルを置き換えるにはドロップ",
+    reorderHint: "実行する前に、サムネイルをドラッグして並べ替えるか、順序を逆にできます。",
   },
   reviewPanel: {
     processedResultAlt: "処理結果",

--- a/packages/shared/src/i18n/ko.ts
+++ b/packages/shared/src/i18n/ko.ts
@@ -3821,6 +3821,7 @@ export const ko: TranslationKeys = {
     filesSelected: "{count}개 파일 선택됨",
     dropToAdd: "파일을 추가하려면 놓기",
     dropToReplace: "파일을 교체하려면 놓기",
+    reorderHint: "실행하기 전에 썸네일을 드래그하여 순서를 변경하거나 순서를 뒤집으세요.",
   },
   reviewPanel: {
     processedResultAlt: "처리 결과",

--- a/packages/shared/src/i18n/nl.ts
+++ b/packages/shared/src/i18n/nl.ts
@@ -3904,6 +3904,7 @@ export const nl: TranslationKeys = {
     filesSelected: "{count} bestanden geselecteerd",
     dropToAdd: "Laat los om bestanden toe te voegen",
     dropToReplace: "Laat los om bestand te vervangen",
+    reorderHint: "Sleep de miniaturen om te herordenen, of keer de volgorde om, voordat je start.",
   },
   reviewPanel: {
     processedResultAlt: "Verwerkt resultaat",

--- a/packages/shared/src/i18n/pl.ts
+++ b/packages/shared/src/i18n/pl.ts
@@ -3908,6 +3908,8 @@ export const pl: TranslationKeys = {
     filesSelected: "Wybrano plików: {count}",
     dropToAdd: "Upuść, aby dodać pliki",
     dropToReplace: "Upuść, aby zastąpić plik",
+    reorderHint:
+      "Przeciągnij miniatury, aby zmienić kolejność, lub odwróć kolejność przed uruchomieniem.",
   },
   reviewPanel: {
     processedResultAlt: "Wynik przetwarzania",

--- a/packages/shared/src/i18n/pt-BR.ts
+++ b/packages/shared/src/i18n/pt-BR.ts
@@ -3903,6 +3903,7 @@ export const ptBR: TranslationKeys = {
     filesSelected: "{count} arquivos selecionados",
     dropToAdd: "Solte para adicionar arquivos",
     dropToReplace: "Solte para substituir arquivo",
+    reorderHint: "Arraste as miniaturas para reordenar, ou inverta a ordem, antes de executar.",
   },
   reviewPanel: {
     processedResultAlt: "Resultado processado",

--- a/packages/shared/src/i18n/ru.ts
+++ b/packages/shared/src/i18n/ru.ts
@@ -3900,6 +3900,7 @@ export const ru: TranslationKeys = {
     filesSelected: "Выбрано файлов: {count}",
     dropToAdd: "Отпустите, чтобы добавить файлы",
     dropToReplace: "Отпустите, чтобы заменить файл",
+    reorderHint: "Перетащите миниатюры, чтобы изменить порядок, или обратите его, перед запуском.",
   },
   reviewPanel: {
     processedResultAlt: "Результат обработки",

--- a/packages/shared/src/i18n/sv.ts
+++ b/packages/shared/src/i18n/sv.ts
@@ -3892,6 +3892,7 @@ export const sv: TranslationKeys = {
     filesSelected: "{count} filer valda",
     dropToAdd: "Släpp för att lägga till filer",
     dropToReplace: "Släpp för att ersätta fil",
+    reorderHint: "Dra miniatyrerna för att ändra ordning, eller vänd ordningen, innan du kör.",
   },
   reviewPanel: {
     processedResultAlt: "Bearbetat resultat",

--- a/packages/shared/src/i18n/th.ts
+++ b/packages/shared/src/i18n/th.ts
@@ -3842,6 +3842,7 @@ export const th: TranslationKeys = {
     filesSelected: "เลือกแล้ว {count} ไฟล์",
     dropToAdd: "วางเพื่อเพิ่มไฟล์",
     dropToReplace: "วางเพื่อแทนที่ไฟล์",
+    reorderHint: "ลากภาพขนาดย่อเพื่อจัดเรียงใหม่ หรือกลับลำดับ ก่อนเรียกใช้",
   },
   reviewPanel: {
     processedResultAlt: "ผลลัพธ์ที่ประมวลผลแล้ว",

--- a/packages/shared/src/i18n/tr.ts
+++ b/packages/shared/src/i18n/tr.ts
@@ -3903,6 +3903,8 @@ export const tr: TranslationKeys = {
     filesSelected: "{count} dosya seçildi",
     dropToAdd: "Dosya eklemek için bırakın",
     dropToReplace: "Dosyayı değiştirmek için bırakın",
+    reorderHint:
+      "Çalıştırmadan önce sıralamak için küçük resimleri sürükleyin veya sırayı tersine çevirin.",
   },
   reviewPanel: {
     processedResultAlt: "İşlenmiş sonuç",

--- a/packages/shared/src/i18n/uk.ts
+++ b/packages/shared/src/i18n/uk.ts
@@ -3898,6 +3898,8 @@ export const uk: TranslationKeys = {
     filesSelected: "Обрано файлів: {count}",
     dropToAdd: "Відпустіть, щоб додати файли",
     dropToReplace: "Відпустіть, щоб замінити файл",
+    reorderHint:
+      "Перетягніть мініатюри, щоб змінити порядок, або змініть його на зворотний, перед запуском.",
   },
   reviewPanel: {
     processedResultAlt: "Результат обробки",

--- a/packages/shared/src/i18n/vi.ts
+++ b/packages/shared/src/i18n/vi.ts
@@ -3888,6 +3888,7 @@ export const vi: TranslationKeys = {
     filesSelected: "Đã chọn {count} tệp",
     dropToAdd: "Thả để thêm tệp",
     dropToReplace: "Thả để thay thế tệp",
+    reorderHint: "Kéo các hình thu nhỏ để sắp xếp lại, hoặc đảo ngược thứ tự, trước khi chạy.",
   },
   reviewPanel: {
     processedResultAlt: "Kết quả đã xử lý",

--- a/packages/shared/src/i18n/zh-CN.ts
+++ b/packages/shared/src/i18n/zh-CN.ts
@@ -3625,6 +3625,7 @@ export const zhCN: TranslationKeys = {
     filesSelected: "已选择 {count} 个文件",
     dropToAdd: "放下以添加文件",
     dropToReplace: "放下以替换文件",
+    reorderHint: "运行前可拖动缩略图重新排序，或反转顺序。",
   },
   reviewPanel: {
     processedResultAlt: "处理结果",

--- a/packages/shared/src/i18n/zh-TW.ts
+++ b/packages/shared/src/i18n/zh-TW.ts
@@ -3626,6 +3626,7 @@ export const zhTW: TranslationKeys = {
     filesSelected: "已選取{count}個檔案",
     dropToAdd: "放下以新增檔案",
     dropToReplace: "放下以取代檔案",
+    reorderHint: "執行前可拖曳縮圖重新排序，或反轉順序。",
   },
   reviewPanel: {
     processedResultAlt: "處理結果",


### PR DESCRIPTION
## What

Follow-up to #756. merge-pdf's settings already told users its files "merge in this order". The other order-sensitive multi-file tools had no such cue, now that drag-to-reorder and the reverse button exist.

They get a short hint above the settings panel: "Drag the thumbnails to reorder, or reverse the order, before running." It shows only when the tool is in `REORDERABLE_TOOLS` and more than one file is loaded.

## How

One shared string, `dropzone.reorderHint`, rendered once in tool-page's settings panel and gated by the existing `canReorder && hasMultiple`. That covers merge-audio, merge-videos, merge-csvs, images-to-video, sprite-sheet, stitch, collage, create-zip, and the image-to-pdf presets in one place, instead of editing nine settings components (three of which aren't internationalized). Added to all 21 locales.

## Tests

Typecheck clean, which is where i18n parity is enforced (`TranslationKeys`). Full web and shared unit suites: 1699 pass. Biome clean.
