### PR TITLE
fix(ai): make the OCR runtime-index canonical JSON ASCII-safe

### DIFF
--- a/packages/ai/src/runtime-index.ts
+++ b/packages/ai/src/runtime-index.ts
@@ -43,7 +43,23 @@ function sortJson(value: unknown): unknown {
 
 /** Canonical representation shared with install_runtime.py and release signing. */
 export function canonicalRuntimeJson(value: unknown): string {
-  return `${JSON.stringify(sortJson(value))}\n`;
+  // Match Python's json.dumps(..., ensure_ascii=True), the form the signer and
+  // verifier use (docker/build-ocr-runtime.sh, docker/verify-ocr-runtime.sh):
+  // escape every UTF-16 code unit at or above 0x7f to \uXXXX (ensure_ascii
+  // escapes DEL too, which plain JSON.stringify leaves raw) so this re-serialization
+  // is byte-identical to the signed, ASCII-only index. Without it, one non-ASCII
+  // char (a model name, license, or source string) makes the raw.equals check
+  // and the Ed25519 verification fail at real install time even though the
+  // release workflow passes on today's all-ASCII metadata (#667). Escaping each
+  // UTF-16 code unit renders astral chars as surrogate pairs, exactly as
+  // ensure_ascii does. Structural JSON is ASCII, so only string contents change.
+  const json = JSON.stringify(sortJson(value));
+  let ascii = "";
+  for (let i = 0; i < json.length; i++) {
+    const code = json.charCodeAt(i);
+    ascii += code >= 0x7f ? `\\u${code.toString(16).padStart(4, "0")}` : json[i];
+  }
+  return `${ascii}\n`;
 }
 
 /** Resolve either the image-pinned release key or an operator-supplied trust store. */

--- a/tests/unit/features/ocr-runtime-install.test.ts
+++ b/tests/unit/features/ocr-runtime-install.test.ts
@@ -106,6 +106,7 @@ function signedIndex(
     archiveSize?: number;
     target?: string;
     minimumMemoryBytes?: number | null;
+    licenseNotice?: string;
   } = {},
 ) {
   const { publicKey, privateKey } = generateKeyPairSync("ed25519");
@@ -139,6 +140,7 @@ function signedIndex(
       qualities: ["balanced", "best"],
       providers: ["CPUExecutionProvider"],
     },
+    ...(options.licenseNotice ? { license: options.licenseNotice } : {}),
     ...(options.minimumMemoryBytes === null
       ? {}
       : { resources: { minimumMemoryBytes: options.minimumMemoryBytes ?? 4 * 1024 ** 3 } }),
@@ -158,6 +160,30 @@ function signedIndex(
   };
   return { artifact, index, raw: Buffer.from(canonicalRuntimeJson(index)), trustKey };
 }
