### PR TITLE
fix(web,api): stop abandoning live batch runs when the connection dies

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -70,6 +70,7 @@ Emitted from `apps/web` through `track()`; properties are filtered by the `ALLOW
 | `sponsor_clicked` | The sponsor link is clicked | none |
 | `feedback_prompt_shown` | A feedback surface becomes visible (usage survey, per-job prompt, admin install card, nav dialog, search miss) | `source`, `survey_id`, `prompt_variant` |
 | `feedback_prompt_dismissed` | A feedback surface is dismissed without submitting | `source`, `survey_id`, `prompt_variant`, `dismiss_kind` (`close`, `dont_ask_again`, or `snooze`) |
+| `tool_run_degraded` | A run's sync HTTP response died after the upload finished and the client fell back to the async SSE path instead of failing the job (#750). High volume on one instance means a reverse proxy is killing sync waits; the fallback hides that from users, so this event is the only operator-visible signal | `tool_id`, `is_batch`, `trigger` (`socket`, `timeout`, `http-502`, or `http-504`), `had_evidence` |
 
 ### SDK-generated events
 

--- a/apps/api/src/jobs/batch-progress.ts
+++ b/apps/api/src/jobs/batch-progress.ts
@@ -56,14 +56,41 @@ export async function recordChildOutcome(
   const errors: Array<{ filename: string; error: string }> = (
     await r.lrange(`${base}:errors`, 0, 99)
   ).map((e) => JSON.parse(e));
-  const finished = completedFiles >= totalFiles;
+  // Child outcomes are always nonterminal (#750): the terminal frame belongs
+  // to batch-finalize, which publishes it only after the durable ZIP and its
+  // download URL exist. Emitting "completed" here would close client SSE
+  // streams before the result they need to settle a degraded run is ready.
   updateJobProgress({
     jobId: parentId,
-    status: finished ? (doneCount > 0 ? "completed" : "failed") : "processing",
+    status: "processing",
     totalFiles,
     completedFiles,
     failedFiles,
     errors,
     currentFile: filename,
   });
+}
+
+export interface BatchCounters {
+  done: number;
+  failed: number;
+  errors: Array<{ filename: string; error: string }>;
+}
+
+/** Read the accumulated child outcomes for a batch parent (errors capped at
+ * 100, same bound the SSE frames use). Used by batch-finalize to build the
+ * terminal frame. */
+export async function readBatchCounters(parentId: string): Promise<BatchCounters> {
+  const r = sharedRedis();
+  const base = `${bullPrefix()}:batch:${parentId}`;
+  const [done, failed, rawErrors] = await Promise.all([
+    r.get(`${base}:done`),
+    r.get(`${base}:failed`),
+    r.lrange(`${base}:errors`, 0, 99),
+  ]);
+  return {
+    done: Number(done ?? 0),
+    failed: Number(failed ?? 0),
+    errors: rawErrors.map((e) => JSON.parse(e)),
+  };
 }

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -24,6 +24,7 @@
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import { context, propagation, ROOT_CONTEXT, SpanStatusCode, trace } from "@opentelemetry/api";
 import {
   ANALYTICS_EVENTS,
@@ -35,6 +36,7 @@ import {
   type PipelineExecutedProperties,
   TOOLS,
 } from "@snapotter/shared";
+import archiver from "archiver";
 import { type Job, UnrecoverableError, Worker } from "bullmq";
 import { eq } from "drizzle-orm";
 import { env } from "../config.js";
@@ -44,13 +46,16 @@ import { analyticsEnabled } from "../lib/analytics-gate.js";
 import { resolveConcurrency } from "../lib/env.js";
 import { classifyError, reportError, safeFormatTag } from "../lib/error-report.js";
 import { friendlyError } from "../lib/errors.js";
+import { createUniqueNamer } from "../lib/filename.js";
 import { logger } from "../lib/logger.js";
 import { jobDuration, jobsTotal } from "../lib/metrics.js";
 import {
   copyObjectToFile,
   getObjectBuffer,
   getObjectSize,
+  getObjectStream,
   putObject,
+  putObjectStream,
 } from "../lib/object-storage.js";
 import { OCR_MAX_ENCODED_INPUT_BYTES } from "../lib/ocr-limits.js";
 import { SCRUB_PDF_PRODUCER_TOOLS, scrubPdfProducer } from "../lib/pdf-producer.js";
@@ -58,6 +63,8 @@ import { setSettingIfAbsent } from "../lib/settings-helpers.js";
 import { timeoutMessage } from "../lib/timeout.js";
 import { InputValidationError } from "../modality/contract.js";
 import {
+  completeBatchJob,
+  failBatchJob,
   publishEphemeral,
   updateSingleFileProgress,
   updateSingleFileProgressAtomically,
@@ -74,7 +81,7 @@ import {
   runAiPathToolJob,
   runAiToolJob,
 } from "./ai-handlers.js";
-import { recordChildOutcome } from "./batch-progress.js";
+import { readBatchCounters, recordChildOutcome } from "./batch-progress.js";
 import { registerCancelable, unregisterCancelable } from "./cancel.js";
 import { createBullMQConnection } from "./connection.js";
 import { createMonotonicReporter } from "./monotonic-progress.js";
@@ -1002,17 +1009,97 @@ async function processBatchChild(job: Job<ToolJobData>): Promise<ToolJobResult> 
 // ── Batch finalize handler ────────────────────────────────────
 
 /**
+ * Stream every successful child output through one archiver pass into a
+ * durable ZIP object. A source stream that fails after opening never rejects
+ * an await on its own, so both the archive and every entry stream funnel
+ * failures into the PassThrough; destroying it makes putObjectStream reject
+ * (and clean up its partial object).
+ */
+async function buildBatchZip(
+  zipKey: string,
+  entries: Array<{ filename: string; outputRef: string }>,
+): Promise<number> {
+  const archive = archiver("zip", { zlib: { level: 5 } });
+  const passthrough = new PassThrough();
+  // fail() can destroy the passthrough before putObjectStream's pipeline has
+  // attached its consumer; an 'error' event in that window has no listener
+  // and would be process-fatal. The upload's rejection is the real signal.
+  passthrough.on("error", () => {});
+  const opened: NodeJS.ReadableStream[] = [];
+  let failed = false;
+  const fail = (err: Error) => {
+    if (failed) return;
+    failed = true;
+    archive.abort();
+    // Destroying the passthrough is what makes the upload reject (and clean
+    // up its partial object); abort() alone leaves it waiting for an end
+    // that never comes.
+    passthrough.destroy(err);
+  };
+  archive.on("error", fail);
+  archive.pipe(passthrough);
+  const upload = putObjectStream(zipKey, passthrough);
+  const feed = (async () => {
+    for (const entry of entries) {
+      const source = await getObjectStream(entry.outputRef);
+      opened.push(source);
+      // Never hand archiver a stream that can emit 'error': it re-emits the
+      // error on an internal listener-less stream, which is process-fatal.
+      // The wrapper ends quietly instead; fail() has already destroyed the
+      // passthrough by then, so the truncated entry can never be mistaken
+      // for a complete archive.
+      const entryStream = new PassThrough();
+      source.on("error", (err: Error) => {
+        fail(err);
+        entryStream.end();
+      });
+      source.pipe(entryStream);
+      archive.append(entryStream, { name: entry.filename });
+    }
+    await archive.finalize();
+  })();
+  // The upload is the one promise that settles in every outcome: it resolves
+  // when the archive ends the passthrough and rejects when fail() destroys
+  // it. finalize() after an abort is not guaranteed to settle, so the feed
+  // is observed but never awaited unguarded.
+  feed.catch((err: unknown) => fail(err instanceof Error ? err : new Error(String(err))));
+  try {
+    return await upload;
+  } catch (err) {
+    // Abandoned entry streams would otherwise hold their descriptors open.
+    for (const stream of opened) {
+      (stream as unknown as { destroy?: (e?: Error) => void }).destroy?.();
+    }
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+}
+
+/**
  * Assembles the ordered manifest from child DB rows after all batch
- * children have completed. Runs on the system pool (concurrency 1)
- * and does only lightweight DB reads -- no heavy processing.
+ * children have completed, packages the successful outputs into a durable
+ * ZIP under outputs/<parentId>/, commits the terminal parent-row state, and
+ * publishes the terminal batch SSE frame carrying the download URL (#750).
+ * Runs on the system pool (concurrency 1); the HTTP route streams the
+ * stored ZIP instead of re-archiving.
  *
- * The manifest `[{index, filename, outputRef?, error?}]` is returned
- * as the job result so the HTTP route can stream the ZIP.
+ * The manifest `[{index, filename, outputRef?, error?}]` is returned in the
+ * job result alongside the zip descriptor so the HTTP route can build its
+ * response without recomputing either.
  */
 async function processBatchFinalize(job: Job<ToolJobData>): Promise<ToolJobResult> {
   const data = job.data;
-  const flowChildCount =
-    (data.settings as { flowChildCount?: number } | null)?.flowChildCount ?? data.totalFiles ?? 0;
+  const settings = (data.settings ?? {}) as {
+    flowChildCount?: number;
+    fileIndexMap?: number[];
+  };
+  const flowChildCount = settings.flowChildCount ?? data.totalFiles ?? 0;
+  // Flow index -> original upload index. Pre-failed uploads never became flow
+  // children, so without this map every index after a pre-failure would pair
+  // a result with the wrong file (#645's alignment contract). Absent on jobs
+  // enqueued before this field existed; identity is correct for those unless
+  // a pre-failure occurred, matching the old route behavior.
+  const fileIndexMap = Array.isArray(settings.fileIndexMap) ? settings.fileIndexMap : null;
+  const totalFiles = data.totalFiles ?? flowChildCount;
 
   const manifest: Array<{
     index: number;
@@ -1040,19 +1127,92 @@ async function processBatchFinalize(job: Job<ToolJobData>): Promise<ToolJobResul
     }
   }
 
-  // Update parent row
-  await db
-    .update(schema.jobs)
-    .set({ status: "completed", completedAt: new Date() })
-    .where(eq(schema.jobs.id, data.jobId));
+  // Deduplicate output names once, here, so the ZIP entries, the terminal
+  // frame's fileResults, and the route's X-File-Results header cannot drift.
+  const getUniqueName = createUniqueNamer();
+  const fileResults: Record<string, string> = {};
+  const successEntries: Array<{ filename: string; outputRef: string }> = [];
+  for (const entry of manifest) {
+    if (!entry.outputRef) continue;
+    const uniqueName = getUniqueName(entry.filename);
+    entry.filename = uniqueName;
+    fileResults[String(fileIndexMap?.[entry.index] ?? entry.index)] = uniqueName;
+    successEntries.push({ filename: uniqueName, outputRef: entry.outputRef });
+  }
+
+  const counters = await readBatchCounters(data.jobId);
+  const failedFiles = Math.max(0, totalFiles - successEntries.length);
+
+  if (successEntries.length === 0) {
+    await failBatchJob({
+      jobId: data.jobId,
+      totalFiles,
+      completedFiles: totalFiles,
+      failedFiles,
+      errors: counters.errors,
+      message: "All files failed processing",
+    });
+    return {
+      outputRefs: [],
+      filename: "",
+      contentType: "application/json",
+      originalSize: 0,
+      processedSize: 0,
+      resultPayload: { manifest, allFailed: true },
+    };
+  }
+
+  const zipFilename =
+    data.toolId === "pipeline-batch"
+      ? `pipeline-batch-${data.jobId.slice(0, 8)}.zip`
+      : `batch-${data.toolId}-${data.jobId.slice(0, 8)}.zip`;
+  const zipKey = `outputs/${data.jobId}/${zipFilename}`;
+
+  let zipSize: number;
+  try {
+    zipSize = await buildBatchZip(zipKey, successEntries);
+  } catch (err) {
+    const packagingError = "Failed to package batch results";
+    await failBatchJob({
+      jobId: data.jobId,
+      totalFiles,
+      completedFiles: totalFiles,
+      failedFiles,
+      errors: [...counters.errors, { filename: "", error: packagingError }],
+      message: packagingError,
+    });
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+
+  const result: Record<string, unknown> = {
+    jobId: data.jobId,
+    downloadUrl: `/api/v1/download/${data.jobId}/${encodeURIComponent(zipFilename)}`,
+    zipFilename,
+    fileResults,
+    processedSize: zipSize,
+  };
+
+  await completeBatchJob({
+    jobId: data.jobId,
+    totalFiles,
+    completedFiles: totalFiles,
+    failedFiles,
+    errors: counters.errors,
+    outputRefs: [zipKey],
+    bytesOut: zipSize,
+    result,
+  });
 
   return {
-    outputRefs: [],
-    filename: "",
-    contentType: "application/json",
+    outputRefs: [zipKey],
+    filename: zipFilename,
+    contentType: "application/zip",
     originalSize: 0,
-    processedSize: 0,
-    resultPayload: { manifest },
+    processedSize: zipSize,
+    resultPayload: {
+      manifest,
+      zip: { key: zipKey, filename: zipFilename, size: zipSize, fileResults },
+    },
   };
 }
 
@@ -1087,10 +1247,26 @@ export function startWorkers(): void {
 
       worker.on("failed", (job, err) => {
         if (!job) return;
+        const data = job.data as ToolJobData | undefined;
+        // Safety net for a finalize that died without reaching its own
+        // terminal write (crash, stall eviction): a degraded client is
+        // waiting on the terminal batch frame and nothing else will send
+        // one. failBatchJob is guarded, so a finalize that already
+        // committed terminal state is left untouched.
+        if (data?.kind === "batch-finalize") {
+          void failBatchJob({
+            jobId: data.jobId,
+            totalFiles: data.totalFiles ?? 0,
+            completedFiles: data.totalFiles ?? 0,
+            failedFiles: data.totalFiles ?? 0,
+            errors: [],
+            message: "Failed to package batch results",
+          }).catch(() => {});
+        }
         void reportError(err, {
           source: "worker",
           pool,
-          toolId: (job.data as ToolJobData | undefined)?.toolId,
+          toolId: data?.toolId,
           jobId: job.id,
         });
       });

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -1015,6 +1015,11 @@ async function processBatchChild(job: Job<ToolJobData>): Promise<ToolJobResult> 
  * failures into the PassThrough; destroying it makes putObjectStream reject
  * (and clean up its partial object).
  */
+// A source stream that neither errors nor ends (half-open S3 read) would
+// otherwise hold the concurrency-1 system pool forever: BullMQ keeps
+// renewing the lock of an "active" job, so stall detection never fires.
+const BATCH_ZIP_TIMEOUT_MS = 15 * 60_000;
+
 async function buildBatchZip(
   zipKey: string,
   entries: Array<{ filename: string; outputRef: string }>,
@@ -1035,13 +1040,25 @@ async function buildBatchZip(
     // up its partial object); abort() alone leaves it waiting for an end
     // that never comes.
     passthrough.destroy(err);
+    // The aborted archive never reads its queued entries, so already-opened
+    // sources would idle with buffered data and hold their descriptors.
+    for (const stream of opened) {
+      (stream as unknown as { destroy?: (e?: Error) => void }).destroy?.();
+    }
   };
   archive.on("error", fail);
   archive.pipe(passthrough);
   const upload = putObjectStream(zipKey, passthrough);
   const feed = (async () => {
     for (const entry of entries) {
+      if (failed) break;
       const source = await getObjectStream(entry.outputRef);
+      if (failed) {
+        // fail() ran while this open was in flight; its cleanup loop cannot
+        // have seen this stream.
+        (source as unknown as { destroy?: () => void }).destroy?.();
+        break;
+      }
       opened.push(source);
       // Never hand archiver a stream that can emit 'error': it re-emits the
       // error on an internal listener-less stream, which is process-fatal.
@@ -1063,14 +1080,20 @@ async function buildBatchZip(
   // it. finalize() after an abort is not guaranteed to settle, so the feed
   // is observed but never awaited unguarded.
   feed.catch((err: unknown) => fail(err instanceof Error ? err : new Error(String(err))));
+  const watchdog = setTimeout(
+    () => fail(new Error("Batch ZIP packaging timed out")),
+    BATCH_ZIP_TIMEOUT_MS,
+  );
   try {
     return await upload;
   } catch (err) {
-    // Abandoned entry streams would otherwise hold their descriptors open.
-    for (const stream of opened) {
-      (stream as unknown as { destroy?: (e?: Error) => void }).destroy?.();
-    }
-    throw err instanceof Error ? err : new Error(String(err));
+    const error = err instanceof Error ? err : new Error(String(err));
+    // The upload can reject without fail() having run (the local capacity
+    // check rejects before consuming); fail() owns all teardown.
+    fail(error);
+    throw error;
+  } finally {
+    clearTimeout(watchdog);
   }
 }
 
@@ -1173,6 +1196,8 @@ async function processBatchFinalize(job: Job<ToolJobData>): Promise<ToolJobResul
     zipSize = await buildBatchZip(zipKey, successEntries);
   } catch (err) {
     const packagingError = "Failed to package batch results";
+    // The terminal write must not displace the packaging root cause: the
+    // rethrow below is what reaches the job record and Sentry.
     await failBatchJob({
       jobId: data.jobId,
       totalFiles,
@@ -1180,6 +1205,11 @@ async function processBatchFinalize(job: Job<ToolJobData>): Promise<ToolJobResul
       failedFiles,
       errors: [...counters.errors, { filename: "", error: packagingError }],
       message: packagingError,
+    }).catch((persistErr) => {
+      logger.error(
+        { err: persistErr, jobId: data.jobId },
+        "failed to record batch packaging failure",
+      );
     });
     throw err instanceof Error ? err : new Error(String(err));
   }
@@ -1259,9 +1289,17 @@ export function startWorkers(): void {
             totalFiles: data.totalFiles ?? 0,
             completedFiles: data.totalFiles ?? 0,
             failedFiles: data.totalFiles ?? 0,
-            errors: [],
+            // The blank-name entry is the synthetic-error contract the client
+            // displays; without it the frame reads as "all files failed" for
+            // a batch whose files all succeeded.
+            errors: [{ filename: "", error: "Failed to package batch results" }],
             message: "Failed to package batch results",
-          }).catch(() => {});
+          }).catch((netErr) => {
+            // The net itself failing means a degraded client may hang on a
+            // row that never goes terminal; that must reach the operator.
+            logger.error({ err: netErr, jobId: data.jobId }, "batch-finalize safety net failed");
+            void reportError(netErr, { source: "worker", pool, jobId: data.jobId });
+          });
         }
         void reportError(err, {
           source: "worker",

--- a/apps/api/src/routes/batch.ts
+++ b/apps/api/src/routes/batch.ts
@@ -46,7 +46,7 @@ import { withRouteScratch } from "../lib/route-scratch.js";
 import { InputValidationError } from "../modality/contract.js";
 import { inputHandlerFor } from "../modality/input-handler.js";
 import { requireToolAccess } from "../permissions.js";
-import { updateJobProgress } from "./progress.js";
+import { failBatchJob, updateJobProgress } from "./progress.js";
 import { getToolConfig } from "./tool-factory.js";
 
 type ParsedFile =
@@ -454,9 +454,14 @@ export async function registerBatchRoutes(app: FastifyInstance): Promise<void> {
                 settings,
                 analyticsDistinctId: request.headers["x-posthog-distinct-id"] as string | undefined,
               } satisfies ToolJobData,
-              // Children swallow failures via return markers, so a retry would
-              // never run; attempts: 1 makes that explicit.
-              opts: { jobId: childId, attempts: 1 },
+              // Children swallow failures via return markers, so a retry
+              // would never run; attempts: 1 makes that explicit. A child can
+              // still hard-fail outside its own handler (stall eviction after
+              // an OOM kill); without ignoreDependencyOnFailure that wedges
+              // the parent in waiting-children forever and no terminal frame
+              // ever reaches a degraded client (#750). With it, the finalize
+              // runs and reports the child as failed from its row.
+              opts: { jobId: childId, attempts: 1, ignoreDependencyOnFailure: true },
             });
 
             fileIndexMap.push(i);
@@ -470,15 +475,18 @@ export async function registerBatchRoutes(app: FastifyInstance): Promise<void> {
 
           if (flowChildren.length === 0) {
             // All files failed validation. There is no flow to run, so no
-            // finalize will ever publish a terminal frame; publish it here so
-            // a client that lost this response settles from SSE (#750).
-            updateJobProgress({
+            // finalize will ever publish a terminal frame; publish it here
+            // (awaited and guarded, like the finalize's own writes) so a
+            // client that lost this response settles from SSE (#750).
+            await failBatchJob({
               jobId: parentId,
-              status: "failed",
               totalFiles: files.length,
               completedFiles: files.length,
               failedFiles: files.length,
               errors: preFailures.map((f) => ({ filename: f.filename, error: f.error })),
+              message: "All files failed processing",
+            }).catch((err) => {
+              request.log.error({ err, jobId: parentId }, "all-prefail terminal write failed");
             });
             return reply.status(422).send({
               error: "All files failed processing",
@@ -588,6 +596,11 @@ export async function registerBatchRoutes(app: FastifyInstance): Promise<void> {
             stream.on("error", (err: Error) => {
               request.log.error({ err, jobId: parentId }, "Batch ZIP stream error");
               reply.raw.destroy(err);
+            });
+            // pipe() only unpipes when the destination dies; the source stays
+            // open and leaks its descriptor on every mid-download disconnect.
+            reply.raw.on("close", () => {
+              stream.destroy();
             });
             stream.pipe(reply.raw);
           } catch (err) {

--- a/apps/api/src/routes/batch.ts
+++ b/apps/api/src/routes/batch.ts
@@ -11,7 +11,6 @@
 import { randomUUID } from "node:crypto";
 import { rm } from "node:fs/promises";
 import { FEATURE_BUNDLES, TOOLS, toolSection } from "@snapotter/shared";
-import archiver from "archiver";
 import type { FlowJob } from "bullmq";
 import { eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
@@ -26,7 +25,7 @@ import { getSecurityHeaders } from "../lib/csp.js";
 import { formatZodErrors } from "../lib/errors.js";
 import { getFirstMissingBundleForTool } from "../lib/feature-status.js";
 import { validateImageBuffer } from "../lib/file-validation.js";
-import { createUniqueNamer, sanitizeFilename } from "../lib/filename.js";
+import { sanitizeFilename } from "../lib/filename.js";
 import { decodeToSharpCompat, needsCliDecode } from "../lib/format-decoders.js";
 import { decodeHeic } from "../lib/heic-converter.js";
 import { deleteObject, getObjectStream, putObject } from "../lib/object-storage.js";
@@ -276,6 +275,9 @@ export async function registerBatchRoutes(app: FastifyInstance): Promise<void> {
           // ── Validate, decode, and upload each file ────────────────────
           const flowChildren: FlowJob[] = [];
           const preFailures: Array<{ originalIndex: number; filename: string; error: string }> = [];
+          // Flow index -> original upload index, consumed by batch-finalize so
+          // fileResults keeps #645's index alignment across pre-failures.
+          const fileIndexMap: number[] = [];
           let flowChildIndex = 0;
 
           // Resolve the tool's modality so non-image files (audio/video/document)
@@ -457,6 +459,7 @@ export async function registerBatchRoutes(app: FastifyInstance): Promise<void> {
               opts: { jobId: childId, attempts: 1 },
             });
 
+            fileIndexMap.push(i);
             flowChildIndex++;
           }
 
@@ -466,7 +469,17 @@ export async function registerBatchRoutes(app: FastifyInstance): Promise<void> {
           }
 
           if (flowChildren.length === 0) {
-            // All files failed validation
+            // All files failed validation. There is no flow to run, so no
+            // finalize will ever publish a terminal frame; publish it here so
+            // a client that lost this response settles from SSE (#750).
+            updateJobProgress({
+              jobId: parentId,
+              status: "failed",
+              totalFiles: files.length,
+              completedFiles: files.length,
+              failedFiles: files.length,
+              errors: preFailures.map((f) => ({ filename: f.filename, error: f.error })),
+            });
             return reply.status(422).send({
               error: "All files failed processing",
               errors: preFailures.map((f) => ({ filename: f.filename, error: f.error })),
@@ -486,7 +499,7 @@ export async function registerBatchRoutes(app: FastifyInstance): Promise<void> {
               totalFiles: files.length,
               inputRefs: [],
               filename: "",
-              settings: { flowChildCount: flowChildren.length },
+              settings: { flowChildCount: flowChildren.length, fileIndexMap },
               analyticsDistinctId: request.headers["x-posthog-distinct-id"] as string | undefined,
             } satisfies ToolJobData,
             opts: { jobId: parentId, attempts: 1 },
@@ -496,7 +509,7 @@ export async function registerBatchRoutes(app: FastifyInstance): Promise<void> {
           // Update the parent row with the final flow child count
           await db
             .update(schema.jobs)
-            .set({ settings: { flowChildCount: flowChildren.length } })
+            .set({ settings: { flowChildCount: flowChildren.length, fileIndexMap } })
             .where(eq(schema.jobs.id, parentId));
 
           // Inject OTel trace context into every node of the batch flow tree
@@ -505,126 +518,81 @@ export async function registerBatchRoutes(app: FastifyInstance): Promise<void> {
           await getFlowProducer().add(batchTree);
           uncommittedOcrKeys.clear();
 
-          // ── Wait for completion and stream ZIP ─────────────────────────
+          // ── Wait for completion and stream the stored ZIP ──────────────
           const batchResult = await waitForJob("system", parentId, 30 * 60_000);
 
           if (!batchResult) {
-            return reply.status(422).send({ error: "Batch processing timed out" });
+            // The flow is still running and nothing couples this response to
+            // it. Answer with the async contract instead of a fake failure:
+            // the client rides the SSE to the terminal frame, which carries
+            // the durable download URL (#750).
+            return reply.status(202).send({ jobId: parentId, async: true });
           }
 
-          const manifest = (batchResult.resultPayload?.manifest ?? []) as Array<{
-            index: number;
-            filename: string;
-            outputRef?: string;
-            error?: string;
-          }>;
-
-          // Combine manifest with pre-failures for the full ordered result
-          const allResults: Array<{
-            originalIndex: number;
-            filename: string;
-            outputRef?: string;
-            error?: string;
-          }> = [];
-
-          let fci = 0;
-          for (let i = 0; i < files.length; i++) {
-            const pf = preFailures.find((p) => p.originalIndex === i);
-            if (pf) {
-              allResults.push({
-                originalIndex: i,
-                filename: pf.filename,
-                error: pf.error,
-              });
-            } else {
-              const entry = manifest.find((m) => m.index === fci);
-              if (entry) {
-                allResults.push({
-                  originalIndex: i,
-                  filename: entry.filename,
-                  outputRef: entry.outputRef,
-                  error: entry.error,
-                });
+          const payload = batchResult.resultPayload as
+            | {
+                manifest?: Array<{
+                  index: number;
+                  filename: string;
+                  outputRef?: string;
+                  error?: string;
+                }>;
+                zip?: {
+                  key: string;
+                  filename: string;
+                  size: number;
+                  fileResults: Record<string, string>;
+                };
               }
-              fci++;
-            }
-          }
+            | undefined;
 
-          const successEntries = allResults.filter((r) => r.outputRef);
-          const failedEntries = allResults.filter((r) => !r.outputRef);
-
-          // If every file failed, return an error instead of an empty ZIP
-          if (successEntries.length === 0) {
+          const zip = payload?.zip;
+          if (!zip) {
+            // Every file failed; the finalize already published the terminal
+            // failed frame. Mirror it on the HTTP contract.
+            const manifestFailures = (payload?.manifest ?? []).filter((m) => !m.outputRef);
             return reply.status(422).send({
               error: "All files failed processing",
-              errors: failedEntries.map((f) => ({
-                filename: f.filename,
-                error: f.error ?? "Failed",
-              })),
+              errors: [
+                ...preFailures.map((f) => ({ filename: f.filename, error: f.error })),
+                ...manifestFailures.map((f) => ({
+                  filename: f.filename,
+                  error: f.error ?? "Failed",
+                })),
+              ],
             });
           }
 
-          // Deduplicate output filenames and build X-File-Results header
-          const getUniqueName = createUniqueNamer();
-
-          const fileResultsMap: Record<string, string> = {};
-          for (const entry of successEntries) {
-            const uniqueName = getUniqueName(entry.filename);
-            entry.filename = uniqueName;
-            fileResultsMap[String(entry.originalIndex)] = uniqueName;
-          }
-
-          // Hijack and stream the ZIP response after all processing
+          // Hijack and stream the ZIP the finalize persisted. Content-Length
+          // is known, so a delivery shortfall is detectable by the client
+          // instead of looking like a complete chunked response.
           reply.hijack();
           reply.raw.writeHead(200, {
             "Content-Type": "application/zip",
-            "Content-Disposition": `attachment; filename="batch-${toolId}-${parentId.slice(0, 8)}.zip"`,
-            "Transfer-Encoding": "chunked",
+            "Content-Disposition": `attachment; filename="${zip.filename}"`,
+            "Content-Length": String(zip.size),
             "X-Job-Id": parentId,
-            "X-File-Results": encodeURIComponent(JSON.stringify(fileResultsMap)),
+            "X-File-Results": encodeURIComponent(JSON.stringify(zip.fileResults)),
             ...getSecurityHeaders(),
           });
 
-          const archive = archiver("zip", { zlib: { level: 5 } });
-
           // The 200 headers are already out, so nothing here can change the
-          // status. Destroy the socket rather than end() it: a clean end on a
-          // chunked response is indistinguishable from success, so the client
-          // would keep a ZIP with no central directory believing it complete.
-          let streamFailed = false;
-          const failStream = (err: Error, msg: string) => {
-            if (streamFailed) return;
-            streamFailed = true;
-            request.log.error({ err, jobId: parentId }, msg);
-            archive.abort();
-            reply.raw.destroy(err);
-          };
-
-          archive.on("error", (err) => failStream(err, "Archiver error during batch processing"));
-
-          archive.pipe(reply.raw);
-
-          // Append results from object storage in original upload order
+          // status. Destroy the socket rather than end() it: a clean end
+          // would hand the client a short body it may mistake for success.
           try {
-            for (const entry of successEntries) {
-              if (!entry.outputRef) continue;
-              const stream = await getObjectStream(entry.outputRef);
-              // A backend that resolves the stream and only then fails (local
-              // createReadStream emitting ENOENT) never rejects here, so the
-              // catch below cannot see it. Without this listener that error is
-              // unhandled and the request hangs instead of terminating.
-              stream.on("error", (err: Error) =>
-                failStream(err, "Object stream error during batch processing"),
-              );
-              archive.append(stream, { name: entry.filename });
-            }
-
-            await archive.finalize();
+            const stream = await getObjectStream(zip.key);
+            // A backend that resolves the stream and only then fails (local
+            // createReadStream emitting ENOENT) never rejects the await, so
+            // the catch below cannot see it. Without this listener that error
+            // is unhandled and the request hangs instead of terminating.
+            stream.on("error", (err: Error) => {
+              request.log.error({ err, jobId: parentId }, "Batch ZIP stream error");
+              reply.raw.destroy(err);
+            });
+            stream.pipe(reply.raw);
           } catch (err) {
-            failStream(
-              err instanceof Error ? err : new Error(String(err)),
-              "Failed to stream ZIP entries during batch processing",
-            );
+            request.log.error({ err, jobId: parentId }, "Failed to open stored batch ZIP");
+            reply.raw.destroy(err instanceof Error ? err : new Error(String(err)));
           }
         } finally {
           request.raw.removeListener("aborted", abortIngress);

--- a/apps/api/src/routes/pipeline.ts
+++ b/apps/api/src/routes/pipeline.ts
@@ -1337,10 +1337,13 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
           const batchResult = await waitForJob("system", parentId, 30 * 60_000);
 
           if (!batchResult) {
-            // The flow is still running; answer with the async contract and
-            // let the client ride the SSE to the terminal frame, which
-            // carries the durable download URL (#750).
-            return reply.status(202).send({ jobId: parentId, async: true });
+            // The flow keeps running and the finalize will persist the ZIP
+            // and publish the terminal frame, but the pipeline client cannot
+            // ride the async contract yet (it settles only from this
+            // response), so a 202 here would hand it JSON it tries to unzip.
+            // Keep the timeout error until the pipeline hook learns the #750
+            // degrade path.
+            return reply.status(422).send({ error: "Pipeline batch processing timed out" });
           }
 
           const payload = batchResult.resultPayload as

--- a/apps/api/src/routes/pipeline.ts
+++ b/apps/api/src/routes/pipeline.ts
@@ -10,7 +10,6 @@
 import { randomUUID } from "node:crypto";
 import { readFile, rm } from "node:fs/promises";
 import { FEATURE_BUNDLES, MODALITY_POOL, TOOLS } from "@snapotter/shared";
-import archiver from "archiver";
 import type { FlowJob } from "bullmq";
 import { eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
@@ -1099,6 +1098,9 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
           // Validate, decode, and upload each file; build per-file pipeline chains
           const perFileChildren: FlowJob[] = [];
           const preFailures: Array<{ originalIndex: number; filename: string; error: string }> = [];
+          // Flow index -> original upload index, consumed by batch-finalize so
+          // fileResults keeps index alignment across pre-failures.
+          const fileIndexMap: number[] = [];
           let flowChildIndex = 0;
 
           // The first step's modality drives input validation for every file, so
@@ -1272,6 +1274,7 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
             });
 
             perFileChildren.push(perFileTree);
+            fileIndexMap.push(fi);
             flowChildIndex++;
           }
 
@@ -1281,7 +1284,17 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
           }
 
           if (perFileChildren.length === 0) {
-            // All files failed validation
+            // All files failed validation. There is no flow to run, so no
+            // finalize will ever publish a terminal frame; publish it here so
+            // a client that lost this response settles from SSE (#750).
+            updateJobProgress({
+              jobId: parentId,
+              status: "failed",
+              totalFiles: files.length,
+              completedFiles: files.length,
+              failedFiles: files.length,
+              errors: preFailures.map((f) => ({ filename: f.filename, error: f.error })),
+            });
             return reply.status(422).send({
               error: "All files failed processing",
               errors: preFailures.map((f) => ({ filename: f.filename, error: f.error })),
@@ -1301,7 +1314,7 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
               totalFiles: files.length,
               inputRefs: [],
               filename: "",
-              settings: { flowChildCount: perFileChildren.length },
+              settings: { flowChildCount: perFileChildren.length, fileIndexMap },
               analyticsDistinctId: request.headers["x-posthog-distinct-id"] as string | undefined,
             } satisfies ToolJobData,
             opts: { jobId: parentId, attempts: 1 },
@@ -1311,7 +1324,7 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
           // Update the parent row with the final flow child count
           await db
             .update(schema.jobs)
-            .set({ settings: { flowChildCount: perFileChildren.length } })
+            .set({ settings: { flowChildCount: perFileChildren.length, fileIndexMap } })
             .where(eq(schema.jobs.id, parentId));
 
           // Inject OTel trace context into every node of the batch flow tree
@@ -1320,132 +1333,74 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
           await getFlowProducer().add(batchTree);
           uncommittedOcrKeys.clear();
 
-          // Wait for batch completion
+          // ── Wait for completion and stream the stored ZIP ────────────────
           const batchResult = await waitForJob("system", parentId, 30 * 60_000);
 
           if (!batchResult) {
-            return reply.status(422).send({ error: "Pipeline batch processing timed out" });
+            // The flow is still running; answer with the async contract and
+            // let the client ride the SSE to the terminal frame, which
+            // carries the durable download URL (#750).
+            return reply.status(202).send({ jobId: parentId, async: true });
           }
 
-          const manifest = (batchResult.resultPayload?.manifest ?? []) as Array<{
-            index: number;
-            filename: string;
-            outputRef?: string;
-            error?: string;
-          }>;
-
-          // Combine manifest with pre-failures
-          const allResults: Array<{
-            originalIndex: number;
-            filename: string;
-            outputRef?: string;
-            error?: string;
-          }> = [];
-
-          // Map flow indices back to original file indices
-          let fci = 0;
-          for (let fi = 0; fi < files.length; fi++) {
-            const pf = preFailures.find((p) => p.originalIndex === fi);
-            if (pf) {
-              allResults.push({
-                originalIndex: fi,
-                filename: pf.filename,
-                error: pf.error,
-              });
-            } else {
-              const entry = manifest.find((m) => m.index === fci);
-              if (entry) {
-                allResults.push({
-                  originalIndex: fi,
-                  filename: entry.filename,
-                  outputRef: entry.outputRef,
-                  error: entry.error,
-                });
+          const payload = batchResult.resultPayload as
+            | {
+                manifest?: Array<{
+                  index: number;
+                  filename: string;
+                  outputRef?: string;
+                  error?: string;
+                }>;
+                zip?: {
+                  key: string;
+                  filename: string;
+                  size: number;
+                  fileResults: Record<string, string>;
+                };
               }
-              fci++;
-            }
-          }
+            | undefined;
 
-          // Deduplicate output filenames
-          const usedNames = new Set<string>();
-          function getUniqueName(name: string): string {
-            if (!usedNames.has(name)) {
-              usedNames.add(name);
-              return name;
-            }
-            const dotIdx = name.lastIndexOf(".");
-            const base = dotIdx > 0 ? name.slice(0, dotIdx) : name;
-            const ext = dotIdx > 0 ? name.slice(dotIdx) : "";
-            let counter = 1;
-            let candidate = `${base}_${counter}${ext}`;
-            while (usedNames.has(candidate)) {
-              counter++;
-              candidate = `${base}_${counter}${ext}`;
-            }
-            usedNames.add(candidate);
-            return candidate;
-          }
-
-          const successEntries = allResults.filter((r) => r.outputRef);
-          const failedEntries = allResults.filter((r) => !r.outputRef);
-
-          if (successEntries.length === 0) {
+          const zip = payload?.zip;
+          if (!zip) {
+            // Every file failed; the finalize already published the terminal
+            // failed frame. Mirror it on the HTTP contract.
+            const manifestFailures = (payload?.manifest ?? []).filter((m) => !m.outputRef);
             return reply.status(422).send({
               error: "All files failed processing",
-              errors: failedEntries.map((f) => ({
-                filename: f.filename,
-                error: f.error ?? "Failed",
-              })),
+              errors: [
+                ...preFailures.map((f) => ({ filename: f.filename, error: f.error })),
+                ...manifestFailures.map((f) => ({
+                  filename: f.filename,
+                  error: f.error ?? "Failed",
+                })),
+              ],
             });
           }
 
-          const fileResultsMap: Record<string, string> = {};
-          for (const entry of successEntries) {
-            const uniqueName = getUniqueName(entry.filename);
-            entry.filename = uniqueName;
-            fileResultsMap[String(entry.originalIndex)] = uniqueName;
-          }
-
-          // ── Stream ZIP response ──────────────────────────────────────────
+          // ── Stream the ZIP the finalize persisted ────────────────────────
           reply.hijack();
           reply.raw.writeHead(200, {
             "Content-Type": "application/zip",
-            "Content-Disposition": `attachment; filename="pipeline-batch-${parentId.slice(0, 8)}.zip"`,
-            "Transfer-Encoding": "chunked",
+            "Content-Disposition": `attachment; filename="${zip.filename}"`,
+            "Content-Length": String(zip.size),
             "X-Job-Id": parentId,
-            "X-File-Results": encodeURIComponent(JSON.stringify(fileResultsMap)),
+            "X-File-Results": encodeURIComponent(JSON.stringify(zip.fileResults)),
             ...getSecurityHeaders(),
           });
 
-          const archive = archiver("zip", { zlib: { level: 5 } });
-
-          archive.on("error", (err) => {
-            request.log.error({ err }, "Archiver error during pipeline batch processing");
-            if (!reply.raw.writableEnded) {
-              reply.raw.end();
-            }
-          });
-
-          archive.pipe(reply.raw);
-
-          // Append results from object storage in original upload order
+          // The 200 headers are already out, so nothing here can change the
+          // status. Destroy the socket rather than end() it: a clean end
+          // would hand the client a short body it may mistake for success.
           try {
-            for (const entry of successEntries) {
-              if (!entry.outputRef) continue;
-              const stream = await getObjectStream(entry.outputRef);
-              archive.append(stream, { name: entry.filename });
-            }
-
-            await archive.finalize();
+            const stream = await getObjectStream(zip.key);
+            stream.on("error", (err: Error) => {
+              request.log.error({ err, jobId: parentId }, "Pipeline batch ZIP stream error");
+              reply.raw.destroy(err);
+            });
+            stream.pipe(reply.raw);
           } catch (err) {
-            request.log.error(
-              { err },
-              "Failed to stream ZIP entries during pipeline batch processing",
-            );
-            archive.abort();
-            if (!reply.raw.writableEnded) {
-              reply.raw.end();
-            }
+            request.log.error({ err, jobId: parentId }, "Failed to open stored pipeline batch ZIP");
+            reply.raw.destroy(err instanceof Error ? err : new Error(String(err)));
           }
         } finally {
           request.raw.removeListener("aborted", abortIngress);

--- a/apps/api/src/routes/pipeline.ts
+++ b/apps/api/src/routes/pipeline.ts
@@ -49,7 +49,7 @@ import { InputValidationError } from "../modality/contract.js";
 import { inputHandlerFor } from "../modality/input-handler.js";
 import { hasEffectivePermission, hasEffectiveToolAccess } from "../permissions.js";
 import { type AuthUser, requireAuth } from "../plugins/auth.js";
-import { updateJobProgress, updateSingleFileProgress } from "./progress.js";
+import { failBatchJob, updateJobProgress, updateSingleFileProgress } from "./progress.js";
 import { getRegisteredToolIds, getToolConfig } from "./tool-factory.js";
 
 /**
@@ -1285,15 +1285,18 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
 
           if (perFileChildren.length === 0) {
             // All files failed validation. There is no flow to run, so no
-            // finalize will ever publish a terminal frame; publish it here so
-            // a client that lost this response settles from SSE (#750).
-            updateJobProgress({
+            // finalize will ever publish a terminal frame; publish it here
+            // (awaited and guarded, like the finalize's own writes) so a
+            // client that lost this response settles from SSE (#750).
+            await failBatchJob({
               jobId: parentId,
-              status: "failed",
               totalFiles: files.length,
               completedFiles: files.length,
               failedFiles: files.length,
               errors: preFailures.map((f) => ({ filename: f.filename, error: f.error })),
+              message: "All files failed processing",
+            }).catch((err) => {
+              request.log.error({ err, jobId: parentId }, "all-prefail terminal write failed");
             });
             return reply.status(422).send({
               error: "All files failed processing",
@@ -1399,6 +1402,11 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
             stream.on("error", (err: Error) => {
               request.log.error({ err, jobId: parentId }, "Pipeline batch ZIP stream error");
               reply.raw.destroy(err);
+            });
+            // pipe() only unpipes when the destination dies; the source stays
+            // open and leaks its descriptor on every mid-download disconnect.
+            reply.raw.on("close", () => {
+              stream.destroy();
             });
             stream.pipe(reply.raw);
           } catch (err) {

--- a/apps/api/src/routes/progress.ts
+++ b/apps/api/src/routes/progress.ts
@@ -356,13 +356,20 @@ function announce(payload: (JobProgress & { type: "batch" }) | SingleFileProgres
 
   // Terminal events write the replay cache BEFORE publishing, so a client
   // connecting right after the live event always finds the terminal key.
+  // A dropped TERMINAL announcement is the one failure a waiting client may
+  // never recover from on its own, so it must at least reach the logs;
+  // nonterminal drops stay quiet (they would spam every frame of an outage).
   const publishPromise = isTerminal
     ? sharedRedis()
         .setex(terminalKey(payload.jobId), TERMINAL_TTL_S, json)
-        .catch(() => {})
+        .catch((err) => {
+          console.error("terminal replay key write failed", payload.jobId, err);
+        })
         .then(() => sharedRedis().publish(progressChannel(), json))
     : sharedRedis().publish(progressChannel(), json);
-  void Promise.resolve(publishPromise).catch(() => {});
+  void Promise.resolve(publishPromise).catch((err) => {
+    if (isTerminal) console.error("terminal progress publish failed", payload.jobId, err);
+  });
 }
 
 function publish(payload: (JobProgress & { type: "batch" }) | SingleFileProgress): Promise<void> {
@@ -531,10 +538,14 @@ export function publishEphemeral(
   const announce = isTerminal
     ? sharedRedis()
         .setex(terminalKey(payload.jobId), TERMINAL_TTL_S, json)
-        .catch(() => {})
+        .catch((err) => {
+          console.error("terminal replay key write failed", payload.jobId, err);
+        })
         .then(() => sharedRedis().publish(progressChannel(), json))
     : sharedRedis().publish(progressChannel(), json);
-  void Promise.resolve(announce).catch(() => {});
+  void Promise.resolve(announce).catch((err) => {
+    if (isTerminal) console.error("terminal progress publish failed", payload.jobId, err);
+  });
 }
 
 // ── SSE subscriber (module-level, shared across all connections) ─

--- a/apps/api/src/routes/progress.ts
+++ b/apps/api/src/routes/progress.ts
@@ -30,6 +30,20 @@ export interface JobProgress {
   errors: Array<{ filename: string; error: string }>;
   /** Current file being processed (if any). */
   currentFile?: string;
+  /**
+   * Terminal frames only: the durable batch result (downloadUrl, fileResults,
+   * ...) so a client that lost its HTTP response can settle from SSE alone
+   * (#750). Absent on nonterminal frames.
+   */
+  result?: Record<string, unknown>;
+}
+
+export interface PersistedJobProgress {
+  percent: number;
+  totalFiles: number;
+  completedFiles: number;
+  failedFiles: number;
+  result?: Record<string, unknown>;
 }
 
 export interface SingleFileProgress {
@@ -54,6 +68,8 @@ interface SingleFileReplayRow {
   progress: unknown;
   error: unknown;
 }
+
+type BatchReplayRow = SingleFileReplayRow;
 
 const MISSING_DURABLE_RESULT_ERROR = "Completed result is no longer available. Run the job again.";
 
@@ -115,6 +131,79 @@ export function buildSingleFileReplayEvent(row: SingleFileReplayRow): SingleFile
   };
 }
 
+function asCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+/** Compute the durable jsonb for a batch parent row. Counts (not just a
+ * percent) persist so a reconnecting client can be shown real batch progress,
+ * and terminal frames keep their result for replay after the Redis terminal
+ * key expires (#750). */
+export function buildPersistedJobProgress(progress: JobProgress): PersistedJobProgress {
+  return {
+    percent:
+      progress.totalFiles > 0
+        ? Math.round((progress.completedFiles / progress.totalFiles) * 100)
+        : 0,
+    totalFiles: progress.totalFiles,
+    completedFiles: progress.completedFiles,
+    failedFiles: progress.failedFiles,
+    ...(progress.result ? { result: progress.result } : {}),
+  };
+}
+
+function storedBatchErrors(error: unknown): Array<{ filename: string; error: string }> {
+  if (!isRecord(error) || !Array.isArray(error.details)) return [];
+  const out: Array<{ filename: string; error: string }> = [];
+  for (const entry of error.details) {
+    if (isRecord(entry) && typeof entry.filename === "string" && typeof entry.error === "string") {
+      out.push({ filename: entry.filename, error: entry.error });
+    }
+  }
+  return out;
+}
+
+/** Reconstruct a batch frame from the parent jobs row: nonterminal for live
+ * rows (proof the batch exists, mirroring the single-file replay of #722),
+ * terminal with the durable result otherwise. */
+export function buildBatchReplayEvent(row: BatchReplayRow): JobProgress & { type: "batch" } {
+  const progress = isRecord(row.progress) ? row.progress : {};
+  const counts = {
+    totalFiles: asCount(progress.totalFiles),
+    completedFiles: asCount(progress.completedFiles),
+    failedFiles: asCount(progress.failedFiles),
+  };
+  const base = { jobId: row.jobId, type: "batch" as const, ...counts };
+
+  if (row.status === "queued" || row.status === "processing") {
+    return { ...base, status: "processing", errors: [] };
+  }
+
+  if (row.status === "completed") {
+    const result = isRecord(progress.result) ? progress.result : undefined;
+    if (!result) {
+      return {
+        ...base,
+        status: "failed",
+        errors: [{ filename: "", error: MISSING_DURABLE_RESULT_ERROR }],
+      };
+    }
+    return { ...base, status: "completed", errors: storedBatchErrors(row.error), result };
+  }
+
+  const errors = storedBatchErrors(row.error);
+  if (errors.length === 0) {
+    const message =
+      isRecord(row.error) && typeof row.error.message === "string"
+        ? row.error.message
+        : row.status === "canceled"
+          ? "Canceled"
+          : "Processing failed";
+    errors.push({ filename: "", error: message });
+  }
+  return { ...base, status: "failed", errors };
+}
+
 // ── Redis channels / keys ──────────────────────────────────────
 
 const progressChannel = () => `${bullPrefix()}:progress`;
@@ -144,10 +233,8 @@ function enqueuePersist(jobId: string, fn: () => Promise<void>): Promise<void> {
 
 async function persistJobProgress(progress: JobProgress): Promise<void> {
   try {
-    const percent =
-      progress.totalFiles > 0
-        ? Math.round((progress.completedFiles / progress.totalFiles) * 100)
-        : 0;
+    const progressJsonb = buildPersistedJobProgress(progress);
+    const isTerminalFrame = progress.status === "completed" || progress.status === "failed";
     const [existing] = await db
       .select({ id: schema.jobs.id })
       .from(schema.jobs)
@@ -158,21 +245,30 @@ async function persistJobProgress(progress: JobProgress): Promise<void> {
         .update(schema.jobs)
         .set({
           status: progress.status,
-          progress: { percent },
+          progress: progressJsonb,
           error:
             progress.errors.length > 0
               ? { message: `${progress.errors.length} file(s) failed`, details: progress.errors }
               : null,
-          completedAt:
-            progress.status === "completed" || progress.status === "failed" ? new Date() : null,
+          completedAt: isTerminalFrame ? new Date() : null,
         })
-        .where(eq(schema.jobs.id, progress.jobId));
+        // Same resurrect guard as the single-file persist: child outcomes are
+        // published fire and forget, so a late nonterminal frame must not
+        // overwrite the terminal state the finalize already committed.
+        .where(
+          isTerminalFrame
+            ? eq(schema.jobs.id, progress.jobId)
+            : and(
+                eq(schema.jobs.id, progress.jobId),
+                notInArray(schema.jobs.status, ["completed", "failed", "canceled"]),
+              ),
+        );
     } else {
       await db.insert(schema.jobs).values({
         id: progress.jobId,
         type: "batch",
         status: progress.status,
-        progress: { percent },
+        progress: progressJsonb,
         inputRefs: [],
         error:
           progress.errors.length > 0
@@ -319,6 +415,102 @@ export async function updateSingleFileProgressAtomically(
     }),
   );
   announce(event);
+}
+
+export interface CompleteBatchJobArgs {
+  jobId: string;
+  totalFiles: number;
+  completedFiles: number;
+  failedFiles: number;
+  errors: Array<{ filename: string; error: string }>;
+  outputRefs: string[];
+  bytesOut: number;
+  result: Record<string, unknown>;
+}
+
+/**
+ * Commit the authoritative batch completion (row status, outputRefs, durable
+ * progress with the result) and only then announce the terminal frame, so a
+ * replay can never observe the frame without the durable state behind it.
+ * Runs through the per-job persist queue: earlier fire-and-forget child
+ * frames land first and cannot overwrite this write afterwards.
+ */
+export async function completeBatchJob(args: CompleteBatchJobArgs): Promise<void> {
+  const frame: JobProgress & { type: "batch" } = {
+    jobId: args.jobId,
+    type: "batch",
+    status: "completed",
+    totalFiles: args.totalFiles,
+    completedFiles: args.completedFiles,
+    failedFiles: args.failedFiles,
+    errors: args.errors,
+    result: args.result,
+  };
+  await enqueuePersist(args.jobId, async () => {
+    await db
+      .update(schema.jobs)
+      .set({
+        status: "completed",
+        completedAt: new Date(),
+        outputRefs: args.outputRefs,
+        bytesOut: args.bytesOut,
+        progress: buildPersistedJobProgress(frame),
+        error:
+          args.errors.length > 0
+            ? { message: `${args.errors.length} file(s) failed`, details: args.errors }
+            : null,
+      })
+      .where(eq(schema.jobs.id, args.jobId));
+  });
+  announce(frame);
+}
+
+export interface FailBatchJobArgs {
+  jobId: string;
+  totalFiles: number;
+  completedFiles: number;
+  failedFiles: number;
+  errors: Array<{ filename: string; error: string }>;
+  message: string;
+}
+
+/**
+ * Terminal batch failure. Guarded so a late safety-net call (the worker's
+ * failed handler) can never downgrade an already-committed completion; the
+ * frame is only announced when this call actually owned the transition.
+ */
+export async function failBatchJob(args: FailBatchJobArgs): Promise<void> {
+  const frame: JobProgress & { type: "batch" } = {
+    jobId: args.jobId,
+    type: "batch",
+    status: "failed",
+    totalFiles: args.totalFiles,
+    completedFiles: args.completedFiles,
+    failedFiles: args.failedFiles,
+    errors: args.errors,
+  };
+  let applied = false;
+  await enqueuePersist(args.jobId, async () => {
+    const res = await db
+      .update(schema.jobs)
+      .set({
+        status: "failed",
+        completedAt: new Date(),
+        progress: buildPersistedJobProgress(frame),
+        error: {
+          message: args.message,
+          ...(args.errors.length > 0 ? { details: args.errors } : {}),
+        },
+      })
+      .where(
+        and(
+          eq(schema.jobs.id, args.jobId),
+          notInArray(schema.jobs.status, ["completed", "failed", "canceled"]),
+        ),
+      );
+    applied = ((res as { rowCount?: number | null } | undefined)?.rowCount ?? 0) > 0;
+  });
+  if (applied) announce(frame);
 }
 
 /**
@@ -520,32 +712,46 @@ export async function registerProgressRoutes(app: FastifyInstance): Promise<void
           };
           sendFrame(JSON.stringify(synthetic));
         }
+        // Live batch parents replay a nonterminal frame for the same reason
+        // the single path does (#722): a client that degraded a dead batch
+        // POST needs proof the batch exists, and heartbeats carry none. The
+        // finalize can also take a while after the last child (ZIP packaging),
+        // where this replay is the only evidence available (#750).
         if (
           row &&
-          (row.status === "completed" || row.status === "failed" || row.status === "canceled")
+          row.type === "batch" &&
+          (row.status === "queued" || row.status === "processing")
         ) {
-          let syntheticJson: string;
-          if (row.type !== "batch") {
-            syntheticJson = JSON.stringify(
-              buildSingleFileReplayEvent({
+          sendFrame(
+            JSON.stringify(
+              buildBatchReplayEvent({
                 jobId,
                 status: row.status,
                 progress: row.progress,
                 error: row.error,
               }),
-            );
-          } else {
-            syntheticJson = JSON.stringify({
-              jobId,
-              type: "batch",
-              status: row.status === "canceled" ? "failed" : row.status,
-              totalFiles: 0,
-              completedFiles: 0,
-              failedFiles: 0,
-              errors: [],
-            });
-          }
-          callback(syntheticJson);
+            ),
+          );
+        }
+        if (
+          row &&
+          (row.status === "completed" || row.status === "failed" || row.status === "canceled")
+        ) {
+          const replayEvent =
+            row.type !== "batch"
+              ? buildSingleFileReplayEvent({
+                  jobId,
+                  status: row.status,
+                  progress: row.progress,
+                  error: row.error,
+                })
+              : buildBatchReplayEvent({
+                  jobId,
+                  status: row.status,
+                  progress: row.progress,
+                  error: row.error,
+                });
+          callback(JSON.stringify(replayEvent));
         }
       } catch {
         // DB unavailable; the listener continues with live updates.

--- a/apps/web/src/hooks/use-tool-processor.ts
+++ b/apps/web/src/hooks/use-tool-processor.ts
@@ -1,6 +1,7 @@
 import { ANALYTICS_EVENTS, apiToolPath, PYTHON_SIDECAR_TOOLS, TOOLS } from "@snapotter/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "@/contexts/i18n-context";
+import { track } from "@/lib/analytics";
 import { formatHeaders, parseApiError } from "@/lib/api";
 import { MULTI_FILE_TOOLS } from "@/lib/tool-display-modes";
 import { generateId } from "@/lib/utils";
@@ -14,6 +15,17 @@ interface ProcessResult {
   processedSize: number;
   savedFileId?: string;
   warning?: string;
+}
+
+interface BatchProgressFrame {
+  status: "processing" | "completed" | "failed";
+  totalFiles: number;
+  completedFiles: number;
+  failedFiles: number;
+  errors?: Array<{ filename: string; error: string }>;
+  currentFile?: string;
+  /** Terminal frames carry the durable batch result (#750). */
+  result?: Record<string, unknown>;
 }
 
 export interface ToolProgress {
@@ -93,7 +105,6 @@ export function useToolProcessor(toolId: string) {
   const elapsedRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const xhrRef = useRef<XMLHttpRequest | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
   const stallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const activeJobIdRef = useRef<string | null>(null);
   const activeEntryIndexRef = useRef<number | null>(null);
@@ -104,12 +115,31 @@ export function useToolProcessor(toolId: string) {
   // original library file on re-runs.
   const saveModeRef = useRef<"new" | "overwrite">("new");
   const jobEvidenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Whether any single-type SSE frame arrived for the current run: proof the
-  // job reached the server, consulted when a dead POST degrades (#722).
+  // Whether any single- or batch-type SSE frame arrived for the current run:
+  // proof the job reached the server, consulted when a dead POST degrades
+  // (#722, #750).
   const sawJobEvidenceRef = useRef(false);
+  // Installed by processAllFiles so the SSE handler can settle a degraded
+  // batch run from its terminal frame (#750). Null outside batch runs.
+  const batchRunRef = useRef<{ onTerminal: (frame: BatchProgressFrame) => void } | null>(null);
 
   const isAiTool = AI_PYTHON_TOOLS.has(toolId);
   const toolName = TOOLS.find((t) => t.id === toolId)?.name ?? toolId;
+
+  // Operator-visible record of a sync wait falling back to the async path:
+  // the fallback masks the network failure from the user by design, so this
+  // event is the only signal a reverse proxy is killing sync waits (#750).
+  const trackDegrade = useCallback(
+    (trigger: "socket" | "timeout" | "http-502" | "http-504", isBatch: boolean) => {
+      track(ANALYTICS_EVENTS.TOOL_RUN_DEGRADED, {
+        tool_id: toolId,
+        is_batch: isBatch,
+        trigger,
+        had_evidence: sawJobEvidenceRef.current,
+      });
+    },
+    [toolId],
+  );
 
   const clearActiveJob = useCallback(() => {
     activeJobIdRef.current = null;
@@ -221,6 +251,40 @@ export function useToolProcessor(toolId: string) {
             const data = JSON.parse(event.data);
             if (data.type === "heartbeat") {
               if (asyncModeRef.current) resetStallTimer();
+              return;
+            }
+            if (data.type === "batch") {
+              // Any batch frame proves the batch reached the server (#750).
+              sawJobEvidenceRef.current = true;
+              clearJobEvidenceTimer();
+              if (asyncModeRef.current) resetStallTimer();
+
+              const frame = data as BatchProgressFrame;
+              if (frame.status !== "completed" && frame.status !== "failed") {
+                const pct =
+                  frame.totalFiles > 0
+                    ? UPLOAD_WEIGHT +
+                      (frame.completedFiles / frame.totalFiles) * (100 - UPLOAD_WEIGHT)
+                    : UPLOAD_WEIGHT;
+                setProgress((prev) => ({
+                  ...prev,
+                  phase: "processing",
+                  percent: pct,
+                  stage: frame.currentFile
+                    ? `Processing ${frame.currentFile} (${frame.completedFiles}/${frame.totalFiles})`
+                    : `Processing ${frame.completedFiles}/${frame.totalFiles}`,
+                }));
+                return;
+              }
+              // In sync mode the XHR response owns settling: the terminal
+              // frame always precedes the streamed ZIP, so acting on it here
+              // would settle the run twice.
+              if (!asyncModeRef.current) return;
+              clearStallTimer();
+              es.close();
+              eventSourceRef.current = null;
+              xhrRef.current?.abort();
+              batchRunRef.current?.onTerminal(frame);
               return;
             }
             if (data.type !== "single") return;
@@ -337,7 +401,6 @@ export function useToolProcessor(toolId: string) {
       if (elapsedRef.current) clearInterval(elapsedRef.current);
       if (eventSourceRef.current) eventSourceRef.current.close();
       if (xhrRef.current) xhrRef.current.abort();
-      if (abortRef.current) abortRef.current.abort();
       if (stallTimerRef.current) clearTimeout(stallTimerRef.current);
       if (jobEvidenceTimerRef.current) clearTimeout(jobEvidenceTimerRef.current);
     };
@@ -454,9 +517,10 @@ export function useToolProcessor(toolId: string) {
       // 202 would, instead of abandoning a live job (#722). A proxy idle
       // timeout on the sync wait otherwise reproduces the failure on every
       // retry while every "failed" job actually completes.
-      const degradeToAsync = () => {
+      const degradeToAsync = (trigger: "socket" | "timeout" | "http-502" | "http-504") => {
         if (!uploadedFully || activeJobIdRef.current !== clientJobId) return false;
         asyncModeRef.current = true;
+        trackDegrade(trigger, false);
         setActiveJob(clientJobId, cancelCurrentJob);
         // Force a fresh SSE: the event that got us here says the network
         // path just died, and a half-open source keeps readyState OPEN while
@@ -480,6 +544,23 @@ export function useToolProcessor(toolId: string) {
           setActiveJob(clientJobId, cancelCurrentJob);
           resetStallTimer();
           return;
+        }
+
+        // A 502/504 whose body is not JSON is an intermediary answering for
+        // a dead sync wait, not the app: app-emitted 5xx always carries a
+        // JSON error body (html-to-image's own 504 stays precise below).
+        // Post-upload the job is live server-side, so degrade instead of
+        // erroring (#750).
+        if (xhr.status === 502 || xhr.status === 504) {
+          let appSpoke = true;
+          try {
+            JSON.parse(xhr.responseText);
+          } catch {
+            appSpoke = false;
+          }
+          if (!appSpoke && degradeToAsync(xhr.status === 502 ? "http-502" : "http-504")) {
+            return;
+          }
         }
 
         if (elapsedRef.current) clearInterval(elapsedRef.current);
@@ -536,7 +617,7 @@ export function useToolProcessor(toolId: string) {
         // newer run took over: a late socket event must neither error a
         // finished result nor tear down the successor's state.
         if (activeJobIdRef.current !== clientJobId) return;
-        if (degradeToAsync()) return;
+        if (degradeToAsync("socket")) return;
         clearStallTimer();
         if (elapsedRef.current) clearInterval(elapsedRef.current);
         if (eventSourceRef.current) {
@@ -551,7 +632,7 @@ export function useToolProcessor(toolId: string) {
 
       xhr.ontimeout = () => {
         if (activeJobIdRef.current !== clientJobId) return;
-        if (degradeToAsync()) return;
+        if (degradeToAsync("timeout")) return;
         clearStallTimer();
         if (elapsedRef.current) clearInterval(elapsedRef.current);
         if (eventSourceRef.current) {
@@ -583,6 +664,7 @@ export function useToolProcessor(toolId: string) {
       resetStallTimer,
       clearJobEvidenceTimer,
       startJobEvidenceTimer,
+      trackDegrade,
       toolName,
     ],
   );
@@ -638,80 +720,32 @@ export function useToolProcessor(toolId: string) {
 
       const clientJobId = generateId();
       activeJobIdRef.current = clientJobId;
+      activeEntryIndexRef.current = null;
+      asyncModeRef.current = false;
 
-      // Open SSE before upload for real-time progress
-      try {
-        const es = new EventSource(`/api/v1/jobs/${clientJobId}/progress`);
-        eventSourceRef.current = es;
-        es.onmessage = (event) => {
-          try {
-            const data = JSON.parse(event.data);
-            if (data.type === "batch") {
-              const pct =
-                data.totalFiles > 0 ? 15 + (data.completedFiles / data.totalFiles) * 85 : 15;
-              setProgress((prev) => ({
-                ...prev,
-                phase: "processing",
-                percent: pct,
-                stage: data.currentFile
-                  ? `Processing ${data.currentFile} (${data.completedFiles}/${data.totalFiles})`
-                  : `Processing ${data.completedFiles}/${data.totalFiles}`,
-              }));
-            }
-          } catch {
-            /* ignore malformed SSE */
-          }
-        };
-        es.onerror = () => {
-          es.close();
-          eventSourceRef.current = null;
-        };
-      } catch {
-        /* SSE failed, proceed without */
-      }
-
-      const formData = new FormData();
-      for (const file of files) formData.append("file", file);
-      formData.append("settings", JSON.stringify(settings));
-      formData.append("clientJobId", clientJobId);
-
-      try {
-        abortRef.current = new AbortController();
-        const response = await fetch(`${apiToolPath(toolId)}/batch`, {
-          method: "POST",
-          headers: formatHeaders(),
-          body: formData,
-          signal: abortRef.current.signal,
-        });
-
+      // Tear down the run without touching the outcome state; callers set
+      // the result or error first.
+      const finishRun = () => {
+        clearJobEvidenceTimer();
+        clearStallTimer();
         if (elapsedRef.current) clearInterval(elapsedRef.current);
         if (eventSourceRef.current) {
           eventSourceRef.current.close();
           eventSourceRef.current = null;
         }
+        batchRunRef.current = null;
+        clearActiveJob();
+        setProcessing(false);
+        setProgress(IDLE_PROGRESS);
+      };
 
-        if (!response.ok) {
-          const text = await response.text();
-          let errorMsg: string;
-          try {
-            const body = JSON.parse(text);
-            const parsed = parseApiError(body, response.status);
-            if (typeof parsed === "object" && parsed.type === "feature_not_installed") {
-              errorMsg = `${toolName} requires the "${parsed.featureName}" feature. Enable it in Settings → AI Features.`;
-            } else {
-              errorMsg = parsed as string;
-            }
-          } catch {
-            errorMsg = `Batch processing failed: ${response.status}`;
-          }
-          setError(errorMsg);
-          setProcessing(false);
-          setProgress(IDLE_PROGRESS);
-          trackBatch("failed");
-          return;
-        }
+      const failRun = (message: string) => {
+        setError(message);
+        finishRun();
+        trackBatch("failed");
+      };
 
-        const zipBlob = await response.blob();
+      const settleFromZip = async (zipBlob: Blob, fileResults: Record<string, string>) => {
         setBatchZip(zipBlob, `batch-${toolId}.zip`);
 
         // Extract files from ZIP using fflate
@@ -720,15 +754,6 @@ export function useToolProcessor(toolId: string) {
         const extracted = unzipSync(zipBuffer);
 
         const entries = useFileStore.getState().entries;
-        let fileResults: Record<string, string> = {};
-        try {
-          fileResults = JSON.parse(
-            decodeURIComponent(response.headers.get("X-File-Results") ?? "%7B%7D"),
-          );
-        } catch {
-          // Malformed header - fall back to empty mapping, all entries marked failed
-        }
-
         for (let i = 0; i < entries.length; i++) {
           const processedName = fileResults[String(i)];
           if (processedName && extracted[processedName]) {
@@ -750,22 +775,199 @@ export function useToolProcessor(toolId: string) {
           }
         }
 
-        setProcessing(false);
-        setProgress(IDLE_PROGRESS);
-        clearActiveJob();
+        finishRun();
         trackBatch("completed");
-      } catch (err) {
-        if (elapsedRef.current) clearInterval(elapsedRef.current);
-        if (eventSourceRef.current) {
-          eventSourceRef.current.close();
-          eventSourceRef.current = null;
+      };
+
+      // A degraded run settles here: download the durable ZIP the terminal
+      // frame points at. Retried, because the reason we are on this path is
+      // that the network just proved flaky.
+      const downloadAndSettle = async (result: Record<string, unknown>) => {
+        const url = String(result.downloadUrl);
+        const fileResults = (result.fileResults ?? {}) as Record<string, string>;
+        for (let attempt = 0; attempt < 3; attempt++) {
+          if (activeJobIdRef.current !== clientJobId) return;
+          try {
+            const res = await fetch(url, { headers: formatHeaders() });
+            if (!res.ok) throw new Error(`Batch download failed: ${res.status}`);
+            const blob = await res.blob();
+            if (activeJobIdRef.current !== clientJobId) return;
+            await settleFromZip(blob, fileResults);
+            return;
+          } catch {
+            if (attempt < 2) {
+              await new Promise((resolve) => setTimeout(resolve, attempt === 0 ? 2_000 : 5_000));
+            }
+          }
         }
-        setError(err instanceof Error ? err.message : "Batch processing failed");
-        setProcessing(false);
-        setProgress(IDLE_PROGRESS);
-        clearActiveJob();
-        trackBatch("failed");
-      }
+        if (activeJobIdRef.current !== clientJobId) return;
+        failRun("Processing was interrupted. Retry when reconnected.");
+      };
+
+      batchRunRef.current = {
+        onTerminal: (frame) => {
+          if (activeJobIdRef.current !== clientJobId) return;
+          if (
+            frame.status === "completed" &&
+            frame.result &&
+            typeof frame.result.downloadUrl === "string"
+          ) {
+            void downloadAndSettle(frame.result);
+            return;
+          }
+          if (frame.status === "completed") {
+            // A batch route without a durable result (custom sub-routes like
+            // pdf-to-image): its ZIP only ever existed on the response this
+            // run lost, so the outcome matches a plain interruption.
+            failRun("Processing was interrupted. Retry when reconnected.");
+            return;
+          }
+          // Replay-synthesized failures carry their message in a blank-name
+          // errors entry (packaging failure, expired result).
+          const syntheticError = frame.errors?.find((e) => e.filename === "")?.error;
+          failRun(
+            syntheticError ??
+              (frame.totalFiles > 0 && frame.failedFiles >= frame.totalFiles
+                ? "All files failed processing"
+                : "Batch processing failed"),
+          );
+        },
+      };
+
+      // Open SSE before the upload. The unified handler in reconnectSSE also
+      // gives batch runs the visibility-change recovery path.
+      reconnectSSE(true);
+
+      const formData = new FormData();
+      for (const file of files) formData.append("file", file);
+      formData.append("settings", JSON.stringify(settings));
+      formData.append("clientJobId", clientJobId);
+
+      const xhr = new XMLHttpRequest();
+      xhrRef.current = xhr;
+      xhr.responseType = "blob";
+      // Batches legitimately hold the sync response for many minutes; the
+      // stall and evidence timers own liveness, not a wall-clock cap.
+      xhr.timeout = 0;
+
+      xhr.upload.onprogress = (event) => {
+        if (event.lengthComputable) {
+          const uploadPercent = (event.loaded / event.total) * UPLOAD_WEIGHT;
+          setProgress((prev) => {
+            if (prev.phase !== "uploading") return prev;
+            return { ...prev, percent: uploadPercent };
+          });
+        }
+      };
+
+      let uploadedFully = false;
+      xhr.upload.onload = () => {
+        uploadedFully = true;
+        setProgress((prev) => ({
+          ...prev,
+          phase: "processing",
+          percent: UPLOAD_WEIGHT,
+          stage: "Processing...",
+        }));
+      };
+
+      // Same shape as the single-run degrade (#722): a dead response after a
+      // finished upload does not mean a dead batch. The flow keeps running
+      // server-side and the terminal SSE frame carries the durable ZIP's
+      // download URL, so the run can settle without the HTTP response (#750).
+      const degradeToAsync = (trigger: "socket" | "timeout" | "http-502" | "http-504") => {
+        if (!uploadedFully || activeJobIdRef.current !== clientJobId) return false;
+        asyncModeRef.current = true;
+        trackDegrade(trigger, true);
+        reconnectSSE(true);
+        resetStallTimer();
+        if (!sawJobEvidenceRef.current) {
+          startJobEvidenceTimer();
+        }
+        return true;
+      };
+
+      xhr.onload = () => {
+        if (activeJobIdRef.current !== clientJobId) return;
+
+        if (xhr.status === 202) {
+          // The server's sync wait expired while the batch keeps running;
+          // ride the SSE to the terminal frame like any degraded run.
+          asyncModeRef.current = true;
+          resetStallTimer();
+          return;
+        }
+
+        if (xhr.status >= 200 && xhr.status < 300) {
+          let fileResults: Record<string, string> = {};
+          try {
+            fileResults = JSON.parse(
+              decodeURIComponent(xhr.getResponseHeader("X-File-Results") ?? "%7B%7D"),
+            );
+          } catch {
+            // Malformed header - fall back to empty mapping, all entries marked failed
+          }
+          const zipBlob = xhr.response as Blob;
+          void (async () => {
+            try {
+              if (activeJobIdRef.current !== clientJobId) return;
+              await settleFromZip(zipBlob, fileResults);
+            } catch {
+              if (activeJobIdRef.current !== clientJobId) return;
+              failRun("Batch processing failed");
+            }
+          })();
+          return;
+        }
+
+        void (async () => {
+          const text = await (xhr.response instanceof Blob
+            ? xhr.response.text()
+            : Promise.resolve(String(xhr.response ?? "")));
+          if (activeJobIdRef.current !== clientJobId) return;
+          let errorMsg: string;
+          try {
+            const body = JSON.parse(text);
+            const parsed = parseApiError(body, xhr.status);
+            if (typeof parsed === "object" && parsed.type === "feature_not_installed") {
+              errorMsg = `${toolName} requires the "${parsed.featureName}" feature. Enable it in Settings → AI Features.`;
+            } else {
+              errorMsg = parsed as string;
+            }
+          } catch {
+            // An unparseable 502/504 body is an intermediary answering for a
+            // dead sync wait, not the app (app 5xx always carries JSON).
+            if (
+              (xhr.status === 502 || xhr.status === 504) &&
+              degradeToAsync(xhr.status === 502 ? "http-502" : "http-504")
+            ) {
+              return;
+            }
+            errorMsg = `Batch processing failed: ${xhr.status}`;
+          }
+          failRun(errorMsg);
+        })();
+      };
+
+      xhr.onerror = () => {
+        // Settled runs and successor runs must not be touched by late socket
+        // events (#722 run-identity guard).
+        if (activeJobIdRef.current !== clientJobId) return;
+        if (degradeToAsync("socket")) return;
+        failRun("Processing was interrupted. Retry when reconnected.");
+      };
+
+      xhr.ontimeout = () => {
+        if (activeJobIdRef.current !== clientJobId) return;
+        if (degradeToAsync("timeout")) return;
+        failRun("Request timed out - the server may be overloaded. Try again.");
+      };
+
+      xhr.open("POST", `${apiToolPath(toolId)}/batch`);
+      formatHeaders().forEach((value, key) => {
+        xhr.setRequestHeader(key, value);
+      });
+      xhr.send(formData);
     },
     [
       toolId,
@@ -774,6 +976,11 @@ export function useToolProcessor(toolId: string) {
       setError,
       clearActiveJob,
       clearJobEvidenceTimer,
+      clearStallTimer,
+      reconnectSSE,
+      resetStallTimer,
+      startJobEvidenceTimer,
+      trackDegrade,
       toolName,
     ],
   );

--- a/apps/web/src/hooks/use-tool-processor.ts
+++ b/apps/web/src/hooks/use-tool-processor.ts
@@ -284,7 +284,20 @@ export function useToolProcessor(toolId: string) {
               es.close();
               eventSourceRef.current = null;
               xhrRef.current?.abort();
-              batchRunRef.current?.onTerminal(frame);
+              const run = batchRunRef.current;
+              if (run) {
+                run.onTerminal(frame);
+              } else {
+                // Unreachable by construction (async mode implies a batch run
+                // installed the handler); if the invariant ever breaks, fail
+                // visibly instead of leaving the run in silent limbo.
+                clearJobEvidenceTimer();
+                if (elapsedRef.current) clearInterval(elapsedRef.current);
+                clearActiveJob();
+                setError("Processing was interrupted. Retry when reconnected.");
+                setProcessing(false);
+                setProgress(IDLE_PROGRESS);
+              }
               return;
             }
             if (data.type !== "single") return;
@@ -789,6 +802,18 @@ export function useToolProcessor(toolId: string) {
           if (activeJobIdRef.current !== clientJobId) return;
           try {
             const res = await fetch(url, { headers: formatHeaders() });
+            // A 4xx is deterministic: the result is gone or this session may
+            // not read it. Retrying cannot help, and the message must not
+            // blame the network.
+            if (res.status >= 400 && res.status < 500) {
+              if (activeJobIdRef.current !== clientJobId) return;
+              failRun(
+                res.status === 404
+                  ? "Completed result is no longer available. Run the job again."
+                  : "The finished batch could not be downloaded. Refresh and try again.",
+              );
+              return;
+            }
             if (!res.ok) throw new Error(`Batch download failed: ${res.status}`);
             const blob = await res.blob();
             if (activeJobIdRef.current !== clientJobId) return;
@@ -892,8 +917,11 @@ export function useToolProcessor(toolId: string) {
 
         if (xhr.status === 202) {
           // The server's sync wait expired while the batch keeps running;
-          // ride the SSE to the terminal frame like any degraded run.
+          // ride the SSE to the terminal frame like any degraded run. Force
+          // a fresh source: a sync-mode SSE error during the long wait nulls
+          // the ref, and the replay-on-connect recovers anything missed.
           asyncModeRef.current = true;
+          reconnectSSE(true);
           resetStallTimer();
           return;
         }
@@ -921,9 +949,14 @@ export function useToolProcessor(toolId: string) {
         }
 
         void (async () => {
-          const text = await (xhr.response instanceof Blob
-            ? xhr.response.text()
-            : Promise.resolve(String(xhr.response ?? "")));
+          let text = "";
+          try {
+            text = await (xhr.response instanceof Blob
+              ? xhr.response.text()
+              : Promise.resolve(String(xhr.response ?? "")));
+          } catch {
+            // Unreadable body; fall through to the status-based handling.
+          }
           if (activeJobIdRef.current !== clientJobId) return;
           let errorMsg: string;
           try {

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -27,6 +27,7 @@ const ALLOWED: Record<string, ReadonlySet<string>> = {
   pipeline_template_selected: new Set(["template_id"]),
   feedback_prompt_shown: new Set(["source", "survey_id", "prompt_variant"]),
   feedback_prompt_dismissed: new Set(["source", "survey_id", "prompt_variant", "dismiss_kind"]),
+  tool_run_degraded: new Set(["tool_id", "is_batch", "trigger", "had_evidence"]),
 };
 
 function sanitize(event: string, properties?: Record<string, unknown>): Record<string, unknown> {

--- a/packages/shared/src/analytics/events.ts
+++ b/packages/shared/src/analytics/events.ts
@@ -32,6 +32,12 @@ export const ANALYTICS_EVENTS = {
   // and skip rates become measurable instead of counting only submissions.
   FEEDBACK_PROMPT_SHOWN: "feedback_prompt_shown",
   FEEDBACK_PROMPT_DISMISSED: "feedback_prompt_dismissed",
+  // A sync tool run lost its HTTP response after the upload fully left the
+  // browser and fell back to the async SSE path instead of erroring (#750).
+  // The fallback deliberately masks proxy problems from the user, so this
+  // event is the only way an operator learns their reverse proxy is killing
+  // every sync wait.
+  TOOL_RUN_DEGRADED: "tool_run_degraded",
 } as const;
 
 export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];
@@ -102,4 +108,15 @@ export interface PipelineSavedProperties {
 
 export interface PipelineTemplateSelectedProperties {
   template_id: string;
+}
+
+export interface ToolRunDegradedProperties {
+  tool_id: string;
+  is_batch: boolean;
+  /** What killed the sync response: a socket error, a client-side timeout, or
+   * an intermediary's 502/504 with an unparseable body. */
+  trigger: "socket" | "timeout" | "http-502" | "http-504";
+  /** Whether an SSE frame had already proven the job reached the server when
+   * the degrade happened. */
+  had_evidence: boolean;
 }

--- a/tests/integration/platform/batch-survives-disconnect.test.ts
+++ b/tests/integration/platform/batch-survives-disconnect.test.ts
@@ -1,0 +1,215 @@
+import { randomUUID } from "node:crypto";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import AdmZip from "adm-zip";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../../apps/api/src/db/index.js";
+import { fixtures, readFixture } from "../../fixtures/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "../test-server.js";
+
+/**
+ * #750 contracts, the batch counterpart of job-survives-disconnect (#722).
+ * The client degrades a dead batch POST to the async path, which is only
+ * sound while three server behaviors hold:
+ *
+ * 1. A batch whose upload request dies AFTER the body arrived keeps running,
+ *    and its terminal SSE frame carries the durable result (downloadUrl +
+ *    fileResults) because the ZIP was persisted, not only streamed.
+ * 2. The download URL in that frame serves a complete ZIP.
+ * 3. SSE connect replays batch parent rows: nonterminal for live batches
+ *    (evidence the batch exists), terminal-with-result for finished ones.
+ *
+ * app.inject cannot kill a socket mid-request, so the upload runs over a
+ * real TCP socket.
+ */
+describe("batch survival and progress replay across client disconnects (#750)", () => {
+  let testApp: TestApp;
+  let baseUrl: string;
+  let adminToken: string;
+
+  beforeAll(async () => {
+    testApp = await buildTestApp();
+    adminToken = await loginAsAdmin(testApp.app);
+    await testApp.app.listen({ port: 0, host: "127.0.0.1" });
+    const addr = testApp.app.server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  }, 30_000);
+
+  afterAll(async () => {
+    await testApp.cleanup();
+  }, 10_000);
+
+  /** Collect SSE frames for a job until the predicate matches or time runs out. */
+  function waitForFrame(
+    jobId: string,
+    match: (frame: Record<string, unknown>) => boolean,
+    timeoutMs: number,
+  ): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      const req = http.get(
+        `${baseUrl}/api/v1/jobs/${jobId}/progress`,
+        { headers: { authorization: `Bearer ${adminToken}`, accept: "text/event-stream" } },
+        (res) => {
+          let buf = "";
+          res.setEncoding("utf8");
+          res.on("data", (chunk: string) => {
+            buf += chunk;
+            let idx = buf.indexOf("\n\n");
+            while (idx !== -1) {
+              const frame = buf.slice(0, idx);
+              buf = buf.slice(idx + 2);
+              const line = frame.split("\n").find((l) => l.startsWith("data: "));
+              if (line) {
+                const data = JSON.parse(line.slice(6)) as Record<string, unknown>;
+                if (match(data)) {
+                  clearTimeout(deadline);
+                  req.destroy();
+                  resolve(data);
+                  return;
+                }
+              }
+              idx = buf.indexOf("\n\n");
+            }
+          });
+        },
+      );
+      const deadline = setTimeout(() => {
+        req.destroy();
+        reject(new Error("No matching SSE frame before the deadline"));
+      }, timeoutMs);
+      req.on("error", () => {
+        // Socket destroyed by resolve/timeout paths; errors there are expected.
+      });
+    });
+  }
+
+  it("finishes a batch whose upload socket died and delivers the ZIP via the terminal frame", async () => {
+    const clientJobId = randomUUID();
+    const png = readFixture(fixtures.image.base.png200);
+    const jpg = readFixture(fixtures.image.base.jpg100);
+
+    const boundary = `----survive${Date.now()}`;
+    const parts: Buffer[] = [];
+    const push = (s: string) => parts.push(Buffer.from(s));
+    push(`--${boundary}\r\n`);
+    push(`Content-Disposition: form-data; name="file"; filename="first.png"\r\n`);
+    push(`Content-Type: image/png\r\n\r\n`);
+    parts.push(png);
+    push(`\r\n--${boundary}\r\n`);
+    push(`Content-Disposition: form-data; name="file"; filename="second.jpg"\r\n`);
+    push(`Content-Type: image/jpeg\r\n\r\n`);
+    parts.push(jpg);
+    push(`\r\n--${boundary}\r\n`);
+    push(`Content-Disposition: form-data; name="settings"\r\n\r\n`);
+    push(JSON.stringify({ width: 50 }));
+    push(`\r\n--${boundary}\r\n`);
+    push(`Content-Disposition: form-data; name="clientJobId"\r\n\r\n`);
+    push(clientJobId);
+    push(`\r\n--${boundary}--\r\n`);
+    const body = Buffer.concat(parts);
+
+    const req = http.request(`${baseUrl}/api/v1/tools/image/resize/batch`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${adminToken}`,
+        "content-type": `multipart/form-data; boundary=${boundary}`,
+        "content-length": body.length,
+      },
+    });
+    req.on("error", () => {
+      // ECONNRESET from our own destroy is the point of the test.
+    });
+    await new Promise<void>((resolve) => {
+      req.end(body, () => {
+        // Body flushed to the kernel; give the server a beat to finish the
+        // multipart parse, then kill the socket the way a proxy would.
+        setTimeout(() => {
+          req.destroy();
+          resolve();
+        }, 250);
+      });
+    });
+
+    const terminal = await waitForFrame(
+      clientJobId,
+      (f) => f.type === "batch" && (f.status === "completed" || f.status === "failed"),
+      30_000,
+    );
+    expect(terminal.status).toBe("completed");
+    expect(terminal.completedFiles).toBe(terminal.totalFiles);
+
+    const result = terminal.result as Record<string, unknown>;
+    const fileResults = result.fileResults as Record<string, string>;
+    expect(fileResults["0"]).toContain("first");
+    expect(fileResults["1"]).toContain("second");
+
+    // The durable ZIP behind the frame's URL is complete and downloadable.
+    const download = await testApp.app.inject({
+      method: "GET",
+      url: String(result.downloadUrl),
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(download.statusCode).toBe(200);
+    const zip = new AdmZip(download.rawPayload);
+    expect(zip.getEntries().length).toBe(2);
+  }, 45_000);
+
+  it("replays a nonterminal frame with counts for a live batch on SSE connect", async () => {
+    const jobId = `batch-live-${randomUUID()}`;
+    await db.insert(schema.jobs).values({
+      id: jobId,
+      type: "batch",
+      status: "processing",
+      progress: { percent: 40, totalFiles: 5, completedFiles: 2, failedFiles: 0 },
+      inputRefs: [],
+    });
+
+    try {
+      // Must arrive well before the 20s heartbeat cadence: it is a replay,
+      // not a live event.
+      const frame = await waitForFrame(
+        jobId,
+        (f) => f.type === "batch" && f.status === "processing",
+        5_000,
+      );
+      expect(frame.totalFiles).toBe(5);
+      expect(frame.completedFiles).toBe(2);
+    } finally {
+      await db.delete(schema.jobs).where(eq(schema.jobs.id, jobId));
+    }
+  }, 15_000);
+
+  it("replays the terminal result for a completed batch row on SSE connect", async () => {
+    const jobId = `batch-done-${randomUUID()}`;
+    await db.insert(schema.jobs).values({
+      id: jobId,
+      type: "batch",
+      status: "completed",
+      progress: {
+        percent: 100,
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 0,
+        result: {
+          downloadUrl: `/api/v1/download/${jobId}/batch-resize-abc.zip`,
+          fileResults: { "0": "a.png", "1": "b.png" },
+        },
+      },
+      inputRefs: [],
+    });
+
+    try {
+      const frame = await waitForFrame(
+        jobId,
+        (f) => f.type === "batch" && f.status !== "processing",
+        5_000,
+      );
+      expect(frame.status).toBe("completed");
+      const result = frame.result as Record<string, unknown>;
+      expect(result.downloadUrl).toBe(`/api/v1/download/${jobId}/batch-resize-abc.zip`);
+    } finally {
+      await db.delete(schema.jobs).where(eq(schema.jobs.id, jobId));
+    }
+  }, 15_000);
+});

