### PR TITLE
feat(landing): add a sticky mobile CTA bar for phone viewports

### DIFF
--- a/apps/landing/src/components/StickyMobileCta.astro
+++ b/apps/landing/src/components/StickyMobileCta.astro
@@ -1,0 +1,50 @@
+---
+// biome-ignore-all lint/correctness/noUnusedVariables: Astro template consumes frontmatter values.
+// biome-ignore-all lint/correctness/noUnusedImports: Astro template consumes frontmatter imports.
+// Persistent bottom CTA for phones. The navbar's CTAs live in its md:flex
+// desktop cluster and are hidden below md, so without this a phone visitor has
+// no call to action until they open the hamburger. Hidden again at md+, where
+// the navbar CTAs reappear. CSS-only, no client JS: it is always-visible while
+// mounted, so the responsive breakpoint alone decides when it shows.
+//
+// Actions mirror what the hero and navbar already offer, reusing their i18n
+// keys so no new strings are needed: "Try the live demo" (lowest friction) and
+// "Get Started Free" (the primary docs quickstart). "Book a Demo" stays in the
+// nav; it is the enterprise path, not the self-serve one this bar is for.
+import { t } from "@/i18n";
+
+interface Props {
+  locale?: string;
+}
+
+const { locale = "en" } = Astro.props;
+---
+
+<div class="md:hidden">
+  {/* In-flow spacer so the fixed bar never covers the last row of the footer.
+      Generous by a hair on purpose; a small gap beats clipping content. */}
+  <div style="height: calc(4.5rem + env(safe-area-inset-bottom));" aria-hidden="true"></div>
+
+  <div
+    id="mobile-cta"
+    class="fixed inset-x-0 bottom-0 z-40 flex gap-2 border-t border-border bg-surface/95 px-4 py-3 backdrop-blur-xl"
+    style="padding-bottom: max(0.75rem, env(safe-area-inset-bottom));"
+  >
+    <a
+      href="https://demo.snapotter.com"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="flex-1 rounded-lg border border-border px-4 py-2.5 text-center text-sm font-medium transition-colors hover:bg-background-alt"
+    >
+      {t(locale, "home.quickstart.tryDemo")}
+    </a>
+    <a
+      href="https://docs.snapotter.com/guide/getting-started.html"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="btn-primary flex-1 rounded-lg px-4 py-2.5 text-center text-sm font-semibold"
+    >
+      {t(locale, "nav.getStartedFree")}
+    </a>
+  </div>
+</div>

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -5,6 +5,7 @@ import "@/styles/globals.css";
 import { TOOLS } from "@snapotter/shared";
 import Analytics from "@/components/Analytics.astro";
 import MachineTranslationBanner from "@/components/MachineTranslationBanner.astro";
+import StickyMobileCta from "@/components/StickyMobileCta.astro";
 import { LANDING_LOCALES, t } from "@/i18n";
 import { altLinks, dirFor, ogLocale } from "@/lib/i18n-page";
 
@@ -17,6 +18,7 @@ interface Props {
   noindex?: boolean;
   locale?: string;
   path?: string; // un-prefixed page path for hreflang, e.g. "/faq" or "/"
+  mobileCta?: boolean; // phone-only bottom CTA bar; off for pages that end in their own CTA
 }
 
 const toolCount = TOOLS.length;
@@ -32,6 +34,7 @@ const {
   noindex = false,
   locale = "en",
   path = "/",
+  mobileCta = true,
 } = Astro.props;
 
 const alternates = altLinks(path);
@@ -131,6 +134,7 @@ const htmlDir = dirFor(locale);
     <a href="#main" class="skip-link">{t(locale, "common.skipToContent")}</a>
     <MachineTranslationBanner locale={locale} />
     <slot />
+    {mobileCta && <StickyMobileCta locale={locale} />}
 
     <!-- Scroll-triggered reveal observer -->
     <script is:inline>