+
+describe("canonicalRuntimeJson (#667)", () => {
+  it("escapes non-ASCII to match Python's json.dumps(ensure_ascii=True) signer form", () => {
+    // The signer (docker/build-ocr-runtime.sh) canonicalizes with
+    // json.dumps(ensure_ascii=True); the JS form must be byte-identical or the
+    // raw.equals and Ed25519 checks fail at install time on any non-ASCII char.
+    // Python: json.dumps({"x":"© 😀"}, sort_keys=True, separators=(",",":"))
+    //   -> {"x":"© 😀"}
+    expect(canonicalRuntimeJson({ x: "© 😀" })).toBe('{"x":"\\u00a9 \\ud83d\\ude00"}\n');
+  });
+
+  it("escapes U+007F (DEL), which ensure_ascii does but plain JSON.stringify leaves raw", () => {
+    expect(canonicalRuntimeJson({ k: String.fromCharCode(0x7f) })).toBe('{"k":"\\u007f"}\n');
+  });
+
+  it("leaves all-ASCII metadata byte-identical, so today's index still verifies", () => {
+    expect(canonicalRuntimeJson({ b: 2, a: "ok" })).toBe('{"a":"ok","b":2}\n');
+  });
+
+  it("emits pure-ASCII bytes so the verifier's ASCII gate accepts a signed non-ASCII index", () => {
+    const bytes = Buffer.from(canonicalRuntimeJson({ note: "café" }));
+    expect(bytes.some((byte) => byte > 0x7f)).toBe(false);
+  });
+});
 
 describe("remainingInstallerTimeoutMs", () => {
   it("floors a fractional remaining budget to the safe integer the installer requires", () => {
@@ -211,6 +237,17 @@ describe("verifyRuntimeIndex", () => {
       "22553579e29b27b75c9b6375d816f02483bd2e6f76f9ffcc9ae5311422410917",
     );
     expect(verified.minimumMemoryBytes).toBe(4 * 1024 ** 3);
+  });
+
+  it("verifies a signed index whose metadata contains non-ASCII, end to end (#667)", () => {
+    const fixture = signedIndex({ licenseNotice: "© 2026 Example Ø" });
+    // The signed bytes stay pure ASCII (the verifier's raw.some(byte > 0x7f) gate
+    // in runtime-index.ts) even though the license carries non-ASCII, because the
+    // canonical form escapes it. Before the fix the JS re-serialization diverged
+    // and this threw.
+    expect(fixture.raw.some((byte) => byte > 0x7f)).toBe(false);
+    const verified = verifyRuntimeIndex(fixture.raw, TARGET, [fixture.trustKey], "2.1.0");
+    expect((verified.artifact as { license?: string }).license).toBe("© 2026 Example Ø");
   });
 
   it("requires a signed positive safe minimum-memory policy", () => {


### PR DESCRIPTION
## What

The OCR runtime-index is signed and verified with two canonical forms that disagree on non-ASCII. The Python signer (`docker/build-ocr-runtime.sh:701-703`) and verifier (`docker/verify-ocr-runtime.sh:88-89`) use `json.dumps(..., ensure_ascii=True)`, which escapes non-ASCII to `\uXXXX`, so the signed index on disk is pure ASCII. The JS verifier's `canonicalRuntimeJson` used `JSON.stringify`, which emits raw UTF-8.

For any codepoint above 0x7f the two forms differ. So the moment the index carries one non-ASCII char (a model name, license, or source string), the `raw.equals(canonicalRuntimeJson(parsed))` check (`runtime-index.ts:159`) and the Ed25519 verification (`:192`) both fail at real install time, even though the release workflow passes on today's all-ASCII metadata. A "workflow green, install broken" trap.

`canonicalRuntimeJson` now escapes every non-ASCII UTF-16 code unit to `\uXXXX`, matching the signer byte for byte. Astral chars become surrogate pairs, exactly as `ensure_ascii` does. A code-unit loop rather than a regex keeps the source itself ASCII (no control char in a regex to trip the linter).

All-ASCII input is untouched, so the current signed index still verifies. The `raw.some(byte > 0x7f)` ASCII gate (`:146`) stays; this only makes the JS re-serialization agree with the ASCII-escaped bytes it compares against.

## Verification

- `tests/unit/features/ocr-runtime-install.test.ts`: three unit cases pin the canonical form (non-ASCII like a copyright sign and an emoji escape to the `\u`-sequences Python's `ensure_ascii` produces, an emoji as a surrogate pair; all-ASCII stays byte-identical; output is pure ASCII), plus a roundtrip that signs an index with a non-ASCII license and verifies it end to end through `verifyRuntimeIndex`. The unit cases were written first and watched fail on the old raw-UTF-8 form.
- Full `ocr-runtime-install` suite green (95 tests). `pnpm typecheck` clean across all 9 workspaces. Biome clean.

The review found and I fixed one boundary the first cut missed: `ensure_ascii` escapes U+007F (DEL) too, which `JSON.stringify` leaves raw, so the escape threshold is `>= 0x7f` (with its own test). Verified byte-parity against real `json.dumps` across all 1.1M code points, plus lone surrogates and a 5000-case fuzz.

## Follow-up

One adjacent, out-of-scope divergence on the key-ordering axis: `sortJson` orders keys by UTF-16 code unit while Python `sort_keys` uses code point. Unreachable on today's all-ASCII-keyed schema (only string values carry non-ASCII, which this PR handles); tracked in #800.

Closes #667
