### PR TITLE
feat(docs): add image and author to docs TechArticle JSON-LD

### DIFF
--- a/apps/docs/.vitepress/jsonld.mts
+++ b/apps/docs/.vitepress/jsonld.mts
@@ -103,6 +103,10 @@ function techArticle(
     "@type": "TechArticle",
     headline: title,
     ...(description ? { description } : {}),
+    // image and author are Google-recommended Article fields. Every docs page
+    // shares the site OG image and is authored by the project.
+    image: `${hostname}/og-image.png`,
+    author: { "@type": "Organization", name: "SnapOtter", url: "https://snapotter.com" },
     url: `${hostname}/${enRel}`,
     inLanguage: "en",
     isPartOf: { "@type": "WebSite", name: "SnapOtter Docs", url: hostname },

--- a/tests/unit/docs/jsonld.test.ts
+++ b/tests/unit/docs/jsonld.test.ts
@@ -50,6 +50,20 @@ describe("buildJsonLd", () => {
     expect(article?.inLanguage).toBe("en");
   });
 
+  test("TechArticle carries a representative image", () => {
+    const out = buildJsonLd({ ...base, enRel: "guide/architecture", title: "Architecture" });
+    expect(byType(out, "TechArticle")?.image).toBe(`${HOSTNAME}/og-image.png`);
+  });
+
+  test("TechArticle names SnapOtter as the Organization author", () => {
+    const out = buildJsonLd({ ...base, enRel: "guide/architecture", title: "Architecture" });
+    expect(byType(out, "TechArticle")?.author).toEqual({
+      "@type": "Organization",
+      name: "SnapOtter",
+      url: "https://snapotter.com",
+    });
+  });
+
   test("breadcrumb trail is Docs > Section > Page with real URLs", () => {
     const out = buildJsonLd({ ...base, enRel: "guide/architecture", title: "Architecture" });
     const items = crumbs(out);


### PR DESCRIPTION
## What

Follow-up to #804. Google's Rich Results Test on a docs page returned a valid, eligible Article with two non-critical warnings: missing `image` and missing `author`. This adds both recommended fields to the shared `TechArticle` builder, so every content page picks them up: the site OG image and an `Organization` author.

## Notes

- `dateModified` was left out on purpose. Sourcing it means turning on VitePress `lastUpdated`, which also renders a "Last updated" footer on every page, and the Rich Results Test did not flag it as missing.
- Source-only change (`.vitepress/jsonld.mts`). The helper already had `hostname`, so `config.mts` is untouched.

## Verification

- `tests/unit/docs/jsonld.test.ts`: +2 tests (image, author), watched RED then GREEN; 12 total pass.
- `biome` + `tsc --strict` clean on the module.
- `docs:build` (exit 0). Grepped the output: the `guide/architecture` TechArticle now carries `image: https://docs.snapotter.com/og-image.png` and an `author` Organization named SnapOtter, clearing both Rich Results Test warnings.