--- a/tests/integration/platform/batch.test.ts
+++ b/tests/integration/platform/batch.test.ts
@@ -48,6 +48,21 @@ const storageMock = vi.hoisted(() => ({
   poison: new Map<string, "reject" | "stream-error">(),
 }));
 
+// Simulates the 30-minute sync wait expiring for a specific parent id: the
+// real window cannot be reached organically in a test (#750).
+const enqueueMock = vi.hoisted(() => ({ timeoutParentIds: new Set<string>() }));
+
+vi.mock("../../../apps/api/src/jobs/enqueue.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../apps/api/src/jobs/enqueue.js")>();
+  return {
+    ...actual,
+    waitForJob: async (...args: Parameters<typeof actual.waitForJob>) => {
+      if (enqueueMock.timeoutParentIds.has(args[1])) return null;
+      return actual.waitForJob(...args);
+    },
+  };
+});
+
 vi.mock("../../../apps/api/src/lib/ocr-limits.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../apps/api/src/lib/ocr-limits.js")>();
   return {
@@ -122,6 +137,21 @@ const heicMetadataReadable = await sharp(HEIC)
 let testApp: TestApp;
 let app: TestApp["app"];
 let adminToken: string;
+
+/** Poll the Redis terminal replay key until the terminal frame appears. */
+async function waitForTerminalFrame(
+  jobId: string,
+  timeoutMs = 30_000,
+): Promise<Record<string, unknown>> {
+  const key = `${bullPrefix()}:terminal:${jobId}`;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const raw = await sharedRedis().get(key);
+    if (raw) return JSON.parse(raw) as Record<string, unknown>;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`No terminal frame for ${jobId} within ${timeoutMs}ms`);
+}
 
 beforeAll(async () => {
   testApp = await buildTestApp();
@@ -997,6 +1027,127 @@ describe("HEIC batch ingress", () => {
   );
 });
 
+// ── Sync-wait expiry answers the async contract (#750) ──────────
+describe("Sync-wait expiry", () => {
+  it("answers 202 and the batch still completes durably", async () => {
+    const clientJobId = randomUUID();
+    enqueueMock.timeoutParentIds.add(clientJobId);
+    try {
+      const { body, contentType } = createMultipartPayload([
+        { name: "file", filename: "a.png", contentType: "image/png", content: PNG },
+        { name: "file", filename: "b.jpg", contentType: "image/jpeg", content: JPG },
+        { name: "settings", content: JSON.stringify({ width: 50 }) },
+        { name: "clientJobId", content: clientJobId },
+      ]);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/tools/image/resize/batch",
+        headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+        body,
+      });
+
+      expect(res.statusCode).toBe(202);
+      expect(JSON.parse(res.body)).toEqual({ jobId: clientJobId, async: true });
+
+      // The flow does not care about the response: the finalize still
+      // persists the ZIP and publishes the terminal frame the client
+      // rides to.
+      const frame = await waitForTerminalFrame(clientJobId);
+      expect(frame.status).toBe("completed");
+      const result = frame.result as Record<string, unknown>;
+      const download = await app.inject({
+        method: "GET",
+        url: String(result.downloadUrl),
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+      expect(download.statusCode).toBe(200);
+      expect(new AdmZip(download.rawPayload).getEntries()).toHaveLength(2);
+    } finally {
+      enqueueMock.timeoutParentIds.delete(clientJobId);
+    }
+  }, 60_000);
+});
+
+// ── ZIP packaging failure fails clean, before headers (#750) ────
+describe("ZIP packaging failure", () => {
+  it("fails with an error status and a durable failed frame when a child output stream dies mid-read", async () => {
+    const clientJobId = randomUUID();
+    // Poison only the child outputs (outputs/<id>-fN/...), not the stored
+    // ZIP: the finalize's packaging pass must fail before the route ever
+    // commits a status. The stream errors on read, after opening, which is
+    // the case a try/catch around getObjectStream cannot see.
+    storageMock.poison.set(`outputs/${clientJobId}-f`, "stream-error");
+    try {
+      const { body, contentType } = createMultipartPayload([
+        { name: "file", filename: "a.png", contentType: "image/png", content: PNG },
+        { name: "file", filename: "b.jpg", contentType: "image/jpeg", content: JPG },
+        { name: "settings", content: JSON.stringify({ width: 50 }) },
+        { name: "clientJobId", content: clientJobId },
+      ]);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/tools/image/resize/batch",
+        headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+        body,
+      });
+
+      expect(res.statusCode).toBeGreaterThanOrEqual(500);
+      expect(res.headers["content-type"]).toContain("application/json");
+
+      // The failure is durable: a degraded client settles from this frame.
+      const frame = await waitForTerminalFrame(clientJobId);
+      expect(frame.status).toBe("failed");
+      const errors = (frame.errors ?? []) as Array<{ filename: string; error: string }>;
+      expect(errors.some((e) => e.error === "Failed to package batch results")).toBe(true);
+    } finally {
+      storageMock.poison.clear();
+    }
+  }, 60_000);
+});
+
+// ── All files fail ingress validation (#750) ────────────────────
+describe("Batch where every file fails validation", () => {
+  it("publishes a terminal failed frame alongside the 422", async () => {
+    const clientJobId = randomUUID();
+    const { body, contentType } = createMultipartPayload([
+      {
+        name: "file",
+        filename: "one.png",
+        contentType: "image/png",
+        content: Buffer.from("not an image"),
+      },
+      {
+        name: "file",
+        filename: "two.jpg",
+        contentType: "image/jpeg",
+        content: Buffer.from("also not an image"),
+      },
+      { name: "settings", content: JSON.stringify({ width: 50 }) },
+      { name: "clientJobId", content: clientJobId },
+    ]);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/tools/image/resize/batch",
+      headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+      body,
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(JSON.parse(res.body).error).toBe("All files failed processing");
+
+    // No flow exists, so no finalize will ever publish a terminal frame;
+    // the route publishes it, or a degraded client waits forever.
+    const frame = await waitForTerminalFrame(clientJobId, 10_000);
+    expect(frame.status).toBe("failed");
+    expect(frame.totalFiles).toBe(2);
+    expect(frame.failedFiles).toBe(2);
+    const errors = (frame.errors ?? []) as Array<{ filename: string; error: string }>;
+    expect(errors).toHaveLength(2);
+    expect(errors[0].filename).toBe("one.png");
+  }, 30_000);
+});
+
 // ── CLI-decode fallback + all-children-failed ───────────────────
 describe("Batch where every worker job fails", () => {
   it("returns 422 with per-file errors when all enqueued children fail", async () => {
@@ -1012,6 +1163,7 @@ describe("Batch where every worker job fails", () => {
       Buffer.alloc(64, 0xab),
     ]);
 
+    const clientJobId = randomUUID();
     const { body, contentType } = createMultipartPayload([
       {
         name: "file",
@@ -1020,6 +1172,7 @@ describe("Batch where every worker job fails", () => {
         content: garbageQoi,
       },
       { name: "settings", content: JSON.stringify({ width: 50 }) },
+      { name: "clientJobId", content: clientJobId },
     ]);
 
     const res = await app.inject({
@@ -1037,6 +1190,15 @@ describe("Batch where every worker job fails", () => {
     expect(String(result.errors[0].filename)).toMatch(/garbage/);
     expect(typeof result.errors[0].error).toBe("string");
     expect(result.errors[0].error.length).toBeGreaterThan(0);
+
+    // The finalize publishes the same outcome as a terminal failed frame,
+    // which is what a degraded client displays (#750).
+    const frame = await waitForTerminalFrame(clientJobId, 15_000);
+    expect(frame.status).toBe("failed");
+    expect(frame.failedFiles).toBe(1);
+    const frameErrors = (frame.errors ?? []) as Array<{ filename: string; error: string }>;
+    expect(frameErrors.length).toBeGreaterThan(0);
+    expect(String(frameErrors[0].filename)).toMatch(/garbage/);
   }, 60_000);
 });
 

--- a/tests/integration/platform/batch.test.ts
+++ b/tests/integration/platform/batch.test.ts
@@ -704,6 +704,52 @@ describe("Legacy batch SSE wire parity", () => {
     expect(parsed.failedFiles).toBe(1);
     expect(parsed.status).toBe("completed");
     expect(parsed.type).toBe("batch");
+
+    // #750: the terminal frame carries the durable result so a client that
+    // lost the HTTP response can settle from SSE alone. fileResults maps
+    // ORIGINAL upload indices (the invalid slot 1 is absent, not shifted).
+    expect(parsed.result).toBeDefined();
+    expect(typeof parsed.result.downloadUrl).toBe("string");
+    expect(parsed.result.fileResults["0"]).toContain("good1");
+    expect(parsed.result.fileResults["1"]).toBeUndefined();
+    expect(parsed.result.fileResults["2"]).toContain("good2");
+    expect(parsed.result.fileResults).toEqual(
+      JSON.parse(decodeURIComponent(res.headers["x-file-results"] as string)),
+    );
+
+    // The durable ZIP is byte-identical to the one the HTTP response streamed.
+    const download = await app.inject({
+      method: "GET",
+      url: parsed.result.downloadUrl,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(download.statusCode).toBe(200);
+    expect(download.rawPayload.equals(res.rawPayload)).toBe(true);
+
+    // The parent row replays the same terminal result after the Redis
+    // terminal key expires (simulated by deleting it).
+    await sharedRedis().del(terminalKeyName);
+    const sse = await app.inject({
+      method: "GET",
+      url: `/api/v1/jobs/${clientJobId}/progress`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payloadAsStream: true,
+    });
+    let replayed: Record<string, unknown> | null = null;
+    for await (const chunk of sse.stream()) {
+      const text = Buffer.from(chunk).toString();
+      for (const line of text.split("\n")) {
+        if (!line.startsWith("data: ")) continue;
+        const data = JSON.parse(line.slice(6));
+        if (data.type === "batch") replayed = data;
+      }
+      if (replayed) break;
+    }
+    expect(replayed).not.toBeNull();
+    expect(replayed?.status).toBe("completed");
+    expect((replayed?.result as Record<string, unknown>)?.downloadUrl).toBe(
+      parsed.result.downloadUrl,
+    );
   });
 });
 

--- a/tests/integration/platform/pipeline-zip-stream-failure.test.ts
+++ b/tests/integration/platform/pipeline-zip-stream-failure.test.ts
@@ -140,6 +140,41 @@ describe("Pipeline batch ZIP delivery", () => {
     expect(terminal?.status).toBe("failed");
   }, 30_000);
 
+  it("keeps original-index alignment in fileResults across a pre-failed upload", async () => {
+    const parentId = "zip-index-alignment-parent";
+    const { body, contentType } = createMultipartPayload([
+      { name: "file", filename: "good1.png", content: PNG_200x150, contentType: "image/png" },
+      {
+        name: "file",
+        filename: "bad.png",
+        content: Buffer.from("not an image"),
+        contentType: "image/png",
+      },
+      { name: "file", filename: "good2.png", content: PNG_200x150, contentType: "image/png" },
+      {
+        name: "pipeline",
+        content: JSON.stringify({ steps: [{ toolId: "resize", settings: { width: 50 } }] }),
+      },
+      { name: "clientJobId", content: parentId },
+    ]);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/pipeline/batch",
+      headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+      body,
+    });
+
+    expect(res.statusCode).toBe(200);
+    // The invalid slot 1 must stay a hole, not shift good2 into it: the
+    // finalize maps flow indices back through fileIndexMap (#750).
+    const fileResults = JSON.parse(
+      decodeURIComponent(res.headers["x-file-results"] as string),
+    ) as Record<string, string>;
+    expect(Object.keys(fileResults).sort()).toEqual(["0", "2"]);
+    expect(fileResults["0"]).toContain("good1");
+    expect(fileResults["2"]).toContain("good2");
+  }, 30_000);
+
   it("destroys the connection when the stored ZIP read dies mid-stream", async () => {
     const parentId = "zip-object-failure-parent";
     mocks.failZipObjectForParentId = parentId;

--- a/tests/integration/platform/pipeline-zip-stream-failure.test.ts
+++ b/tests/integration/platform/pipeline-zip-stream-failure.test.ts
@@ -1,13 +1,19 @@
 /**
- * Pipeline batch ZIP streaming failure path.
+ * Pipeline batch ZIP failure paths.
  *
- * The batch route writes the 200 header before it streams ZIP entries from
- * object storage. If a read fails mid-stream the route must abort the archive
- * and end the response instead of hanging the connection. That branch cannot
- * be reached through public inputs (the manifest only lists outputs the worker
- * just wrote), so this file swaps getObjectStream for a passthrough that fails
- * ONLY for the per-file output keys of one designated batch parent id. Workers
- * read inputs from uploads/ keys and the pipeline finalize copy uses
+ * Since #750 the batch-finalize worker packages the ZIP into durable storage
+ * before the route responds, so an entry read failure surfaces as a clean
+ * error status (nothing was committed to the wire yet) instead of a destroyed
+ * mid-stream response. The mid-stream failure surface still exists, but only
+ * for the stored ZIP itself: the route commits the 200 header and then
+ * streams outputs/<parentId>/<zip>; if that read dies the route must destroy
+ * the connection rather than end it cleanly (a clean end of a short body
+ * would be indistinguishable from success).
+ *
+ * Neither branch is reachable through public inputs (the finalize only lists
+ * outputs the workers just wrote), so this file swaps getObjectStream for a
+ * passthrough that fails ONLY for the designated parent's keys. Workers read
+ * inputs from uploads/ keys and the pipeline finalize copy uses
  * getObjectBuffer, so normal processing is untouched.
  */
 
@@ -21,8 +27,12 @@ import {
 } from "../test-server.js";
 
 const mocks = vi.hoisted(() => ({
-  // When set, getObjectStream throws for keys matching outputs/<id>-f<N>/...
-  failZipStreamsForParentId: null as string | null,
+  // When set, getObjectStream throws for the per-file output keys
+  // (outputs/<id>-f<N>/...) read by the batch-finalize ZIP packaging.
+  failEntryStreamsForParentId: null as string | null,
+  // When set, getObjectStream throws for the stored batch ZIP itself
+  // (outputs/<id>/...), the key the route streams after the finalize.
+  failZipObjectForParentId: null as string | null,
 }));
 
 vi.mock("../../../apps/api/src/lib/object-storage.js", async (importOriginal) => {
@@ -31,8 +41,12 @@ vi.mock("../../../apps/api/src/lib/object-storage.js", async (importOriginal) =>
   return {
     ...actual,
     getObjectStream: async (key: string, range?: { start: number; end?: number }) => {
-      const parentId = mocks.failZipStreamsForParentId;
-      if (parentId && new RegExp(`^outputs/${parentId}-f\\d+/`).test(key)) {
+      const entryParent = mocks.failEntryStreamsForParentId;
+      if (entryParent && new RegExp(`^outputs/${entryParent}-f\\d+/`).test(key)) {
+        throw new Error("simulated object storage outage");
+      }
+      const zipParent = mocks.failZipObjectForParentId;
+      if (zipParent && key.startsWith(`outputs/${zipParent}/`)) {
         throw new Error("simulated object storage outage");
       }
       return actual.getObjectStream(key, range);
@@ -60,7 +74,8 @@ afterAll(async () => {
 }, 10_000);
 
 afterEach(() => {
-  mocks.failZipStreamsForParentId = null;
+  mocks.failEntryStreamsForParentId = null;
+  mocks.failZipObjectForParentId = null;
 });
 
 function postBatch(clientJobId: string) {
@@ -80,7 +95,7 @@ function postBatch(clientJobId: string) {
   });
 }
 
-describe("Pipeline batch ZIP streaming", () => {
+describe("Pipeline batch ZIP delivery", () => {
   it("streams a complete ZIP when object storage is healthy", async () => {
     const res = await postBatch("zip-stream-healthy-parent");
 
@@ -91,19 +106,59 @@ describe("Pipeline batch ZIP streaming", () => {
     expect(res.rawPayload.includes(ZIP_EOCD)).toBe(true);
   }, 30_000);
 
-  it("aborts the archive and ends the response when an entry read fails", async () => {
-    const parentId = "zip-stream-failure-parent";
-    mocks.failZipStreamsForParentId = parentId;
+  it("fails with a clean error status when an entry read dies during ZIP packaging", async () => {
+    const parentId = "zip-entry-failure-parent";
+    mocks.failEntryStreamsForParentId = parentId;
 
     const res = await postBatch(parentId);
 
-    // Headers were already committed before streaming began.
-    expect(res.statusCode).toBe(200);
-    expect(res.headers["content-type"]).toBe("application/zip");
-    expect(res.headers["x-job-id"]).toBe(parentId);
-    // The stream failed before finalize(), so the body must terminate without
-    // a complete archive (no end-of-central-directory record), and the
-    // request must resolve rather than hang.
+    // The finalize failed before the route committed anything to the wire,
+    // so the client gets a real error status and JSON body, not a destroyed
+    // 200 stream (#750 moved packaging ahead of the response).
+    expect(res.statusCode).toBeGreaterThanOrEqual(500);
+    expect(res.headers["content-type"]).toContain("application/json");
     expect(res.rawPayload.includes(ZIP_EOCD)).toBe(false);
+
+    // The failure is durable: the parent row replays a terminal failed frame,
+    // which is what settles a client that degraded to the SSE path.
+    const sse = await app.inject({
+      method: "GET",
+      url: `/api/v1/jobs/${parentId}/progress`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payloadAsStream: true,
+    });
+    let terminal: Record<string, unknown> | null = null;
+    for await (const chunk of sse.stream()) {
+      const text = Buffer.from(chunk).toString();
+      for (const line of text.split("\n")) {
+        if (!line.startsWith("data: ")) continue;
+        const data = JSON.parse(line.slice(6));
+        if (data.type === "batch" && data.status !== "processing") terminal = data;
+      }
+      if (terminal) break;
+    }
+    expect(terminal?.status).toBe("failed");
+  }, 30_000);
+
+  it("destroys the connection when the stored ZIP read dies mid-stream", async () => {
+    const parentId = "zip-object-failure-parent";
+    mocks.failZipObjectForParentId = parentId;
+
+    // The 200 header goes out before the stored ZIP is opened; the poisoned
+    // read must then surface as a transport failure (destroyed socket), never
+    // as a cleanly-ended short body. app.inject reports that either as a
+    // rejected request or as a truncated payload, depending on timing.
+    let sawTransportFailure = false;
+    let payload: Buffer | null = null;
+    try {
+      const res = await postBatch(parentId);
+      payload = res.rawPayload;
+    } catch {
+      sawTransportFailure = true;
+    }
+
+    if (!sawTransportFailure) {
+      expect(payload?.includes(ZIP_EOCD)).toBe(false);
+    }
   }, 30_000);
 });

--- a/tests/integration/platform/progress-terminal-guard.test.ts
+++ b/tests/integration/platform/progress-terminal-guard.test.ts
@@ -25,7 +25,13 @@ import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { db, schema } from "../../../apps/api/src/db/index.js";
-import { updateSingleFileProgress } from "../../../apps/api/src/routes/progress.js";
+import { sharedRedis } from "../../../apps/api/src/jobs/connection.js";
+import { bullPrefix } from "../../../apps/api/src/jobs/types.js";
+import {
+  failBatchJob,
+  updateJobProgress,
+  updateSingleFileProgress,
+} from "../../../apps/api/src/routes/progress.js";
 import { buildTestApp, type TestApp } from "../test-server.js";
 
 let testApp: TestApp;
@@ -104,5 +110,102 @@ describe("late progress frames against a terminal job row", () => {
     const row = await readJob(id);
     expect(row.status).toBe("completed");
     expect(row.completedAt).not.toBeNull();
+  });
+});
+
+/**
+ * The batch twin (#750): child outcomes are fire-and-forget nonterminal
+ * frames, and the finalize's terminal write can race them. A late child frame
+ * must not resurrect a completed parent (it would wipe the durable result the
+ * SSE replay depends on), and the crashed-finalize safety net (failBatchJob)
+ * must never downgrade a committed completion nor announce a failed frame
+ * over one.
+ */
+describe("late batch frames and the failBatchJob guard", () => {
+  const BATCH_RESULT = {
+    downloadUrl: "/api/v1/download/x/batch-resize-x.zip",
+    fileResults: { "0": "a.png" },
+  };
+
+  async function seedBatchJob(status: "completed" | "processing"): Promise<string> {
+    const id = randomUUID();
+    await db.insert(schema.jobs).values({
+      id,
+      type: "batch",
+      status,
+      inputRefs: [],
+      completedAt: status === "processing" ? null : new Date(),
+      progress:
+        status === "completed"
+          ? { percent: 100, totalFiles: 1, completedFiles: 1, failedFiles: 0, result: BATCH_RESULT }
+          : { percent: 0, totalFiles: 1, completedFiles: 0, failedFiles: 0 },
+    });
+    return id;
+  }
+
+  it("a late nonterminal child frame cannot resurrect a completed batch row", async () => {
+    const id = await seedBatchJob("completed");
+
+    updateJobProgress({
+      jobId: id,
+      status: "processing",
+      totalFiles: 1,
+      completedFiles: 0,
+      failedFiles: 0,
+      errors: [],
+    });
+    // updateJobProgress persists fire and forget; give its queue time to
+    // drain before asserting nothing changed.
+    await new Promise((r) => setTimeout(r, 500));
+
+    const row = await readJob(id);
+    expect(row.status, "completed batch row was resurrected").toBe("completed");
+    expect(row.completedAt).not.toBeNull();
+    expect((row.progress as { result?: unknown } | null)?.result, "durable result wiped").toEqual(
+      BATCH_RESULT,
+    );
+  });
+
+  it("failBatchJob refuses to downgrade a completed batch and announces nothing", async () => {
+    const id = await seedBatchJob("completed");
+
+    await failBatchJob({
+      jobId: id,
+      totalFiles: 1,
+      completedFiles: 1,
+      failedFiles: 1,
+      errors: [],
+      message: "Failed to package batch results",
+    });
+
+    const row = await readJob(id);
+    expect(row.status).toBe("completed");
+    expect((row.progress as { result?: unknown } | null)?.result).toEqual(BATCH_RESULT);
+    // No terminal failed frame may be announced over the completion: a
+    // reconnecting client would settle on whichever it reads.
+    expect(await sharedRedis().get(`${bullPrefix()}:terminal:${id}`)).toBeNull();
+  });
+
+  it("failBatchJob owns the transition on a live batch and announces it", async () => {
+    const id = await seedBatchJob("processing");
+
+    await failBatchJob({
+      jobId: id,
+      totalFiles: 1,
+      completedFiles: 1,
+      failedFiles: 1,
+      errors: [{ filename: "a.png", error: "boom" }],
+      message: "Failed to package batch results",
+    });
+
+    const row = await readJob(id);
+    expect(row.status).toBe("failed");
+    expect(row.completedAt).not.toBeNull();
+
+    const raw = await sharedRedis().get(`${bullPrefix()}:terminal:${id}`);
+    expect(raw).not.toBeNull();
+    const frame = JSON.parse(raw as string) as Record<string, unknown>;
+    expect(frame.type).toBe("batch");
+    expect(frame.status).toBe("failed");
   });
 });

--- a/tests/integration/platform/worker-branches.test.ts
+++ b/tests/integration/platform/worker-branches.test.ts
@@ -24,6 +24,26 @@ import { setTimeout as delay } from "node:timers/promises";
 import { ANALYTICS_EVENTS, ONBOARDING_FIRST_PROCESSED_KEY, TOOLS } from "@snapotter/shared";
 import AdmZip from "adm-zip";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Makes the finalize die before its own failure handling (readBatchCounters
+// runs outside the packaging try/catch), so the worker failed-handler safety
+// net is the only thing standing between a crash and a hung degraded client.
+const batchProgressMock = vi.hoisted(() => ({ failCountersForParentId: null as string | null }));
+
+vi.mock("../../../apps/api/src/jobs/batch-progress.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../apps/api/src/jobs/batch-progress.js")>();
+  return {
+    ...actual,
+    readBatchCounters: async (parentId: string) => {
+      if (batchProgressMock.failCountersForParentId === parentId) {
+        throw new Error("injected counters outage");
+      }
+      return actual.readBatchCounters(parentId);
+    },
+  };
+});
+
 import type { ToolJobData } from "../../../apps/api/src/jobs/types.js";
 import type { ToolProcessCtx } from "../../../apps/api/src/routes/tool-factory.js";
 
@@ -822,6 +842,60 @@ describe("batch children and finalize", () => {
     const entries = new AdmZip(zipBytes).getEntries();
     expect(entries.map((e) => e.entryName)).toEqual(["a_wt-echo.png"]);
     expect(entries[0].getData().toString("utf8")).toBe("aaa");
+  }, 30_000);
+
+  it("the failed-handler safety net publishes a terminal failed frame when the finalize crashes", async () => {
+    const parentId = `bnet-${randomUUID()}`;
+    // The parent row a real batch route inserts before enqueueing the flow.
+    await db.insert(schema.jobs).values({
+      id: parentId,
+      type: "batch",
+      status: "processing",
+      pool: "system",
+      inputRefs: [],
+      progress: { percent: 50, totalFiles: 1, completedFiles: 1, failedFiles: 0 },
+    });
+    await putObject("outputs/seed-net/ok.png", Buffer.from("net-bytes"));
+    await db.insert(schema.jobs).values({
+      id: `${parentId}-f0`,
+      type: "batch-child",
+      status: "completed",
+      toolId: "wt-echo",
+      pool: "image",
+      inputRefs: ["uploads/seed-net/in0.png"],
+      outputRefs: ["outputs/seed-net/ok.png"],
+    });
+
+    batchProgressMock.failCountersForParentId = parentId;
+    try {
+      await getQueue("system").add(
+        "batch-finalize",
+        toolJob({
+          jobId: parentId,
+          toolId: "wt-echo",
+          kind: "batch-finalize",
+          pool: "system",
+          totalFiles: 1,
+          settings: { flowChildCount: 1 },
+          filename: "",
+        }),
+        { jobId: parentId, attempts: 1 },
+      );
+
+      // Without the net nobody publishes a terminal frame: the crash happens
+      // before the finalize's own failure handling.
+      const frame = await terminalFrame(parentId);
+      expect(frame.type).toBe("batch");
+      expect(frame.status).toBe("failed");
+
+      const row = await waitFor(async () => {
+        const candidate = await jobRow(parentId);
+        return candidate?.status === "failed" ? candidate : undefined;
+      });
+      expect(row.error?.message).toBe("Failed to package batch results");
+    } finally {
+      batchProgressMock.failCountersForParentId = null;
+    }
   }, 30_000);
 
   it("assembles the ordered manifest across completed, failed, and missing children", async () => {

--- a/tests/integration/platform/worker-branches.test.ts
+++ b/tests/integration/platform/worker-branches.test.ts
@@ -22,6 +22,7 @@ import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { ANALYTICS_EVENTS, ONBOARDING_FIRST_PROCESSED_KEY, TOOLS } from "@snapotter/shared";
+import AdmZip from "adm-zip";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ToolJobData } from "../../../apps/api/src/jobs/types.js";
 import type { ToolProcessCtx } from "../../../apps/api/src/routes/tool-factory.js";
@@ -579,13 +580,28 @@ describe("pipeline finalize", () => {
     expect(row.status).toBe("failed");
     expect(row.error?.message).toBe("Step 2: kaboom");
 
-    // Child outcome recorded against the pipeline-batch parent.
+    // Child outcome recorded against the pipeline-batch parent. Outcomes are
+    // nonterminal since #750 (only batch-finalize publishes the terminal
+    // frame, after the durable ZIP exists), so the record shows up in the
+    // Redis counters and the parent row's persisted counts.
     expect(await sharedRedis().get(`${bullPrefix()}:batch:${batchParent}:failed`)).toBe("1");
-    const parentFrame = await terminalFrame(batchParent);
-    expect(parentFrame.status).toBe("failed");
-    expect(parentFrame.failedFiles).toBe(1);
-    const errors = (parentFrame.errors ?? []) as Array<{ filename: string; error: string }>;
-    expect(errors).toEqual([{ filename: "b.png", error: "Step 2: kaboom" }]);
+    const errorsRaw = await sharedRedis().lrange(
+      `${bullPrefix()}:batch:${batchParent}:errors`,
+      0,
+      -1,
+    );
+    expect(errorsRaw.map((e) => JSON.parse(e))).toEqual([
+      { filename: "b.png", error: "Step 2: kaboom" },
+    ]);
+    const parentRow = await waitFor(async () => {
+      const candidate = await jobRow(batchParent);
+      return candidate?.status === "processing" ? candidate : undefined;
+    });
+    expect(parentRow.progress).toMatchObject({
+      totalFiles: 1,
+      completedFiles: 1,
+      failedFiles: 1,
+    });
 
     const events = await emittedEvents(ANALYTICS_EVENTS.PIPELINE_EXECUTED, jobId);
     const props = events[0];
@@ -657,10 +673,18 @@ describe("pipeline finalize", () => {
       { step: 2, toolId: "compress", size: 5 },
     ]);
 
-    // Success recorded against the pipeline-batch parent.
+    // Success recorded against the pipeline-batch parent; the record stays
+    // nonterminal since #750 (the batch-finalize owns the terminal frame).
     expect(await sharedRedis().get(`${bullPrefix()}:batch:${batchParent}:done`)).toBe("1");
-    const parentFrame = await terminalFrame(batchParent);
-    expect(parentFrame.status).toBe("completed");
+    const parentRow = await waitFor(async () => {
+      const candidate = await jobRow(batchParent);
+      return candidate?.status === "processing" ? candidate : undefined;
+    });
+    expect(parentRow.progress).toMatchObject({
+      totalFiles: 1,
+      completedFiles: 1,
+      failedFiles: 0,
+    });
 
     const events = await emittedEvents(ANALYTICS_EVENTS.PIPELINE_EXECUTED, jobId);
     const props = events[0];
@@ -704,10 +728,10 @@ describe("pipeline finalize", () => {
 });
 
 describe("batch children and finalize", () => {
-  it("records one success and one failure, then emits the terminal batch frame", async () => {
+  it("records one success and one failure, then the finalize emits the terminal batch frame", async () => {
     const parentId = `bparent-${randomUUID()}`;
-    const okId = randomUUID();
-    const boomId = randomUUID();
+    const okId = `${parentId}-f0`;
+    const boomId = `${parentId}-f1`;
     const okRef = await seedInput(okId, "a.png", Buffer.from("aaa"));
     const boomRef = await seedInput(boomId, "b.png", Buffer.from("bbb"));
 
@@ -734,18 +758,6 @@ describe("batch children and finalize", () => {
       }),
     );
 
-    // The terminal batch frame appears once both children have recorded.
-    const parentFrame = await terminalFrame(parentId);
-    expect(parentFrame.status).toBe("completed"); // one success => batch completed
-    expect(parentFrame.totalFiles).toBe(2);
-    expect(parentFrame.completedFiles).toBe(2);
-    expect(parentFrame.failedFiles).toBe(1);
-    const errors = (parentFrame.errors ?? []) as Array<{ filename: string; error: string }>;
-    expect(errors).toEqual([{ filename: "b.png", error: "boom" }]);
-
-    expect(await sharedRedis().get(`${bullPrefix()}:batch:${parentId}:done`)).toBe("1");
-    expect(await sharedRedis().get(`${bullPrefix()}:batch:${parentId}:failed`)).toBe("1");
-
     // The successful child completed normally with its own output.
     const okRow = await terminalRow(okId);
     expect(okRow.status).toBe("completed");
@@ -763,16 +775,60 @@ describe("batch children and finalize", () => {
     });
     expect(boomResult.resultPayload).toEqual({ failed: true, error: "boom" });
 
-    // The durable batch parent row carries the failure summary.
+    // Child outcomes alone stay nonterminal since #750; only the finalize
+    // publishes the terminal frame, once the durable ZIP exists.
+    expect(await sharedRedis().get(`${bullPrefix()}:batch:${parentId}:done`)).toBe("1");
+    expect(await sharedRedis().get(`${bullPrefix()}:batch:${parentId}:failed`)).toBe("1");
+    expect(await sharedRedis().get(`${bullPrefix()}:terminal:${parentId}`)).toBeNull();
+
+    // The parent row already exists (the nonterminal persist created it), so
+    // enqueue the finalize the way the flow producer does: queue-only.
+    await getQueue("system").add(
+      "batch-finalize",
+      toolJob({
+        jobId: parentId,
+        toolId: "wt-echo",
+        kind: "batch-finalize",
+        pool: "system",
+        totalFiles: 2,
+        settings: { flowChildCount: 2, fileIndexMap: [0, 1] },
+        filename: "",
+      }),
+      { jobId: parentId, attempts: 1 },
+    );
+
+    const parentFrame = await terminalFrame(parentId);
+    expect(parentFrame.status).toBe("completed"); // one success => batch completed
+    expect(parentFrame.totalFiles).toBe(2);
+    expect(parentFrame.completedFiles).toBe(2);
+    expect(parentFrame.failedFiles).toBe(1);
+    const errors = (parentFrame.errors ?? []) as Array<{ filename: string; error: string }>;
+    expect(errors).toEqual([{ filename: "b.png", error: "boom" }]);
+
+    // The terminal frame carries the durable result a degraded client needs.
+    const frameResult = (parentFrame.result ?? {}) as Record<string, unknown>;
+    expect(String(frameResult.downloadUrl)).toContain(`/api/v1/download/${parentId}/`);
+    expect(frameResult.fileResults).toEqual({ "0": "a_wt-echo.png" });
+
+    // The durable batch parent row carries the failure summary and the ZIP.
     const parentRow = await waitFor(async () => {
       const row = await jobRow(parentId);
       return row?.status === "completed" ? row : undefined;
     });
     expect(parentRow.error?.message).toBe("1 file(s) failed");
+    const zipKey = (parentRow.outputRefs ?? [])[0];
+    expect(zipKey).toContain(`outputs/${parentId}/`);
+    const zipBytes = await getObjectBuffer(zipKey);
+    const entries = new AdmZip(zipBytes).getEntries();
+    expect(entries.map((e) => e.entryName)).toEqual(["a_wt-echo.png"]);
+    expect(entries[0].getData().toString("utf8")).toBe("aaa");
   }, 30_000);
 
   it("assembles the ordered manifest across completed, failed, and missing children", async () => {
     const jobId = `bf-${randomUUID()}`;
+    // The finalize streams every successful output into the durable ZIP
+    // (#750), so the fabricated ref must exist as a real object.
+    await putObject("outputs/seed/ok.png", Buffer.from("ok-bytes"));
     await db.insert(schema.jobs).values({
       id: `${jobId}-f0`,
       type: "batch-child",

--- a/tests/integration/platform/worker-branches.test.ts
+++ b/tests/integration/platform/worker-branches.test.ts
@@ -887,6 +887,9 @@ describe("batch children and finalize", () => {
       const frame = await terminalFrame(parentId);
       expect(frame.type).toBe("batch");
       expect(frame.status).toBe("failed");
+      // The blank-name synthetic entry is what the client displays; without
+      // it this frame would read as "all files failed".
+      expect(frame.errors).toEqual([{ filename: "", error: "Failed to package batch results" }]);
 
       const row = await waitFor(async () => {
         const candidate = await jobRow(parentId);

--- a/tests/unit/api/progress-batch-replay.test.ts
+++ b/tests/unit/api/progress-batch-replay.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Unit tests for durable batch progress state (#750).
+ *
+ * A batch parent row must be able to reconstruct both a nonterminal
+ * "the batch is alive" frame and the terminal frame carrying the durable
+ * ZIP result, so a client that degraded a dead batch POST to the async
+ * path can settle from SSE replay alone.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({ failure: null as Error | null }));
+
+vi.mock("../../../apps/api/src/db/index.js", () => ({
+  db: (() => {
+    const executor = {
+      select: () => ({
+        from: () => ({
+          where: async () => {
+            if (dbMocks.failure) throw dbMocks.failure;
+            return [];
+          },
+        }),
+      }),
+      insert: () => ({
+        values: async () => {
+          if (dbMocks.failure) throw dbMocks.failure;
+        },
+      }),
+      update: () => ({
+        set: () => ({
+          where: async () => {
+            if (dbMocks.failure) throw dbMocks.failure;
+          },
+        }),
+      }),
+    };
+    return {
+      ...executor,
+      transaction: async (callback: (tx: typeof executor) => Promise<void>) => callback(executor),
+    };
+  })(),
+  pool: {},
+  closeDb: async () => {},
+  schema: {
+    jobs: { id: {}, status: {} },
+  },
+}));
+
+vi.mock("../../../apps/api/src/config.js", () => ({
+  env: { WORKSPACE_PATH: "/tmp/test" },
+}));
+
+import {
+  buildBatchReplayEvent,
+  buildPersistedJobProgress,
+  completeBatchJob,
+  failBatchJob,
+} from "../../../apps/api/src/routes/progress.js";
+
+describe("buildPersistedJobProgress", () => {
+  it("stores the counts a reconnecting client needs, not just percent", () => {
+    expect(
+      buildPersistedJobProgress({
+        jobId: "batch-1",
+        status: "processing",
+        totalFiles: 5,
+        completedFiles: 2,
+        failedFiles: 1,
+        errors: [{ filename: "b.png", error: "corrupt" }],
+      }),
+    ).toEqual({
+      percent: 40,
+      totalFiles: 5,
+      completedFiles: 2,
+      failedFiles: 1,
+    });
+  });
+
+  it("carries the terminal result when present", () => {
+    expect(
+      buildPersistedJobProgress({
+        jobId: "batch-2",
+        status: "completed",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 0,
+        errors: [],
+        result: { downloadUrl: "/api/v1/download/batch-2/batch-compress-batch-2.zip" },
+      }),
+    ).toEqual({
+      percent: 100,
+      totalFiles: 2,
+      completedFiles: 2,
+      failedFiles: 0,
+      result: { downloadUrl: "/api/v1/download/batch-2/batch-compress-batch-2.zip" },
+    });
+  });
+
+  it("guards the percent against a zero total", () => {
+    expect(
+      buildPersistedJobProgress({
+        jobId: "batch-3",
+        status: "processing",
+        totalFiles: 0,
+        completedFiles: 0,
+        failedFiles: 0,
+        errors: [],
+      }),
+    ).toEqual({ percent: 0, totalFiles: 0, completedFiles: 0, failedFiles: 0 });
+  });
+});
+
+describe("buildBatchReplayEvent", () => {
+  it("replays a live processing row as a nonterminal frame with counts", () => {
+    expect(
+      buildBatchReplayEvent({
+        jobId: "batch-live",
+        status: "processing",
+        progress: { percent: 40, totalFiles: 5, completedFiles: 2, failedFiles: 0 },
+        error: null,
+      }),
+    ).toEqual({
+      jobId: "batch-live",
+      type: "batch",
+      status: "processing",
+      totalFiles: 5,
+      completedFiles: 2,
+      failedFiles: 0,
+      errors: [],
+    });
+  });
+
+  it("replays a queued row as a nonterminal frame", () => {
+    expect(
+      buildBatchReplayEvent({
+        jobId: "batch-queued",
+        status: "queued",
+        progress: { percent: 0, totalFiles: 3, completedFiles: 0, failedFiles: 0 },
+        error: null,
+      }),
+    ).toEqual({
+      jobId: "batch-queued",
+      type: "batch",
+      status: "processing",
+      totalFiles: 3,
+      completedFiles: 0,
+      failedFiles: 0,
+      errors: [],
+    });
+  });
+
+  it("replays a completed row with its durable result and recorded errors", () => {
+    expect(
+      buildBatchReplayEvent({
+        jobId: "batch-done",
+        status: "completed",
+        progress: {
+          percent: 100,
+          totalFiles: 3,
+          completedFiles: 3,
+          failedFiles: 1,
+          result: {
+            downloadUrl: "/api/v1/download/batch-done/batch-compress-batch-do.zip",
+            fileResults: { "0": "a.png", "2": "c.png" },
+          },
+        },
+        error: {
+          message: "1 file(s) failed",
+          details: [{ filename: "b.png", error: "corrupt" }],
+        },
+      }),
+    ).toEqual({
+      jobId: "batch-done",
+      type: "batch",
+      status: "completed",
+      totalFiles: 3,
+      completedFiles: 3,
+      failedFiles: 1,
+      errors: [{ filename: "b.png", error: "corrupt" }],
+      result: {
+        downloadUrl: "/api/v1/download/batch-done/batch-compress-batch-do.zip",
+        fileResults: { "0": "a.png", "2": "c.png" },
+      },
+    });
+  });
+
+  it("turns a completed row without a durable result into an explicit failure", () => {
+    expect(
+      buildBatchReplayEvent({
+        jobId: "batch-legacy",
+        status: "completed",
+        progress: { percent: 100, totalFiles: 2, completedFiles: 2, failedFiles: 0 },
+        error: null,
+      }),
+    ).toEqual({
+      jobId: "batch-legacy",
+      type: "batch",
+      status: "failed",
+      totalFiles: 2,
+      completedFiles: 2,
+      failedFiles: 0,
+      errors: [
+        { filename: "", error: "Completed result is no longer available. Run the job again." },
+      ],
+    });
+  });
+
+  it("replays a failed row with its per-file errors", () => {
+    expect(
+      buildBatchReplayEvent({
+        jobId: "batch-failed",
+        status: "failed",
+        progress: { percent: 100, totalFiles: 2, completedFiles: 2, failedFiles: 2 },
+        error: {
+          message: "All files failed processing",
+          details: [
+            { filename: "a.png", error: "corrupt" },
+            { filename: "b.png", error: "too large" },
+          ],
+        },
+      }),
+    ).toEqual({
+      jobId: "batch-failed",
+      type: "batch",
+      status: "failed",
+      totalFiles: 2,
+      completedFiles: 2,
+      failedFiles: 2,
+      errors: [
+        { filename: "a.png", error: "corrupt" },
+        { filename: "b.png", error: "too large" },
+      ],
+    });
+  });
+
+  it("falls back to the error message when a failed row has no details", () => {
+    expect(
+      buildBatchReplayEvent({
+        jobId: "batch-msg-only",
+        status: "failed",
+        progress: { percent: 0, totalFiles: 1, completedFiles: 1, failedFiles: 1 },
+        error: { message: "Failed to package batch results" },
+      }),
+    ).toEqual({
+      jobId: "batch-msg-only",
+      type: "batch",
+      status: "failed",
+      totalFiles: 1,
+      completedFiles: 1,
+      failedFiles: 1,
+      errors: [{ filename: "", error: "Failed to package batch results" }],
+    });
+  });
+
+  it("replays a canceled row as failed with a Canceled marker", () => {
+    expect(
+      buildBatchReplayEvent({
+        jobId: "batch-canceled",
+        status: "canceled",
+        progress: { percent: 50, totalFiles: 2, completedFiles: 1, failedFiles: 0 },
+        error: null,
+      }),
+    ).toEqual({
+      jobId: "batch-canceled",
+      type: "batch",
+      status: "failed",
+      totalFiles: 2,
+      completedFiles: 1,
+      failedFiles: 0,
+      errors: [{ filename: "", error: "Canceled" }],
+    });
+  });
+
+  it("tolerates legacy rows whose progress has only a percent", () => {
+    expect(
+      buildBatchReplayEvent({
+        jobId: "batch-old",
+        status: "processing",
+        progress: { percent: 40 },
+        error: null,
+      }),
+    ).toEqual({
+      jobId: "batch-old",
+      type: "batch",
+      status: "processing",
+      totalFiles: 0,
+      completedFiles: 0,
+      failedFiles: 0,
+      errors: [],
+    });
+  });
+});
+
+describe("terminal batch writers", () => {
+  it("completeBatchJob resolves after the durable write settles", async () => {
+    dbMocks.failure = null;
+    await expect(
+      completeBatchJob({
+        jobId: "batch-writer-1",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 0,
+        errors: [],
+        outputRefs: ["outputs/batch-writer-1/batch-compress-batch-wr.zip"],
+        bytesOut: 1234,
+        result: {
+          downloadUrl: "/api/v1/download/batch-writer-1/batch-compress-batch-wr.zip",
+          fileResults: { "0": "a.png", "1": "b.png" },
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("failBatchJob resolves after the durable write settles", async () => {
+    dbMocks.failure = null;
+    await expect(
+      failBatchJob({
+        jobId: "batch-writer-2",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 2,
+        errors: [{ filename: "a.png", error: "corrupt" }],
+        message: "All files failed processing",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("completeBatchJob propagates a durable persistence failure", async () => {
+    dbMocks.failure = new Error("database unavailable");
+    await expect(
+      completeBatchJob({
+        jobId: "batch-writer-3",
+        totalFiles: 1,
+        completedFiles: 1,
+        failedFiles: 0,
+        errors: [],
+        outputRefs: ["outputs/batch-writer-3/batch-compress-batch-wr.zip"],
+        bytesOut: 10,
+        result: { downloadUrl: "/x", fileResults: {} },
+      }),
+    ).rejects.toThrow("database unavailable");
+    dbMocks.failure = null;
+  });
+});

--- a/tests/unit/shared/analytics-events.test.ts
+++ b/tests/unit/shared/analytics-events.test.ts
@@ -2,8 +2,8 @@ import { ANALYTICS_EVENTS } from "@snapotter/shared";
 import { describe, expect, it } from "vitest";
 
 describe("ANALYTICS_EVENTS", () => {
-  it("has exactly 27 event keys", () => {
-    expect(Object.keys(ANALYTICS_EVENTS)).toHaveLength(27);
+  it("has exactly 28 event keys", () => {
+    expect(Object.keys(ANALYTICS_EVENTS)).toHaveLength(28);
   });
 
   it("contains the expected keys", () => {
@@ -34,6 +34,11 @@ describe("ANALYTICS_EVENTS", () => {
     expect(ANALYTICS_EVENTS).toHaveProperty("AUTH_LOGIN_FAILED");
     expect(ANALYTICS_EVENTS).toHaveProperty("FEEDBACK_PROMPT_SHOWN");
     expect(ANALYTICS_EVENTS).toHaveProperty("FEEDBACK_PROMPT_DISMISSED");
+    expect(ANALYTICS_EVENTS).toHaveProperty("TOOL_RUN_DEGRADED");
+  });
+
+  it("TOOL_RUN_DEGRADED has the correct snake_case value", () => {
+    expect(ANALYTICS_EVENTS.TOOL_RUN_DEGRADED).toBe("tool_run_degraded");
   });
 
   it("all event values are strings", () => {

--- a/tests/unit/web/analytics.test.ts
+++ b/tests/unit/web/analytics.test.ts
@@ -146,6 +146,23 @@ describe("analytics lib (baked model)", () => {
       expect(mockCapture).toHaveBeenCalledWith("tool_opened", {});
     });
 
+    it("forwards the tool_run_degraded dimensions (#750)", async () => {
+      await mod.initAnalytics(enabledConfig);
+      mod.track("tool_run_degraded", {
+        tool_id: "trim-video",
+        is_batch: false,
+        trigger: "socket",
+        had_evidence: true,
+        message: "leak",
+      });
+      expect(mockCapture).toHaveBeenCalledWith("tool_run_degraded", {
+        tool_id: "trim-video",
+        is_batch: false,
+        trigger: "socket",
+        had_evidence: true,
+      });
+    });
+
     it("drops all properties for an unknown event", async () => {
       await mod.initAnalytics(enabledConfig);
       mod.track("not_allow_listed", { tool_id: "resize" });

--- a/tests/unit/web/conversion-preset-image-to-pdf-multifile.test.tsx
+++ b/tests/unit/web/conversion-preset-image-to-pdf-multifile.test.tsx
@@ -131,9 +131,14 @@ describe("ConversionPresetSettings multi-file dispatch (issue #627)", () => {
     render(<ConversionPresetSettings />);
     fireEvent.click(screen.getByTestId("preset-submit"));
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0][0]).toBe("/api/v1/tools/image/jpg-to-png/batch");
-    expect(xhrInstances).toHaveLength(0);
+    // The batch path rides XHR since #750 (it needs upload.onload to know a
+    // degrade is safe), so the /batch URL is the discriminator now.
+    expect(xhrInstances).toHaveLength(1);
+    expect(xhrInstances[0].open).toHaveBeenCalledWith(
+      "POST",
+      "/api/v1/tools/image/jpg-to-png/batch",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("uses the single-file request for jpg-to-pdf when only 1 file is selected", () => {

--- a/tests/unit/web/use-tool-processor-batch-recovery.test.ts
+++ b/tests/unit/web/use-tool-processor-batch-recovery.test.ts
@@ -1,0 +1,572 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import AdmZip from "adm-zip";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/image-preview", () => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  formatHeaders: () => new Map<string, string>(),
+  parseApiError: () => "error",
+}));
+
+vi.mock("@/lib/utils", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  return { ...actual, generateId: () => "33333333-3333-4333-8333-333333333333" };
+});
+
+import { useToolProcessor } from "@/hooks/use-tool-processor";
+import { track } from "@/lib/analytics";
+import { useFileStore } from "@/stores/file-store";
+
+interface MockXhr {
+  status: number;
+  responseText: string;
+  responseType: string;
+  response: unknown;
+  timeout: number;
+  upload: { onprogress?: unknown; onload?: (() => void) | null };
+  onload?: () => void;
+  onerror?: (() => void) | null;
+  ontimeout?: (() => void) | null;
+  open: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  setRequestHeader: ReturnType<typeof vi.fn>;
+  getResponseHeader: ReturnType<typeof vi.fn>;
+  abort: ReturnType<typeof vi.fn>;
+}
+
+class MockEventSource {
+  static OPEN = 1;
+  static instances: MockEventSource[] = [];
+
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = MockEventSource.OPEN;
+  close = vi.fn(() => {
+    this.readyState = 2;
+  });
+
+  constructor(readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+}
+
+let xhrs: MockXhr[];
+
+const JOB_ID = "33333333-3333-4333-8333-333333333333";
+
+const ZIP_NAMES = { "0": "first_resize.png", "1": "second_resize.jpg" } as const;
+const ZIP_BYTES = (() => {
+  const zip = new AdmZip();
+  zip.addFile("first_resize.png", Buffer.from([1, 2, 3, 4]));
+  zip.addFile("second_resize.jpg", Buffer.from([5, 6]));
+  return new Uint8Array(zip.toBuffer());
+})();
+const zipBlob = () => new Blob([ZIP_BYTES.slice().buffer], { type: "application/zip" });
+const encodedFileResults = () => encodeURIComponent(JSON.stringify(ZIP_NAMES));
+
+function latestSse(): MockEventSource {
+  return MockEventSource.instances[MockEventSource.instances.length - 1];
+}
+
+function sendBatchFrame(frame: Record<string, unknown>) {
+  latestSse().onmessage?.({
+    data: JSON.stringify({ type: "batch", jobId: JOB_ID, ...frame }),
+  } as MessageEvent);
+}
+
+function sendSingleFrame(frame: Record<string, unknown>) {
+  latestSse().onmessage?.({
+    data: JSON.stringify({ type: "single", jobId: JOB_ID, ...frame }),
+  } as MessageEvent);
+}
+
+const TERMINAL_RESULT = {
+  jobId: JOB_ID,
+  downloadUrl: `/api/v1/download/${JOB_ID}/batch-resize-33333333.zip`,
+  zipFilename: "batch-resize-33333333.zip",
+  fileResults: ZIP_NAMES,
+  processedSize: ZIP_BYTES.length,
+};
+
+function completedTerminalFrame() {
+  return {
+    status: "completed",
+    totalFiles: 2,
+    completedFiles: 2,
+    failedFiles: 0,
+    errors: [],
+    result: TERMINAL_RESULT,
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal("URL", {
+    ...globalThis.URL,
+    createObjectURL: vi.fn(() => "blob:fake-url"),
+    revokeObjectURL: vi.fn(),
+  });
+  useFileStore.getState().reset();
+  xhrs = [];
+  MockEventSource.instances = [];
+  vi.stubGlobal("EventSource", MockEventSource);
+  vi.stubGlobal(
+    "XMLHttpRequest",
+    vi.fn(() => {
+      const xhr: MockXhr = {
+        status: 0,
+        responseText: "",
+        responseType: "",
+        response: null,
+        timeout: 0,
+        upload: {},
+        open: vi.fn(),
+        send: vi.fn(),
+        setRequestHeader: vi.fn(),
+        getResponseHeader: vi.fn(() => null),
+        abort: vi.fn(),
+      };
+      xhrs.push(xhr);
+      return xhr;
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.mocked(track).mockClear();
+});
+
+function startBatchRun() {
+  const files = [
+    new File([new ArrayBuffer(16)], "first.png", { type: "image/png" }),
+    new File([new ArrayBuffer(16)], "second.jpg", { type: "image/jpeg" }),
+  ];
+  useFileStore.getState().setFiles(files);
+  const hook = renderHook(() => useToolProcessor("resize"));
+  act(() => {
+    void hook.result.current.processAllFiles(files, { width: 50 });
+  });
+  return hook;
+}
+
+function startSingleRun() {
+  const file = new File([new ArrayBuffer(64)], "clip.mp4", { type: "video/mp4" });
+  useFileStore.getState().setFiles([file]);
+  const hook = renderHook(() => useToolProcessor("trim-video"));
+  act(() => {
+    hook.result.current.processFiles([file], { startS: 0, endS: 2 });
+  });
+  return hook;
+}
+
+async function settled(check: () => void) {
+  await vi.waitFor(check, { timeout: 3_000 });
+}
+
+/**
+ * #750: the batch path gets the #722 treatment. A dead POST after the upload
+ * finished degrades to the async path; the terminal batch SSE frame carries
+ * the durable ZIP's downloadUrl + fileResults, and the client settles the run
+ * from that instead of abandoning a batch that keeps running server-side.
+ */
+describe("useToolProcessor batch recovery (#750)", () => {
+  it("settles the happy path from the XHR response ZIP", async () => {
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 200;
+      xhrs[0].response = zipBlob();
+      xhrs[0].getResponseHeader = vi.fn((name: string) =>
+        name === "X-File-Results" ? encodedFileResults() : null,
+      );
+      xhrs[0].onload?.();
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[0].status).toBe("completed");
+      expect(useFileStore.getState().entries[1].status).toBe("completed");
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().batchZipBlob).not.toBeNull();
+
+    unmount();
+  });
+
+  it("ignores the terminal SSE frame while the sync response is still the settling path", async () => {
+    const { unmount } = startBatchRun();
+
+    // The finalize publishes the terminal frame before the route streams the
+    // ZIP, so in sync mode the frame always precedes the response.
+    act(() => {
+      xhrs[0].upload.onload?.();
+      sendBatchFrame(completedTerminalFrame());
+    });
+    expect(useFileStore.getState().processing).toBe(true);
+
+    act(() => {
+      xhrs[0].status = 200;
+      xhrs[0].response = zipBlob();
+      xhrs[0].getResponseHeader = vi.fn((name: string) =>
+        name === "X-File-Results" ? encodedFileResults() : null,
+      );
+      xhrs[0].onload?.();
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[0].status).toBe("completed");
+    });
+    const batchEvents = vi
+      .mocked(track)
+      .mock.calls.filter(([event]) => event === "batch_processed");
+    expect(batchEvents).toHaveLength(1);
+    expect(batchEvents[0][1]).toMatchObject({ status: "completed" });
+
+    unmount();
+  });
+
+  it("degrades a dead post-upload socket and settles from the terminal frame's download URL", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 200, blob: () => Promise.resolve(zipBlob()) }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    // Not an error: the batch is live server-side and tracked via SSE.
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    act(() => {
+      sendBatchFrame(completedTerminalFrame());
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[0].status).toBe("completed");
+      expect(useFileStore.getState().entries[1].status).toBe("completed");
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().batchZipBlob).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith(TERMINAL_RESULT.downloadUrl, expect.anything());
+
+    unmount();
+  });
+
+  it("still fails immediately when the socket dies mid-upload", () => {
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      // No upload.onload: the request body never fully left the browser.
+      xhrs[0].onerror?.();
+    });
+
+    expect(useFileStore.getState().error).toBe(
+      "Processing was interrupted. Retry when reconnected.",
+    );
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("surfaces the never-confirmed error when no batch evidence ever arrives", () => {
+    vi.useFakeTimers();
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    expect(useFileStore.getState().processing).toBe(true);
+
+    act(() => {
+      latestSse().onmessage?.({
+        data: JSON.stringify({ type: "heartbeat" }),
+      } as MessageEvent);
+      vi.advanceTimersByTime(30_001);
+    });
+
+    expect(useFileStore.getState().error).toBe(
+      "Processing was interrupted and the server never confirmed the job. Retry when reconnected.",
+    );
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("skips the evidence timer when a batch frame already proved the batch exists", () => {
+    vi.useFakeTimers();
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      sendBatchFrame({
+        status: "processing",
+        totalFiles: 2,
+        completedFiles: 0,
+        failedFiles: 0,
+        errors: [],
+      });
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    unmount();
+  });
+
+  it("treats a 202 as the async contract and settles from the terminal frame", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 200, blob: () => Promise.resolve(zipBlob()) }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 202;
+      xhrs[0].onload?.();
+    });
+    expect(useFileStore.getState().processing).toBe(true);
+    expect(useFileStore.getState().error).toBeNull();
+
+    act(() => {
+      sendBatchFrame(completedTerminalFrame());
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[1].status).toBe("completed");
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("fails the run when the terminal frame reports every file failed", async () => {
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    act(() => {
+      sendBatchFrame({
+        status: "failed",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 2,
+        errors: [
+          { filename: "first.png", error: "corrupt" },
+          { filename: "second.jpg", error: "too large" },
+        ],
+      });
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().error).toBe("All files failed processing");
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("fails a degraded run when a completed terminal frame has no durable result", async () => {
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    // Custom batch sub-routes (pdf-to-image, svg-to-raster) emit terminal
+    // frames without a result; their ZIP only ever existed on the dead
+    // response, so the run cannot be recovered.
+    act(() => {
+      sendBatchFrame({
+        status: "completed",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 0,
+        errors: [],
+      });
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().error).toBe(
+        "Processing was interrupted. Retry when reconnected.",
+      );
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("gives up after download retries are exhausted", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(() => Promise.reject(new Error("network down")));
+    vi.stubGlobal("fetch", fetchMock);
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    act(() => {
+      sendBatchFrame(completedTerminalFrame());
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(useFileStore.getState().error).toBe(
+      "Processing was interrupted. Retry when reconnected.",
+    );
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("emits tool_run_degraded with batch dimensions on degrade", async () => {
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    await settled(() => {
+      expect(vi.mocked(track)).toHaveBeenCalledWith("tool_run_degraded", {
+        tool_id: "resize",
+        is_batch: true,
+        trigger: "socket",
+        had_evidence: false,
+      });
+    });
+
+    unmount();
+  });
+});
+
+/**
+ * #750 item 2: a gateway that answers 502/504 with a body (nginx/haproxy
+ * error pages) after a fully sent upload is an intermediary speaking, not the
+ * app. The app's own 5xx always carries a parseable JSON error body and must
+ * keep its precise message.
+ */
+describe("useToolProcessor proxy 5xx degrade (#750)", () => {
+  it("degrades a post-upload 502 with an unparseable body", async () => {
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 502;
+      xhrs[0].responseText = "<html><body>502 Bad Gateway</body></html>";
+      xhrs[0].onload?.();
+    });
+
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+    expect(useFileStore.getState().activeJobId).toBe(JOB_ID);
+
+    act(() => {
+      sendSingleFrame({
+        phase: "complete",
+        percent: 100,
+        result: {
+          jobId: "server-job",
+          downloadUrl: "/api/v1/download/server-job/clip_trimmed.mp4",
+          originalSize: 64,
+          processedSize: 32,
+        },
+      });
+    });
+
+    expect(useFileStore.getState().entries[0].status).toBe("completed");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    await settled(() => {
+      expect(vi.mocked(track)).toHaveBeenCalledWith("tool_run_degraded", {
+        tool_id: "trim-video",
+        is_batch: false,
+        trigger: "http-502",
+        had_evidence: false,
+      });
+    });
+
+    unmount();
+  });
+
+  it("degrades a post-upload 504 with an empty body", () => {
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 504;
+      xhrs[0].responseText = "";
+      xhrs[0].onload?.();
+    });
+
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    unmount();
+  });
+
+  it("keeps the precise error for a 504 with a JSON body (the app spoke)", () => {
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 504;
+      xhrs[0].responseText = JSON.stringify({ error: "Page took too long to load" });
+      xhrs[0].onload?.();
+    });
+
+    // parseApiError is mocked to "error"; the point is it went through the
+    // normal error path instead of degrading.
+    expect(useFileStore.getState().error).toBe("error");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("does not degrade a 502 that arrived before the upload finished", () => {
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      xhrs[0].status = 502;
+      xhrs[0].responseText = "<html>bad gateway</html>";
+      xhrs[0].onload?.();
+    });
+
+    expect(useFileStore.getState().error).toBe("Processing failed: 502");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+});

--- a/tests/unit/web/use-tool-processor-batch-recovery.test.ts
+++ b/tests/unit/web/use-tool-processor-batch-recovery.test.ts
@@ -451,6 +451,79 @@ describe("useToolProcessor batch recovery (#750)", () => {
     unmount();
   });
 
+  it("degrades a batch 502 whose blob body is not JSON", async () => {
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 502;
+      xhrs[0].response = new Blob(["<html><body>502 Bad Gateway</body></html>"], {
+        type: "text/html",
+      });
+      xhrs[0].onload?.();
+    });
+
+    // The 5xx body read is async (Blob.text), so the degrade lands a tick
+    // later; what must never happen is an error.
+    await settled(() => {
+      expect(vi.mocked(track)).toHaveBeenCalledWith("tool_run_degraded", {
+        tool_id: "resize",
+        is_batch: true,
+        trigger: "http-502",
+        had_evidence: false,
+      });
+    });
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    unmount();
+  });
+
+  it("recovers through the stall timer when the terminal frame was missed", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 200, blob: () => Promise.resolve(zipBlob()) }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      // Evidence first, so the 30s evidence timer never arms and the 300s
+      // stall timer is the recovery path under test.
+      sendBatchFrame({
+        status: "processing",
+        totalFiles: 2,
+        completedFiles: 1,
+        failedFiles: 0,
+        errors: [],
+      });
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    const sourcesAfterDegrade = MockEventSource.instances.length;
+
+    // The terminal frame never arrives on this source (half-open SSE). The
+    // stall timer must force a fresh source, whose server-side replay then
+    // delivers the terminal frame.
+    act(() => {
+      vi.advanceTimersByTime(300_001);
+    });
+    expect(MockEventSource.instances.length).toBeGreaterThan(sourcesAfterDegrade);
+    expect(useFileStore.getState().processing).toBe(true);
+
+    act(() => {
+      sendBatchFrame(completedTerminalFrame());
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    expect(useFileStore.getState().entries[0].status).toBe("completed");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
   it("emits tool_run_degraded with batch dimensions on degrade", async () => {
     const { unmount } = startBatchRun();
 

--- a/tests/unit/web/use-tool-processor-batch-recovery.test.ts
+++ b/tests/unit/web/use-tool-processor-batch-recovery.test.ts
@@ -423,6 +423,33 @@ describe("useToolProcessor batch recovery (#750)", () => {
     unmount();
   });
 
+  it("fails fast with the right message when the durable ZIP is already gone", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: false, status: 404, blob: () => Promise.resolve(new Blob()) }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    act(() => {
+      sendBatchFrame(completedTerminalFrame());
+    });
+
+    // A 404 is deterministic: no retries, no network blame.
+    await settled(() => {
+      expect(useFileStore.getState().error).toBe(
+        "Completed result is no longer available. Run the job again.",
+      );
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
   it("gives up after download retries are exhausted", async () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn(() => Promise.reject(new Error("network down")));


### PR DESCRIPTION
Fixes #750. All three follow-ups from the #722 review: the batch path no longer abandons live runs, a proxy 502/504 after a finished upload degrades instead of erroring, and every degrade is visible to operators.

**1. Batch runs survive a dead HTTP response.** The ZIP used to exist only in the response stream (reply.hijack plus archiver), so there was nothing to reconnect to. The batch-finalize worker now packages the ZIP into `outputs/<parentId>/` through `putObjectStream`, commits the terminal parent-row state, and publishes the terminal batch SSE frame carrying `{downloadUrl, fileResults}`. `recordChildOutcome` went nonterminal: the terminal frame belongs to the finalize alone, published only after the durable result exists. The batch route streams the stored ZIP (with Content-Length now, so a delivery shortfall is client-detectable) and answers 202 instead of a fake 422 when the 30-minute sync wait expires. The client batch path moved from fetch to XHR so it knows when the upload fully left the browser, and reuses the #722 degrade machinery as is: socket death or timeout after the upload flips to async mode, the terminal frame settles the run by downloading the durable ZIP (retried, with 4xx failing fast on an accurate message), and the #722 evidence timer still tells "the batch never reached the server" apart from "the batch is running". Pipeline batches share the same finalize, so their ZIP is durable too; their route keeps the 422 timeout answer for now because `use-pipeline-processor` settles only from the HTTP response and would have tried to unzip a 202 JSON body. Real upload progress for batches comes along with the XHR switch.

**2. Proxy 502/504 with a body degrades.** A gateway answering 502/504 after a fully sent upload lands in the XHR onload error branch, not onerror. App-emitted 5xx always carries a parseable JSON error body (html-to-image's own 504 keeps its precise message), so an unparseable body on those two statuses means an intermediary is speaking for a job that is still running: degrade instead of erroring. Applies to both single and batch runs.

**3. Degrades are operator-visible.** New `tool_run_degraded` analytics event (`tool_id`, `is_batch`, `trigger`: socket / timeout / http-502 / http-504, `had_evidence`), registered in TELEMETRY.md and the web ALLOWED map. An instance whose reverse proxy kills every sync wait now shows up as a query instead of needing a live repro. No Sentry breadcrumb: web Sentry initializes late behind the early-error buffer, so a breadcrumb would mostly be dropped.

**Hardening from review.**

- The ZIP feed stops opening source streams once packaging has failed, and `fail()` owns all teardown, so a failure at entry 3 of a 100-file batch no longer leaks the other 97 handles.
- Packaging gets a 15-minute watchdog. Without one, a half-open storage read holds the concurrency-1 system pool hostage instance-wide.
- Batch children get `ignoreDependencyOnFailure`: a stall-evicted child (OOM kill) used to wedge the parent in waiting-children forever, with no terminal frame ever coming. Now the finalize runs and reports that child failed from its row, which also turns the old 30-minutes-then-422 outcome into a partial result.
- A crashed finalize is caught by a worker failed-handler net that publishes a guarded terminal failed frame carrying the packaging message the client displays. The net logs and reports its own failures, and a terminal frame that Redis refuses at least reaches the logs.
- The all-prefail branch publishes its terminal frame through the same awaited, guarded writer the finalize uses.
- Stored-ZIP downloads destroy the source stream when the client disconnects mid-download, mirroring `guardedDownloadStream`.
- The client re-opens the SSE on a 202 and fails loudly if the terminal dispatch invariant ever breaks.

**Wire compatibility.** The batch HTTP contract is unchanged on the happy path (200 + ZIP + `X-Job-Id` + `X-File-Results`). Terminal batch semantics are unchanged: `completed` when at least one file succeeded, `completedFiles === totalFiles` on the terminal frame. `type: "single"` frames untouched. Custom batch sub-routes (pdf-to-image, svg-to-raster) keep emitting result-less frames; a degraded client treats those as a plain interruption, which is exactly today's outcome for them. A storage read failing during packaging now surfaces as a clean error status before headers go out, instead of a destroyed mid-stream 200; the mid-stream destroy-on-error contract still holds for the stored-ZIP read itself.

**Accepted edge cases.** Batches finalized by pre-upgrade code have no stored ZIP; a degraded client replaying their terminal row gets an explicit "result no longer available" failure (one-restart window). A stale cached SPA seeing the new 202 on a 30-minute batch shows a generic error, the same class of outcome it had before. A finalize crash between the ZIP write and the row write fails the run despite the durable ZIP, a crash window equivalent to what exists today. `completeBatchJob` intentionally overwrites a `canceled` parent row: batches are not user-cancelable today and the completed work is delivered either way.

Follow-ups worth filing: port the degrade path to `use-pipeline-processor` (then restore the pipeline 202), and end-to-end batch cancel. The degraded batch UI shows no cancel button because there is no server-side batch cancel to wire it to.

**Tests.** 18 jsdom tests on the hook (degrade matrix, terminal settle, evidence and stall timers, 202, download retry exhaustion and 4xx fast-fail, 502/504 matrix including the batch blob path, degrade telemetry, two no-regression pins), 14 unit tests on the replay/persist builders, a raw-TCP suite proving a batch whose POST socket died still delivers its ZIP through the terminal frame, terminal-guard tests for the resurrect race and the failBatchJob no-downgrade guard, a crashed-finalize safety-net test, the batch parity test extended (durable result, byte-identical download, replay after Redis expiry, 202 contract, packaging failure, all-prefail and all-failed terminal frames), the pipeline ZIP suite rewritten to the new contract plus a mixed-validity index-alignment pin, and the worker finalize branches updated end-to-end.

Verified: typecheck 9/9, Biome clean, full unit suite 8342 passed, platform integration 1639 passed, batch-adjacent tool integration 162 passed, batch e2e 33 passed twice (before and after the hardening round), license boundary clean. The i18n check fails only on pre-existing docs-surface Thai drift untouched by this diff.
