### PR TITLE
fix(web,api): batch runs can be canceled

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -54,7 +54,7 @@ Emitted from `apps/web` through `track()`; properties are filtered by the `ALLOW
 | `tool_opened` | A tool page opens | `tool_id`, `category`, `modality` |
 | `file_added` | Files are added | `file_count` |
 | `tool_started` | Processing starts | `tool_id`, `is_batch`, `file_count` |
-| `batch_processed` | A batch run finishes | `tool_id`, `file_count`, `status` (`completed`, `failed`, or `canceled`; canceled is intent-based: the user clicked cancel, even if the batch finished first) |
+| `batch_processed` | A batch run finishes | `tool_id`, `file_count`, `status` (`completed`, `failed`, or `canceled`; canceled means the server acknowledged a cancel request during the run, even if every file had already finished) |
 | `result_downloaded` | A result is downloaded | `tool_id` |
 | `result_saved` | A result is saved to the library | `tool_id` |
 | `search` | A tool search runs | `results_count`, `clicked_tool_id` |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -54,7 +54,7 @@ Emitted from `apps/web` through `track()`; properties are filtered by the `ALLOW
 | `tool_opened` | A tool page opens | `tool_id`, `category`, `modality` |
 | `file_added` | Files are added | `file_count` |
 | `tool_started` | Processing starts | `tool_id`, `is_batch`, `file_count` |
-| `batch_processed` | A batch run finishes | `tool_id`, `file_count`, `status` |
+| `batch_processed` | A batch run finishes | `tool_id`, `file_count`, `status` (`completed`, `failed`, or `canceled`; canceled is intent-based: the user clicked cancel, even if the batch finished first) |
 | `result_downloaded` | A result is downloaded | `tool_id` |
 | `result_saved` | A result is saved to the library | `tool_id` |
 | `search` | A tool search runs | `results_count`, `clicked_tool_id` |

--- a/apps/api/src/jobs/batch-progress.ts
+++ b/apps/api/src/jobs/batch-progress.ts
@@ -81,11 +81,14 @@ export async function markBatchCanceled(parentId: string): Promise<void> {
 
 /** Whether a cooperative batch cancel was requested. A Redis read fault
  * reports false: keep-working is the safe direction, and a Redis outage has
- * already stopped the queues themselves. */
+ * already stopped the queues themselves. The swallowed error is still
+ * logged, because at the finalize this read labels the terminal outcome and
+ * a silent false can commit "completed" for a canceled batch. */
 export async function isBatchCanceled(parentId: string): Promise<boolean> {
   try {
     return (await sharedRedis().exists(canceledKey(parentId))) === 1;
-  } catch {
+  } catch (err) {
+    console.error("batch cancel flag read failed", parentId, err);
     return false;
   }
 }

--- a/apps/api/src/jobs/batch-progress.ts
+++ b/apps/api/src/jobs/batch-progress.ts
@@ -71,6 +71,25 @@ export async function recordChildOutcome(
   });
 }
 
