### PR TITLE
fix(web,api): stop showing the wrong or stale image as a tool result

### DIFF
--- a/apps/api/src/jobs/postprocess.ts
+++ b/apps/api/src/jobs/postprocess.ts
@@ -15,6 +15,7 @@ import type { LibrarySaveMode } from "@snapotter/shared";
 import { eq } from "drizzle-orm";
 import sharp from "sharp";
 import { db, schema } from "../db/index.js";
+import { logger } from "../lib/logger.js";
 import { putObject } from "../lib/object-storage.js";
 import { pdfFirstPagePreview, videoPosterPreview } from "../modality/preview.js";
 
@@ -120,7 +121,6 @@ export async function generatePreview(
   buffer: Buffer,
   contentType: string,
   jobId: string,
-  fallbackInput?: Buffer,
 ): Promise<string | undefined> {
   // Per-modality dispatch (before the image logic)
   if (contentType.startsWith("video/")) {
@@ -154,18 +154,16 @@ export async function generatePreview(
     const previewBuffer = await sharp(previewInput).webp({ quality: 80 }).toBuffer();
     await putObject(key, previewBuffer);
     return key;
-  } catch {
-    // Retry with the original input buffer (pre-processing) which was
-    // already validated and decoded during the intake phase.
-    if (fallbackInput) {
-      try {
-        const fallbackBuffer = await sharp(fallbackInput).webp({ quality: 80 }).toBuffer();
-        await putObject(key, fallbackBuffer);
-        return key;
-      } catch {
-        // Both attempts failed; frontend will use the upload preview
-      }
-    }
+  } catch (err) {
+    // The result itself can't be decoded for a preview. Do NOT fall back to the
+    // pre-processing input: the client renders this preview under the processed
+    // filename, so an input-derived preview would show the untouched original as
+    // if it were the result (#746). No honest preview exists, so the frontend
+    // shows a success card instead.
+    logger.warn(
+      { err, jobId, contentType },
+      "preview generation failed; result has no renderable preview",
+    );
   }
   return undefined;
 }

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -432,7 +432,7 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
       }
 
       // Generate preview for non-browser-previewable formats
-      const previewRef = await generatePreview(resultBuffer, resultContentType, jobId, inputBuffer);
+      const previewRef = await generatePreview(resultBuffer, resultContentType, jobId);
 
       // Auto-save when the input came from the user's library (data.fileId is
       // set by the route when the upload referenced a library file). saveMode

