### PR TITLE
fix(api,web): stop masking collage infrastructure failures as 422

### DIFF
--- a/apps/api/src/routes/tools/collage.ts
+++ b/apps/api/src/routes/tools/collage.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { COLLAGE_PAN_LIMIT } from "@snapotter/shared";
 import type { FastifyInstance } from "fastify";
 import sharp, { type OverlayOptions } from "sharp";
 import { z } from "zod";
@@ -322,11 +323,12 @@ const TEMPLATES: Template[] = [
 
 const cellSchema = z.object({
   imageIndex: z.number().int().min(0),
-  // +/-200 mirrors the preview's drag clamp (collage-preview.tsx); anything
-  // narrower turns a draggable position into a 400 at submit time (#718). In
-  // cover mode the extract saturates at the image edge for values past 100.
-  panX: z.number().min(-200).max(200).default(0),
-  panY: z.number().min(-200).max(200).default(0),
+  // COLLAGE_PAN_LIMIT mirrors the preview's drag clamp (collage-preview.tsx),
+  // shared so the two can't drift; anything narrower turns a draggable position
+  // into a 400 at submit time (#718). In cover mode the extract saturates at the
+  // image edge for values past 100.
+  panX: z.number().min(-COLLAGE_PAN_LIMIT).max(COLLAGE_PAN_LIMIT).default(0),
+  panY: z.number().min(-COLLAGE_PAN_LIMIT).max(COLLAGE_PAN_LIMIT).default(0),
   zoom: z.number().min(1).max(10).default(1),
   objectFit: z.enum(["cover", "contain"]).default("cover"),
 });
@@ -768,10 +770,20 @@ export function registerCollage(app: FastifyInstance) {
         processedSize: finalBuffer.length,
       });
     } catch (err) {
-      return reply.status(422).send({
-        error: "Collage creation failed",
-        details: err instanceof Error ? err.message : "Unknown error",
-      });
+      if (err instanceof InputValidationError) {
+        // Genuine bad input (e.g. an image whose dimensions won't decode). The
+        // 422 here is the documented worker-error convention, not the factory's
+        // 400 (see #718); keep it.
+        return reply.status(422).send({
+          error: "Collage creation failed",
+          details: err.message,
+        });
+      }
+      // Everything else is infrastructure, not the user's images: a storage
+      // outage (putObject), a missing cjxl/ImageMagick binary (encodeJxl), a
+      // sharp crash. Rethrow so the global handler logs it and reports to Sentry
+      // instead of masking it as an input error the user retries forever (#740).
+      throw err;
     }
   });
 }