+const canceledKey = (parentId: string) => `${bullPrefix()}:batch:${parentId}:canceled`;
+
+/** Flag a batch as canceled (#767). Children consult the flag before doing
+ * any work; the TTL matches the outcome counters above. */
+export async function markBatchCanceled(parentId: string): Promise<void> {
+  await sharedRedis().setex(canceledKey(parentId), 3600, "1");
+}
+
+/** Whether a cooperative batch cancel was requested. A Redis read fault
+ * reports false: keep-working is the safe direction, and a Redis outage has
+ * already stopped the queues themselves. */
+export async function isBatchCanceled(parentId: string): Promise<boolean> {
+  try {
+    return (await sharedRedis().exists(canceledKey(parentId))) === 1;
+  } catch {
+    return false;
+  }
+}
+
 export interface BatchCounters {
   done: number;
   failed: number;

--- a/apps/api/src/jobs/cancel.ts
+++ b/apps/api/src/jobs/cancel.ts
@@ -95,6 +95,12 @@ export async function requestCancel(jobId: string): Promise<boolean> {
     // Pipeline-batch children are pipeline flows without a cooperative
     // check; a flag would report canceled while every step keeps running.
     if (row.toolId === "pipeline-batch") return false;
+    // Custom batch sub-routes (pdf-to-image, svg-to-raster) process inline
+    // and only publish progress frames; their rows are implicit inserts with
+    // no settings and nothing reads the flag. Claiming canceled: true for
+    // them would be a lie. Real batch parents write settings (with
+    // flowChildCount) at insert time, before the enqueue window.
+    if (!row.settings) return false;
     if (row.status === "completed" || row.status === "failed" || row.status === "canceled") {
       return false;
     }
@@ -102,7 +108,14 @@ export async function requestCancel(jobId: string): Promise<boolean> {
     const flowChildCount =
       (row.settings as { flowChildCount?: number } | null)?.flowChildCount ?? 0;
     for (let i = 0; i < flowChildCount; i++) {
-      await sharedRedis().publish(CANCEL_CHANNEL(), `${jobId}-f${i}`);
+      // Best-effort accelerant for active children; the flag above is the
+      // durable mechanism, so one failed publish must not 500 a cancel that
+      // already committed.
+      await sharedRedis()
+        .publish(CANCEL_CHANNEL(), `${jobId}-f${i}`)
+        .catch((err) => {
+          console.error("batch child cancel publish failed", `${jobId}-f${i}`, err);
+        });
     }
     return true;
   }

--- a/apps/api/src/jobs/cancel.ts
+++ b/apps/api/src/jobs/cancel.ts
@@ -2,11 +2,13 @@
  * Cooperative job cancellation via Redis pub/sub.
  *
  * - Workers call registerCancelable(jobId) on start and unregister on finish.
- * - requestCancel(jobId) handles three states:
- *   1. Waiting/delayed: remove from queue, mark DB row canceled.
- *   2. Active (in a worker): publish the jobId on the cancel channel;
+ * - requestCancel(jobId) handles four states:
+ *   1. Batch parent: flag the batch canceled and publish every flow child
+ *      id on the cancel channel; batch-finalize commits terminal state (#767).
+ *   2. Waiting/delayed: remove from queue, mark DB row canceled.
+ *   3. Active (in a worker): publish the jobId on the cancel channel;
  *      the worker's AbortSignal fires and it cleans up.
- *   3. Terminal or absent: no-op, returns false.
+ *   4. Terminal or absent: no-op, returns false.
  * - startCancelListener() subscribes to the cancel channel and fires
  *   registered AbortControllers.
  */
@@ -14,6 +16,7 @@
 import { eq } from "drizzle-orm";
 import type Redis from "ioredis";
 import { db, schema } from "../db/index.js";
+import { markBatchCanceled } from "./batch-progress.js";
 import { createRedisSubscriberConnection, sharedRedis } from "./connection.js";
 import { getQueue } from "./queues.js";
 import { bullPrefix, POOLS } from "./types.js";
@@ -71,6 +74,39 @@ export async function stopCancelListener(): Promise<void> {
  * terminal or not found in any queue.
  */
 export async function requestCancel(jobId: string): Promise<boolean> {
+  // Batch parents never match the single-job states below: they sit in
+  // waiting-children while their <parentId>-fN children run, so a cancel
+  // against the parent id used to cancel nothing (#767). Cancel them
+  // cooperatively instead: flag the batch (children consult the flag before
+  // doing any work), abort active children over the cancel channel, and let
+  // batch-finalize commit the canceled terminal state. Keyed off the DB row,
+  // not the queue job, so a cancel landing between the parent row insert and
+  // the flow enqueue still takes effect.
+  const [row] = await db
+    .select({
+      type: schema.jobs.type,
+      toolId: schema.jobs.toolId,
+      status: schema.jobs.status,
+      settings: schema.jobs.settings,
+    })
+    .from(schema.jobs)
+    .where(eq(schema.jobs.id, jobId));
+  if (row?.type === "batch") {
+    // Pipeline-batch children are pipeline flows without a cooperative
+    // check; a flag would report canceled while every step keeps running.
+    if (row.toolId === "pipeline-batch") return false;
+    if (row.status === "completed" || row.status === "failed" || row.status === "canceled") {
+      return false;
+    }
+    await markBatchCanceled(jobId);
+    const flowChildCount =
+      (row.settings as { flowChildCount?: number } | null)?.flowChildCount ?? 0;
+    for (let i = 0; i < flowChildCount; i++) {
+      await sharedRedis().publish(CANCEL_CHANNEL(), `${jobId}-f${i}`);
+    }
+    return true;
+  }
+
   for (const pool of POOLS) {
     const queue = getQueue(pool);
     const job = await queue.getJob(jobId);

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -993,26 +993,39 @@ async function processBatchChild(job: Job<ToolJobData>): Promise<ToolJobResult> 
   // work at all. Active children are aborted through the cancel channel and
   // land in the catch below via processToolJob's own cancel handling. The
   // guarded write cannot clobber a row another path already settled.
-  if (parentId && (await isBatchCanceled(parentId))) {
-    await db
-      .update(schema.jobs)
-      .set({ status: "canceled", completedAt: new Date(), error: { message: "Canceled" } })
-      .where(
-        and(
-          eq(schema.jobs.id, job.data.jobId),
-          notInArray(schema.jobs.status, ["completed", "failed", "canceled"]),
-        ),
+  if (parentId) {
+    try {
+      if (await isBatchCanceled(parentId)) {
+        await db
+          .update(schema.jobs)
+          .set({ status: "canceled", completedAt: new Date(), error: { message: "Canceled" } })
+          .where(
+            and(
+              eq(schema.jobs.id, job.data.jobId),
+              notInArray(schema.jobs.status, ["completed", "failed", "canceled"]),
+            ),
+          );
+        jobsTotal.inc({ pool: job.data.pool, status: "canceled" });
+        await recordChildOutcome(parentId, totalFiles, job.data.filename, "Canceled");
+        return {
+          outputRefs: [],
+          filename: job.data.filename,
+          contentType: "",
+          originalSize: 0,
+          processedSize: 0,
+          resultPayload: { failed: true, canceled: true, error: "Canceled" },
+        };
+      }
+    } catch (err) {
+      // The skip must stay inside this function's no-throw contract: a hard
+      // failure here would leave the child row non-terminal forever
+      // (attempts: 1, and nothing else revisits it). Fall through and
+      // process normally instead; the file becomes a too-late cancel.
+      logger.warn(
+        { err, jobId: job.data.jobId, parentId },
+        "batch cancel skip failed; processing the child normally",
       );
-    jobsTotal.inc({ pool: job.data.pool, status: "canceled" });
-    await recordChildOutcome(parentId, totalFiles, job.data.filename, "Canceled");
-    return {
-      outputRefs: [],
-      filename: job.data.filename,
-      contentType: "",
-      originalSize: 0,
-      processedSize: 0,
-      resultPayload: { failed: true, canceled: true, error: "Canceled" },
-    };
+    }
   }
   try {
     const result = await processToolJob(job);

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -38,7 +38,7 @@ import {
 } from "@snapotter/shared";
 import archiver from "archiver";
 import { type Job, UnrecoverableError, Worker } from "bullmq";
-import { eq } from "drizzle-orm";
+import { and, eq, notInArray } from "drizzle-orm";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { trackEvent } from "../lib/analytics.js";
@@ -63,6 +63,7 @@ import { setSettingIfAbsent } from "../lib/settings-helpers.js";
 import { timeoutMessage } from "../lib/timeout.js";
 import { InputValidationError } from "../modality/contract.js";
 import {
+  cancelBatchJob,
   completeBatchJob,
   failBatchJob,
   failSingleJobGuarded,
@@ -82,7 +83,7 @@ import {
   runAiPathToolJob,
   runAiToolJob,
 } from "./ai-handlers.js";
-import { readBatchCounters, recordChildOutcome } from "./batch-progress.js";
+import { isBatchCanceled, readBatchCounters, recordChildOutcome } from "./batch-progress.js";
 import { registerCancelable, unregisterCancelable } from "./cancel.js";
 import { createBullMQConnection } from "./connection.js";
 import { createMonotonicReporter } from "./monotonic-progress.js";
@@ -988,6 +989,31 @@ async function processPipelineFinalize(job: Job<ToolJobData>): Promise<ToolJobRe
 async function processBatchChild(job: Job<ToolJobData>): Promise<ToolJobResult> {
   const parentId = job.data.parentId ?? "";
   const totalFiles = job.data.totalFiles ?? 0;
+  // Cooperative batch cancel (#767): children queued behind the cancel do no
+  // work at all. Active children are aborted through the cancel channel and
+  // land in the catch below via processToolJob's own cancel handling. The
+  // guarded write cannot clobber a row another path already settled.
+  if (parentId && (await isBatchCanceled(parentId))) {
+    await db
+      .update(schema.jobs)
+      .set({ status: "canceled", completedAt: new Date(), error: { message: "Canceled" } })
+      .where(
+        and(
+          eq(schema.jobs.id, job.data.jobId),
+          notInArray(schema.jobs.status, ["completed", "failed", "canceled"]),
+        ),
+      );
+    jobsTotal.inc({ pool: job.data.pool, status: "canceled" });
+    await recordChildOutcome(parentId, totalFiles, job.data.filename, "Canceled");
+    return {
+      outputRefs: [],
+      filename: job.data.filename,
+      contentType: "",
+      originalSize: 0,
+      processedSize: 0,
+      resultPayload: { failed: true, canceled: true, error: "Canceled" },
+    };
+  }
   try {
     const result = await processToolJob(job);
     await recordChildOutcome(parentId, totalFiles, job.data.filename);
@@ -1132,6 +1158,7 @@ async function processBatchFinalize(job: Job<ToolJobData>): Promise<ToolJobResul
     error?: string;
   }> = [];
 
+  let canceledChildren = 0;
   for (let i = 0; i < flowChildCount; i++) {
     const childId = `${data.jobId}-f${i}`;
     const [row] = await db.select().from(schema.jobs).where(eq(schema.jobs.id, childId));
@@ -1145,6 +1172,7 @@ async function processBatchFinalize(job: Job<ToolJobData>): Promise<ToolJobResul
       const outFilename = row.outputRefs[0].split("/").pop() ?? "output";
       manifest.push({ index: i, filename: outFilename, outputRef: row.outputRefs[0] });
     } else {
+      if (row.status === "canceled") canceledChildren++;
       const errorMsg = (row.error as { message?: string } | null)?.message ?? "Processing failed";
       const inputFilename = row.inputRefs?.[0]?.split("/").pop() ?? `file-${i}`;
       manifest.push({ index: i, filename: inputFilename, error: friendlyError(errorMsg) });
@@ -1166,6 +1194,30 @@ async function processBatchFinalize(job: Job<ToolJobData>): Promise<ToolJobResul
 
   const counters = await readBatchCounters(data.jobId);
   const failedFiles = Math.max(0, totalFiles - successEntries.length);
+
+  // Cancel requires both halves: the flag proves a cancel was requested, a
+  // canceled child proves it landed before the work finished. A flag with
+  // zero canceled children means every file completed first; that batch
+  // completes normally, matching a too-late cancel on a single run.
+  const canceled = canceledChildren > 0 && (await isBatchCanceled(data.jobId));
+
+  if (canceled && successEntries.length === 0) {
+    await cancelBatchJob({
+      jobId: data.jobId,
+      totalFiles,
+      completedFiles: totalFiles,
+      failedFiles,
+      errors: [{ filename: "", error: "Canceled" }, ...counters.errors],
+    });
+    return {
+      outputRefs: [],
+      filename: "",
+      contentType: "application/json",
+      originalSize: 0,
+      processedSize: 0,
+      resultPayload: { manifest, canceled: true, allFailed: true },
+    };
+  }
 
   if (successEntries.length === 0) {
     await failBatchJob({
@@ -1223,16 +1275,29 @@ async function processBatchFinalize(job: Job<ToolJobData>): Promise<ToolJobResul
     processedSize: zipSize,
   };
 
-  await completeBatchJob({
-    jobId: data.jobId,
-    totalFiles,
-    completedFiles: totalFiles,
-    failedFiles,
-    errors: counters.errors,
-    outputRefs: [zipKey],
-    bytesOut: zipSize,
-    result,
-  });
+  if (canceled) {
+    await cancelBatchJob({
+      jobId: data.jobId,
+      totalFiles,
+      completedFiles: totalFiles,
+      failedFiles,
+      errors: counters.errors,
+      outputRefs: [zipKey],
+      bytesOut: zipSize,
+      result,
+    });
+  } else {
+    await completeBatchJob({
+      jobId: data.jobId,
+      totalFiles,
+      completedFiles: totalFiles,
+      failedFiles,
+      errors: counters.errors,
+      outputRefs: [zipKey],
+      bytesOut: zipSize,
+      result,
+    });
+  }
 
   return {
     outputRefs: [zipKey],
@@ -1242,6 +1307,7 @@ async function processBatchFinalize(job: Job<ToolJobData>): Promise<ToolJobResul
     processedSize: zipSize,
     resultPayload: {
       manifest,
+      ...(canceled ? { canceled: true } : {}),
       zip: { key: zipKey, filename: zipFilename, size: zipSize, fileResults },
     },
   };

--- a/apps/api/src/routes/batch.ts
+++ b/apps/api/src/routes/batch.ts
@@ -564,6 +564,9 @@ export async function registerBatchRoutes(app: FastifyInstance): Promise<void> {
             const manifestFailures = (payload?.manifest ?? []).filter((m) => !m.outputRef);
             return reply.status(422).send({
               error: payload?.canceled ? "Batch canceled" : "All files failed processing",
+              // Structured so clients key on the outcome instead of matching
+              // the message string.
+              ...(payload?.canceled ? { canceled: true } : {}),
               errors: [
                 ...preFailures.map((f) => ({ filename: f.filename, error: f.error })),
                 ...manifestFailures.map((f) => ({

--- a/apps/api/src/routes/batch.ts
+++ b/apps/api/src/routes/batch.ts
@@ -545,6 +545,7 @@ export async function registerBatchRoutes(app: FastifyInstance): Promise<void> {
                   outputRef?: string;
                   error?: string;
                 }>;
+                canceled?: boolean;
                 zip?: {
                   key: string;
                   filename: string;
@@ -556,11 +557,13 @@ export async function registerBatchRoutes(app: FastifyInstance): Promise<void> {
 
           const zip = payload?.zip;
           if (!zip) {
-            // Every file failed; the finalize already published the terminal
-            // failed frame. Mirror it on the HTTP contract.
+            // No file produced output; the finalize already published the
+            // terminal frame. Mirror it on the HTTP contract. A fully
+            // canceled batch is not a processing failure; keep the message
+            // honest for API consumers that never see the SSE (#767).
             const manifestFailures = (payload?.manifest ?? []).filter((m) => !m.outputRef);
             return reply.status(422).send({
-              error: "All files failed processing",
+              error: payload?.canceled ? "Batch canceled" : "All files failed processing",
               errors: [
                 ...preFailures.map((f) => ({ filename: f.filename, error: f.error })),
                 ...manifestFailures.map((f) => ({

--- a/apps/api/src/routes/progress.ts
+++ b/apps/api/src/routes/progress.ts
@@ -179,16 +179,21 @@ export function buildBatchReplayEvent(row: BatchReplayRow): JobProgress & { type
     return { ...base, status: "processing", errors: [] };
   }
 
-  if (row.status === "completed") {
-    const result = isRecord(progress.result) ? progress.result : undefined;
-    if (!result) {
-      return {
-        ...base,
-        status: "failed",
-        errors: [{ filename: "", error: MISSING_DURABLE_RESULT_ERROR }],
-      };
-    }
+  const result = isRecord(progress.result) ? progress.result : undefined;
+  // A canceled batch that packaged its finished files before stopping replays
+  // as completed-with-result so the partial ZIP stays reachable after the
+  // Redis terminal key expires (#767). Only a resultless completed row is a
+  // lost result; a resultless canceled row is a full cancellation and takes
+  // the failed shape below.
+  if (result && (row.status === "completed" || row.status === "canceled")) {
     return { ...base, status: "completed", errors: storedBatchErrors(row.error), result };
+  }
+  if (row.status === "completed") {
+    return {
+      ...base,
+      status: "failed",
+      errors: [{ filename: "", error: MISSING_DURABLE_RESULT_ERROR }],
+    };
   }
 
   const errors = storedBatchErrors(row.error);
@@ -441,6 +446,12 @@ export interface CompleteBatchJobArgs {
  * replay can never observe the frame without the durable state behind it.
  * Runs through the per-job persist queue: earlier fire-and-forget child
  * frames land first and cannot overwrite this write afterwards.
+ *
+ * Guarded since #767: with real batch cancel, cancelBatchJob commits
+ * "canceled" from the same finalize, so nothing may overwrite an existing
+ * terminal state (the remaining writer conflict is a stall-evicted zombie
+ * finalize double-writing). A call that lost the transition announces
+ * nothing, so a duplicate frame can never contradict the committed outcome.
  */
 export async function completeBatchJob(args: CompleteBatchJobArgs): Promise<void> {
   const frame: JobProgress & { type: "batch" } = {
@@ -453,8 +464,9 @@ export async function completeBatchJob(args: CompleteBatchJobArgs): Promise<void
     errors: args.errors,
     result: args.result,
   };
+  let applied = false;
   await enqueuePersist(args.jobId, async () => {
-    await db
+    const res = await db
       .update(schema.jobs)
       .set({
         status: "completed",
@@ -467,9 +479,70 @@ export async function completeBatchJob(args: CompleteBatchJobArgs): Promise<void
             ? { message: `${args.errors.length} file(s) failed`, details: args.errors }
             : null,
       })
-      .where(eq(schema.jobs.id, args.jobId));
+      .where(
+        and(
+          eq(schema.jobs.id, args.jobId),
+          notInArray(schema.jobs.status, ["completed", "failed", "canceled"]),
+        ),
+      );
+    applied = ((res as { rowCount?: number | null } | undefined)?.rowCount ?? 0) > 0;
   });
-  announce(frame);
+  if (applied) announce(frame);
+}
+
+export interface CancelBatchJobArgs {
+  jobId: string;
+  totalFiles: number;
+  completedFiles: number;
+  failedFiles: number;
+  errors: Array<{ filename: string; error: string }>;
+  outputRefs?: string[];
+  bytesOut?: number;
+  result?: Record<string, unknown>;
+}
+
+/**
+ * Terminal batch cancellation (#767). The authoritative row becomes
+ * "canceled" either way; the announced frame reuses the existing wire
+ * vocabulary so clients need no new terminal type: completed-with-result
+ * when finished files were packaged (the client settles on the partial ZIP),
+ * failed with a leading blank-name "Canceled" entry when nothing survived.
+ * Guarded like failBatchJob: never downgrades a committed terminal state and
+ * announces only a transition it owned.
+ */
+export async function cancelBatchJob(args: CancelBatchJobArgs): Promise<void> {
+  const base = {
+    jobId: args.jobId,
+    type: "batch" as const,
+    totalFiles: args.totalFiles,
+    completedFiles: args.completedFiles,
+    failedFiles: args.failedFiles,
+    errors: args.errors,
+  };
+  const frame: JobProgress & { type: "batch" } = args.result
+    ? { ...base, status: "completed", result: args.result }
+    : { ...base, status: "failed" };
+  let applied = false;
+  await enqueuePersist(args.jobId, async () => {
+    const res = await db
+      .update(schema.jobs)
+      .set({
+        status: "canceled",
+        completedAt: new Date(),
+        ...(args.outputRefs ? { outputRefs: args.outputRefs } : {}),
+        ...(args.bytesOut !== undefined ? { bytesOut: args.bytesOut } : {}),
+        progress: buildPersistedJobProgress(frame),
+        error: { message: "Canceled", details: args.errors },
+      })
+      .where(
+        and(
+          eq(schema.jobs.id, args.jobId),
+          notInArray(schema.jobs.status, ["completed", "failed", "canceled"]),
+        ),
+      );
+    applied = ((res as { rowCount?: number | null } | undefined)?.rowCount ?? 0) > 0;
+  });
+  if (applied) announce(frame);
 }
 
 export interface FailBatchJobArgs {

--- a/apps/web/src/hooks/use-tool-processor.ts
+++ b/apps/web/src/hooks/use-tool-processor.ts
@@ -122,11 +122,13 @@ export function useToolProcessor(toolId: string) {
   // Installed by processAllFiles so the SSE handler can settle a degraded
   // batch run from its terminal frame (#750) and the cancel path can record
   // intent or settle a run the server never saw (#767). Null outside batch
-  // runs.
+  // runs. cancelLocally reports whether it acted: a stale closure from an
+  // already-settled run refuses, and the caller must fall through to the
+  // single-run settle instead of treating the cancel as handled.
   const batchRunRef = useRef<{
     onTerminal: (frame: BatchProgressFrame) => void;
     markCanceled: () => void;
-    cancelLocally: () => void;
+    cancelLocally: () => boolean;
   } | null>(null);
 
   const isAiTool = AI_PYTHON_TOOLS.has(toolId);
@@ -190,6 +192,9 @@ export function useToolProcessor(toolId: string) {
         eventSourceRef.current.close();
         eventSourceRef.current = null;
       }
+      // This teardown ends whatever run armed it; a batch closure left
+      // behind would swallow a later run's cancel-404 settle (#767).
+      batchRunRef.current = null;
       clearActiveJob();
       setError(
         "Processing was interrupted and the server never confirmed the job. Retry when reconnected.",
@@ -216,12 +221,10 @@ export function useToolProcessor(toolId: string) {
       // 30 seconds later.
       if (res.status === 404 && activeJobIdRef.current === jobId) {
         // A batch upload may still be in flight; its settle path also has to
-        // abort the XHR and tear down the run's own state (#767).
-        const batchRun = batchRunRef.current;
-        if (batchRun) {
-          batchRun.cancelLocally();
-          return;
-        }
+        // abort the XHR and tear down the run's own state (#767). A refusal
+        // means the closure belongs to an earlier run: fall through and
+        // settle the live run the single-run way.
+        if (batchRunRef.current?.cancelLocally()) return;
         clearJobEvidenceTimer();
         clearStallTimer();
         if (elapsedRef.current) clearInterval(elapsedRef.current);
@@ -866,12 +869,13 @@ export function useToolProcessor(toolId: string) {
           canceledByUser = true;
         },
         cancelLocally: () => {
-          if (activeJobIdRef.current !== clientJobId) return;
+          if (activeJobIdRef.current !== clientJobId) return false;
           canceledByUser = true;
           // The upload may still be in flight; aborting it is what actually
           // stops ingress when no job row exists server-side yet.
           xhrRef.current?.abort();
           failRun("Canceled");
+          return true;
         },
         onTerminal: (frame) => {
           if (activeJobIdRef.current !== clientJobId) return;

--- a/apps/web/src/hooks/use-tool-processor.ts
+++ b/apps/web/src/hooks/use-tool-processor.ts
@@ -207,14 +207,21 @@ export function useToolProcessor(toolId: string) {
   const cancelCurrentJob = useCallback(async () => {
     const jobId = activeJobIdRef.current;
     if (!jobId) return;
-    // Record intent before the request: outcome labeling must not depend on
-    // the response racing the terminal frame (#767).
-    batchRunRef.current?.markCanceled();
     try {
       const res = await fetch(`/api/v1/jobs/${jobId}/cancel`, {
         method: "POST",
         headers: formatHeaders(),
       });
+      // Record intent only once the server acknowledged the cancel: a failed
+      // or refused POST must not repaint the run's real outcome as canceled
+      // (#767). The ack always precedes the terminal frame (the finalize
+      // still has children to drain), so labeling cannot race it.
+      if (res.ok) {
+        const body = (await res.json().catch(() => null)) as { canceled?: boolean } | null;
+        if (body?.canceled === true && activeJobIdRef.current === jobId) {
+          batchRunRef.current?.markCanceled();
+        }
+      }
       // 404 means no job exists server-side (possible in the degraded #722
       // state when the request tail never arrived). Nothing will ever emit a
       // frame, so settle locally as canceled instead of blaming the network
@@ -1006,8 +1013,14 @@ export function useToolProcessor(toolId: string) {
           }
           if (activeJobIdRef.current !== clientJobId) return;
           let errorMsg: string;
+          let serverCanceled = false;
           try {
             const body = JSON.parse(text);
+            // The route marks a fully canceled batch structurally; only that
+            // settles as a cancellation. A real failure after a cancel click
+            // (the cancel lost the race, a 500) keeps its own message
+            // instead of being repainted as "Canceled".
+            serverCanceled = (body as { canceled?: boolean } | null)?.canceled === true;
             const parsed = parseApiError(body, xhr.status);
             if (typeof parsed === "object" && parsed.type === "feature_not_installed") {
               errorMsg = `${toolName} requires the "${parsed.featureName}" feature. Enable it in Settings → AI Features.`;
@@ -1025,10 +1038,9 @@ export function useToolProcessor(toolId: string) {
             }
             errorMsg = `Batch processing failed: ${xhr.status}`;
           }
-          // After a user cancel, the route's 422 ("Batch canceled" when
-          // nothing finished) settles as the cancellation it is, through the
-          // same message the i18n layer already maps.
-          failRun(canceledByUser ? "Canceled" : errorMsg);
+          // "Canceled" (not the route's message) so the existing i18n
+          // mapping renders it localized.
+          failRun(serverCanceled ? "Canceled" : errorMsg);
         })();
       };
 

--- a/apps/web/src/hooks/use-tool-processor.ts
+++ b/apps/web/src/hooks/use-tool-processor.ts
@@ -120,8 +120,14 @@ export function useToolProcessor(toolId: string) {
   // (#722, #750).
   const sawJobEvidenceRef = useRef(false);
   // Installed by processAllFiles so the SSE handler can settle a degraded
-  // batch run from its terminal frame (#750). Null outside batch runs.
-  const batchRunRef = useRef<{ onTerminal: (frame: BatchProgressFrame) => void } | null>(null);
+  // batch run from its terminal frame (#750) and the cancel path can record
+  // intent or settle a run the server never saw (#767). Null outside batch
+  // runs.
+  const batchRunRef = useRef<{
+    onTerminal: (frame: BatchProgressFrame) => void;
+    markCanceled: () => void;
+    cancelLocally: () => void;
+  } | null>(null);
 
   const isAiTool = AI_PYTHON_TOOLS.has(toolId);
   const toolName = TOOLS.find((t) => t.id === toolId)?.name ?? toolId;
@@ -196,6 +202,9 @@ export function useToolProcessor(toolId: string) {
   const cancelCurrentJob = useCallback(async () => {
     const jobId = activeJobIdRef.current;
     if (!jobId) return;
+    // Record intent before the request: outcome labeling must not depend on
+    // the response racing the terminal frame (#767).
+    batchRunRef.current?.markCanceled();
     try {
       const res = await fetch(`/api/v1/jobs/${jobId}/cancel`, {
         method: "POST",
@@ -206,6 +215,13 @@ export function useToolProcessor(toolId: string) {
       // frame, so settle locally as canceled instead of blaming the network
       // 30 seconds later.
       if (res.status === 404 && activeJobIdRef.current === jobId) {
+        // A batch upload may still be in flight; its settle path also has to
+        // abort the XHR and tear down the run's own state (#767).
+        const batchRun = batchRunRef.current;
+        if (batchRun) {
+          batchRun.cancelLocally();
+          return;
+        }
         clearJobEvidenceTimer();
         clearStallTimer();
         if (elapsedRef.current) clearInterval(elapsedRef.current);
@@ -704,7 +720,7 @@ export function useToolProcessor(toolId: string) {
 
       // batch_processed fires once for the batch as a unit (distinct from the N
       // per-file tool_used events), so batch usage is separable from single runs.
-      const trackBatch = (status: "completed" | "failed") =>
+      const trackBatch = (status: "completed" | "failed" | "canceled") =>
         void import("@/lib/analytics").then(({ track }) =>
           track(ANALYTICS_EVENTS.BATCH_PROCESSED, {
             tool_id: toolId,
@@ -712,6 +728,11 @@ export function useToolProcessor(toolId: string) {
             status,
           }),
         );
+
+      // Set on the user's cancel click; drives outcome labeling and the
+      // batch_processed status. The server keeps its own truth in the row
+      // status; this flag only shapes what this client shows (#767).
+      let canceledByUser = false;
 
       const { updateEntry, setBatchZip } = useFileStore.getState();
 
@@ -735,6 +756,12 @@ export function useToolProcessor(toolId: string) {
       activeJobIdRef.current = clientJobId;
       activeEntryIndexRef.current = null;
       asyncModeRef.current = false;
+      // The cancel button lives behind the store's activeJob handle. Batch
+      // runs arm it for the whole run, sync wait included: since #750 the
+      // HTTP response is only an observer, so without this the only exit
+      // from a long unwanted batch was closing the tab, which stopped
+      // nothing server-side (#767).
+      setActiveJob(clientJobId, cancelCurrentJob);
 
       // Tear down the run without touching the outcome state; callers set
       // the result or error first.
@@ -755,7 +782,7 @@ export function useToolProcessor(toolId: string) {
       const failRun = (message: string) => {
         setError(message);
         finishRun();
-        trackBatch("failed");
+        trackBatch(canceledByUser ? "canceled" : "failed");
       };
 
       const settleFromZip = async (zipBlob: Blob, fileResults: Record<string, string>) => {
@@ -784,12 +811,17 @@ export function useToolProcessor(toolId: string) {
               error: null,
             });
           } else {
-            updateEntry(i, { status: "failed", error: "File not found in batch results" });
+            // After a user cancel, a missing result is the cancel doing its
+            // job, not a lookup failure.
+            updateEntry(i, {
+              status: "failed",
+              error: canceledByUser ? "Canceled" : "File not found in batch results",
+            });
           }
         }
 
         finishRun();
-        trackBatch("completed");
+        trackBatch(canceledByUser ? "canceled" : "completed");
       };
 
       // A degraded run settles here: download the durable ZIP the terminal
@@ -830,6 +862,17 @@ export function useToolProcessor(toolId: string) {
       };
 
       batchRunRef.current = {
+        markCanceled: () => {
+          canceledByUser = true;
+        },
+        cancelLocally: () => {
+          if (activeJobIdRef.current !== clientJobId) return;
+          canceledByUser = true;
+          // The upload may still be in flight; aborting it is what actually
+          // stops ingress when no job row exists server-side yet.
+          xhrRef.current?.abort();
+          failRun("Canceled");
+        },
         onTerminal: (frame) => {
           if (activeJobIdRef.current !== clientJobId) return;
           if (
@@ -978,7 +1021,10 @@ export function useToolProcessor(toolId: string) {
             }
             errorMsg = `Batch processing failed: ${xhr.status}`;
           }
-          failRun(errorMsg);
+          // After a user cancel, the route's 422 ("Batch canceled" when
+          // nothing finished) settles as the cancellation it is, through the
+          // same message the i18n layer already maps.
+          failRun(canceledByUser ? "Canceled" : errorMsg);
         })();
       };
 
@@ -1007,6 +1053,8 @@ export function useToolProcessor(toolId: string) {
       processFiles,
       setProcessing,
       setError,
+      setActiveJob,
+      cancelCurrentJob,
       clearActiveJob,
       clearJobEvidenceTimer,
       clearStallTimer,

--- a/tests/integration/platform/batch-cancel.test.ts
+++ b/tests/integration/platform/batch-cancel.test.ts
@@ -17,6 +17,29 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { ToolJobData } from "../../../apps/api/src/jobs/types.js";
 import type { ToolProcessCtx } from "../../../apps/api/src/routes/tool-factory.js";
 
+// Injects a fault into the skip path's outcome recording so the fall-through
+// contract (a failing skip must not wedge the child) is testable.
+const cancelSkipFault = vi.hoisted(() => ({ parentId: null as string | null }));
+
+vi.mock("../../../apps/api/src/jobs/batch-progress.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../apps/api/src/jobs/batch-progress.js")>();
+  return {
+    ...actual,
+    recordChildOutcome: async (
+      parentId: string,
+      totalFiles: number,
+      filename: string,
+      error?: string,
+    ) => {
+      if (parentId === cancelSkipFault.parentId && error === "Canceled") {
+        throw new Error("injected outcome-recording outage");
+      }
+      return actual.recordChildOutcome(parentId, totalFiles, filename, error);
+    },
+  };
+});
+
 const { eq } = await import("drizzle-orm");
 const { db, schema } = await import("../../../apps/api/src/db/index.js");
 const { runMigrations } = await import("../../../apps/api/src/db/migrate.js");
@@ -279,6 +302,15 @@ describe("requestCancel on a batch parent", () => {
     expect(await requestCancel(id)).toBe(false);
     expect(await isBatchCanceled(id)).toBe(false);
   });
+
+  it("returns false for an implicit batch row with no cooperative machinery", async () => {
+    // Custom batch sub-routes (pdf-to-image, svg-to-raster) get their rows
+    // from the progress persist layer: type batch, no settings, nothing
+    // reading the flag. Claiming canceled: true for them would be a lie.
+    const id = await seedParent({ toolId: null, settings: null });
+    expect(await requestCancel(id)).toBe(false);
+    expect(await isBatchCanceled(id)).toBe(false);
+  });
 });
 
 describe("cooperative child skip and canceled finalize", () => {
@@ -326,6 +358,54 @@ describe("cooperative child skip and canceled finalize", () => {
       (e) => JSON.parse(e) as { filename: string; error: string },
     );
     expect(errors).toEqual([{ filename: "skipme.png", error: "Canceled" }]);
+  });
+
+  it("a failing skip falls through to normal processing instead of wedging the child", async () => {
+    const parentId = randomUUID();
+    const childId = `${parentId}-f0`;
+    const key = `uploads/${childId}/fallthrough.png`;
+    await putObject(key, Buffer.from("payload"));
+    await db.insert(schema.jobs).values({
+      id: childId,
+      type: "batch-child",
+      toolId: "wt-batch-cancel",
+      pool: "image",
+      status: "queued",
+      inputRefs: [key],
+    });
+    await markBatchCanceled(parentId);
+    cancelSkipFault.parentId = parentId;
+
+    try {
+      await getQueue("image").add(
+        "wt-batch-cancel",
+        {
+          kind: "batch-child",
+          jobId: childId,
+          toolId: "wt-batch-cancel",
+          userId: null,
+          pool: "image",
+          parentId,
+          totalFiles: 1,
+          fileIndex: 0,
+          inputRefs: [key],
+          filename: "fallthrough.png",
+          settings: {},
+        } satisfies ToolJobData,
+        { jobId: childId, attempts: 1 },
+      );
+
+      // The injected fault hits the skip's outcome recording; the child must
+      // end terminal through normal processing (a too-late cancel), never
+      // stuck queued with a hard-failed job behind it.
+      const row = await terminalRow(childId);
+      expect(row.status).toBe("completed");
+      const base = `${bullPrefix()}:batch:${parentId}`;
+      expect(await sharedRedis().get(`${base}:done`)).toBe("1");
+      expect(await sharedRedis().get(`${base}:failed`)).toBeNull();
+    } finally {
+      cancelSkipFault.parentId = null;
+    }
   });
 
   it("cancel mid-batch commits a canceled row with a partial ZIP", async () => {

--- a/tests/integration/platform/batch-cancel.test.ts
+++ b/tests/integration/platform/batch-cancel.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Batch cancel (#767): the cooperative cancel flag, requestCancel's batch
+ * branch, the batch-child skip, and the finalize's canceled terminal paths.
+ *
+ * Follows the worker-branches.test.ts harness: no HTTP app is built. The
+ * test tool is registered directly in the process registry, flows are
+ * enqueued the same way routes/batch.ts builds them, and the real workers
+ * drain them against this fork's Postgres + Redis.
+ */
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const { runMigrations } = await import("../../../apps/api/src/db/migrate.js");
+const { isBatchCanceled, markBatchCanceled } = await import(
+  "../../../apps/api/src/jobs/batch-progress.js"
+);
+const { sharedRedis } = await import("../../../apps/api/src/jobs/connection.js");
+const { bullPrefix } = await import("../../../apps/api/src/jobs/types.js");
+
+beforeAll(async () => {
+  await runMigrations();
+}, 30_000);
+
+afterAll(async () => {
+  await sharedRedis().quit();
+});
+
+describe("batch cancel flag", () => {
+  it("marks and reads the canceled flag with a TTL", async () => {
+    const parentId = randomUUID();
+    expect(await isBatchCanceled(parentId)).toBe(false);
+    await markBatchCanceled(parentId);
+    expect(await isBatchCanceled(parentId)).toBe(true);
+    const ttl = await sharedRedis().ttl(`${bullPrefix()}:batch:${parentId}:canceled`);
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(3600);
+  });
+});

--- a/tests/integration/platform/batch-cancel.test.ts
+++ b/tests/integration/platform/batch-cancel.test.ts
@@ -8,7 +8,14 @@
  * drain them against this fork's Postgres + Redis.
  */
 import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
+import AdmZip from "adm-zip";
+import type { FlowJob } from "bullmq";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { ToolJobData } from "../../../apps/api/src/jobs/types.js";
+import type { ToolProcessCtx } from "../../../apps/api/src/routes/tool-factory.js";
 
 const { eq } = await import("drizzle-orm");
 const { db, schema } = await import("../../../apps/api/src/db/index.js");
@@ -16,19 +23,180 @@ const { runMigrations } = await import("../../../apps/api/src/db/migrate.js");
 const { isBatchCanceled, markBatchCanceled } = await import(
   "../../../apps/api/src/jobs/batch-progress.js"
 );
-const { requestCancel } = await import("../../../apps/api/src/jobs/cancel.js");
+const { requestCancel, startCancelListener, stopCancelListener } = await import(
+  "../../../apps/api/src/jobs/cancel.js"
+);
 const { createRedisSubscriberConnection, sharedRedis } = await import(
   "../../../apps/api/src/jobs/connection.js"
 );
-const { bullPrefix } = await import("../../../apps/api/src/jobs/types.js");
+const { getFlowProducer } = await import("../../../apps/api/src/jobs/enqueue.js");
+const { closeQueues, getQueue } = await import("../../../apps/api/src/jobs/queues.js");
+const { bullPrefix, queueName } = await import("../../../apps/api/src/jobs/types.js");
+const { closeWorkers, startWorkers } = await import("../../../apps/api/src/jobs/worker.js");
+const { getObjectBuffer, putObject } = await import("../../../apps/api/src/lib/object-storage.js");
+const { registerToolProcessFn } = await import("../../../apps/api/src/routes/tool-factory.js");
+
+const passthroughSchema = { parse: (v: unknown) => v } as never;
+
+// Behavior keyed on filename: fast*.png returns instantly, slow*.png waits on
+// the worker's abort signal, so a cancel mid-batch has a real running target.
+registerToolProcessFn({
+  toolId: "wt-batch-cancel",
+  settingsSchema: passthroughSchema,
+  process: async (
+    inputBuffer: Buffer,
+    _settings: unknown,
+    filename: string,
+    ctx?: ToolProcessCtx,
+  ) => {
+    if (filename.startsWith("slow")) {
+      await new Promise<void>((resolve, reject) => {
+        const signal = ctx?.signal;
+        if (!signal) {
+          reject(new Error("wt-batch-cancel requires an abort signal"));
+          return;
+        }
+        if (signal.aborted) {
+          reject(new Error("aborted before start"));
+          return;
+        }
+        const timer = setTimeout(resolve, 20_000);
+        signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            reject(new Error("aborted by signal"));
+          },
+          { once: true },
+        );
+      });
+    }
+    return { buffer: inputBuffer, filename, contentType: "image/png" };
+  },
+});
+
+mkdirSync(process.env.WORKSPACE_PATH ?? "", { recursive: true });
+await runMigrations();
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+type JobRow = typeof schema.jobs.$inferSelect;
+
+async function waitFor<T>(probe: () => Promise<T | undefined>, timeoutMs = 20_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await probe();
+    if (value !== undefined) return value;
+    if (Date.now() > deadline) throw new Error(`condition not met within ${timeoutMs}ms`);
+    await delay(150);
+  }
+}
+
+async function jobRow(jobId: string): Promise<JobRow | undefined> {
+  const [row] = await db.select().from(schema.jobs).where(eq(schema.jobs.id, jobId));
+  return row;
+}
+
+async function terminalRow(jobId: string, timeoutMs = 25_000): Promise<JobRow> {
+  return waitFor(async () => {
+    const row = await jobRow(jobId);
+    return row && row.status !== "queued" && row.status !== "processing" ? row : undefined;
+  }, timeoutMs);
+}
+
+async function terminalFrame(jobId: string): Promise<Record<string, unknown>> {
+  const raw = await waitFor(async () => {
+    const value = await sharedRedis().get(`${bullPrefix()}:terminal:${jobId}`);
+    return value ?? undefined;
+  }, 25_000);
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+/** Insert the parent and child rows and enqueue the flow exactly the way
+ * routes/batch.ts does (batch-finalize parent on the system queue, one
+ * batch-child per file with attempts 1 + ignoreDependencyOnFailure). */
+async function enqueueBatchFlow(files: string[]): Promise<{ parentId: string }> {
+  const parentId = randomUUID();
+  const fileIndexMap = files.map((_, i) => i);
+
+  await db.insert(schema.jobs).values({
+    id: parentId,
+    type: "batch",
+    toolId: "wt-batch-cancel",
+    pool: "system",
+    status: "queued",
+    inputRefs: [],
+    settings: { flowChildCount: files.length, fileIndexMap },
+  });
+
+  const children: FlowJob[] = [];
+  for (let i = 0; i < files.length; i++) {
+    const childId = `${parentId}-f${i}`;
+    const key = `uploads/${childId}/${files[i]}`;
+    await putObject(key, Buffer.from(`payload-${i}`));
+    await db.insert(schema.jobs).values({
+      id: childId,
+      type: "batch-child",
+      toolId: "wt-batch-cancel",
+      pool: "image",
+      status: "queued",
+      inputRefs: [key],
+    });
+    children.push({
+      name: "wt-batch-cancel",
+      queueName: queueName("image"),
+      data: {
+        kind: "batch-child",
+        jobId: childId,
+        toolId: "wt-batch-cancel",
+        userId: null,
+        pool: "image",
+        parentId,
+        totalFiles: files.length,
+        fileIndex: i,
+        inputRefs: [key],
+        filename: files[i],
+        settings: {},
+      } satisfies ToolJobData,
+      opts: { jobId: childId, attempts: 1, ignoreDependencyOnFailure: true },
+    });
+  }
+
+  const tree: FlowJob = {
+    name: "batch-finalize",
+    queueName: queueName("system"),
+    data: {
+      kind: "batch-finalize",
+      jobId: parentId,
+      toolId: "wt-batch-cancel",
+      userId: null,
+      pool: "system",
+      totalFiles: files.length,
+      inputRefs: [],
+      filename: "",
+      settings: { flowChildCount: files.length, fileIndexMap },
+    } satisfies ToolJobData,
+    opts: { jobId: parentId, attempts: 1 },
+    children,
+  };
+
+  await getFlowProducer().add(tree);
+  return { parentId };
+}
 
 beforeAll(async () => {
-  await runMigrations();
+  await startCancelListener();
+  startWorkers();
 }, 30_000);
 
 afterAll(async () => {
+  await closeWorkers();
+  await stopCancelListener();
+  await closeQueues();
   await sharedRedis().quit();
-});
+}, 20_000);
+
+// ── Tests ───────────────────────────────────────────────────────
 
 describe("batch cancel flag", () => {
   it("marks and reads the canceled flag with a TTL", async () => {
@@ -95,5 +263,188 @@ describe("requestCancel on a batch parent", () => {
     const id = await seedParent({ toolId: "pipeline-batch" });
     expect(await requestCancel(id)).toBe(false);
     expect(await isBatchCanceled(id)).toBe(false);
+  });
+});
+
+describe("cooperative child skip and canceled finalize", () => {
+  it("skips a pending child when the batch is canceled", async () => {
+    const parentId = randomUUID();
+    const childId = `${parentId}-f0`;
+    const key = `uploads/${childId}/skipme.png`;
+    await putObject(key, Buffer.from("payload"));
+    await db.insert(schema.jobs).values({
+      id: childId,
+      type: "batch-child",
+      toolId: "wt-batch-cancel",
+      pool: "image",
+      status: "queued",
+      inputRefs: [key],
+    });
+    await markBatchCanceled(parentId);
+
+    await getQueue("image").add(
+      "wt-batch-cancel",
+      {
+        kind: "batch-child",
+        jobId: childId,
+        toolId: "wt-batch-cancel",
+        userId: null,
+        pool: "image",
+        parentId,
+        totalFiles: 1,
+        fileIndex: 0,
+        inputRefs: [key],
+        filename: "skipme.png",
+        settings: {},
+      } satisfies ToolJobData,
+      { jobId: childId, attempts: 1 },
+    );
+
+    const row = await terminalRow(childId);
+    expect(row.status).toBe("canceled");
+    expect((row.error as { message?: string } | null)?.message).toBe("Canceled");
+
+    const base = `${bullPrefix()}:batch:${parentId}`;
+    expect(await sharedRedis().get(`${base}:done`)).toBeNull();
+    expect(await sharedRedis().get(`${base}:failed`)).toBe("1");
+    const errors = (await sharedRedis().lrange(`${base}:errors`, 0, -1)).map(
+      (e) => JSON.parse(e) as { filename: string; error: string },
+    );
+    expect(errors).toEqual([{ filename: "skipme.png", error: "Canceled" }]);
+  });
+
+  it("cancel mid-batch commits a canceled row with a partial ZIP", async () => {
+    const { parentId } = await enqueueBatchFlow(["fast.png", "slow-1.png", "slow-2.png"]);
+
+    // The fast child must be done before the cancel so the batch has real
+    // finished work to keep.
+    await waitFor(async () => {
+      const row = await jobRow(`${parentId}-f0`);
+      return row?.status === "completed" ? row : undefined;
+    });
+
+    expect(await requestCancel(parentId)).toBe(true);
+
+    const parent = await terminalRow(parentId);
+    expect(parent.status).toBe("canceled");
+    expect(parent.outputRefs?.length).toBe(1);
+    const zipKey = parent.outputRefs?.[0] as string;
+
+    const frame = await terminalFrame(parentId);
+    expect(frame.status).toBe("completed");
+    const result = frame.result as { downloadUrl?: string; fileResults?: Record<string, string> };
+    expect(result.downloadUrl).toContain(`/api/v1/download/${parentId}/`);
+    expect(Object.keys(result.fileResults ?? {})).toEqual(["0"]);
+
+    const zip = new AdmZip(await getObjectBuffer(zipKey));
+    const names = zip.getEntries().map((e) => e.entryName);
+    expect(names).toHaveLength(1);
+    expect(names[0]).toMatch(/^fast/);
+
+    for (const slow of [`${parentId}-f1`, `${parentId}-f2`]) {
+      const row = await terminalRow(slow);
+      expect(row.status).toBe("canceled");
+    }
+  });
+
+  it("a cancel that lands after every child finished completes normally", async () => {
+    const { parentId } = await enqueueBatchFlow(["fast-a.png", "fast-b.png"]);
+
+    await waitFor(async () => {
+      const a = await jobRow(`${parentId}-f0`);
+      const b = await jobRow(`${parentId}-f1`);
+      return a?.status === "completed" && b?.status === "completed" ? true : undefined;
+    });
+    await markBatchCanceled(parentId);
+
+    const parent = await terminalRow(parentId);
+    expect(parent.status).toBe("completed");
+    const frame = await terminalFrame(parentId);
+    expect(frame.status).toBe("completed");
+    const result = frame.result as { fileResults?: Record<string, string> };
+    expect(Object.keys(result.fileResults ?? {})).toEqual(["0", "1"]);
+  });
+
+  it("a full cancel before any child ran fails with the Canceled synthetic", async () => {
+    const parentId = randomUUID();
+    // Flag first so both children skip regardless of worker timing. The flow
+    // is enqueued afterwards with a fresh id, so reuse enqueueBatchFlow's
+    // internals inline with the pre-set flag.
+    const files = ["slow-x.png", "slow-y.png"];
+    const fileIndexMap = files.map((_, i) => i);
+    await db.insert(schema.jobs).values({
+      id: parentId,
+      type: "batch",
+      toolId: "wt-batch-cancel",
+      pool: "system",
+      status: "queued",
+      inputRefs: [],
+      settings: { flowChildCount: files.length, fileIndexMap },
+    });
+    await markBatchCanceled(parentId);
+
+    const children: FlowJob[] = [];
+    for (let i = 0; i < files.length; i++) {
+      const childId = `${parentId}-f${i}`;
+      const key = `uploads/${childId}/${files[i]}`;
+      await putObject(key, Buffer.from(`payload-${i}`));
+      await db.insert(schema.jobs).values({
+        id: childId,
+        type: "batch-child",
+        toolId: "wt-batch-cancel",
+        pool: "image",
+        status: "queued",
+        inputRefs: [key],
+      });
+      children.push({
+        name: "wt-batch-cancel",
+        queueName: queueName("image"),
+        data: {
+          kind: "batch-child",
+          jobId: childId,
+          toolId: "wt-batch-cancel",
+          userId: null,
+          pool: "image",
+          parentId,
+          totalFiles: files.length,
+          fileIndex: i,
+          inputRefs: [key],
+          filename: files[i],
+          settings: {},
+        } satisfies ToolJobData,
+        opts: { jobId: childId, attempts: 1, ignoreDependencyOnFailure: true },
+      });
+    }
+    await getFlowProducer().add({
+      name: "batch-finalize",
+      queueName: queueName("system"),
+      data: {
+        kind: "batch-finalize",
+        jobId: parentId,
+        toolId: "wt-batch-cancel",
+        userId: null,
+        pool: "system",
+        totalFiles: files.length,
+        inputRefs: [],
+        filename: "",
+        settings: { flowChildCount: files.length, fileIndexMap },
+      } satisfies ToolJobData,
+      opts: { jobId: parentId, attempts: 1 },
+      children,
+    });
+
+    const parent = await terminalRow(parentId);
+    expect(parent.status).toBe("canceled");
+    expect(parent.outputRefs ?? []).toEqual([]);
+
+    const frame = await terminalFrame(parentId);
+    expect(frame.status).toBe("failed");
+    const errors = frame.errors as Array<{ filename: string; error: string }>;
+    expect(errors[0]).toEqual({ filename: "", error: "Canceled" });
+
+    for (const childId of [`${parentId}-f0`, `${parentId}-f1`]) {
+      const row = await jobRow(childId);
+      expect(row?.status).toBe("canceled");
+    }
   });
 });

--- a/tests/integration/platform/batch-cancel.test.ts
+++ b/tests/integration/platform/batch-cancel.test.ts
@@ -114,8 +114,13 @@ async function terminalFrame(jobId: string): Promise<Record<string, unknown>> {
 
 /** Insert the parent and child rows and enqueue the flow exactly the way
  * routes/batch.ts does (batch-finalize parent on the system queue, one
- * batch-child per file with attempts 1 + ignoreDependencyOnFailure). */
-async function enqueueBatchFlow(files: string[]): Promise<{ parentId: string }> {
+ * batch-child per file with attempts 1 + ignoreDependencyOnFailure).
+ * beforeEnqueue runs between the row inserts and the FlowProducer add, the
+ * window a pre-enqueue cancel lands in. */
+async function enqueueBatchFlow(
+  files: string[],
+  opts: { beforeEnqueue?: (parentId: string) => Promise<void> } = {},
+): Promise<{ parentId: string }> {
   const parentId = randomUUID();
   const fileIndexMap = files.map((_, i) => i);
 
@@ -180,8 +185,18 @@ async function enqueueBatchFlow(files: string[]): Promise<{ parentId: string }> 
     children,
   };
 
+  await opts.beforeEnqueue?.(parentId);
   await getFlowProducer().add(tree);
   return { parentId };
+}
+
+/** The finalize's BullMQ return value, what routes/batch.ts branches on. */
+async function finalizeReturnValue(parentId: string): Promise<Record<string, unknown>> {
+  const job = await waitFor(async () => {
+    const j = await getQueue("system").getJob(parentId);
+    return j?.returnvalue ? j : undefined;
+  });
+  return job.returnvalue as Record<string, unknown>;
 }
 
 beforeAll(async () => {
@@ -317,10 +332,14 @@ describe("cooperative child skip and canceled finalize", () => {
     const { parentId } = await enqueueBatchFlow(["fast.png", "slow-1.png", "slow-2.png"]);
 
     // The fast child must be done before the cancel so the batch has real
-    // finished work to keep.
+    // finished work to keep, and a slow child must be actively running so
+    // the abort-over-the-channel path is exercised deterministically (a
+    // queued slow child would take the flag-skip path, which has its own
+    // test above).
     await waitFor(async () => {
-      const row = await jobRow(`${parentId}-f0`);
-      return row?.status === "completed" ? row : undefined;
+      const fast = await jobRow(`${parentId}-f0`);
+      const slow = await jobRow(`${parentId}-f1`);
+      return fast?.status === "completed" && slow?.status === "processing" ? true : undefined;
     });
 
     expect(await requestCancel(parentId)).toBe(true);
@@ -345,6 +364,10 @@ describe("cooperative child skip and canceled finalize", () => {
       const row = await terminalRow(slow);
       expect(row.status).toBe("canceled");
     }
+
+    // routes/batch.ts branches its sync response on this payload.
+    const returned = await finalizeReturnValue(parentId);
+    expect((returned.resultPayload as { canceled?: boolean }).canceled).toBe(true);
   });
 
   it("a cancel that lands after every child finished completes normally", async () => {
@@ -366,71 +389,11 @@ describe("cooperative child skip and canceled finalize", () => {
   });
 
   it("a full cancel before any child ran fails with the Canceled synthetic", async () => {
-    const parentId = randomUUID();
-    // Flag first so both children skip regardless of worker timing. The flow
-    // is enqueued afterwards with a fresh id, so reuse enqueueBatchFlow's
-    // internals inline with the pre-set flag.
-    const files = ["slow-x.png", "slow-y.png"];
-    const fileIndexMap = files.map((_, i) => i);
-    await db.insert(schema.jobs).values({
-      id: parentId,
-      type: "batch",
-      toolId: "wt-batch-cancel",
-      pool: "system",
-      status: "queued",
-      inputRefs: [],
-      settings: { flowChildCount: files.length, fileIndexMap },
-    });
-    await markBatchCanceled(parentId);
-
-    const children: FlowJob[] = [];
-    for (let i = 0; i < files.length; i++) {
-      const childId = `${parentId}-f${i}`;
-      const key = `uploads/${childId}/${files[i]}`;
-      await putObject(key, Buffer.from(`payload-${i}`));
-      await db.insert(schema.jobs).values({
-        id: childId,
-        type: "batch-child",
-        toolId: "wt-batch-cancel",
-        pool: "image",
-        status: "queued",
-        inputRefs: [key],
-      });
-      children.push({
-        name: "wt-batch-cancel",
-        queueName: queueName("image"),
-        data: {
-          kind: "batch-child",
-          jobId: childId,
-          toolId: "wt-batch-cancel",
-          userId: null,
-          pool: "image",
-          parentId,
-          totalFiles: files.length,
-          fileIndex: i,
-          inputRefs: [key],
-          filename: files[i],
-          settings: {},
-        } satisfies ToolJobData,
-        opts: { jobId: childId, attempts: 1, ignoreDependencyOnFailure: true },
-      });
-    }
-    await getFlowProducer().add({
-      name: "batch-finalize",
-      queueName: queueName("system"),
-      data: {
-        kind: "batch-finalize",
-        jobId: parentId,
-        toolId: "wt-batch-cancel",
-        userId: null,
-        pool: "system",
-        totalFiles: files.length,
-        inputRefs: [],
-        filename: "",
-        settings: { flowChildCount: files.length, fileIndexMap },
-      } satisfies ToolJobData,
-      opts: { jobId: parentId, attempts: 1 },
-      children,
+    // Flag inside the insert-to-enqueue window so both children skip
+    // regardless of worker timing: the pre-enqueue cancel race the DB-row
+    // branch of requestCancel exists for.
+    const { parentId } = await enqueueBatchFlow(["slow-x.png", "slow-y.png"], {
+      beforeEnqueue: (id) => markBatchCanceled(id),
     });
 
     const parent = await terminalRow(parentId);
@@ -446,5 +409,11 @@ describe("cooperative child skip and canceled finalize", () => {
       const row = await jobRow(childId);
       expect(row?.status).toBe("canceled");
     }
+
+    // routes/batch.ts turns this payload into the "Batch canceled" 422.
+    const returned = await finalizeReturnValue(parentId);
+    const resultPayload = returned.resultPayload as { canceled?: boolean; allFailed?: boolean };
+    expect(resultPayload.canceled).toBe(true);
+    expect(resultPayload.allFailed).toBe(true);
   });
 });

--- a/tests/integration/platform/batch-cancel.test.ts
+++ b/tests/integration/platform/batch-cancel.test.ts
@@ -10,11 +10,16 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
+const { eq } = await import("drizzle-orm");
+const { db, schema } = await import("../../../apps/api/src/db/index.js");
 const { runMigrations } = await import("../../../apps/api/src/db/migrate.js");
 const { isBatchCanceled, markBatchCanceled } = await import(
   "../../../apps/api/src/jobs/batch-progress.js"
 );
-const { sharedRedis } = await import("../../../apps/api/src/jobs/connection.js");
+const { requestCancel } = await import("../../../apps/api/src/jobs/cancel.js");
+const { createRedisSubscriberConnection, sharedRedis } = await import(
+  "../../../apps/api/src/jobs/connection.js"
+);
 const { bullPrefix } = await import("../../../apps/api/src/jobs/types.js");
 
 beforeAll(async () => {
@@ -34,5 +39,61 @@ describe("batch cancel flag", () => {
     const ttl = await sharedRedis().ttl(`${bullPrefix()}:batch:${parentId}:canceled`);
     expect(ttl).toBeGreaterThan(0);
     expect(ttl).toBeLessThanOrEqual(3600);
+  });
+});
+
+describe("requestCancel on a batch parent", () => {
+  async function seedParent(
+    overrides: Partial<typeof schema.jobs.$inferInsert> = {},
+  ): Promise<string> {
+    const id = randomUUID();
+    await db.insert(schema.jobs).values({
+      id,
+      type: "batch",
+      toolId: "resize",
+      status: "processing",
+      inputRefs: [],
+      settings: { flowChildCount: 3 },
+      ...overrides,
+    });
+    return id;
+  }
+
+  it("flags the batch and publishes a cancel for every flow child id", async () => {
+    const id = await seedParent();
+    const received: string[] = [];
+    const sub = createRedisSubscriberConnection();
+    await sub.subscribe(`${bullPrefix()}:cancel`);
+    sub.on("message", (_ch: string, msg: string) => received.push(msg));
+
+    try {
+      expect(await requestCancel(id)).toBe(true);
+      expect(await isBatchCanceled(id)).toBe(true);
+      await vi.waitFor(() => {
+        expect(received).toEqual([`${id}-f0`, `${id}-f1`, `${id}-f2`]);
+      });
+    } finally {
+      await sub.quit();
+    }
+  });
+
+  it("leaves the parent row alone: the finalize owns terminal state", async () => {
+    const id = await seedParent();
+    await requestCancel(id);
+    const [row] = await db.select().from(schema.jobs).where(eq(schema.jobs.id, id));
+    expect(row.status).toBe("processing");
+    expect(row.completedAt).toBeNull();
+  });
+
+  it("returns false for a terminal batch and does not flag it", async () => {
+    const id = await seedParent({ status: "completed" });
+    expect(await requestCancel(id)).toBe(false);
+    expect(await isBatchCanceled(id)).toBe(false);
+  });
+
+  it("returns false for a pipeline-batch parent", async () => {
+    const id = await seedParent({ toolId: "pipeline-batch" });
+    expect(await requestCancel(id)).toBe(false);
+    expect(await isBatchCanceled(id)).toBe(false);
   });
 });

--- a/tests/integration/platform/progress-terminal-guard.test.ts
+++ b/tests/integration/platform/progress-terminal-guard.test.ts
@@ -28,6 +28,8 @@ import { db, schema } from "../../../apps/api/src/db/index.js";
 import { sharedRedis } from "../../../apps/api/src/jobs/connection.js";
 import { bullPrefix } from "../../../apps/api/src/jobs/types.js";
 import {
+  cancelBatchJob,
+  completeBatchJob,
   failBatchJob,
   updateJobProgress,
   updateSingleFileProgress,
@@ -127,7 +129,7 @@ describe("late batch frames and the failBatchJob guard", () => {
     fileResults: { "0": "a.png" },
   };
 
-  async function seedBatchJob(status: "completed" | "processing"): Promise<string> {
+  async function seedBatchJob(status: "completed" | "processing" | "canceled"): Promise<string> {
     const id = randomUUID();
     await db.insert(schema.jobs).values({
       id,
@@ -183,6 +185,89 @@ describe("late batch frames and the failBatchJob guard", () => {
     expect((row.progress as { result?: unknown } | null)?.result).toEqual(BATCH_RESULT);
     // No terminal failed frame may be announced over the completion: a
     // reconnecting client would settle on whichever it reads.
+    expect(await sharedRedis().get(`${bullPrefix()}:terminal:${id}`)).toBeNull();
+  });
+
+  it("completeBatchJob refuses to overwrite a canceled batch row (#767)", async () => {
+    const id = await seedBatchJob("canceled");
+
+    await completeBatchJob({
+      jobId: id,
+      totalFiles: 1,
+      completedFiles: 1,
+      failedFiles: 0,
+      errors: [],
+      outputRefs: ["outputs/x/batch.zip"],
+      bytesOut: 10,
+      result: BATCH_RESULT,
+    });
+
+    const row = await readJob(id);
+    expect(row.status).toBe("canceled");
+    // The loser must not announce a completed frame contradicting the
+    // committed cancellation.
+    expect(await sharedRedis().get(`${bullPrefix()}:terminal:${id}`)).toBeNull();
+  });
+
+  it("cancelBatchJob with a result announces completed-with-result and cancels the row", async () => {
+    const id = await seedBatchJob("processing");
+
+    await cancelBatchJob({
+      jobId: id,
+      totalFiles: 2,
+      completedFiles: 2,
+      failedFiles: 1,
+      errors: [{ filename: "b.png", error: "Canceled" }],
+      outputRefs: ["outputs/x/batch.zip"],
+      bytesOut: 10,
+      result: BATCH_RESULT,
+    });
+
+    const row = await readJob(id);
+    expect(row.status).toBe("canceled");
+    expect(row.outputRefs).toEqual(["outputs/x/batch.zip"]);
+    expect((row.progress as { result?: unknown } | null)?.result).toEqual(BATCH_RESULT);
+
+    const frame = JSON.parse(
+      (await sharedRedis().get(`${bullPrefix()}:terminal:${id}`)) as string,
+    ) as Record<string, unknown>;
+    expect(frame.status).toBe("completed");
+    expect(frame.result).toEqual(BATCH_RESULT);
+  });
+
+  it("cancelBatchJob without a result announces failed with the Canceled synthetic", async () => {
+    const id = await seedBatchJob("processing");
+
+    await cancelBatchJob({
+      jobId: id,
+      totalFiles: 1,
+      completedFiles: 1,
+      failedFiles: 1,
+      errors: [{ filename: "", error: "Canceled" }],
+    });
+
+    const row = await readJob(id);
+    expect(row.status).toBe("canceled");
+    const frame = JSON.parse(
+      (await sharedRedis().get(`${bullPrefix()}:terminal:${id}`)) as string,
+    ) as { status: string; errors: Array<{ filename: string; error: string }> };
+    expect(frame.status).toBe("failed");
+    expect(frame.errors[0]).toEqual({ filename: "", error: "Canceled" });
+  });
+
+  it("cancelBatchJob refuses to downgrade a completed batch", async () => {
+    const id = await seedBatchJob("completed");
+
+    await cancelBatchJob({
+      jobId: id,
+      totalFiles: 1,
+      completedFiles: 1,
+      failedFiles: 1,
+      errors: [{ filename: "", error: "Canceled" }],
+    });
+
+    const row = await readJob(id);
+    expect(row.status).toBe("completed");
     expect(await sharedRedis().get(`${bullPrefix()}:terminal:${id}`)).toBeNull();
   });
 

--- a/tests/unit/api/progress-batch-replay.test.ts
+++ b/tests/unit/api/progress-batch-replay.test.ts
@@ -295,6 +295,34 @@ describe("buildBatchReplayEvent", () => {
     });
   });
 
+  it("replays a resultless canceled row as failed with its stored details (#767)", () => {
+    expect(
+      buildBatchReplayEvent({
+        jobId: "batch-canceled-full",
+        status: "canceled",
+        progress: { percent: 100, totalFiles: 2, completedFiles: 2, failedFiles: 2 },
+        error: {
+          message: "Canceled",
+          details: [
+            { filename: "", error: "Canceled" },
+            { filename: "a.png", error: "Canceled" },
+          ],
+        },
+      }),
+    ).toEqual({
+      jobId: "batch-canceled-full",
+      type: "batch",
+      status: "failed",
+      totalFiles: 2,
+      completedFiles: 2,
+      failedFiles: 2,
+      errors: [
+        { filename: "", error: "Canceled" },
+        { filename: "a.png", error: "Canceled" },
+      ],
+    });
+  });
+
   it("tolerates legacy rows whose progress has only a percent", () => {
     expect(
       buildBatchReplayEvent({

--- a/tests/unit/api/progress-batch-replay.test.ts
+++ b/tests/unit/api/progress-batch-replay.test.ts
@@ -271,6 +271,30 @@ describe("buildBatchReplayEvent", () => {
     });
   });
 
+  it("replays a canceled row with a durable result as completed-with-result (#767)", () => {
+    const result = {
+      downloadUrl: "/api/v1/download/b/batch-resize-b.zip",
+      fileResults: { "0": "a.png" },
+    };
+    expect(
+      buildBatchReplayEvent({
+        jobId: "batch-canceled-partial",
+        status: "canceled",
+        progress: { percent: 100, totalFiles: 3, completedFiles: 3, failedFiles: 2, result },
+        error: { message: "Canceled", details: [{ filename: "b.png", error: "Canceled" }] },
+      }),
+    ).toEqual({
+      jobId: "batch-canceled-partial",
+      type: "batch",
+      status: "completed",
+      totalFiles: 3,
+      completedFiles: 3,
+      failedFiles: 2,
+      errors: [{ filename: "b.png", error: "Canceled" }],
+      result,
+    });
+  });
+
   it("tolerates legacy rows whose progress has only a percent", () => {
     expect(
       buildBatchReplayEvent({

--- a/tests/unit/web/use-tool-processor-batch-cancel.test.ts
+++ b/tests/unit/web/use-tool-processor-batch-cancel.test.ts
@@ -1,0 +1,396 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import AdmZip from "adm-zip";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/image-preview", () => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  formatHeaders: () => new Map<string, string>(),
+  parseApiError: (body: unknown) => (body as { error?: string } | null)?.error ?? "error",
+}));
+
+vi.mock("@/lib/utils", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  return { ...actual, generateId: () => "44444444-4444-4444-8444-444444444444" };
+});
+
+import { useToolProcessor } from "@/hooks/use-tool-processor";
+import { track } from "@/lib/analytics";
+import { useFileStore } from "@/stores/file-store";
+
+interface MockXhr {
+  status: number;
+  responseText: string;
+  responseType: string;
+  response: unknown;
+  timeout: number;
+  upload: { onprogress?: unknown; onload?: (() => void) | null };
+  onload?: () => void;
+  onerror?: (() => void) | null;
+  ontimeout?: (() => void) | null;
+  open: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  setRequestHeader: ReturnType<typeof vi.fn>;
+  getResponseHeader: ReturnType<typeof vi.fn>;
+  abort: ReturnType<typeof vi.fn>;
+}
+
+class MockEventSource {
+  static OPEN = 1;
+  static instances: MockEventSource[] = [];
+
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = MockEventSource.OPEN;
+  close = vi.fn(() => {
+    this.readyState = 2;
+  });
+
+  constructor(readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+}
+
+let xhrs: MockXhr[];
+
+const JOB_ID = "44444444-4444-4444-8444-444444444444";
+
+// Only the first file finished before the cancel landed.
+const PARTIAL_NAMES = { "0": "first_resize.png" } as const;
+const PARTIAL_ZIP_BYTES = (() => {
+  const zip = new AdmZip();
+  zip.addFile("first_resize.png", Buffer.from([1, 2, 3, 4]));
+  return new Uint8Array(zip.toBuffer());
+})();
+const partialZipBlob = () =>
+  new Blob([PARTIAL_ZIP_BYTES.slice().buffer], { type: "application/zip" });
+const encodedPartialResults = () => encodeURIComponent(JSON.stringify(PARTIAL_NAMES));
+
+function latestSse(): MockEventSource {
+  return MockEventSource.instances[MockEventSource.instances.length - 1];
+}
+
+function sendBatchFrame(frame: Record<string, unknown>) {
+  latestSse().onmessage?.({
+    data: JSON.stringify({ type: "batch", jobId: JOB_ID, ...frame }),
+  } as MessageEvent);
+}
+
+const PARTIAL_RESULT = {
+  jobId: JOB_ID,
+  downloadUrl: `/api/v1/download/${JOB_ID}/batch-resize-44444444.zip`,
+  zipFilename: "batch-resize-44444444.zip",
+  fileResults: PARTIAL_NAMES,
+  processedSize: PARTIAL_ZIP_BYTES.length,
+};
+
+function canceledPartialFrame() {
+  return {
+    status: "completed",
+    totalFiles: 2,
+    completedFiles: 2,
+    failedFiles: 1,
+    errors: [{ filename: "second.jpg", error: "Canceled" }],
+    result: PARTIAL_RESULT,
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal("URL", {
+    ...globalThis.URL,
+    createObjectURL: vi.fn(() => "blob:fake-url"),
+    revokeObjectURL: vi.fn(),
+  });
+  useFileStore.getState().reset();
+  xhrs = [];
+  MockEventSource.instances = [];
+  vi.stubGlobal("EventSource", MockEventSource);
+  vi.stubGlobal(
+    "XMLHttpRequest",
+    vi.fn(() => {
+      const xhr: MockXhr = {
+        status: 0,
+        responseText: "",
+        responseType: "",
+        response: null,
+        timeout: 0,
+        upload: {},
+        open: vi.fn(),
+        send: vi.fn(),
+        setRequestHeader: vi.fn(),
+        getResponseHeader: vi.fn(() => null),
+        abort: vi.fn(),
+      };
+      xhrs.push(xhr);
+      return xhr;
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.mocked(track).mockClear();
+});
+
+function startBatchRun() {
+  const files = [
+    new File([new ArrayBuffer(16)], "first.png", { type: "image/png" }),
+    new File([new ArrayBuffer(16)], "second.jpg", { type: "image/jpeg" }),
+  ];
+  useFileStore.getState().setFiles(files);
+  const hook = renderHook(() => useToolProcessor("resize"));
+  act(() => {
+    void hook.result.current.processAllFiles(files, { width: 50 });
+  });
+  return hook;
+}
+
+async function settled(check: () => void) {
+  await vi.waitFor(check, { timeout: 3_000 });
+}
+
+function batchProcessedEvents() {
+  return vi.mocked(track).mock.calls.filter(([event]) => event === "batch_processed");
+}
+
+/**
+ * #767: batch runs are cancelable. The progress-card button is armed for the
+ * whole run, a cancel settles the run with the partial results the server
+ * kept, and files the cancel skipped read "Canceled" instead of a lookup
+ * failure.
+ */
+describe("useToolProcessor batch cancel (#767)", () => {
+  it("arms the progress-card cancel handle for the whole batch run", () => {
+    const { unmount } = startBatchRun();
+
+    expect(useFileStore.getState().activeJobId).toBe(JOB_ID);
+    expect(typeof useFileStore.getState().cancelCurrentJob).toBe("function");
+
+    unmount();
+  });
+
+  it("labels files the cancel skipped and reports batch_processed canceled", async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/cancel")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ canceled: true }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(partialZipBlob()),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 202;
+      xhrs[0].responseText = JSON.stringify({ jobId: JOB_ID, async: true });
+      xhrs[0].onload?.();
+    });
+
+    await act(async () => {
+      await hook.result.current.cancelCurrentJob();
+    });
+
+    act(() => {
+      sendBatchFrame(canceledPartialFrame());
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[0].status).toBe("completed");
+      expect(useFileStore.getState().entries[1].status).toBe("failed");
+    });
+    expect(useFileStore.getState().entries[1].error).toBe("Canceled");
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(false);
+
+    // trackBatch lands through a dynamic analytics import, one tick after
+    // the run settles; assert with a wait so the event is not raced.
+    await settled(() => expect(batchProcessedEvents()).toHaveLength(1));
+    expect(batchProcessedEvents()[0][1]).toMatchObject({ status: "canceled" });
+
+    hook.unmount();
+  });
+
+  it("settles a full cancel from the failed frame's Canceled synthetic", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ canceled: true }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 202;
+      xhrs[0].responseText = JSON.stringify({ jobId: JOB_ID, async: true });
+      xhrs[0].onload?.();
+    });
+
+    await act(async () => {
+      await hook.result.current.cancelCurrentJob();
+    });
+
+    act(() => {
+      sendBatchFrame({
+        status: "failed",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 2,
+        errors: [
+          { filename: "", error: "Canceled" },
+          { filename: "first.png", error: "Canceled" },
+          { filename: "second.jpg", error: "Canceled" },
+        ],
+      });
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().processing).toBe(false);
+    });
+    expect(useFileStore.getState().error).toBe("Canceled");
+    expect(useFileStore.getState().activeJobId).toBeNull();
+
+    // trackBatch lands through a dynamic analytics import, one tick after
+    // the run settles; assert with a wait so the event is not raced.
+    await settled(() => expect(batchProcessedEvents()).toHaveLength(1));
+    expect(batchProcessedEvents()[0][1]).toMatchObject({ status: "canceled" });
+
+    hook.unmount();
+  });
+
+  it("cancel during a run the server never saw aborts the upload and settles locally", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ error: "Job not found" }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startBatchRun();
+
+    // Upload still in flight: no upload.onload, no server response yet.
+    await act(async () => {
+      await hook.result.current.cancelCurrentJob();
+    });
+
+    expect(xhrs[0].abort).toHaveBeenCalled();
+    expect(useFileStore.getState().error).toBe("Canceled");
+    expect(useFileStore.getState().processing).toBe(false);
+    expect(useFileStore.getState().activeJobId).toBeNull();
+
+    // trackBatch lands through a dynamic analytics import, one tick after
+    // the run settles; assert with a wait so the event is not raced.
+    await settled(() => expect(batchProcessedEvents()).toHaveLength(1));
+    expect(batchProcessedEvents()[0][1]).toMatchObject({ status: "canceled" });
+
+    hook.unmount();
+  });
+
+  it("labels skipped files on the sync partial-ZIP response after a cancel", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ canceled: true }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+    });
+
+    await act(async () => {
+      await hook.result.current.cancelCurrentJob();
+    });
+
+    // The route streams the partial ZIP on the still-open sync response.
+    act(() => {
+      xhrs[0].status = 200;
+      xhrs[0].response = partialZipBlob();
+      xhrs[0].getResponseHeader = vi.fn((name: string) =>
+        name === "X-File-Results" ? encodedPartialResults() : null,
+      );
+      xhrs[0].onload?.();
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[0].status).toBe("completed");
+      expect(useFileStore.getState().entries[1].status).toBe("failed");
+    });
+    expect(useFileStore.getState().entries[1].error).toBe("Canceled");
+
+    // trackBatch lands through a dynamic analytics import, one tick after
+    // the run settles; assert with a wait so the event is not raced.
+    await settled(() => expect(batchProcessedEvents()).toHaveLength(1));
+    expect(batchProcessedEvents()[0][1]).toMatchObject({ status: "canceled" });
+
+    hook.unmount();
+  });
+
+  it("reports a canceled 422 as Canceled, not a processing failure", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ canceled: true }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+    });
+
+    await act(async () => {
+      await hook.result.current.cancelCurrentJob();
+    });
+
+    act(() => {
+      xhrs[0].status = 422;
+      xhrs[0].response = new Blob(
+        [
+          JSON.stringify({
+            error: "Batch canceled",
+            errors: [
+              { filename: "first.png", error: "Canceled" },
+              { filename: "second.jpg", error: "Canceled" },
+            ],
+          }),
+        ],
+        { type: "application/json" },
+      );
+      xhrs[0].onload?.();
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().processing).toBe(false);
+    });
+    expect(useFileStore.getState().error).toBe("Canceled");
+
+    hook.unmount();
+  });
+});

--- a/tests/unit/web/use-tool-processor-batch-cancel.test.ts
+++ b/tests/unit/web/use-tool-processor-batch-cancel.test.ts
@@ -18,9 +18,16 @@ vi.mock("@/lib/api", () => ({
   parseApiError: (body: unknown) => (body as { error?: string } | null)?.error ?? "error",
 }));
 
+// Deterministic run ids. Tests that start a second run must queue a distinct
+// id, or run-identity guards degenerate into always-true comparisons.
+const generateIdMock = vi.hoisted(() => ({ queue: [] as string[] }));
+
 vi.mock("@/lib/utils", async (importOriginal) => {
   const actual: Record<string, unknown> = await importOriginal();
-  return { ...actual, generateId: () => "44444444-4444-4444-8444-444444444444" };
+  return {
+    ...actual,
+    generateId: () => generateIdMock.queue.shift() ?? "44444444-4444-4444-8444-444444444444",
+  };
 });
 
 import { useToolProcessor } from "@/hooks/use-tool-processor";
@@ -412,6 +419,56 @@ describe("useToolProcessor batch cancel (#767)", () => {
     // failedFiles on the frame carries the outcome.
     await settled(() => expect(batchProcessedEvents()).toHaveLength(1));
     expect(batchProcessedEvents()[0][1]).toMatchObject({ status: "canceled" });
+
+    hook.unmount();
+  });
+
+  it("a batch closure orphaned by the evidence timer cannot swallow a later single-run cancel", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ error: "Job not found" }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Batch run degrades with no evidence and the 30s timer settles it.
+    const hook = startBatchRun();
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    act(() => {
+      vi.advanceTimersByTime(30_001);
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+    vi.useRealTimers();
+
+    // A later single run degrades the same way; its cancel must settle
+    // immediately instead of being handed to the dead batch closure. The id
+    // must differ from the batch run's or the closure's identity guard
+    // cannot tell the runs apart.
+    generateIdMock.queue.push("55555555-5555-4555-8555-555555555555");
+    const file = new File([new ArrayBuffer(16)], "third.png", { type: "image/png" });
+    useFileStore.getState().setFiles([file]);
+    act(() => {
+      hook.result.current.processFiles([file], { width: 50 });
+    });
+    act(() => {
+      xhrs[1].upload.onload?.();
+      xhrs[1].onerror?.();
+    });
+    expect(useFileStore.getState().processing).toBe(true);
+
+    await act(async () => {
+      await hook.result.current.cancelCurrentJob();
+    });
+
+    expect(useFileStore.getState().error).toBe("Canceled");
+    expect(useFileStore.getState().processing).toBe(false);
+    expect(useFileStore.getState().activeJobId).toBeNull();
 
     hook.unmount();
   });

--- a/tests/unit/web/use-tool-processor-batch-cancel.test.ts
+++ b/tests/unit/web/use-tool-processor-batch-cancel.test.ts
@@ -75,6 +75,16 @@ const partialZipBlob = () =>
   new Blob([PARTIAL_ZIP_BYTES.slice().buffer], { type: "application/zip" });
 const encodedPartialResults = () => encodeURIComponent(JSON.stringify(PARTIAL_NAMES));
 
+// Every file finished: the cancel lost the race.
+const FULL_NAMES = { "0": "first_resize.png", "1": "second_resize.jpg" } as const;
+const FULL_ZIP_BYTES = (() => {
+  const zip = new AdmZip();
+  zip.addFile("first_resize.png", Buffer.from([1, 2, 3, 4]));
+  zip.addFile("second_resize.jpg", Buffer.from([5, 6]));
+  return new Uint8Array(zip.toBuffer());
+})();
+const fullZipBlob = () => new Blob([FULL_ZIP_BYTES.slice().buffer], { type: "application/zip" });
+
 function latestSse(): MockEventSource {
   return MockEventSource.instances[MockEventSource.instances.length - 1];
 }
@@ -344,6 +354,62 @@ describe("useToolProcessor batch cancel (#767)", () => {
 
     // trackBatch lands through a dynamic analytics import, one tick after
     // the run settles; assert with a wait so the event is not raced.
+    await settled(() => expect(batchProcessedEvents()).toHaveLength(1));
+    expect(batchProcessedEvents()[0][1]).toMatchObject({ status: "canceled" });
+
+    hook.unmount();
+  });
+
+  it("a cancel that lost the race settles the full result without Canceled labels", async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/cancel")) {
+        // Too late: the server found the batch already terminal.
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ canceled: false }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(fullZipBlob()),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 202;
+      xhrs[0].responseText = JSON.stringify({ jobId: JOB_ID, async: true });
+      xhrs[0].onload?.();
+    });
+
+    await act(async () => {
+      await hook.result.current.cancelCurrentJob();
+    });
+
+    act(() => {
+      sendBatchFrame({
+        status: "completed",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 0,
+        errors: [],
+        result: { ...PARTIAL_RESULT, fileResults: FULL_NAMES },
+      });
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[0].status).toBe("completed");
+      expect(useFileStore.getState().entries[1].status).toBe("completed");
+    });
+    expect(useFileStore.getState().entries[1].error).toBeNull();
+    expect(useFileStore.getState().error).toBeNull();
+
+    // Intent-based: the click is what batch_processed's "canceled" measures;
+    // failedFiles on the frame carries the outcome.
     await settled(() => expect(batchProcessedEvents()).toHaveLength(1));
     expect(batchProcessedEvents()[0][1]).toMatchObject({ status: "canceled" });
 

--- a/tests/unit/web/use-tool-processor-batch-cancel.test.ts
+++ b/tests/unit/web/use-tool-processor-batch-cancel.test.ts
@@ -367,7 +367,7 @@ describe("useToolProcessor batch cancel (#767)", () => {
     hook.unmount();
   });
 
-  it("a cancel that lost the race settles the full result without Canceled labels", async () => {
+  it("a cancel the server refused settles the full result as a plain completion", async () => {
     const fetchMock = vi.fn((url: string) => {
       if (url.endsWith("/cancel")) {
         // Too late: the server found the batch already terminal.
@@ -415,10 +415,10 @@ describe("useToolProcessor batch cancel (#767)", () => {
     expect(useFileStore.getState().entries[1].error).toBeNull();
     expect(useFileStore.getState().error).toBeNull();
 
-    // Intent-based: the click is what batch_processed's "canceled" measures;
-    // failedFiles on the frame carries the outcome.
+    // The server said canceled: false, so nothing was canceled: the event
+    // reports the outcome, not the declined click.
     await settled(() => expect(batchProcessedEvents()).toHaveLength(1));
-    expect(batchProcessedEvents()[0][1]).toMatchObject({ status: "canceled" });
+    expect(batchProcessedEvents()[0][1]).toMatchObject({ status: "completed" });
 
     hook.unmount();
   });
@@ -498,6 +498,7 @@ describe("useToolProcessor batch cancel (#767)", () => {
         [
           JSON.stringify({
             error: "Batch canceled",
+            canceled: true,
             errors: [
               { filename: "first.png", error: "Canceled" },
               { filename: "second.jpg", error: "Canceled" },
@@ -513,6 +514,52 @@ describe("useToolProcessor batch cancel (#767)", () => {
       expect(useFileStore.getState().processing).toBe(false);
     });
     expect(useFileStore.getState().error).toBe("Canceled");
+
+    hook.unmount();
+  });
+
+  it("keeps a genuine failure message when the cancel lost to a real all-failed outcome", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ canceled: true }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+    });
+
+    await act(async () => {
+      await hook.result.current.cancelCurrentJob();
+    });
+
+    // Every file had already failed for real reasons before the cancel
+    // registered; the route reports the failure, not a cancellation.
+    act(() => {
+      xhrs[0].status = 422;
+      xhrs[0].response = new Blob(
+        [
+          JSON.stringify({
+            error: "All files failed processing",
+            errors: [
+              { filename: "first.png", error: "Invalid image" },
+              { filename: "second.jpg", error: "Invalid image" },
+            ],
+          }),
+        ],
+        { type: "application/json" },
+      );
+      xhrs[0].onload?.();
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().processing).toBe(false);
+    });
+    expect(useFileStore.getState().error).toBe("All files failed processing");
 
     hook.unmount();
   });


### PR DESCRIPTION
Fixes #767.

Single runs cancel end to end; batches had neither half. The parent sits in BullMQ waiting-children, which matches no branch of requestCancel, so a cancel against the parent id canceled nothing, and the client never armed the progress-card button for batch runs. Since #765 the HTTP response is only an observer, so the only exit from a long unwanted batch was closing the tab. That stopped nothing server-side.

A partially canceled batch now returns a ZIP of the finished files, with the rest marked "Canceled" (the issue's lean).

## Server

Cooperative cancel, no flow surgery. requestCancel recognizes batch parents by their jobs row (so it works even in the window between row insert and flow enqueue), flags the batch in Redis (`batch:<parentId>:canceled`, same 1h TTL as the outcome counters), and publishes every `<parentId>-fN` id on the existing cancel channel. Active children abort immediately through the same AbortSignal machinery single runs use; the publishes are best-effort accelerants behind the durable flag. The parent row and queue job are left alone, because batch-finalize owns terminal state, exactly as in #765.

It refuses what it cannot cancel: pipeline-batch parents (their children are pipeline flows with no cooperative check) and the implicit batch rows the pdf-to-image and svg-to-raster sub-routes get from the progress persist layer. Claiming `canceled: true` for either would be a lie.

processBatchChild consults the flag before doing any work. A child queued behind the cancel writes its row canceled (guarded), records a "Canceled" outcome, and returns the usual failure marker, so the flow drains naturally. The skip stays inside the function's no-throw contract: a fault mid-skip logs and falls through to normal processing instead of wedging the child row non-terminal.

processBatchFinalize counts canceled child rows and requires both halves before it commits a cancel: the flag proves one was requested, a canceled child proves it landed before the work finished. A cancel that arrives after every file completed is a no-op and the batch completes normally, same as a too-late cancel on a single run.

The new cancelBatchJob commits the canceled row, guarded like failBatchJob, and announces only a transition it owned. The wire vocabulary is unchanged: with finished files it announces completed-with-result carrying the partial ZIP's downloadUrl and fileResults, with none it announces failed with the blank-name "Canceled" synthetic the client already displays. completeBatchJob gets the same guard, which is the semantics revisit the issue called for: nothing overwrites an existing terminal state, and a lost transition announces nothing.

buildBatchReplayEvent replays a canceled row that has a durable result as completed-with-result, so the partial ZIP stays reachable after the Redis terminal key expires. The batch route's no-zip 422 says "Batch canceled" with a structured `canceled: true` field instead of "All files failed processing".

## Client

processAllFiles arms setActiveJob(clientJobId, cancelCurrentJob) for the whole run, so the existing progress-card Cancel button renders during batches. The issue named the two async spots; arming at run start covers those plus the sync window, where the wait can hold for 30 minutes with no other exit.

Cancel intent is recorded only when the server acknowledges the POST with `{canceled: true}`, so a failed or refused cancel cannot repaint the run's real outcome. The sync path keys "Canceled" off the route's structured field, which means a cancel that lost to a genuine all-failed outcome keeps its real error message. After an acknowledged cancel, entries missing from fileResults read "Canceled" instead of "File not found in batch results", and batch_processed reports status "canceled" (existing properties, new value; TELEMETRY.md updated).

The cancel-404 path (a degraded run the server never saw) aborts the still-uploading XHR, which is what actually stops ingress, then settles locally. A batch closure orphaned by the evidence-timer teardown can no longer swallow a later run's cancel: the teardown drops the ref and cancelLocally reports whether it acted.

## Tradeoffs

Pending canceled children drain as fast no-ops through their pool instead of being removed from the queue; active ones abort instantly, so the CPU burn stops immediately either way. BullMQ child removal would confirm faster on busy shared pools if that latency ever matters. The finalize's flag read stays lenient on Redis faults (now logged): a blip there mislabels a canceled batch as completed rather than failing a finished one, the less destructive direction. The flag TTL is 1h, matching the outcome counters.

## Tests

tests/integration/platform/batch-cancel.test.ts (new, 11 tests) runs real workers: flag round-trip, the requestCancel branch with its three refusals, the pending-child skip, the skip-fault fall-through with an injected outcome-recording outage, a mid-batch cancel that keeps the fast child in a partial ZIP while an active slow child aborts and a queued one skips, the too-late no-op, and the full cancel with the Canceled synthetic. progress-terminal-guard pins both cancelBatchJob frame shapes and both guard directions, plus completeBatchJob refusing to overwrite a canceled row. progress-batch-replay pins both canceled replay shapes.

tests/unit/web/use-tool-processor-batch-cancel.test.ts (new, 9 tests) covers the button contract, all five settle transports after a cancel, the refused cancel settling as a plain completion, a genuine all-failed 422 keeping its message, and the evidence-timer stale-closure regression.

Verified with pnpm typecheck, pnpm lint, full test:unit (8373 passed) and full test:integration (9935 passed; the 680 skips are the usual binary-gated ones), with the touched platform suites re-run after every review fix.

Follow-up candidates, not in scope here: pipeline-batch cancel and use-pipeline-processor wiring.
