### PR TITLE
feat(landing): route analytics through the first-party e.snapotter.com proxy

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -32,6 +32,13 @@ jobs:
           # Authenticated GitHub API (5,000 req/hr) so the build-time star-count
           # fetch isn't rate-limited on shared runner IPs (60 req/hr unauth).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Turn on the landing $pageview beacon and route it through the
+          # first-party proxy (e.snapotter.com) so ad blockers don't drop it.
+          # Reuses the same phc_ project key the app image bakes. In forks and
+          # PRs the secret is empty, so Analytics.astro's `key &&` gate keeps the
+          # beacon off and nothing is emitted.
+          PUBLIC_POSTHOG_KEY: ${{ secrets.SNAPOTTER_POSTHOG_KEY }}
+          PUBLIC_POSTHOG_HOST: https://e.snapotter.com
 
       # Astro's getRelativeLocaleUrl lowercases locale segments by default, so a
       # regression could re-emit /zh-cn/ etc. in hrefs and hreflang. Those 404 on


### PR DESCRIPTION
## What

Point the landing pageview beacon at the managed first-party proxy (`https://e.snapotter.com`) instead of `us.i.posthog.com`, and turn the beacon on in the deploy build.

## Why

Two reasons. Ad blockers drop a chunk of direct-to-PostHog pageviews, which is what a managed proxy on a neutral subdomain routes around. And the beacon was off in production anyway: `deploy-landing.yml` builds the Astro site then `wrangler pages deploy`s the prebuilt `dist/`, so Cloudflare Pages never runs the build and any `PUBLIC_POSTHOG_*` set in its dashboard never applied. The build step only carried `GITHUB_TOKEN`, so `Analytics.astro`'s `key &&` gate emitted nothing.

## Change

Two env lines on the build step: `PUBLIC_POSTHOG_KEY` (reusing the existing `SNAPOTTER_POSTHOG_KEY` secret, the same phc_ project key the app image bakes) and `PUBLIC_POSTHOG_HOST=https://e.snapotter.com`. Forks and PRs get an empty secret, so the beacon stays off there.

## Ops, before this helps

1. Add a gray-cloud (DNS-only) CNAME `e` -> `e95f8f2a44540078d3e8.cf-prod-us-proxy.proxyhog.com` in the snapotter.com zone. PostHog terminates SSL, so it can't be Cloudflare-proxied.
2. Wait for the managed proxy to report live, then merge. The next landing deploy sends pageviews through it.

Landing analytics is client-side `$pageview` only, so this is the only surface the managed proxy carries. The self-hosted app routes through its own first-party proxy in a separate PR.