--- a/apps/web/src/components/tools/collage-preview.tsx
+++ b/apps/web/src/components/tools/collage-preview.tsx
@@ -10,6 +10,7 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
+import { COLLAGE_PAN_LIMIT } from "@snapotter/shared";
 import { useDrag, usePinch } from "@use-gesture/react";
 import {
   Download,
@@ -361,8 +362,14 @@ function CollageCell({
       if (first) memo = { panX: transform.panX, panY: transform.panY };
       const rect = cellRef.current?.getBoundingClientRect();
       if (!rect || !memo) return memo;
-      const panX = Math.max(-200, Math.min(200, memo.panX + (mx / rect.width) * 100));
-      const panY = Math.max(-200, Math.min(200, memo.panY + (my / rect.height) * 100));
+      const panX = Math.max(
+        -COLLAGE_PAN_LIMIT,
+        Math.min(COLLAGE_PAN_LIMIT, memo.panX + (mx / rect.width) * 100),
+      );
+      const panY = Math.max(
+        -COLLAGE_PAN_LIMIT,
+        Math.min(COLLAGE_PAN_LIMIT, memo.panY + (my / rect.height) * 100),
+      );
       store.setCellTransform(cellIndex, { panX, panY });
       return memo;
     },

--- a/packages/shared/src/collage.ts
+++ b/packages/shared/src/collage.ts
@@ -1,0 +1,8 @@
+/**
+ * Maximum cell pan offset for the collage tool, as a percentage of the cell
+ * dimension, in either direction. The preview clamps drag to +/-this
+ * (collage-preview.tsx) and the route schema validates cell pan against it
+ * (routes/tools/collage.ts). Defined once so the two cannot drift: a mismatch
+ * between them is what produced #718.
+ */
+export const COLLAGE_PAN_LIMIT = 200;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,6 +6,7 @@ export * from "./analytics/proxy.js";
 export { redactMessage } from "./analytics/redact-message.js";
 export * from "./analytics/types.js";
 export * from "./audit-events.js";
+export * from "./collage.js";
 export * from "./constants.js";
 export * from "./conversion-presets.js";
 export * from "./features.js";

--- a/tests/integration/tools/image/collage-error-visibility.test.ts
+++ b/tests/integration/tools/image/collage-error-visibility.test.ts
@@ -1,0 +1,87 @@
+/**
+ * #740: the collage route wrapped its entire processing block in one catch that
+ * returned 422 "Collage creation failed" for EVERY error, including an
+ * object-storage outage (putObject) or a missing cjxl/ImageMagick binary
+ * (encodeJxl). That masked infrastructure failures as bad user input, so users
+ * retried forever, and because the error was handled inline the global error
+ * handler never ran: no request.log.error, no Sentry event. The fix keeps
+ * InputValidationError -> 422 but rethrows everything else so it propagates to
+ * the global handler (a 500 with telemetry).
+ *
+ * The test app (test-server.ts) uses Fastify's default error handling, so a
+ * propagated error surfaces here as 500. In production the setErrorHandler at
+ * index.ts:350 turns that same propagation into request.log.error + reportError.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { fixtures, readFixture } from "../../../fixtures/index.js";
+import {
+  buildTestApp,
+  createMultipartPayload,
+  loginAsAdmin,
+  type TestApp,
+} from "../../test-server.js";
+
+// putObject rejects only while `failPut` is set, so the same app instance can
+// serve a normal collage and, on demand, simulate a storage outage.
+const storageMock = vi.hoisted(() => ({ failPut: false }));
+
+vi.mock("../../../../apps/api/src/lib/object-storage.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../../apps/api/src/lib/object-storage.js")>();
+  return {
+    ...actual,
+    putObject: async (key: string, body: Buffer) => {
+      if (storageMock.failPut) {
+        throw new Error("test: object storage is unavailable");
+      }
+      return actual.putObject(key, body);
+    },
+  };
+});
+
+const PNG = readFixture(fixtures.image.base.png200);
+const JPG = readFixture(fixtures.image.base.jpg100);
+
+let testApp: TestApp;
+let app: TestApp["app"];
+let adminToken: string;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  app = testApp.app;
+  adminToken = await loginAsAdmin(app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+afterEach(() => {
+  storageMock.failPut = false;
+});
+
+function collageRequest(extra: Record<string, unknown> = {}) {
+  const { body, contentType } = createMultipartPayload([
+    { name: "f1", filename: "a.png", contentType: "image/png", content: PNG },
+    { name: "f2", filename: "b.jpg", contentType: "image/jpeg", content: JPG },
+    { name: "settings", content: JSON.stringify({ templateId: "2-h-equal", ...extra }) },
+  ]);
+  return app.inject({
+    method: "POST",
+    url: "/api/v1/tools/image/collage",
+    headers: { authorization: `Bearer ${adminToken}`, "content-type": contentType },
+    body,
+  });
+}
+
+describe("Collage error visibility (#740)", () => {
+  it("surfaces an object-storage failure as a server error, not a 422 masked as bad input", async () => {
+    storageMock.failPut = true;
+
+    const res = await collageRequest();
+
+    // Before the fix this returned 422 "Collage creation failed" and never
+    // reached the global handler. An infra failure must propagate instead.
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/tests/integration/tools/image/collage.test.ts
+++ b/tests/integration/tools/image/collage.test.ts
@@ -682,6 +682,35 @@ describe("Collage", () => {
     expect(result.processedSize).toBeGreaterThan(0);
   });
 
+  it("rejects a cell pan beyond the shared limit (COLLAGE_PAN_LIMIT + 1)", async () => {
+    // Pan past +/-200 is clamped in the preview and rejected by the route
+    // schema; both derive from the shared COLLAGE_PAN_LIMIT so they can't drift
+    // (#740). 201 is COLLAGE_PAN_LIMIT + 1.
+    const { body, contentType } = createMultipartPayload([
+      { name: "f1", filename: "a.png", contentType: "image/png", content: PNG },
+      { name: "f2", filename: "b.jpg", contentType: "image/jpeg", content: JPG },
+      {
+        name: "settings",
+        content: JSON.stringify({
+          templateId: "2-h-equal",
+          cells: [{ imageIndex: 0, panX: 201, panY: 0, zoom: 1, objectFit: "cover" }],
+        }),
+      },
+    ]);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/tools/image/collage",
+      headers: {
+        authorization: `Bearer ${adminToken}`,
+        "content-type": contentType,
+      },
+      body,
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
   it("uses 16:9 aspect ratio", async () => {
     const { body, contentType } = createMultipartPayload([
       { name: "f1", filename: "a.png", contentType: "image/png", content: PNG },
@@ -1857,7 +1886,7 @@ describe("Collage", () => {
 
   // ── JXL output format ─────────────────────────────────────────────
 
-  it("accepts jxl output format (succeeds if Sharp supports JXL)", async () => {
+  it("accepts jxl output format (succeeds if the cjxl/ImageMagick encoder is present)", async () => {
     const { body, contentType } = createMultipartPayload([
       { name: "f1", filename: "a.png", contentType: "image/png", content: PNG },
       { name: "f2", filename: "b.jpg", contentType: "image/jpeg", content: JPG },
@@ -1881,8 +1910,10 @@ describe("Collage", () => {
       body,
     });
 
-    // JXL support depends on the Sharp build; either succeeds or fails gracefully
-    expect([200, 422]).toContain(res.statusCode);
+    // JXL support depends on cjxl / ImageMagick being present. Either it encodes
+    // (200), or the binary is missing and that infra failure now surfaces as a
+    // real 500 with telemetry, not a 422 masked as bad input (#740).
+    expect([200, 500]).toContain(res.statusCode);
     if (res.statusCode === 200) {
       const result = JSON.parse(res.body);
       expect(result.processedSize).toBeGreaterThan(0);


### PR DESCRIPTION
## What

The collage route wrapped its whole processing block in one `catch` that returned `422 "Collage creation failed"` for every error. That span includes `putObject` and `encodeJxl`, so an object-storage outage or a missing cjxl/ImageMagick binary reached the user as unprocessable input. They retry with different images forever, and because the error was handled inline the global handler at `apps/api/src/index.ts:350` never ran: no `request.log.error`, no Sentry event. An operator debugging "collage always 422s" got nothing.

`InputValidationError` still returns 422 (the documented worker convention, see #718). Everything else now rethrows and propagates to the global handler, which logs it and reports to Sentry. In the test app, which uses Fastify's default handler, that surfaces as a 500.

Second change: the `+/-200` cell-pan clamp lived in two files, the route schema and the preview drag handler, joined only by comments pointing at each other. Both now read `COLLAGE_PAN_LIMIT` from `packages/shared/src/collage.ts`. That drift is what produced #718.

## Verification

- New `tests/integration/tools/image/collage-error-visibility.test.ts` forces `putObject` to reject and asserts the collage POST returns 500, not 422. Written first, watched it fail (`expected 422 to be 500`), then implemented the fix.
- `collage.test.ts`: added a guard that a cell pan past the shared limit is rejected (400), and retuned the JXL test from `[200, 422]` to `[200, 500]`, since a missing encoder is now a real failure instead of a masked one.
- Full collage suite green (91 tests). `pnpm typecheck` clean across all 9 workspaces. Biome clean on the changed files.

Closes #740
