### PR TITLE
fix(web,api): pipeline runs ride out dead connections instead of erroring

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -70,7 +70,7 @@ Emitted from `apps/web` through `track()`; properties are filtered by the `ALLOW
 | `sponsor_clicked` | The sponsor link is clicked | none |
 | `feedback_prompt_shown` | A feedback surface becomes visible (usage survey, per-job prompt, admin install card, nav dialog, search miss) | `source`, `survey_id`, `prompt_variant` |
 | `feedback_prompt_dismissed` | A feedback surface is dismissed without submitting | `source`, `survey_id`, `prompt_variant`, `dismiss_kind` (`close`, `dont_ask_again`, or `snooze`) |
-| `tool_run_degraded` | A run's sync HTTP response died after the upload finished and the client fell back to the async SSE path instead of failing the job (#750). High volume on one instance means a reverse proxy is killing sync waits; the fallback hides that from users, so this event is the only operator-visible signal | `tool_id`, `is_batch`, `trigger` (`socket`, `timeout`, `http-502`, or `http-504`), `had_evidence` |
+| `tool_run_degraded` | A run's sync HTTP response died after the upload finished and the client fell back to the async SSE path instead of failing the job (#750, #766). High volume on one instance means a reverse proxy is killing sync waits; the fallback hides that from users, so this event is the only operator-visible signal | `tool_id` (pipeline runs report `pipeline`), `is_batch`, `trigger` (`socket`, `timeout`, `http-502`, or `http-504`), `had_evidence` |
 
 ### SDK-generated events
 

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -65,6 +65,7 @@ import { InputValidationError } from "../modality/contract.js";
 import {
   completeBatchJob,
   failBatchJob,
+  failSingleJobGuarded,
   publishEphemeral,
   updateSingleFileProgress,
   updateSingleFileProgressAtomically,
@@ -1333,6 +1334,25 @@ export function startWorkers(): void {
 
     worker.on("failed", (job, err) => {
       if (!job) return;
+      const data = job.data as ToolJobData | undefined;
+      // Safety net, the pipeline twin of the batch-finalize net (#766): a
+      // finalize that died without reaching its own terminal write (hard
+      // throw in the output copy or preview, stall eviction) leaves a
+      // degraded or 202 client riding the SSE with nothing ever coming. The
+      // SSE channel (clientJobId) and the authoritative flow row can differ,
+      // so both get the guarded write; a committed completion is never
+      // downgraded, and the frame is announced only for a transition this
+      // call owned.
+      if (data?.kind === "pipeline-finalize") {
+        const netFail = (jobId: string) =>
+          failSingleJobGuarded({ jobId, message: "Pipeline processing failed" }).catch((netErr) => {
+            logger.error({ err: netErr, jobId }, "pipeline-finalize safety net failed");
+            void reportError(netErr, { source: "worker", pool, jobId });
+          });
+        const frameId = data.clientJobId ?? data.jobId;
+        void netFail(frameId);
+        if (frameId !== data.jobId) void netFail(data.jobId);
+      }
       const pf = (err as { pythonFrames?: unknown }).pythonFrames;
       if (Array.isArray(pf) && pf.length) {
         logger.error({ pool, jobId: job.id, pythonFrames: pf }, "sidecar failure");
@@ -1340,10 +1360,10 @@ export function startWorkers(): void {
       void reportError(err, {
         source: "worker",
         pool,
-        toolId: (job.data as ToolJobData | undefined)?.toolId,
+        toolId: data?.toolId,
         jobId: job.id,
-        inputFormat: safeFormatTag((job.data as ToolJobData | undefined)?.filename),
-        settings: (job.data as ToolJobData | undefined)?.settings,
+        inputFormat: safeFormatTag(data?.filename),
+        settings: data?.settings,
       });
     });
 

--- a/apps/api/src/routes/pipeline.ts
+++ b/apps/api/src/routes/pipeline.ts
@@ -609,9 +609,13 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
             await putObject(uploadKey, processBuffer);
           }
 
-          // Report initial progress
+          // Report initial progress. Awaited: this insert creates the
+          // client-facing row the SSE replays, which is the evidence a
+          // degraded client's fresh connection relies on (#766). Dropped
+          // fire-and-forget, a failed insert would fabricate "the server
+          // never confirmed the job" for a flow that is queued and fine.
           if (clientJobId) {
-            void updateSingleFileProgress({
+            await updateSingleFileProgress({
               jobId: clientJobId,
               phase: "processing",
               percent: 0,

--- a/apps/api/src/routes/pipeline.ts
+++ b/apps/api/src/routes/pipeline.ts
@@ -185,7 +185,12 @@ function buildPipelineFlowTree(opts: {
 
   // Build bottom-up: step 0 is the deepest leaf
   // Steps swallow failures via return markers, so a retry would never
-  // run; attempts: 1 makes that explicit.
+  // run; attempts: 1 makes that explicit. A step can still hard-fail
+  // outside its own handler (stall eviction after an OOM kill); without
+  // ignoreDependencyOnFailure that wedges its parent in waiting-children
+  // forever and no terminal frame ever reaches the client. With it, the
+  // parent step runs, sees the predecessor has no output, and propagates a
+  // clean failure up to the finalize (#766).
   let currentNode: FlowJob = {
     name: parsedSteps[0].resolvedToolId,
     queueName: queueName(parsedSteps[0].pool),
@@ -204,7 +209,7 @@ function buildPipelineFlowTree(opts: {
       settings: parsedSteps[0].parsedSettings,
       analyticsDistinctId,
     } satisfies ToolJobData,
-    opts: { jobId: stepJobIds[0], attempts: 1 },
+    opts: { jobId: stepJobIds[0], attempts: 1, ignoreDependencyOnFailure: true },
   };
 
   for (let i = 1; i < totalSteps; i++) {
@@ -226,7 +231,7 @@ function buildPipelineFlowTree(opts: {
         settings: parsedSteps[i].parsedSettings,
         analyticsDistinctId,
       } satisfies ToolJobData,
-      opts: { jobId: stepJobIds[i], attempts: 1 },
+      opts: { jobId: stepJobIds[i], attempts: 1, ignoreDependencyOnFailure: true },
       children: [currentNode],
     };
   }
@@ -252,7 +257,9 @@ function buildPipelineFlowTree(opts: {
       settings: {},
       analyticsDistinctId,
     } satisfies ToolJobData,
-    opts: { jobId, attempts: 1 },
+    // In a batch, this finalize is itself a child of batch-finalize and must
+    // not wedge the batch if it hard-fails.
+    opts: { jobId, attempts: 1, ...(parentId ? { ignoreDependencyOnFailure: true } : {}) },
     children: [currentNode],
   };
 
@@ -669,9 +676,10 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
             const result = await waitForJob(pipelinePool, jobId, 10 * 60_000);
 
             if (!result) {
-              return reply.status(422).send({
-                error: "Pipeline processing timed out",
-              });
+              // The flow keeps running and the finalize's terminal single
+              // frame carries the full result; the client rides the SSE to
+              // it instead of being told the run failed (#766).
+              return reply.status(202).send({ jobId: clientJobId ?? jobId, async: true });
             }
 
             // Check for step failure reported by the finalize handler
@@ -1340,13 +1348,10 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
           const batchResult = await waitForJob("system", parentId, 30 * 60_000);
 
           if (!batchResult) {
-            // The flow keeps running and the finalize will persist the ZIP
-            // and publish the terminal frame, but the pipeline client cannot
-            // ride the async contract yet (it settles only from this
-            // response), so a 202 here would hand it JSON it tries to unzip.
-            // Keep the timeout error until the pipeline hook learns the #750
-            // degrade path.
-            return reply.status(422).send({ error: "Pipeline batch processing timed out" });
+            // The flow keeps running; the finalize persists the ZIP and
+            // publishes the terminal frame carrying its download URL, and
+            // the pipeline hook speaks the async contract since #766.
+            return reply.status(202).send({ jobId: parentId, async: true });
           }
 
           const payload = batchResult.resultPayload as

--- a/apps/api/src/routes/progress.ts
+++ b/apps/api/src/routes/progress.ts
@@ -520,6 +520,47 @@ export async function failBatchJob(args: FailBatchJobArgs): Promise<void> {
   if (applied) announce(frame);
 }
 
+export interface FailSingleJobArgs {
+  jobId: string;
+  message: string;
+}
+
+/**
+ * Terminal single-run failure with failBatchJob's guarantees (#766): the
+ * guarded write never downgrades a committed completion, and the frame is
+ * announced only when this call owned the transition. Used by the worker's
+ * pipeline-finalize safety net, where the SSE channel id (clientJobId) and
+ * the authoritative flow row can differ; call it per row id.
+ */
+export async function failSingleJobGuarded(args: FailSingleJobArgs): Promise<void> {
+  const frame: SingleFileProgress = {
+    jobId: args.jobId,
+    type: "single",
+    phase: "failed",
+    percent: 0,
+    error: args.message,
+  };
+  let applied = false;
+  await enqueuePersist(args.jobId, async () => {
+    const res = await db
+      .update(schema.jobs)
+      .set({
+        status: "failed",
+        completedAt: new Date(),
+        progress: { percent: 0 },
+        error: { message: args.message },
+      })
+      .where(
+        and(
+          eq(schema.jobs.id, args.jobId),
+          notInArray(schema.jobs.status, ["completed", "failed", "canceled"]),
+        ),
+      );
+    applied = ((res as { rowCount?: number | null } | undefined)?.rowCount ?? 0) > 0;
+  });
+  if (applied) announce(frame);
+}
+
 /**
  * Publish a progress event to Redis pub/sub and set the terminal replay
  * key, but do NOT persist to the durable DB row. Used by the worker's

--- a/apps/web/src/hooks/use-pipeline-processor.ts
+++ b/apps/web/src/hooks/use-pipeline-processor.ts
@@ -360,7 +360,12 @@ export function usePipelineProcessor() {
       const xhr = new XMLHttpRequest();
       xhrRef.current = xhr;
 
-      xhr.timeout = 600_000;
+      // The server holds this response for up to its 10-minute sync wait and
+      // then answers 202; a client wall-clock cap would always fire first,
+      // turning every legitimately long pipeline into a spurious degrade.
+      // Liveness is owned by the SSE settle plus the evidence and stall
+      // timers.
+      xhr.timeout = 0;
 
       xhr.upload.onprogress = (event) => {
         if (event.lengthComputable) {

--- a/apps/web/src/hooks/use-pipeline-processor.ts
+++ b/apps/web/src/hooks/use-pipeline-processor.ts
@@ -1,4 +1,6 @@
+import { ANALYTICS_EVENTS } from "@snapotter/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { track } from "@/lib/analytics";
 import { formatHeaders, parseApiError } from "@/lib/api";
 import { generateId } from "@/lib/utils";
 import { useFileStore } from "@/stores/file-store";
@@ -11,6 +13,17 @@ interface ProcessResult {
   originalSize: number;
   processedSize: number;
   savedFileId?: string;
+}
+
+interface BatchProgressFrame {
+  status: "processing" | "completed" | "failed";
+  totalFiles: number;
+  completedFiles: number;
+  failedFiles: number;
+  errors?: Array<{ filename: string; error: string }>;
+  currentFile?: string;
+  /** Terminal frames carry the durable batch result (#750). */
+  result?: Record<string, unknown>;
 }
 
 export interface PipelineProgress {
@@ -27,7 +40,19 @@ const IDLE_PROGRESS: PipelineProgress = {
 };
 
 const UPLOAD_WEIGHT = 15;
+const SSE_STALL_TIMEOUT_MS = 300_000;
+// After degrading a dead POST to the async path, how long to wait for any SSE
+// frame proving the flow reached the server. Only armed when no frame arrived
+// before the degrade; the progress route replays live rows on connect (#722),
+// so a silent 30s on a fresh SSE means the request tail never arrived.
+const JOB_EVIDENCE_TIMEOUT_MS = 30_000;
 
+/**
+ * Pipeline twin of use-tool-processor's #722/#750 recovery machinery. A dead
+ * response after the upload finished does not mean a dead flow: the terminal
+ * SSE frame settles the run instead (the single frame carries the pipeline
+ * result; the batch frame carries the durable ZIP's download URL).
+ */
 export function usePipelineProcessor() {
   const { processing, error, processedUrl, originalSize, processedSize, setProcessing, setError } =
     useFileStore();
@@ -36,14 +61,85 @@ export function usePipelineProcessor() {
   const elapsedRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const xhrRef = useRef<XMLHttpRequest | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
+  const stallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const jobEvidenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const activeJobIdRef = useRef<string | null>(null);
+  const activeEntryIndexRef = useRef<number | null>(null);
+  const asyncModeRef = useRef(false);
+  const sawJobEvidenceRef = useRef(false);
+  // Installed by processAll so the SSE handler can settle a degraded batch
+  // run from its terminal frame. Null outside batch runs.
+  const batchRunRef = useRef<{ onTerminal: (frame: BatchProgressFrame) => void } | null>(null);
+  const reconnectSSERef = useRef<(force?: boolean) => void>(() => {});
 
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.visibilityState !== "visible") return;
+  // Operator-visible record of a sync wait falling back to the async path
+  // (#750). Static import: the analytics module is light (posthog-js loads
+  // lazily inside it).
+  const trackDegrade = useCallback(
+    (trigger: "socket" | "timeout" | "http-502" | "http-504", isBatch: boolean) => {
+      track(ANALYTICS_EVENTS.TOOL_RUN_DEGRADED, {
+        tool_id: "pipeline",
+        is_batch: isBatch,
+        trigger,
+        had_evidence: sawJobEvidenceRef.current,
+      });
+    },
+    [],
+  );
+
+  const clearStallTimer = useCallback(() => {
+    if (stallTimerRef.current) {
+      clearTimeout(stallTimerRef.current);
+      stallTimerRef.current = null;
+    }
+  }, []);
+
+  const resetStallTimer = useCallback(() => {
+    clearStallTimer();
+    stallTimerRef.current = setTimeout(() => {
+      stallTimerRef.current = null;
+      if (!activeJobIdRef.current || !asyncModeRef.current) return;
+      reconnectSSERef.current(true);
+    }, SSE_STALL_TIMEOUT_MS);
+  }, [clearStallTimer]);
+
+  const clearJobEvidenceTimer = useCallback(() => {
+    if (jobEvidenceTimerRef.current) {
+      clearTimeout(jobEvidenceTimerRef.current);
+      jobEvidenceTimerRef.current = null;
+    }
+  }, []);
+
+  const startJobEvidenceTimer = useCallback(() => {
+    clearJobEvidenceTimer();
+    jobEvidenceTimerRef.current = setTimeout(() => {
+      jobEvidenceTimerRef.current = null;
       if (!activeJobIdRef.current) return;
-      if (eventSourceRef.current && eventSourceRef.current.readyState === EventSource.OPEN) {
+      clearStallTimer();
+      if (elapsedRef.current) clearInterval(elapsedRef.current);
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+      activeJobIdRef.current = null;
+      batchRunRef.current = null;
+      setError(
+        "Processing was interrupted and the server never confirmed the job. Retry when reconnected.",
+      );
+      setProcessing(false);
+      setProgress(IDLE_PROGRESS);
+    }, JOB_EVIDENCE_TIMEOUT_MS);
+  }, [clearJobEvidenceTimer, clearStallTimer, setError, setProcessing]);
+
+  const reconnectSSE = useCallback(
+    (force = false) => {
+      const jobId = activeJobIdRef.current;
+      if (!jobId) return;
+      if (
+        !force &&
+        eventSourceRef.current &&
+        eventSourceRef.current.readyState === EventSource.OPEN
+      ) {
         return;
       }
 
@@ -52,50 +148,156 @@ export function usePipelineProcessor() {
         eventSourceRef.current = null;
       }
 
-      const jobId = activeJobIdRef.current;
-      setTimeout(() => {
-        if (!activeJobIdRef.current || activeJobIdRef.current !== jobId) return;
-        try {
-          const es = new EventSource(`/api/v1/jobs/${jobId}/progress`);
-          eventSourceRef.current = es;
+      try {
+        const es = new EventSource(`/api/v1/jobs/${jobId}/progress`);
+        eventSourceRef.current = es;
+        if (asyncModeRef.current) resetStallTimer();
 
-          es.onmessage = (event) => {
-            try {
-              const data = JSON.parse(event.data);
-              if (data.type === "single" && typeof data.percent === "number") {
-                const scaled = UPLOAD_WEIGHT + (data.percent / 100) * (100 - UPLOAD_WEIGHT);
-                setProgress((prev) => ({
-                  ...prev,
-                  phase: "processing",
-                  percent: Math.max(prev.percent, scaled),
-                  stage: data.stage,
-                }));
-              }
-              if (data.type === "batch") {
+        es.onmessage = (event) => {
+          if (eventSourceRef.current !== es) return;
+          try {
+            const data = JSON.parse(event.data);
+            if (data.type === "heartbeat") {
+              if (asyncModeRef.current) resetStallTimer();
+              return;
+            }
+            if (data.type === "batch") {
+              // Any batch frame proves the flow reached the server.
+              sawJobEvidenceRef.current = true;
+              clearJobEvidenceTimer();
+              if (asyncModeRef.current) resetStallTimer();
+
+              const frame = data as BatchProgressFrame;
+              if (frame.status !== "completed" && frame.status !== "failed") {
                 const pct =
-                  data.totalFiles > 0 ? 15 + (data.completedFiles / data.totalFiles) * 85 : 15;
+                  frame.totalFiles > 0
+                    ? UPLOAD_WEIGHT +
+                      (frame.completedFiles / frame.totalFiles) * (100 - UPLOAD_WEIGHT)
+                    : UPLOAD_WEIGHT;
                 setProgress((prev) => ({
                   ...prev,
                   phase: "processing",
                   percent: pct,
-                  stage: data.currentFile
-                    ? `Processing ${data.currentFile} (${data.completedFiles}/${data.totalFiles})`
-                    : `Processing ${data.completedFiles}/${data.totalFiles}`,
+                  stage: frame.currentFile
+                    ? `Processing ${frame.currentFile} (${frame.completedFiles}/${frame.totalFiles})`
+                    : `Processing ${frame.completedFiles}/${frame.totalFiles}`,
                 }));
+                return;
               }
-            } catch {
-              // Ignore malformed SSE
+              // In sync mode the XHR response owns settling: the terminal
+              // frame always precedes the streamed ZIP.
+              if (!asyncModeRef.current) return;
+              clearStallTimer();
+              es.close();
+              eventSourceRef.current = null;
+              xhrRef.current?.abort();
+              const run = batchRunRef.current;
+              if (run) {
+                run.onTerminal(frame);
+              } else {
+                // Unreachable by construction; fail visibly instead of
+                // leaving the run in silent limbo.
+                clearJobEvidenceTimer();
+                if (elapsedRef.current) clearInterval(elapsedRef.current);
+                activeJobIdRef.current = null;
+                setError("Processing was interrupted. Retry when reconnected.");
+                setProcessing(false);
+                setProgress(IDLE_PROGRESS);
+              }
+              return;
             }
-          };
+            if (data.type !== "single") return;
 
-          es.onerror = () => {
+            // Any single frame proves the flow reached the server.
+            sawJobEvidenceRef.current = true;
+            clearJobEvidenceTimer();
+            if (asyncModeRef.current) resetStallTimer();
+
+            if (data.phase === "complete" && data.result) {
+              clearStallTimer();
+              if (elapsedRef.current) clearInterval(elapsedRef.current);
+              es.close();
+              eventSourceRef.current = null;
+              // The SSE settles the run; a still-open sync POST must not
+              // fire a late onerror/ontimeout over this result.
+              xhrRef.current?.abort();
+              const idx = activeEntryIndexRef.current ?? useFileStore.getState().selectedIndex;
+
+              const result = data.result as ProcessResult;
+              useFileStore.getState().updateEntry(idx, {
+                processedUrl: result.downloadUrl,
+                processedPreviewUrl: result.previewUrl ?? null,
+                processedFilename: null,
+                status: "completed",
+                originalSize: result.originalSize,
+                processedSize: result.processedSize,
+                ...(result.savedFileId ? { serverFileId: result.savedFileId } : {}),
+              });
+              activeJobIdRef.current = null;
+              activeEntryIndexRef.current = null;
+              batchRunRef.current = null;
+              setProcessing(false);
+              setProgress(IDLE_PROGRESS);
+              return;
+            }
+
+            if (data.phase === "failed") {
+              clearStallTimer();
+              if (elapsedRef.current) clearInterval(elapsedRef.current);
+              es.close();
+              eventSourceRef.current = null;
+              xhrRef.current?.abort();
+              activeJobIdRef.current = null;
+              activeEntryIndexRef.current = null;
+              batchRunRef.current = null;
+              setError(data.error || "Processing failed");
+              setProcessing(false);
+              setProgress(IDLE_PROGRESS);
+              return;
+            }
+
+            if (typeof data.percent === "number") {
+              const scaled = UPLOAD_WEIGHT + (data.percent / 100) * (100 - UPLOAD_WEIGHT);
+              setProgress((prev) => ({
+                ...prev,
+                phase: "processing",
+                percent: Math.max(prev.percent, scaled),
+                stage: data.stage,
+              }));
+            }
+          } catch {
+            // Ignore malformed SSE
+          }
+        };
+
+        es.onerror = () => {
+          if (!asyncModeRef.current) {
             es.close();
-            eventSourceRef.current = null;
-          };
-        } catch {
-          // EventSource creation failed
-        }
-      }, 500);
+            if (eventSourceRef.current === es) {
+              eventSourceRef.current = null;
+            }
+          }
+        };
+      } catch {
+        // EventSource creation failed
+      }
+    },
+    [clearStallTimer, clearJobEvidenceTimer, resetStallTimer, setError, setProcessing],
+  );
+
+  useEffect(() => {
+    reconnectSSERef.current = reconnectSSE;
+  }, [reconnectSSE]);
+
+  // Reconnect SSE when tab becomes visible again (mobile tab recovery)
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") return;
+      if (!activeJobIdRef.current) return;
+      if (eventSourceRef.current && eventSourceRef.current.readyState === EventSource.OPEN) {
+        return;
+      }
+      setTimeout(() => reconnectSSERef.current(), 500);
     };
 
     document.addEventListener("visibilitychange", handleVisibilityChange);
@@ -105,7 +307,8 @@ export function usePipelineProcessor() {
       if (elapsedRef.current) clearInterval(elapsedRef.current);
       if (eventSourceRef.current) eventSourceRef.current.close();
       if (xhrRef.current) xhrRef.current.abort();
-      if (abortRef.current) abortRef.current.abort();
+      if (stallTimerRef.current) clearTimeout(stallTimerRef.current);
+      if (jobEvidenceTimerRef.current) clearTimeout(jobEvidenceTimerRef.current);
     };
   }, []);
 
@@ -123,6 +326,12 @@ export function usePipelineProcessor() {
       });
       setProcessing(true);
       setProgress({ phase: "uploading", percent: 0, elapsed: 0 });
+      // A stale evidence timer from a previous degraded run must not fire
+      // into this run, and evidence never carries across runs.
+      clearJobEvidenceTimer();
+      sawJobEvidenceRef.current = false;
+      asyncModeRef.current = false;
+      batchRunRef.current = null;
 
       const startTime = Date.now();
       elapsedRef.current = setInterval(() => {
@@ -134,38 +343,10 @@ export function usePipelineProcessor() {
 
       const clientJobId = generateId();
       activeJobIdRef.current = clientJobId;
+      activeEntryIndexRef.current = capturedIndex;
 
       // Open SSE for real-time progress from the server
-      try {
-        const es = new EventSource(`/api/v1/jobs/${clientJobId}/progress`);
-        eventSourceRef.current = es;
-
-        es.onmessage = (event) => {
-          try {
-            const data = JSON.parse(event.data);
-            if (data.type !== "single") return;
-
-            if (typeof data.percent === "number") {
-              const scaled = UPLOAD_WEIGHT + (data.percent / 100) * (100 - UPLOAD_WEIGHT);
-              setProgress((prev) => ({
-                ...prev,
-                phase: "processing",
-                percent: Math.max(prev.percent, scaled),
-                stage: data.stage,
-              }));
-            }
-          } catch {
-            // Ignore malformed SSE
-          }
-        };
-
-        es.onerror = () => {
-          es.close();
-          eventSourceRef.current = null;
-        };
-      } catch {
-        // EventSource creation failed -- proceed without SSE
-      }
+      reconnectSSE(true);
 
       const pipeline = {
         steps: steps.map((s) => ({ toolId: s.toolId, settings: s.settings })),
@@ -191,7 +372,9 @@ export function usePipelineProcessor() {
         }
       };
 
+      let uploadedFully = false;
       xhr.upload.onload = () => {
+        uploadedFully = true;
         setProgress((prev) => ({
           ...prev,
           phase: "processing",
@@ -200,7 +383,48 @@ export function usePipelineProcessor() {
         }));
       };
 
+      // A dead response after a finished upload does not mean a dead flow:
+      // the pipeline keeps running under clientJobId and the terminal single
+      // frame carries the full result (#766, mirroring #722).
+      const degradeToAsync = (trigger: "socket" | "timeout" | "http-502" | "http-504") => {
+        if (!uploadedFully || activeJobIdRef.current !== clientJobId) return false;
+        asyncModeRef.current = true;
+        trackDegrade(trigger, false);
+        reconnectSSE(true);
+        resetStallTimer();
+        if (!sawJobEvidenceRef.current) {
+          startJobEvidenceTimer();
+        }
+        return true;
+      };
+
       xhr.onload = () => {
+        if (activeJobIdRef.current !== clientJobId) return;
+
+        if (xhr.status === 202) {
+          // The server's sync wait expired while the flow keeps running;
+          // ride the SSE to the terminal frame. Force a fresh source: a
+          // sync-mode SSE error during the wait nulls the ref.
+          asyncModeRef.current = true;
+          reconnectSSE(true);
+          resetStallTimer();
+          return;
+        }
+
+        // An unparseable 502/504 body is an intermediary answering for a
+        // dead sync wait, not the app (app 5xx always carries JSON).
+        if (xhr.status === 502 || xhr.status === 504) {
+          let appSpoke = true;
+          try {
+            JSON.parse(xhr.responseText);
+          } catch {
+            appSpoke = false;
+          }
+          if (!appSpoke && degradeToAsync(xhr.status === 502 ? "http-502" : "http-504")) {
+            return;
+          }
+        }
+
         if (elapsedRef.current) clearInterval(elapsedRef.current);
         if (eventSourceRef.current) {
           eventSourceRef.current.close();
@@ -241,21 +465,31 @@ export function usePipelineProcessor() {
         setProcessing(false);
         setProgress(IDLE_PROGRESS);
         activeJobIdRef.current = null;
+        activeEntryIndexRef.current = null;
       };
 
       xhr.onerror = () => {
+        // Settled runs and successor runs must not be touched by late socket
+        // events (#722 run-identity guard).
+        if (activeJobIdRef.current !== clientJobId) return;
+        if (degradeToAsync("socket")) return;
+        clearStallTimer();
         if (elapsedRef.current) clearInterval(elapsedRef.current);
         if (eventSourceRef.current) {
           eventSourceRef.current.close();
           eventSourceRef.current = null;
         }
-        setError("Network error - check your connection");
+        setError("Processing was interrupted. Retry when reconnected.");
         setProcessing(false);
         setProgress(IDLE_PROGRESS);
         activeJobIdRef.current = null;
+        activeEntryIndexRef.current = null;
       };
 
       xhr.ontimeout = () => {
+        if (activeJobIdRef.current !== clientJobId) return;
+        if (degradeToAsync("timeout")) return;
+        clearStallTimer();
         if (elapsedRef.current) clearInterval(elapsedRef.current);
         if (eventSourceRef.current) {
           eventSourceRef.current.close();
@@ -265,6 +499,7 @@ export function usePipelineProcessor() {
         setProcessing(false);
         setProgress(IDLE_PROGRESS);
         activeJobIdRef.current = null;
+        activeEntryIndexRef.current = null;
       };
 
       xhr.open("POST", "/api/v1/pipeline/execute");
@@ -273,7 +508,16 @@ export function usePipelineProcessor() {
       });
       xhr.send(formData);
     },
-    [setProcessing, setError],
+    [
+      setProcessing,
+      setError,
+      clearJobEvidenceTimer,
+      clearStallTimer,
+      reconnectSSE,
+      resetStallTimer,
+      startJobEvidenceTimer,
+      trackDegrade,
+    ],
   );
 
   const processAll = useCallback(
@@ -292,6 +536,9 @@ export function usePipelineProcessor() {
       setError(null);
       setProcessing(true);
       setProgress({ phase: "uploading", percent: 0, elapsed: 0 });
+      clearJobEvidenceTimer();
+      sawJobEvidenceRef.current = false;
+      asyncModeRef.current = false;
 
       const startTime = Date.now();
       elapsedRef.current = setInterval(() => {
@@ -300,92 +547,30 @@ export function usePipelineProcessor() {
 
       const clientJobId = generateId();
       activeJobIdRef.current = clientJobId;
+      activeEntryIndexRef.current = null;
 
-      // Open SSE before upload for real-time progress
-      try {
-        const es = new EventSource(`/api/v1/jobs/${clientJobId}/progress`);
-        eventSourceRef.current = es;
-        es.onmessage = (event) => {
-          try {
-            const data = JSON.parse(event.data);
-            if (data.type === "batch") {
-              const pct =
-                data.totalFiles > 0 ? 15 + (data.completedFiles / data.totalFiles) * 85 : 15;
-              setProgress((prev) => ({
-                ...prev,
-                phase: "processing",
-                percent: pct,
-                stage: data.currentFile
-                  ? `Processing ${data.currentFile} (${data.completedFiles}/${data.totalFiles})`
-                  : `Processing ${data.completedFiles}/${data.totalFiles}`,
-              }));
-            }
-          } catch {
-            /* ignore malformed SSE */
-          }
-        };
-        es.onerror = () => {
-          es.close();
-          eventSourceRef.current = null;
-        };
-      } catch {
-        /* SSE failed, proceed without */
-      }
-
-      const pipeline = {
-        steps: steps.map((s) => ({ toolId: s.toolId, settings: s.settings })),
-      };
-
-      const formData = new FormData();
-      for (const file of files) formData.append("file", file);
-      formData.append("pipeline", JSON.stringify(pipeline));
-      formData.append("clientJobId", clientJobId);
-
-      try {
-        abortRef.current = new AbortController();
-        const response = await fetch("/api/v1/pipeline/batch", {
-          method: "POST",
-          headers: formatHeaders(),
-          body: formData,
-          signal: abortRef.current.signal,
-        });
-
+      // Tear down the run without touching the outcome state; callers set
+      // the result or error first.
+      const finishRun = () => {
+        clearJobEvidenceTimer();
+        clearStallTimer();
         if (elapsedRef.current) clearInterval(elapsedRef.current);
         if (eventSourceRef.current) {
           eventSourceRef.current.close();
           eventSourceRef.current = null;
         }
+        batchRunRef.current = null;
+        activeJobIdRef.current = null;
+        setProcessing(false);
+        setProgress(IDLE_PROGRESS);
+      };
 
-        if (!response.ok) {
-          const text = await response.text();
-          let errorMsg: string;
-          try {
-            const body = JSON.parse(text);
-            if (body.errors && Array.isArray(body.errors) && body.errors.length > 0) {
-              // Show the first file's step-level error (all files typically fail at the same step)
-              const first = body.errors[0];
-              errorMsg = first.error;
-              if (body.errors.length > 1) {
-                errorMsg += ` (${body.errors.length} files failed)`;
-              }
-            } else {
-              const parsed = parseApiError(body, response.status);
-              if (typeof parsed === "object" && parsed.type === "feature_not_installed") {
-                errorMsg = `The "${parsed.featureName}" feature is not installed. Enable it in Settings → AI Features.`;
-              } else {
-                errorMsg = parsed as string;
-              }
-            }
-          } catch {
-            errorMsg = `Batch processing failed: ${response.status}`;
-          }
-          setError(errorMsg);
-          setProcessing(false);
-          setProgress(IDLE_PROGRESS);
-          return;
-        }
+      const failRun = (message: string) => {
+        setError(message);
+        finishRun();
+      };
 
-        const zipBlob = await response.blob();
+      const settleFromZip = async (zipBlob: Blob, fileResults: Record<string, string>) => {
         setBatchZip(zipBlob, "batch-pipeline.zip");
 
         // Extract files from ZIP using fflate
@@ -394,15 +579,6 @@ export function usePipelineProcessor() {
         const extracted = unzipSync(zipBuffer);
 
         const entries = useFileStore.getState().entries;
-        let fileResults: Record<string, string> = {};
-        try {
-          fileResults = JSON.parse(
-            decodeURIComponent(response.headers.get("X-File-Results") ?? "%7B%7D"),
-          );
-        } catch {
-          // Malformed header - fall back to empty mapping, all entries marked failed
-        }
-
         for (let i = 0; i < entries.length; i++) {
           const processedName = fileResults[String(i)];
           if (processedName && extracted[processedName]) {
@@ -419,22 +595,231 @@ export function usePipelineProcessor() {
           }
         }
 
-        setProcessing(false);
-        setProgress(IDLE_PROGRESS);
-        activeJobIdRef.current = null;
-      } catch (err) {
-        if (elapsedRef.current) clearInterval(elapsedRef.current);
-        if (eventSourceRef.current) {
-          eventSourceRef.current.close();
-          eventSourceRef.current = null;
+        finishRun();
+      };
+
+      // A degraded run settles here: download the durable ZIP the terminal
+      // frame points at. Retried, because the reason we are on this path is
+      // that the network just proved flaky.
+      const downloadAndSettle = async (result: Record<string, unknown>) => {
+        const url = String(result.downloadUrl);
+        const fileResults = (result.fileResults ?? {}) as Record<string, string>;
+        for (let attempt = 0; attempt < 3; attempt++) {
+          if (activeJobIdRef.current !== clientJobId) return;
+          try {
+            const res = await fetch(url, { headers: formatHeaders() });
+            // A 4xx is deterministic: retrying cannot help, and the message
+            // must not blame the network.
+            if (res.status >= 400 && res.status < 500) {
+              if (activeJobIdRef.current !== clientJobId) return;
+              failRun(
+                res.status === 404
+                  ? "Completed result is no longer available. Run the job again."
+                  : "The finished batch could not be downloaded. Refresh and try again.",
+              );
+              return;
+            }
+            if (!res.ok) throw new Error(`Batch download failed: ${res.status}`);
+            const blob = await res.blob();
+            if (activeJobIdRef.current !== clientJobId) return;
+            await settleFromZip(blob, fileResults);
+            return;
+          } catch {
+            if (attempt < 2) {
+              await new Promise((resolve) => setTimeout(resolve, attempt === 0 ? 2_000 : 5_000));
+            }
+          }
         }
-        setError(err instanceof Error ? err.message : "Batch processing failed");
-        setProcessing(false);
-        setProgress(IDLE_PROGRESS);
-        activeJobIdRef.current = null;
-      }
+        if (activeJobIdRef.current !== clientJobId) return;
+        failRun("Processing was interrupted. Retry when reconnected.");
+      };
+
+      batchRunRef.current = {
+        onTerminal: (frame) => {
+          if (activeJobIdRef.current !== clientJobId) return;
+          if (
+            frame.status === "completed" &&
+            frame.result &&
+            typeof frame.result.downloadUrl === "string"
+          ) {
+            void downloadAndSettle(frame.result);
+            return;
+          }
+          if (frame.status === "completed") {
+            // No durable result to recover from: the ZIP only ever existed
+            // on the response this run lost.
+            failRun("Processing was interrupted. Retry when reconnected.");
+            return;
+          }
+          // Replay-synthesized failures carry their message in a blank-name
+          // errors entry (packaging failure, expired result).
+          const syntheticError = frame.errors?.find((e) => e.filename === "")?.error;
+          failRun(
+            syntheticError ??
+              (frame.totalFiles > 0 && frame.failedFiles >= frame.totalFiles
+                ? "All files failed processing"
+                : "Batch processing failed"),
+          );
+        },
+      };
+
+      // Open SSE before the upload; the unified handler also gives batch
+      // runs the visibility-change recovery path.
+      reconnectSSE(true);
+
+      const pipeline = {
+        steps: steps.map((s) => ({ toolId: s.toolId, settings: s.settings })),
+      };
+
+      const formData = new FormData();
+      for (const file of files) formData.append("file", file);
+      formData.append("pipeline", JSON.stringify(pipeline));
+      formData.append("clientJobId", clientJobId);
+
+      const xhr = new XMLHttpRequest();
+      xhrRef.current = xhr;
+      xhr.responseType = "blob";
+      // Pipeline batches legitimately hold the sync response for many
+      // minutes; the stall and evidence timers own liveness.
+      xhr.timeout = 0;
+
+      xhr.upload.onprogress = (event) => {
+        if (event.lengthComputable) {
+          const uploadPercent = (event.loaded / event.total) * UPLOAD_WEIGHT;
+          setProgress((prev) => {
+            if (prev.phase !== "uploading") return prev;
+            return { ...prev, percent: uploadPercent };
+          });
+        }
+      };
+
+      let uploadedFully = false;
+      xhr.upload.onload = () => {
+        uploadedFully = true;
+        setProgress((prev) => ({
+          ...prev,
+          phase: "processing",
+          percent: UPLOAD_WEIGHT,
+          stage: "Processing...",
+        }));
+      };
+
+      const degradeToAsync = (trigger: "socket" | "timeout" | "http-502" | "http-504") => {
+        if (!uploadedFully || activeJobIdRef.current !== clientJobId) return false;
+        asyncModeRef.current = true;
+        trackDegrade(trigger, true);
+        reconnectSSE(true);
+        resetStallTimer();
+        if (!sawJobEvidenceRef.current) {
+          startJobEvidenceTimer();
+        }
+        return true;
+      };
+
+      xhr.onload = () => {
+        if (activeJobIdRef.current !== clientJobId) return;
+
+        if (xhr.status === 202) {
+          asyncModeRef.current = true;
+          reconnectSSE(true);
+          resetStallTimer();
+          return;
+        }
+
+        if (xhr.status >= 200 && xhr.status < 300) {
+          let fileResults: Record<string, string> = {};
+          try {
+            fileResults = JSON.parse(
+              decodeURIComponent(xhr.getResponseHeader("X-File-Results") ?? "%7B%7D"),
+            );
+          } catch {
+            // Malformed header - fall back to empty mapping, all entries marked failed
+          }
+          const zipBlob = xhr.response as Blob;
+          void (async () => {
+            try {
+              if (activeJobIdRef.current !== clientJobId) return;
+              await settleFromZip(zipBlob, fileResults);
+            } catch {
+              if (activeJobIdRef.current !== clientJobId) return;
+              failRun("Batch processing failed");
+            }
+          })();
+          return;
+        }
+
+        void (async () => {
+          let text = "";
+          try {
+            text = await (xhr.response instanceof Blob
+              ? xhr.response.text()
+              : Promise.resolve(String(xhr.response ?? "")));
+          } catch {
+            // Unreadable body; fall through to the status-based handling.
+          }
+          if (activeJobIdRef.current !== clientJobId) return;
+          let errorMsg: string;
+          try {
+            const body = JSON.parse(text);
+            if (body.errors && Array.isArray(body.errors) && body.errors.length > 0) {
+              // Show the first file's step-level error (all files typically fail at the same step)
+              const first = body.errors[0];
+              errorMsg = first.error;
+              if (body.errors.length > 1) {
+                errorMsg += ` (${body.errors.length} files failed)`;
+              }
+            } else {
+              const parsed = parseApiError(body, xhr.status);
+              if (typeof parsed === "object" && parsed.type === "feature_not_installed") {
+                errorMsg = `The "${parsed.featureName}" feature is not installed. Enable it in Settings → AI Features.`;
+              } else {
+                errorMsg = parsed as string;
+              }
+            }
+          } catch {
+            // An unparseable 502/504 body is an intermediary answering for a
+            // dead sync wait, not the app.
+            if (
+              (xhr.status === 502 || xhr.status === 504) &&
+              degradeToAsync(xhr.status === 502 ? "http-502" : "http-504")
+            ) {
+              return;
+            }
+            errorMsg = `Batch processing failed: ${xhr.status}`;
+          }
+          failRun(errorMsg);
+        })();
+      };
+
+      xhr.onerror = () => {
+        if (activeJobIdRef.current !== clientJobId) return;
+        if (degradeToAsync("socket")) return;
+        failRun("Processing was interrupted. Retry when reconnected.");
+      };
+
+      xhr.ontimeout = () => {
+        if (activeJobIdRef.current !== clientJobId) return;
+        if (degradeToAsync("timeout")) return;
+        failRun("Request timed out - the server may be overloaded. Try again.");
+      };
+
+      xhr.open("POST", "/api/v1/pipeline/batch");
+      formatHeaders().forEach((value, key) => {
+        xhr.setRequestHeader(key, value);
+      });
+      xhr.send(formData);
     },
-    [processSingle, setProcessing, setError],
+    [
+      processSingle,
+      setProcessing,
+      setError,
+      clearJobEvidenceTimer,
+      clearStallTimer,
+      reconnectSSE,
+      resetStallTimer,
+      startJobEvidenceTimer,
+      trackDegrade,
+    ],
   );
 
   return {

--- a/tests/integration/platform/pipeline-sync-wait-202.test.ts
+++ b/tests/integration/platform/pipeline-sync-wait-202.test.ts
@@ -14,6 +14,7 @@ import { randomUUID } from "node:crypto";
 import AdmZip from "adm-zip";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { sharedRedis } from "../../../apps/api/src/jobs/connection.js";
+import { getQueue } from "../../../apps/api/src/jobs/queues.js";
 import { bullPrefix } from "../../../apps/api/src/jobs/types.js";
 import { fixtures, readFixture } from "../../fixtures/index.js";
 import {
@@ -148,8 +149,52 @@ describe("pipeline sync-wait expiry (#766)", () => {
       });
       expect(download.statusCode).toBe(200);
       expect(new AdmZip(download.rawPayload).getEntries()).toHaveLength(2);
+
+      // Drift pin for ignoreDependencyOnFailure: its behavior (a stall-
+      // evicted node not wedging its parent) needs an evicted lock-holder,
+      // which an in-process test cannot produce, so pin the wiring instead.
+      // Steps and per-file finalize roots carry the flag; the batch parent
+      // does not (it has no parent to unwedge).
+      const step = await getQueue("image").getJob(`${clientJobId}-f0-s0`);
+      expect(step?.opts.ignoreDependencyOnFailure).toBe(true);
+      const perFileFinalize = await getQueue("image").getJob(`${clientJobId}-f0`);
+      expect(perFileFinalize?.opts.ignoreDependencyOnFailure).toBe(true);
+      const batchParent = await getQueue("system").getJob(clientJobId);
+      expect(batchParent?.opts.ignoreDependencyOnFailure ?? false).toBe(false);
     } finally {
       enqueueMock.timeoutPools.delete("system");
+    }
+  }, 60_000);
+
+  it("execute without a clientJobId answers 202 under the id its frames publish on", async () => {
+    enqueueMock.timeoutPools.add("image");
+    try {
+      const { body, contentType } = createMultipartPayload([
+        { name: "file", filename: "photo.png", contentType: "image/png", content: PNG },
+        {
+          name: "pipeline",
+          content: JSON.stringify({ steps: [{ toolId: "resize", settings: { width: 50 } }] }),
+        },
+      ]);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/pipeline/execute",
+        headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+        body,
+      });
+
+      expect(res.statusCode).toBe(202);
+      const parsed = JSON.parse(res.body) as { jobId: string; async: boolean };
+      expect(parsed.async).toBe(true);
+      expect(parsed.jobId.length).toBeGreaterThan(0);
+
+      // The two `clientJobId ?? jobId` sites (frame channel and 202 body)
+      // must never drift apart: an API consumer subscribes to the body's id.
+      const frame = await waitForTerminalFrame(parsed.jobId);
+      expect(frame.type).toBe("single");
+      expect(frame.phase).toBe("complete");
+    } finally {
+      enqueueMock.timeoutPools.delete("image");
     }
   }, 60_000);
 });

--- a/tests/integration/platform/pipeline-sync-wait-202.test.ts
+++ b/tests/integration/platform/pipeline-sync-wait-202.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Pipeline sync-wait expiry answers the async contract (#766).
+ *
+ * Both pipeline routes used to answer a fake 422 "timed out" while the flow
+ * kept running. Since #750 the terminal SSE frame carries everything a client
+ * needs to settle (the single frame's result for /execute, the durable ZIP's
+ * downloadUrl for /batch), so expiry now degrades to `202 {jobId, async}`
+ * exactly like the tool routes. The real windows (10 and 30 minutes) cannot
+ * be reached in a test, so waitForJob is swapped for a passthrough that
+ * returns null for designated job ids.
+ */
+
+import { randomUUID } from "node:crypto";
+import AdmZip from "adm-zip";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { sharedRedis } from "../../../apps/api/src/jobs/connection.js";
+import { bullPrefix } from "../../../apps/api/src/jobs/types.js";
+import { fixtures, readFixture } from "../../fixtures/index.js";
+import {
+  buildTestApp,
+  createMultipartPayload,
+  loginAsAdmin,
+  type TestApp,
+} from "../test-server.js";
+
+// /execute waits under a server-generated job id the test cannot know, so
+// the expiry is keyed on the pool the wait runs against instead: "image" for
+// a resize pipeline's finalize, "system" for the batch finalize. Each test
+// arms its pool inside try/finally; the file is isolated, so nothing else
+// waits on those pools meanwhile.
+const enqueueMock = vi.hoisted(() => ({ timeoutPools: new Set<string>() }));
+
+vi.mock("../../../apps/api/src/jobs/enqueue.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../apps/api/src/jobs/enqueue.js")>();
+  return {
+    ...actual,
+    waitForJob: async (...args: Parameters<typeof actual.waitForJob>) => {
+      if (enqueueMock.timeoutPools.has(args[0])) return null;
+      return actual.waitForJob(...args);
+    },
+  };
+});
+
+const PNG = readFixture(fixtures.image.base.png200);
+const JPG = readFixture(fixtures.image.base.jpg100);
+
+let testApp: TestApp;
+let app: TestApp["app"];
+let adminToken: string;
+
+/** Poll the Redis terminal replay key until the terminal frame appears. */
+async function waitForTerminalFrame(
+  jobId: string,
+  timeoutMs = 30_000,
+): Promise<Record<string, unknown>> {
+  const key = `${bullPrefix()}:terminal:${jobId}`;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const raw = await sharedRedis().get(key);
+    if (raw) return JSON.parse(raw) as Record<string, unknown>;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`No terminal frame for ${jobId} within ${timeoutMs}ms`);
+}
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  app = testApp.app;
+  adminToken = await loginAsAdmin(app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+describe("pipeline sync-wait expiry (#766)", () => {
+  it("execute answers 202 and the terminal single frame still delivers the result", async () => {
+    const clientJobId = randomUUID();
+    enqueueMock.timeoutPools.add("image");
+    try {
+      const { body, contentType } = createMultipartPayload([
+        { name: "file", filename: "photo.png", contentType: "image/png", content: PNG },
+        {
+          name: "pipeline",
+          content: JSON.stringify({ steps: [{ toolId: "resize", settings: { width: 50 } }] }),
+        },
+        { name: "clientJobId", content: clientJobId },
+      ]);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/pipeline/execute",
+        headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+        body,
+      });
+
+      expect(res.statusCode).toBe(202);
+      expect(JSON.parse(res.body)).toEqual({ jobId: clientJobId, async: true });
+
+      // The flow does not care about the response: the finalize publishes
+      // the terminal single frame whose result the client settles from.
+      const frame = await waitForTerminalFrame(clientJobId);
+      expect(frame.type).toBe("single");
+      expect(frame.phase).toBe("complete");
+      const result = frame.result as Record<string, unknown>;
+      const download = await app.inject({
+        method: "GET",
+        url: String(result.downloadUrl),
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+      expect(download.statusCode).toBe(200);
+      expect(download.rawPayload.length).toBeGreaterThan(0);
+    } finally {
+      enqueueMock.timeoutPools.delete("image");
+    }
+  }, 60_000);
+
+  it("batch answers 202 and the terminal batch frame still delivers the durable ZIP", async () => {
+    const clientJobId = randomUUID();
+    enqueueMock.timeoutPools.add("system");
+    try {
+      const { body, contentType } = createMultipartPayload([
+        { name: "file", filename: "a.png", contentType: "image/png", content: PNG },
+        { name: "file", filename: "b.jpg", contentType: "image/jpeg", content: JPG },
+        {
+          name: "pipeline",
+          content: JSON.stringify({ steps: [{ toolId: "resize", settings: { width: 50 } }] }),
+        },
+        { name: "clientJobId", content: clientJobId },
+      ]);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/pipeline/batch",
+        headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+        body,
+      });
+
+      expect(res.statusCode).toBe(202);
+      expect(JSON.parse(res.body)).toEqual({ jobId: clientJobId, async: true });
+
+      const frame = await waitForTerminalFrame(clientJobId);
+      expect(frame.type).toBe("batch");
+      expect(frame.status).toBe("completed");
+      const result = frame.result as Record<string, unknown>;
+      const download = await app.inject({
+        method: "GET",
+        url: String(result.downloadUrl),
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+      expect(download.statusCode).toBe(200);
+      expect(new AdmZip(download.rawPayload).getEntries()).toHaveLength(2);
+    } finally {
+      enqueueMock.timeoutPools.delete("system");
+    }
+  }, 60_000);
+});

--- a/tests/integration/platform/worker-branches.test.ts
+++ b/tests/integration/platform/worker-branches.test.ts
@@ -716,6 +716,7 @@ describe("pipeline finalize", () => {
 
   it("hard-fails the finalize job when the last step has no output ref", async () => {
     const jobId = `pf-${randomUUID()}`;
+    const clientJobId = `pfc-${randomUUID()}`;
     await db.insert(schema.jobs).values({
       id: `${jobId}-s0`,
       type: "pipeline-step",
@@ -725,6 +726,15 @@ describe("pipeline finalize", () => {
       inputRefs: [],
       outputRefs: [],
     });
+    // The client-facing row the SSE replays, as the route's first progress
+    // publish would have created it.
+    await db.insert(schema.jobs).values({
+      id: clientJobId,
+      type: "single",
+      status: "processing",
+      inputRefs: [],
+      progress: { percent: 0, stage: "Preparing pipeline..." },
+    });
 
     await enqueueToolJob(
       toolJob({
@@ -733,6 +743,7 @@ describe("pipeline finalize", () => {
         kind: "pipeline-finalize",
         totalSteps: 1,
         filename: "chain.png",
+        clientJobId,
       }),
     );
 
@@ -744,6 +755,22 @@ describe("pipeline finalize", () => {
       return (await job.getState()) === "failed" ? job : undefined;
     }, 25_000);
     expect(failedJob.failedReason).toContain("Last step has no output");
+
+    // A degraded or 202 client is riding the SSE under clientJobId; without
+    // a terminal frame it spins forever (#766 safety net, the pipeline twin
+    // of the batch-finalize net from #750).
+    const frame = await terminalFrame(clientJobId);
+    expect(frame.type).toBe("single");
+    expect(frame.phase).toBe("failed");
+    expect(String(frame.error).length).toBeGreaterThan(0);
+
+    // The client row goes terminal too, so replay after the Redis key
+    // expires stays failed instead of resurrecting a processing spinner.
+    const clientRow = await waitFor(async () => {
+      const row = await jobRow(clientJobId);
+      return row?.status === "failed" ? row : undefined;
+    });
+    expect(clientRow.completedAt).not.toBeNull();
   }, 30_000);
 });
 

--- a/tests/unit/web/use-pipeline-processor-recovery.test.ts
+++ b/tests/unit/web/use-pipeline-processor-recovery.test.ts
@@ -1,0 +1,569 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import AdmZip from "adm-zip";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/image-preview", () => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  formatHeaders: () => new Map<string, string>(),
+  parseApiError: () => "error",
+}));
+
+vi.mock("@/lib/utils", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  return { ...actual, generateId: () => "44444444-4444-4444-8444-444444444444" };
+});
+
+import { usePipelineProcessor } from "@/hooks/use-pipeline-processor";
+import { track } from "@/lib/analytics";
+import { useFileStore } from "@/stores/file-store";
+import type { PipelineStep } from "@/stores/pipeline-store";
+
+interface MockXhr {
+  status: number;
+  responseText: string;
+  responseType: string;
+  response: unknown;
+  timeout: number;
+  upload: { onprogress?: unknown; onload?: (() => void) | null };
+  onload?: () => void;
+  onerror?: (() => void) | null;
+  ontimeout?: (() => void) | null;
+  open: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  setRequestHeader: ReturnType<typeof vi.fn>;
+  getResponseHeader: ReturnType<typeof vi.fn>;
+  abort: ReturnType<typeof vi.fn>;
+}
+
+class MockEventSource {
+  static OPEN = 1;
+  static instances: MockEventSource[] = [];
+
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = MockEventSource.OPEN;
+  close = vi.fn(() => {
+    this.readyState = 2;
+  });
+
+  constructor(readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+}
+
+let xhrs: MockXhr[];
+
+const JOB_ID = "44444444-4444-4444-8444-444444444444";
+
+const STEPS = [
+  { id: "s1", toolId: "resize", settings: { width: 50 } },
+] as unknown as PipelineStep[];
+
+const ZIP_NAMES = { "0": "first_resize.png", "1": "second_resize.jpg" } as const;
+const ZIP_BYTES = (() => {
+  const zip = new AdmZip();
+  zip.addFile("first_resize.png", Buffer.from([1, 2, 3, 4]));
+  zip.addFile("second_resize.jpg", Buffer.from([5, 6]));
+  return new Uint8Array(zip.toBuffer());
+})();
+const zipBlob = () => new Blob([ZIP_BYTES.slice().buffer], { type: "application/zip" });
+const encodedFileResults = () => encodeURIComponent(JSON.stringify(ZIP_NAMES));
+
+function latestSse(): MockEventSource {
+  return MockEventSource.instances[MockEventSource.instances.length - 1];
+}
+
+function sendSingleFrame(frame: Record<string, unknown>) {
+  latestSse().onmessage?.({
+    data: JSON.stringify({ type: "single", jobId: JOB_ID, ...frame }),
+  } as MessageEvent);
+}
+
+function sendBatchFrame(frame: Record<string, unknown>) {
+  latestSse().onmessage?.({
+    data: JSON.stringify({ type: "batch", jobId: JOB_ID, ...frame }),
+  } as MessageEvent);
+}
+
+const SINGLE_RESULT = {
+  jobId: JOB_ID,
+  downloadUrl: `/api/v1/download/${JOB_ID}/photo_final.png`,
+  originalSize: 64,
+  processedSize: 32,
+  stepsCompleted: 1,
+  steps: [{ step: 1, toolId: "resize", size: 32 }],
+};
+
+const BATCH_RESULT = {
+  jobId: JOB_ID,
+  downloadUrl: `/api/v1/download/${JOB_ID}/pipeline-batch-44444444.zip`,
+  zipFilename: "pipeline-batch-44444444.zip",
+  fileResults: ZIP_NAMES,
+  processedSize: ZIP_BYTES.length,
+};
+
+function completedBatchTerminal() {
+  return {
+    status: "completed",
+    totalFiles: 2,
+    completedFiles: 2,
+    failedFiles: 0,
+    errors: [],
+    result: BATCH_RESULT,
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal("URL", {
+    ...globalThis.URL,
+    createObjectURL: vi.fn(() => "blob:fake-url"),
+    revokeObjectURL: vi.fn(),
+  });
+  useFileStore.getState().reset();
+  xhrs = [];
+  MockEventSource.instances = [];
+  vi.stubGlobal("EventSource", MockEventSource);
+  vi.stubGlobal(
+    "XMLHttpRequest",
+    vi.fn(() => {
+      const xhr: MockXhr = {
+        status: 0,
+        responseText: "",
+        responseType: "",
+        response: null,
+        timeout: 0,
+        upload: {},
+        open: vi.fn(),
+        send: vi.fn(),
+        setRequestHeader: vi.fn(),
+        getResponseHeader: vi.fn(() => null),
+        abort: vi.fn(),
+      };
+      xhrs.push(xhr);
+      return xhr;
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.mocked(track).mockClear();
+});
+
+function startSingleRun() {
+  const file = new File([new ArrayBuffer(64)], "photo.png", { type: "image/png" });
+  useFileStore.getState().setFiles([file]);
+  const hook = renderHook(() => usePipelineProcessor());
+  act(() => {
+    hook.result.current.processSingle(file, STEPS);
+  });
+  return hook;
+}
+
+function startBatchRun() {
+  const files = [
+    new File([new ArrayBuffer(16)], "first.png", { type: "image/png" }),
+    new File([new ArrayBuffer(16)], "second.jpg", { type: "image/jpeg" }),
+  ];
+  useFileStore.getState().setFiles(files);
+  const hook = renderHook(() => usePipelineProcessor());
+  act(() => {
+    void hook.result.current.processAll(files, STEPS);
+  });
+  return hook;
+}
+
+async function settled(check: () => void) {
+  await vi.waitFor(check, { timeout: 3_000 });
+}
+
+/**
+ * #766: the pipeline hook gets the #750 treatment. A dead response after the
+ * upload finished degrades to the async path; the terminal SSE frame settles
+ * the run (the single frame's own result, or the batch frame's durable ZIP).
+ */
+describe("usePipelineProcessor single-run recovery (#766)", () => {
+  it("degrades a dead post-upload socket and settles from the terminal single frame", () => {
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    // Not an error: the flow is live server-side and tracked via SSE.
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    act(() => {
+      sendSingleFrame({ phase: "complete", percent: 100, result: SINGLE_RESULT });
+    });
+
+    expect(useFileStore.getState().entries[0]).toMatchObject({
+      status: "completed",
+      processedUrl: SINGLE_RESULT.downloadUrl,
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("still fails immediately when the socket dies mid-upload", () => {
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      // No upload.onload: the request body never fully left the browser.
+      xhrs[0].onerror?.();
+    });
+
+    expect(useFileStore.getState().error).toBe(
+      "Processing was interrupted. Retry when reconnected.",
+    );
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("degrades a post-upload 502 with an unparseable body and tracks it", async () => {
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 502;
+      xhrs[0].responseText = "<html><body>502 Bad Gateway</body></html>";
+      xhrs[0].onload?.();
+    });
+
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    await settled(() => {
+      expect(vi.mocked(track)).toHaveBeenCalledWith("tool_run_degraded", {
+        tool_id: "pipeline",
+        is_batch: false,
+        trigger: "http-502",
+        had_evidence: false,
+      });
+    });
+
+    act(() => {
+      sendSingleFrame({ phase: "complete", percent: 100, result: SINGLE_RESULT });
+    });
+    expect(useFileStore.getState().entries[0].status).toBe("completed");
+
+    unmount();
+  });
+
+  it("keeps the precise error for a 504 with a JSON body", () => {
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 504;
+      xhrs[0].responseText = JSON.stringify({ error: "Page took too long to load" });
+      xhrs[0].onload?.();
+    });
+
+    expect(useFileStore.getState().error).toBe("error");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("treats a 202 as the async contract and settles from the terminal frame", () => {
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 202;
+      xhrs[0].responseText = JSON.stringify({ jobId: JOB_ID, async: true });
+      xhrs[0].onload?.();
+    });
+    expect(useFileStore.getState().processing).toBe(true);
+    expect(useFileStore.getState().error).toBeNull();
+
+    act(() => {
+      sendSingleFrame({ phase: "complete", percent: 100, result: SINGLE_RESULT });
+    });
+    expect(useFileStore.getState().entries[0].status).toBe("completed");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("surfaces the never-confirmed error when no evidence ever arrives", () => {
+    vi.useFakeTimers();
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    expect(useFileStore.getState().processing).toBe(true);
+
+    act(() => {
+      latestSse().onmessage?.({
+        data: JSON.stringify({ type: "heartbeat" }),
+      } as MessageEvent);
+      vi.advanceTimersByTime(30_001);
+    });
+
+    expect(useFileStore.getState().error).toBe(
+      "Processing was interrupted and the server never confirmed the job. Retry when reconnected.",
+    );
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("settles a failed frame with its step error", () => {
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    act(() => {
+      sendSingleFrame({ phase: "failed", percent: 0, error: "Step 2: kaboom" });
+    });
+
+    expect(useFileStore.getState().error).toBe("Step 2: kaboom");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+});
+
+describe("usePipelineProcessor batch recovery (#766)", () => {
+  it("settles the happy path from the XHR response ZIP", async () => {
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 200;
+      xhrs[0].response = zipBlob();
+      xhrs[0].getResponseHeader = vi.fn((name: string) =>
+        name === "X-File-Results" ? encodedFileResults() : null,
+      );
+      xhrs[0].onload?.();
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[0].status).toBe("completed");
+      expect(useFileStore.getState().entries[1].status).toBe("completed");
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+    expect(useFileStore.getState().batchZipBlob).not.toBeNull();
+
+    unmount();
+  });
+
+  it("ignores the terminal frame in sync mode so the response cannot double-settle", async () => {
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      sendBatchFrame(completedBatchTerminal());
+    });
+    expect(useFileStore.getState().processing).toBe(true);
+
+    act(() => {
+      xhrs[0].status = 200;
+      xhrs[0].response = zipBlob();
+      xhrs[0].getResponseHeader = vi.fn((name: string) =>
+        name === "X-File-Results" ? encodedFileResults() : null,
+      );
+      xhrs[0].onload?.();
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[0].status).toBe("completed");
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("degrades a dead post-upload socket and settles from the durable ZIP", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 200, blob: () => Promise.resolve(zipBlob()) }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    await settled(() => {
+      expect(vi.mocked(track)).toHaveBeenCalledWith("tool_run_degraded", {
+        tool_id: "pipeline",
+        is_batch: true,
+        trigger: "socket",
+        had_evidence: false,
+      });
+    });
+
+    act(() => {
+      sendBatchFrame(completedBatchTerminal());
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[0].status).toBe("completed");
+      expect(useFileStore.getState().entries[1].status).toBe("completed");
+    });
+    expect(fetchMock).toHaveBeenCalledWith(BATCH_RESULT.downloadUrl, expect.anything());
+    expect(useFileStore.getState().batchZipBlob).not.toBeNull();
+
+    unmount();
+  });
+
+  it("treats a 202 as the async contract and settles from the terminal frame", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 200, blob: () => Promise.resolve(zipBlob()) }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 202;
+      xhrs[0].onload?.();
+    });
+    expect(useFileStore.getState().processing).toBe(true);
+    expect(useFileStore.getState().error).toBeNull();
+
+    act(() => {
+      sendBatchFrame(completedBatchTerminal());
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[1].status).toBe("completed");
+    });
+
+    unmount();
+  });
+
+  it("fails the run when the terminal frame reports every file failed", async () => {
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    act(() => {
+      sendBatchFrame({
+        status: "failed",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 2,
+        errors: [
+          { filename: "first.png", error: "Step 1: corrupt" },
+          { filename: "second.jpg", error: "Step 1: corrupt" },
+        ],
+      });
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().error).toBe("All files failed processing");
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("fails a degraded run when a completed terminal frame has no durable result", async () => {
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    act(() => {
+      sendBatchFrame({
+        status: "completed",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 0,
+        errors: [],
+      });
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().error).toBe(
+        "Processing was interrupted. Retry when reconnected.",
+      );
+    });
+
+    unmount();
+  });
+
+  it("fails fast with the right message when the durable ZIP is already gone", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: false, status: 404, blob: () => Promise.resolve(new Blob()) }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    act(() => {
+      sendBatchFrame(completedBatchTerminal());
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().error).toBe(
+        "Completed result is no longer available. Run the job again.",
+      );
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+
+  it("skips the evidence timer when a batch frame already proved the flow exists", () => {
+    vi.useFakeTimers();
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      sendBatchFrame({
+        status: "processing",
+        totalFiles: 2,
+        completedFiles: 0,
+        failedFiles: 0,
+        errors: [],
+      });
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    unmount();
+  });
+});

--- a/tests/unit/web/use-pipeline-processor-recovery.test.ts
+++ b/tests/unit/web/use-pipeline-processor-recovery.test.ts
@@ -327,6 +327,92 @@ describe("usePipelineProcessor single-run recovery (#766)", () => {
     unmount();
   });
 
+  it("recovers through the stall timer when the terminal frame was missed", () => {
+    vi.useFakeTimers();
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      // Evidence first, so the 30s evidence timer never arms and the 300s
+      // stall timer is the recovery path under test.
+      sendSingleFrame({ phase: "processing", percent: 40, stage: "Step 1/1" });
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    const sourcesAfterDegrade = MockEventSource.instances.length;
+
+    // The terminal frame never arrives on this source (half-open SSE). The
+    // stall timer must force a fresh source, whose server-side replay then
+    // delivers the terminal frame.
+    act(() => {
+      vi.advanceTimersByTime(300_001);
+    });
+    expect(MockEventSource.instances.length).toBeGreaterThan(sourcesAfterDegrade);
+    expect(useFileStore.getState().processing).toBe(true);
+
+    act(() => {
+      sendSingleFrame({ phase: "complete", percent: 100, result: SINGLE_RESULT });
+    });
+    expect(useFileStore.getState().entries[0].status).toBe("completed");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("recovers via the visibility handler when the tab comes back with a dead SSE", () => {
+    vi.useFakeTimers();
+    const { unmount } = startSingleRun();
+
+    act(() => {
+      sendSingleFrame({ phase: "processing", percent: 40, stage: "Step 1/1" });
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    // The phone comes back from background with a source that died while
+    // suspended: not OPEN, so the handler must open a fresh one able to
+    // settle the run (the old handler could only render progress).
+    act(() => {
+      latestSse().readyState = 2;
+      document.dispatchEvent(new Event("visibilitychange"));
+      vi.advanceTimersByTime(501);
+    });
+
+    act(() => {
+      sendSingleFrame({ phase: "complete", percent: 100, result: SINGLE_RESULT });
+    });
+    expect(useFileStore.getState().entries[0].status).toBe("completed");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("keeps a degraded run's leftovers away from the next run", () => {
+    vi.useFakeTimers();
+    const { result, unmount } = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    expect(useFileStore.getState().processing).toBe(true);
+
+    // Second run: the previous run's evidence timer must not fire into it.
+    const file = new File([new ArrayBuffer(64)], "photo2.png", { type: "image/png" });
+    act(() => {
+      useFileStore.getState().setFiles([file]);
+      result.current.processSingle(file, STEPS);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    unmount();
+  });
+
   it("settles a failed frame with its step error", () => {
     const { unmount } = startSingleRun();
 
@@ -539,6 +625,81 @@ describe("usePipelineProcessor batch recovery (#766)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     unmount();
+  });
+
+  it("degrades a batch 502 whose blob body is not JSON", async () => {
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 502;
+      xhrs[0].response = new Blob(["<html><body>502 Bad Gateway</body></html>"], {
+        type: "text/html",
+      });
+      xhrs[0].onload?.();
+    });
+
+    // The 5xx body read is async (Blob.text), so the degrade lands a tick
+    // later; what must never happen is an error.
+    await settled(() => {
+      expect(vi.mocked(track)).toHaveBeenCalledWith("tool_run_degraded", {
+        tool_id: "pipeline",
+        is_batch: true,
+        trigger: "http-502",
+        had_evidence: false,
+      });
+    });
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(true);
+
+    unmount();
+  });
+
+  it("keeps original-index alignment when fileResults has a hole", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 200, blob: () => Promise.resolve(zipBlob()) }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const files = [
+      new File([new ArrayBuffer(16)], "good1.png", { type: "image/png" }),
+      new File([new ArrayBuffer(16)], "bad.png", { type: "image/png" }),
+      new File([new ArrayBuffer(16)], "good2.jpg", { type: "image/jpeg" }),
+    ];
+    useFileStore.getState().setFiles(files);
+    const hook = renderHook(() => usePipelineProcessor());
+    act(() => {
+      void hook.result.current.processAll(files, STEPS);
+    });
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    act(() => {
+      // Slot 1 pre-failed server-side: it is a hole in fileResults, and the
+      // outputs for slots 0 and 2 must not shift into it.
+      sendBatchFrame({
+        status: "completed",
+        totalFiles: 3,
+        completedFiles: 3,
+        failedFiles: 1,
+        errors: [{ filename: "bad.png", error: "Invalid image" }],
+        result: {
+          ...BATCH_RESULT,
+          fileResults: { "0": "first_resize.png", "2": "second_resize.jpg" },
+        },
+      });
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[0].status).toBe("completed");
+      expect(useFileStore.getState().entries[2].status).toBe("completed");
+    });
+    expect(useFileStore.getState().entries[0].processedFilename).toBe("first_resize.png");
+    expect(useFileStore.getState().entries[1].status).toBe("failed");
+    expect(useFileStore.getState().entries[2].processedFilename).toBe("second_resize.jpg");
+
+    hook.unmount();
   });
 
   it("skips the evidence timer when a batch frame already proved the flow exists", () => {


### PR DESCRIPTION
Fixes #766. The pipeline hook gets the #750 treatment (#765 already shipped the durable-ZIP server side, since both batch routes share the finalize), and both pipeline routes stop answering a fake "timed out" while the flow keeps running.

**Client.** `use-pipeline-processor` now mirrors `use-tool-processor`'s recovery machinery, keeping the pipeline flavor where it differs (per-file step error formatting, `batch-pipeline.zip` naming, no library save):

- A dead response after the upload finished degrades to the async path instead of erroring, on both single runs and batches. Socket death and an unparseable 502/504 body qualify; app-emitted 5xx keeps its precise message.
- Degraded single runs settle from the terminal single frame, which has carried the full pipeline result all along. Degraded batches settle by downloading the durable ZIP from the terminal batch frame, with 4xx failing fast on an accurate message.
- The #722 evidence timer tells "the flow never reached the server" apart from "the flow is running"; the 300s stall timer forces a fresh SSE whose replay recovers a missed terminal frame. The batch path moved from fetch to XHR, which also gives pipeline batches real upload progress.
- Degrades emit `tool_run_degraded` with `tool_id: "pipeline"`.

**Server.** Both `waitForJob` expiry branches answer `202 {jobId, async: true}` (10-minute execute wait, 30-minute batch wait); the client rides the SSE to the terminal frame. This is the change #765 held back because the old client would have tried to unzip the 202 JSON body.

`buildPipelineFlowTree` puts `ignoreDependencyOnFailure` on step nodes and on the per-file finalize root when it is a batch child. Steps already swallow their own failures, so the only hard failure left is stall eviction (OOM kill), which used to wedge the parent in waiting-children forever. Now the next step runs, sees the predecessor has no output, and propagates a clean failure to the finalize; a wedged pipeline becomes a reported failure (or a partial batch result) instead of an eternal spinner.

**Hardening from review.** Three findings landed, one of them critical:

- A hard-failed pipeline finalize (storage blip during the output copy, preview write, stall eviction of the finalize itself) published no terminal frame at all, and the 202/degrade paths made that frame load-bearing: a degraded client would spin forever on heartbeats and nonterminal replays. The pool workers' failed handler now runs the pipeline twin of #765's batch safety net (`failSingleJobGuarded`): a guarded terminal failed write plus frame under the id the client watches, never downgrading a committed completion, covering both the clientJobId channel and the authoritative flow row since they differ for pipelines.
- The single-run XHR carried a 600s wall clock while the server holds the response for up to 10 minutes, so the client timeout always fired first: the restored 202 was dead code for the web client and every legitimately long pipeline emitted a spurious `tool_run_degraded` with `trigger: timeout`, polluting the one signal the fallback design gives operators. The timeout is now 0; liveness belongs to the SSE settle and the evidence and stall timers, same as the batch path.
- The execute route published its initial progress frame fire-and-forget, but that publish creates the client-facing row the SSE replays, which is exactly the evidence a degraded client's fresh connection relies on. A failed insert would have fabricated "the server never confirmed the job" for a queued flow. It is awaited now.

**Known limits.** Pipelines still have no cancel affordance; that is #767 territory (there is no server-side batch or flow cancel to wire a button to). A terminal single frame with `phase: complete` and no `result` is ignored by design in both hooks; the server cannot produce one (live finalize frames always attach the result, and the replay builder converts result-less completed rows into an explicit failure). A true stall-eviction test is not feasible in-process (it needs an evicted lock holder), so the `ignoreDependencyOnFailure` wiring is pinned via job opts instead, with the propagation halves covered by existing worker tests.

**Tests.** 20 jsdom tests on the hook (degrade matrix for both paths, terminal settles, evidence timer both ways, stall-timer recovery, visibility recovery with a dead source, cross-run leftover hygiene, 202s, 4xx fast-fail, result-less terminal, holey fileResults alignment, sync-mode double-settle guard, degrade telemetry, and the 504-JSON no-regression pin), 3 integration tests pinning the 202 contract end to end (execute with and without a clientJobId, batch with a durable two-entry ZIP download, plus the opts drift pin), and the finalize hard-fail test extended to assert the safety net's terminal frame and row transition.

Verified: typecheck 9/9, Biome clean on the diff, full unit suite 8362 passed, platform integration 1642 passed, pipeline and automate e2e 52 passed.