--- a/apps/web/src/hooks/use-tool-processor.ts
+++ b/apps/web/src/hooks/use-tool-processor.ts
@@ -750,6 +750,23 @@ export function useToolProcessor(toolId: string) {
       // Batch runs never auto-save to the library (no fileId is sent), so a
       // previous single run's saved indicator must not survive into this one.
       useFileStore.getState().setLastSavedLibraryFileId(null);
+      // Mirror the single-file reset: clear every entry's stale processed state
+      // before this run uploads, so a failed or absent result can't render a
+      // previous run's output under the new run's filename and size (#746).
+      // Revoke stale result blob URLs so they don't leak.
+      const priorEntries = useFileStore.getState().entries;
+      for (let i = 0; i < priorEntries.length; i++) {
+        const staleUrl = priorEntries[i]?.processedUrl;
+        if (staleUrl?.startsWith("blob:")) URL.revokeObjectURL(staleUrl);
+        updateEntry(i, {
+          processedUrl: null,
+          processedPreviewUrl: null,
+          processedFilename: null,
+          processedSize: null,
+          status: "processing",
+          error: null,
+        });
+      }
       setProcessing(true);
       setProgress({ phase: "uploading", percent: 0, elapsed: 0 });
       // A stale evidence timer from a previous degraded run must not fire
@@ -790,6 +807,16 @@ export function useToolProcessor(toolId: string) {
       };
 
       const failRun = (message: string) => {
+        // Entries were set to "processing" at kickoff (the reset loop above). A
+        // whole-run failure that never reached settleFromZip must settle them,
+        // or the result pane keeps pulsing on the stale original because the
+        // entry never leaves "processing" (#746).
+        const runEntries = useFileStore.getState().entries;
+        for (let i = 0; i < runEntries.length; i++) {
+          if (runEntries[i]?.status === "processing") {
+            updateEntry(i, { status: "failed", error: message });
+          }
+        }
         setError(message);
         finishRun();
         trackBatch(canceledByUser ? "canceled" : "failed");
@@ -817,6 +844,10 @@ export function useToolProcessor(toolId: string) {
               processedUrl: URL.createObjectURL(blob),
               processedFilename: processedName,
               processedSize: blob.size,
+              // Batch results come from the ZIP, not a server preview; clear any
+              // stale processedPreviewUrl so an earlier single run's preview
+              // can't win over this result (displayUrl prefers it) (#746).
+              processedPreviewUrl: null,
               status: "completed",
               error: null,
             });
@@ -824,6 +855,11 @@ export function useToolProcessor(toolId: string) {
             // After a user cancel, a missing result is the cancel doing its
             // job, not a lookup failure.
             updateEntry(i, {
+              // Clear the result so hasProcessed goes false and the failure
+              // screen (guarded by !hasProcessed) renders instead of a stale
+              // previous result (#746).
+              processedUrl: null,
+              processedPreviewUrl: null,
               status: "failed",
               error: canceledByUser ? "Canceled" : "File not found in batch results",
             });

--- a/apps/web/src/lib/result-display.ts
+++ b/apps/web/src/lib/result-display.ts
@@ -1,0 +1,32 @@
+/**
+ * Whether the result area should render the "conversion complete" success card
+ * instead of an image, because the processed result has no renderable source.
+ *
+ * A non-previewable result (TIFF/JXL) whose server preview also failed has no
+ * honest src. The side-by-side, no-comparison, plain live-preview, and
+ * before-after branches all render `displayUrl` as the result, and `displayUrl`
+ * falls back to the original upload, so without this guard they show the
+ * untouched original under the processed filename and size (#746).
+ *
+ * The live-preview + imageWrapperStyle branch is the one exception: with the
+ * original present it either simulates the result in CSS (WYSIWYG tools) or
+ * handles the missing preview itself (input-overlay tools, #713), so it is not
+ * pre-empted here.
+ */
+export function shouldShowConversionCard(state: {
+  hasProcessed: boolean;
+  isProcessedPreviewable: boolean;
+  processedPreviewUrl: string | null | undefined;
+  originalBlobUrl: string | null | undefined;
+  displayMode: string;
+  hasImageWrapperStyle: boolean;
+}): boolean {
+  if (!state.hasProcessed) return false;
+  const resultIsRenderable = state.processedPreviewUrl != null || state.isProcessedPreviewable;
+  if (resultIsRenderable) return false;
+  const wysiwygCanRender =
+    state.displayMode === "live-preview" &&
+    state.hasImageWrapperStyle &&
+    state.originalBlobUrl != null;
+  return !wysiwygCanRender;
+}

--- a/apps/web/src/pages/tool-page.tsx
+++ b/apps/web/src/pages/tool-page.tsx
@@ -49,6 +49,7 @@ import { formatFileSize } from "@/lib/download";
 import { classifyFeedbackError } from "@/lib/feedback";
 import { format } from "@/lib/format";
 import { ICON_MAP } from "@/lib/icon-map";
+import { shouldShowConversionCard } from "@/lib/result-display";
 import {
   LIVE_PREVIEW_INPUT_OVERLAY_TOOLS,
   MULTI_FILE_TOOLS,
@@ -928,8 +929,21 @@ export function ToolPage() {
       </div>
     );
 
-    // Non-previewable format with no fallback at all - show success card
-    if (hasProcessed && !isProcessedPreviewable && !processedPreviewUrl && !originalBlobUrl) {
+    // A processed result with no renderable preview must not fall back to the
+    // original: the branches below render displayUrl as the result, so they
+    // would otherwise show the untouched original under the processed filename
+    // and size (#746). The live-preview + imageWrapperStyle branch is excluded
+    // (WYSIWYG CSS simulation, or #713 input-overlay handling).
+    if (
+      shouldShowConversionCard({
+        hasProcessed,
+        isProcessedPreviewable,
+        processedPreviewUrl,
+        originalBlobUrl,
+        displayMode,
+        hasImageWrapperStyle: imageWrapperStyle != null,
+      })
+    ) {
       return conversionCompleteCard;
     }
 

--- a/tests/unit/api/generate-preview.test.ts
+++ b/tests/unit/api/generate-preview.test.ts
@@ -1,0 +1,75 @@
+/**
+ * generatePreview honesty (#746). When the processed result can't be decoded
+ * for a preview, generatePreview must return no preview and log the failure. It
+ * must never fabricate a "result preview" from a different buffer (the old code
+ * fell back to the pre-processing input, which the client renders under the
+ * processed filename, so a converted file showed the untouched original).
+ *
+ * Uses REAL sharp (the sibling postprocess.test.ts mocks it) so an undecodable
+ * buffer actually throws and a valid one actually encodes.
+ */
+
+import sharp from "sharp";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../apps/api/src/db/index.js", () => ({
+  db: {},
+  schema: { jobs: {}, userFiles: {} },
+}));
+
+const putObjectMock = vi.hoisted(() => vi.fn());
+vi.mock("../../../apps/api/src/lib/object-storage.js", () => ({
+  putObject: putObjectMock,
+}));
+
+const loggerMock = vi.hoisted(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}));
+vi.mock("../../../apps/api/src/lib/logger.js", () => ({ logger: loggerMock }));
+
+import { generatePreview } from "../../../apps/api/src/jobs/postprocess.js";
+
+const JOB_ID = "job-preview-test";
+
+beforeEach(() => {
+  putObjectMock.mockReset();
+  loggerMock.warn.mockReset();
+});
+
+describe("generatePreview honesty (#746)", () => {
+  it("previews the actual result for a non-browser-previewable format", async () => {
+    const tiffResult = await sharp({
+      create: { width: 8, height: 8, channels: 3, background: { r: 10, g: 20, b: 30 } },
+    })
+      .tiff()
+      .toBuffer();
+
+    const key = await generatePreview(tiffResult, "image/tiff", JOB_ID);
+
+    expect(key).toBe(`outputs/${JOB_ID}/preview.webp`);
+    expect(putObjectMock).toHaveBeenCalledOnce();
+    expect(loggerMock.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns no preview and logs when the result can't be decoded, never fabricating one from the input", async () => {
+    const undecodableResult = Buffer.from("this is not a decodable image at all");
+    const decodableInput = await sharp({
+      create: { width: 8, height: 8, channels: 3, background: { r: 1, g: 2, b: 3 } },
+    })
+      .png()
+      .toBuffer();
+
+    // The 4th arg is the pre-processing input the old code fell back to. It is no
+    // longer a parameter (#746); passing it anyway proves the result preview is
+    // never fabricated from it.
+    // @ts-expect-error generatePreview no longer accepts a fallback input buffer.
+    const key = await generatePreview(undecodableResult, "image/tiff", JOB_ID, decodableInput);
+
+    expect(key).toBeUndefined();
+    expect(putObjectMock).not.toHaveBeenCalled();
+    expect(loggerMock.warn).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/web/result-display.test.ts
+++ b/tests/unit/web/result-display.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowConversionCard } from "@/lib/result-display";
+
+/**
+ * #746: a non-previewable result (TIFF/JXL) whose server preview also failed has
+ * no renderable source. The side-by-side, no-comparison, plain live-preview, and
+ * before-after branches render displayUrl as the result, and displayUrl falls
+ * back to the original upload, so without a guard they show the untouched
+ * original under the processed filename. shouldShowConversionCard decides when
+ * to render the success card instead.
+ */
+const base = {
+  hasProcessed: true,
+  isProcessedPreviewable: false,
+  processedPreviewUrl: null as string | null,
+  originalBlobUrl: "blob:original" as string | null,
+  displayMode: "side-by-side",
+  hasImageWrapperStyle: false,
+};
+
+describe("shouldShowConversionCard (#746)", () => {
+  it("is false before a result exists", () => {
+    expect(shouldShowConversionCard({ ...base, hasProcessed: false })).toBe(false);
+  });
+
+  it("is false when the processed result is browser-previewable", () => {
+    expect(shouldShowConversionCard({ ...base, isProcessedPreviewable: true })).toBe(false);
+  });
+
+  it("is false when a server-generated preview exists", () => {
+    expect(shouldShowConversionCard({ ...base, processedPreviewUrl: "blob:preview" })).toBe(false);
+  });
+
+  it("is true for a non-renderable result in the side-by-side branch", () => {
+    expect(shouldShowConversionCard({ ...base, displayMode: "side-by-side" })).toBe(true);
+  });
+
+  it("is true for a non-renderable result in the no-comparison branch", () => {
+    expect(shouldShowConversionCard({ ...base, displayMode: "no-comparison" })).toBe(true);
+  });
+
+  it("is true for a non-renderable result in the before-after branch", () => {
+    expect(shouldShowConversionCard({ ...base, displayMode: "before-after" })).toBe(true);
+  });
+
+  it("is true for plain live-preview without a wrapper style", () => {
+    expect(
+      shouldShowConversionCard({
+        ...base,
+        displayMode: "live-preview",
+        hasImageWrapperStyle: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false for live-preview + wrapper style with the original present (WYSIWYG / #713 handles it)", () => {
+    expect(
+      shouldShowConversionCard({
+        ...base,
+        displayMode: "live-preview",
+        hasImageWrapperStyle: true,
+        originalBlobUrl: "blob:original",
+      }),
+    ).toBe(false);
+  });
+
+  it("is true for live-preview + wrapper style when the original is gone", () => {
+    expect(
+      shouldShowConversionCard({
+        ...base,
+        displayMode: "live-preview",
+        hasImageWrapperStyle: true,
+        originalBlobUrl: null,
+      }),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/web/use-tool-processor-batch-recovery.test.ts
+++ b/tests/unit/web/use-tool-processor-batch-recovery.test.ts
@@ -670,3 +670,54 @@ describe("useToolProcessor proxy 5xx degrade (#750)", () => {
     unmount();
   });
 });
+
+describe("useToolProcessor batch stale-state reset (#746)", () => {
+  it("clears each entry's stale processed state and revokes its blob before uploading", () => {
+    const files = [
+      new File([new ArrayBuffer(16)], "first.png", { type: "image/png" }),
+      new File([new ArrayBuffer(16)], "second.jpg", { type: "image/jpeg" }),
+    ];
+    useFileStore.getState().setFiles(files);
+    // A previous run left a result on the first entry.
+    useFileStore.getState().updateEntry(0, {
+      processedUrl: "blob:old-result",
+      processedPreviewUrl: "/api/v1/download/old/preview.webp",
+      processedFilename: "first_old.png",
+      processedSize: 4321,
+      status: "completed",
+    });
+
+    const hook = renderHook(() => useToolProcessor("resize"));
+    act(() => {
+      void hook.result.current.processAllFiles(files, { width: 50 });
+    });
+
+    const entry = useFileStore.getState().entries[0];
+    expect(entry.processedUrl).toBeNull();
+    expect(entry.processedPreviewUrl).toBeNull();
+    expect(entry.processedFilename).toBeNull();
+    expect(entry.processedSize).toBeNull();
+    expect(entry.status).toBe("processing");
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:old-result");
+
+    hook.unmount();
+  });
+
+  it("settles entries as failed, not stuck at processing, when a whole-run failure never reaches the ZIP", () => {
+    const { unmount } = startBatchRun();
+
+    act(() => {
+      // Socket dies mid-upload (no upload.onload): the run fails via failRun
+      // without a terminal ZIP. Entries must not stay pulsing at "processing".
+      xhrs[0].onerror?.();
+    });
+
+    const entries = useFileStore.getState().entries;
+    expect(entries[0].status).toBe("failed");
+    expect(entries[1].status).toBe("failed");
+    expect(entries[0].processedUrl).toBeNull();
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+});


### PR DESCRIPTION
## What

Parts 1 and 2 of #746, the result-display and batch-state defects from the #713 review. Part 3 (ImageViewer's silent result-load error that eats the overlay) is a different failure mode in a different component; it's filed as #797 with the issue's own lower-priority tail.

### 1. Result branches showed the original as the result

`tool-page.tsx` builds `displayUrl` with a fallback to the original upload. The side-by-side, no-comparison, plain live-preview, and before-after branches render it as the result, so a non-previewable result (TIFF/JXL) whose server preview failed showed the untouched original under the processed filename and size. #713 fixed this for the input-overlay path only.

A shared `shouldShowConversionCard` (`apps/web/src/lib/result-display.ts`) now decides when the result has no renderable source, and those branches show the success card instead. The live-preview + imageWrapperStyle branch is the exception: with the original present it either simulates the result in CSS (WYSIWYG tools) or handles the missing preview itself (#713).

### 1, server side. generatePreview stopped fabricating a preview from the input

On a result it can't decode, `generatePreview` used to fall back to previewing the pre-processing input buffer and store that as the result preview. The client renders it under the processed filename, so it read as the result. It now logs the failure through the shared logger and returns nothing (the frontend shows the success card). The dead `fallbackInput` param and its single-file caller argument are gone.

### 2. Batch runs leaked stale processed state

`processAllFiles` now resets every entry's processed fields before uploading (revoking stale result blob URLs), writes `processedPreviewUrl` on completion, and clears the result on per-entry failure. Before this a failed entry kept its old `processedUrl`, so `hasProcessed` stayed true and the failure screen never rendered; and an earlier single run's `processedPreviewUrl` won over the fresh batch result, because `displayUrl` prefers it.

## Verification

- `tests/unit/web/result-display.test.ts` (9 cases): pins `shouldShowConversionCard` across the result branches, the renderable cases, and the WYSIWYG exception with and without the original.
- `tests/unit/api/generate-preview.test.ts` (2 cases): a real TIFF result still previews; an undecodable result returns nothing and logs, even when a decodable input is handed in. Written first, watched it fail on the old fabricating code (`expected 'outputs/.../preview.webp' to be undefined`).
- Two new cases in `tests/unit/web/use-tool-processor-batch-recovery.test.ts`: the kickoff reset clears stale processed fields and revokes the old blob URL; a whole-run failure settles in-flight entries as `failed` (not stuck at `processing`).
- Existing postprocess and batch-recovery unit tests still green (38 across the four files). `pnpm typecheck` clean across all 9 workspaces.

The review of the first cut caught that a whole-run failure left entries pulsing at `processing`; that `failRun` settle and its test are in this commit. It also noted the single-file error paths have the same latent stuck-pulse (pre-existing, out of scope here); worth a follow-up if it bites.

Part of #746.