--- a/apps/landing/src/pages/[...locale]/contact.astro
+++ b/apps/landing/src/pages/[...locale]/contact.astro
@@ -59,6 +59,7 @@ const subjects = [
   canonical={`https://snapotter.com${localizeHref(locale, PATH)}`}
   locale={locale}
   path={PATH}
+  mobileCta={false}
 >
   <Fragment slot="head">
     <JsonLd data={breadcrumbJsonLd} />

--- a/apps/landing/src/pages/[...locale]/enterprise.astro
+++ b/apps/landing/src/pages/[...locale]/enterprise.astro
@@ -185,6 +185,7 @@ const xSvg =
   canonical={`https://snapotter.com${localizeHref(locale, PATH)}`}
   locale={locale}
   path={PATH}
+  mobileCta={false}
 >
   <Fragment slot="head">
     <JsonLd data={[breadcrumbJsonLd, productJsonLd]} />

--- a/apps/landing/src/pages/[...locale]/privacy.astro
+++ b/apps/landing/src/pages/[...locale]/privacy.astro
@@ -39,6 +39,7 @@ const breadcrumbJsonLd = {
   canonical={`https://snapotter.com${localizeHref(locale, PATH)}`}
   locale={locale}
   path={PATH}
+  mobileCta={false}
 >
   <Fragment slot="head">
     <JsonLd data={breadcrumbJsonLd} />

--- a/apps/landing/src/pages/[...locale]/terms.astro
+++ b/apps/landing/src/pages/[...locale]/terms.astro
@@ -39,6 +39,7 @@ const breadcrumbJsonLd = {
   canonical={`https://snapotter.com${localizeHref(locale, PATH)}`}
   locale={locale}
   path={PATH}
+  mobileCta={false}
 >
   <Fragment slot="head">
     <JsonLd data={breadcrumbJsonLd} />

--- a/tests/e2e-landing/sticky-mobile-cta.spec.ts
+++ b/tests/e2e-landing/sticky-mobile-cta.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+// The navbar's CTAs live in the md:flex desktop cluster, so on phones they are
+// hidden until the hamburger is opened. This bar keeps a one-tap action in view.
+const PHONE = { width: 390, height: 844 };
+const DESKTOP = { width: 1280, height: 800 };
+
+test.describe("Sticky mobile CTA", () => {
+  test("shows a persistent CTA bar on phone viewports", async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await page.goto("/");
+
+    const bar = page.locator("#mobile-cta");
+    await expect(bar).toBeVisible();
+
+    // Both actions are reachable without opening the hamburger menu.
+    await expect(bar.getByRole("link", { name: "Try the live demo" })).toHaveAttribute(
+      "href",
+      "https://demo.snapotter.com",
+    );
+    await expect(bar.getByRole("link", { name: "Get Started Free" })).toHaveAttribute(
+      "href",
+      "https://docs.snapotter.com/guide/getting-started.html",
+    );
+  });
+
+  test("is hidden on desktop where the navbar CTAs are already visible", async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await page.goto("/");
+
+    // Present in the DOM but display:none via md:hidden, not simply absent.
+    const bar = page.locator("#mobile-cta");
+    await expect(bar).toBeAttached();
+    await expect(bar).toBeHidden();
+  });
+
+  test("does not render on pages that already end in their own CTA", async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await page.goto("/contact");
+
+    // contact opts out (the form is the page's CTA), so the bar is absent entirely.
+    await expect(page.locator("#mobile-cta")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## What

On phones the landing page had no visible call to action until you opened the hamburger, because the navbar's CTAs sit in its `md:flex` desktop cluster and are hidden below `md`. This adds a fixed bottom bar carrying the two self-serve actions, "Try the live demo" and "Get Started Free", so a phone visitor always has a one-tap action in view. It hides again at `md+`, where the navbar CTAs come back.

## How

- New `StickyMobileCta.astro`, CSS-only (`md:hidden`), fixed to the bottom, reusing the existing `home.quickstart.tryDemo` and `nav.getStartedFree` i18n keys. No new strings across the 21 landing locales.
- Rendered site-wide from `Base.astro` behind a `mobileCta` prop (default on). Pages that already end in their own CTA opt out: `contact`, `enterprise`, `privacy`, `terms`.
- An in-flow spacer reserves height so the fixed bar never covers the last footer row on mobile. iOS home-indicator overlap is handled with `env(safe-area-inset-bottom)`.

## Verification

- New `tests/e2e-landing/sticky-mobile-cta.spec.ts`, written test-first: visible on a phone viewport with both hrefs correct, present-but-hidden on desktop, absent on the opted-out contact page. Watched it fail on the missing `#mobile-cta` before implementing.
- Full landing e2e suite green: 129 passed. Existing a11y, mobile-nav, subpages, and homepage specs are unaffected.
- `biome check` clean; `astro check && tsc --noEmit` clean.
- Eyeballed at 390px and 1280px: bar pinned to the bottom on mobile, footer clears it, no bar and no leftover gap on desktop, no bar on the contact opt-out.

Closes #802
