### PR TITLE
feat(docs): emit JSON-LD structured data on docs pages

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -4,6 +4,7 @@ import { pagefindPlugin } from "vitepress-plugin-pagefind";
 import pkg from "../../../package.json";
 import { SUPPORTED_LOCALES } from "../../../packages/shared/src/i18n/index.ts";
 import { t } from "./i18n/ui.mjs";
+import { buildJsonLd } from "./jsonld.mts";
 import { pageOnlySidebar } from "./llms-sidebar.mjs";
 
 const NON_EN = SUPPORTED_LOCALES.filter((l) => l.code !== "en");
@@ -176,7 +177,10 @@ export default defineConfig({
   ],
 
   transformHead({ pageData }) {
-    const head: Array<[string, Record<string, string>]> = [];
+    // Widened past the 2-tuple form so the JSON-LD <script> tags below, which
+    // carry inner text as a third element, typecheck.
+    const head: Array<[string, Record<string, string>] | [string, Record<string, string>, string]> =
+      [];
     const rel = pageData.relativePath.replace(/(^|\/)index\.md$/, "$1").replace(/\.md$/, "");
     const codes = NON_EN.map((l) => l.code);
     const firstSeg = rel.split("/")[0];
@@ -219,6 +223,18 @@ export default defineConfig({
       head.push(["meta", { name: "twitter:description", content: pageData.description }]);
     }
     head.push(["meta", { name: "twitter:title", content: pageData.title }]);
+
+    // Structured data. buildJsonLd returns nothing for the noindexed locale
+    // trees, so this only fires on the indexable English pages.
+    for (const schema of buildJsonLd({
+      hostname: HOSTNAME,
+      enRel,
+      isLocale,
+      title: pageData.title,
+      description: pageData.description,
+    })) {
+      head.push(["script", { type: "application/ld+json" }, JSON.stringify(schema)]);
+    }
     return head;
   },
 

--- a/apps/docs/.vitepress/jsonld.mts
+++ b/apps/docs/.vitepress/jsonld.mts
@@ -1,0 +1,118 @@
+// Per-page JSON-LD structured data for the docs site. Kept free of vitepress
+// imports so it stays a pure function the unit test can exercise directly
+// (tests/unit/docs/jsonld.test.ts). config.mts wires the output into
+// transformHead as <script type="application/ld+json"> tags.
+
+export interface SectionCrumb {
+  name: string;
+  path: string;
+}
+
+// The docs site has no /guide, /tools, or /api index pages, so a breadcrumb
+// cannot point a section node at a section landing page. These are the entry
+// pages the top nav itself links each section to (see themeConfig.nav in
+// config.mts): real, indexable URLs. The jsonld unit test asserts each target
+// still exists, so a rename that would turn a breadcrumb into a 404 fails CI.
+export const SECTION_CRUMB: Record<string, SectionCrumb> = {
+  guide: { name: "Guide", path: "guide/getting-started" },
+  tools: { name: "Tools", path: "tools/image/resize" },
+  api: { name: "API Reference", path: "api/rest" },
+};
+
+export interface JsonLdInput {
+  hostname: string;
+  // Extension-less, locale-stripped page path: "" for the home page,
+  // "guide/architecture" for a content page.
+  enRel: string;
+  // True for the translated trees, which transformHead marks noindex.
+  isLocale: boolean;
+  title: string;
+  description?: string;
+}
+
+const CONTEXT = "https://schema.org";
+
+const ORG_SAME_AS = [
+  "https://github.com/snapotter-hq/snapotter",
+  "https://x.com/SnapOtterHQ",
+  "https://discord.gg/hr3s7HPUsr",
+  "https://hub.docker.com/r/snapotter/snapotter",
+];
+
+function homeSchemas(hostname: string): Array<Record<string, unknown>> {
+  return [
+    {
+      "@context": CONTEXT,
+      "@type": "WebSite",
+      name: "SnapOtter Docs",
+      url: hostname,
+      description:
+        "Documentation for SnapOtter, the open-source self-hosted file-processing suite: setup guides, REST API reference, and per-tool docs.",
+      publisher: {
+        "@type": "Organization",
+        name: "SnapOtter",
+        logo: { "@type": "ImageObject", url: "https://snapotter.com/logo.png" },
+        sameAs: ORG_SAME_AS,
+      },
+    },
+    {
+      "@context": CONTEXT,
+      "@type": "SoftwareApplication",
+      name: "SnapOtter",
+      applicationCategory: "UtilitiesApplication",
+      operatingSystem: "Docker, Linux, macOS, Windows",
+      description:
+        "Open-source, self-hosted file-processing suite with 200+ tools across image, video, audio, PDF, and documents.",
+      offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+      license: "https://www.gnu.org/licenses/agpl-3.0.en.html",
+      downloadUrl: "https://hub.docker.com/r/snapotter/snapotter",
+      url: "https://snapotter.com",
+    },
+  ];
+}
+
+function breadcrumb(hostname: string, enRel: string, title: string): Record<string, unknown> {
+  const trail: Array<{ name: string; item: string }> = [{ name: "SnapOtter Docs", item: hostname }];
+  const section = SECTION_CRUMB[enRel.split("/")[0]];
+  // Skip the section node when the current page IS the section entry, so it is
+  // not listed twice with the same URL.
+  if (section && section.path !== enRel) {
+    trail.push({ name: section.name, item: `${hostname}/${section.path}` });
+  }
+  trail.push({ name: title, item: `${hostname}/${enRel}` });
+  return {
+    "@context": CONTEXT,
+    "@type": "BreadcrumbList",
+    itemListElement: trail.map((node, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: node.name,
+      item: node.item,
+    })),
+  };
+}
+
+function techArticle(
+  hostname: string,
+  enRel: string,
+  title: string,
+  description?: string,
+): Record<string, unknown> {
+  return {
+    "@context": CONTEXT,
+    "@type": "TechArticle",
+    headline: title,
+    ...(description ? { description } : {}),
+    url: `${hostname}/${enRel}`,
+    inLanguage: "en",
+    isPartOf: { "@type": "WebSite", name: "SnapOtter Docs", url: hostname },
+  };
+}
+
+export function buildJsonLd(input: JsonLdInput): Array<Record<string, unknown>> {
+  const { hostname, enRel, isLocale, title, description } = input;
+  // Only the indexable English pages carry structured data.
+  if (isLocale) return [];
+  if (enRel === "") return homeSchemas(hostname);
+  return [breadcrumb(hostname, enRel, title), techArticle(hostname, enRel, title, description)];
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docs:dev": "vitepress dev .",
     "docs:build": "vitepress build .",
-    "lint": "biome check .vitepress/config.mts .vitepress/i18n .vitepress/llms-sidebar.mjs .vitepress/theme",
+    "lint": "biome check .vitepress/config.mts .vitepress/jsonld.mts .vitepress/i18n .vitepress/llms-sidebar.mjs .vitepress/theme",
     "docs:preview": "vitepress preview ."
   },
   "devDependencies": {

--- a/tests/unit/docs/jsonld.test.ts
+++ b/tests/unit/docs/jsonld.test.ts
@@ -1,0 +1,101 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import { buildJsonLd, SECTION_CRUMB } from "../../../apps/docs/.vitepress/jsonld.mts";
+
+const HOSTNAME = "https://docs.snapotter.com";
+const base = { hostname: HOSTNAME, isLocale: false };
+
+type Schema = Record<string, unknown>;
+type Crumb = { position: number; name: string; item: string };
+
+const byType = (out: Schema[], type: string) => out.find((s) => s["@type"] === type);
+const crumbs = (out: Schema[]) => (byType(out, "BreadcrumbList")?.itemListElement ?? []) as Crumb[];
+
+describe("buildJsonLd", () => {
+  test("emits nothing on noindexed non-English pages", () => {
+    // transformHead noindexes the translated trees; structured data on a
+    // noindexed page is wasted and self-contradictory.
+    const out = buildJsonLd({
+      ...base,
+      isLocale: true,
+      enRel: "guide/architecture",
+      title: "Architektur",
+    });
+    expect(out).toEqual([]);
+  });
+
+  test("home page carries WebSite and SoftwareApplication and no breadcrumb", () => {
+    const out = buildJsonLd({ ...base, enRel: "", title: "SnapOtter Docs", description: "d" });
+    const types = out.map((s) => s["@type"]);
+    expect(types).toContain("WebSite");
+    expect(types).toContain("SoftwareApplication");
+    expect(types).not.toContain("BreadcrumbList");
+    expect(byType(out, "SoftwareApplication")?.name).toBe("SnapOtter");
+  });
+
+  test("content page emits a BreadcrumbList then a TechArticle", () => {
+    const out = buildJsonLd({
+      ...base,
+      enRel: "guide/architecture",
+      title: "Architecture",
+      description: "How it fits together",
+    });
+    expect(out.map((s) => s["@type"])).toEqual(["BreadcrumbList", "TechArticle"]);
+    const article = byType(out, "TechArticle");
+    expect(article?.headline).toBe("Architecture");
+    expect(article?.url).toBe(`${HOSTNAME}/guide/architecture`);
+    expect(article?.description).toBe("How it fits together");
+    expect(article?.inLanguage).toBe("en");
+  });
+
+  test("breadcrumb trail is Docs > Section > Page with real URLs", () => {
+    const out = buildJsonLd({ ...base, enRel: "guide/architecture", title: "Architecture" });
+    const items = crumbs(out);
+    expect(items.map((i) => i.name)).toEqual(["SnapOtter Docs", "Guide", "Architecture"]);
+    expect(items.map((i) => i.position)).toEqual([1, 2, 3]);
+    expect(items[0].item).toBe(HOSTNAME);
+    expect(items[1].item).toBe(`${HOSTNAME}/guide/getting-started`);
+    expect(items[2].item).toBe(`${HOSTNAME}/guide/architecture`);
+  });
+
+  test("a tools page resolves its section to the tools entry page", () => {
+    const out = buildJsonLd({ ...base, enRel: "tools/video/trim", title: "Trim Video" });
+    const items = crumbs(out);
+    expect(items.map((i) => i.name)).toEqual(["SnapOtter Docs", "Tools", "Trim Video"]);
+    expect(items[1].item).toBe(`${HOSTNAME}/tools/image/resize`);
+    expect(items[2].item).toBe(`${HOSTNAME}/tools/video/trim`);
+  });
+
+  test("the section entry page itself is not duplicated in the trail", () => {
+    const out = buildJsonLd({ ...base, enRel: "guide/getting-started", title: "Getting started" });
+    expect(crumbs(out).map((i) => i.name)).toEqual(["SnapOtter Docs", "Getting started"]);
+  });
+
+  test("a top-level page with no section gets a two-level breadcrumb", () => {
+    const out = buildJsonLd({ ...base, enRel: "changelog", title: "Changelog" });
+    expect(crumbs(out).map((i) => i.name)).toEqual(["SnapOtter Docs", "Changelog"]);
+  });
+
+  test("TechArticle omits description when the page has none", () => {
+    const out = buildJsonLd({ ...base, enRel: "guide/architecture", title: "Architecture" });
+    expect(byType(out, "TechArticle")).not.toHaveProperty("description");
+  });
+
+  test("every schema declares the schema.org context", () => {
+    const out = buildJsonLd({ ...base, enRel: "guide/architecture", title: "Architecture" });
+    for (const s of out) {
+      expect(s["@context"]).toBe("https://schema.org");
+    }
+  });
+
+  test("every section-crumb target is a real docs page (guards silent 404s)", () => {
+    const root = join(dirname(fileURLToPath(import.meta.url)), "../../../apps/docs");
+    const targets = Object.values(SECTION_CRUMB);
+    expect(targets.length).toBeGreaterThan(0);
+    for (const { path } of targets) {
+      expect(existsSync(join(root, `${path}.md`)), `${path}.md must exist`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What

`docs.snapotter.com` was the only public surface without JSON-LD structured data (the gap that opened #803). This adds it through the existing `transformHead` hook in `apps/docs/.vitepress/config.mts`:

- Home page: `WebSite` + `SoftwareApplication`
- Every content page: `BreadcrumbList` + `TechArticle`

## Notes

- Only the indexable English pages carry it. The translated trees are already noindexed, so `buildJsonLd` returns `[]` for them.
- The docs site has no `/guide`, `/tools`, or `/api` index pages, so each breadcrumb section node points at the entry page the top nav already uses for that section (a real URL). A unit test asserts those targets exist, so a rename that would turn a crumb into a 404 fails CI instead of shipping silently.
- Schema logic lives in a pure module, `.vitepress/jsonld.mts`, so it's unit-testable without loading VitePress. The `head` tuple type in `transformHead` is widened to allow the `<script>` inner-text element.

## Verification

- `tests/unit/docs/jsonld.test.ts`: 10 tests, watched RED then GREEN. Covers noindex gating, home vs content schemas, the breadcrumb trail and URLs, section-entry dedup, description omitted when absent, and the guard that every section-crumb target file exists.
- `biome check` clean on the touched files; `tsc --strict` clean on the module.
- Full `docs:build` (exit 0). Grepped the output: home has `WebSite` + `SoftwareApplication` and no breadcrumb; `guide/architecture` has a three-level `BreadcrumbList` (Docs > Guide > Architecture, real URLs) plus `TechArticle`; `de/guide/architecture` has zero ld+json and keeps its `noindex`.

Closes #803
