### PR TITLE
feat(api,web): pipeline runs can be canceled

### DIFF
--- a/apps/api/src/jobs/cancel.ts
+++ b/apps/api/src/jobs/cancel.ts
@@ -2,13 +2,18 @@
  * Cooperative job cancellation via Redis pub/sub.
  *
  * - Workers call registerCancelable(jobId) on start and unregister on finish.
- * - requestCancel(jobId) handles four states:
- *   1. Batch parent: flag the batch canceled and publish every flow child
- *      id on the cancel channel; batch-finalize commits terminal state (#767).
- *   2. Waiting/delayed: remove from queue, mark DB row canceled.
- *   3. Active (in a worker): publish the jobId on the cancel channel;
+ * - requestCancel(jobId) handles six states:
+ *   1. Batch parent (plain or pipeline-batch): flag the batch canceled and
+ *      publish every runnable child id on the cancel channel; batch-finalize
+ *      commits terminal state (#767, #771).
+ *   2. Pipeline flow row: flag the run under the id its steps carry and
+ *      publish the step ids; pipeline-finalize commits terminal state (#771).
+ *   3. Pipeline SSE alias: resolve the settings.pipelineFlowId pointer the
+ *      route stamped, then cancel the flow the same way (#771).
+ *   4. Waiting/delayed: remove from queue, mark DB row canceled.
+ *   5. Active (in a worker): publish the jobId on the cancel channel;
  *      the worker's AbortSignal fires and it cleans up.
- *   4. Terminal or absent: no-op, returns false.
+ *   6. Terminal or absent: no-op, returns false.
  * - startCancelListener() subscribes to the cancel channel and fires
  *   registered AbortControllers.
  */
@@ -66,22 +71,46 @@ export async function stopCancelListener(): Promise<void> {
 
 // ── Cancel request ──────────────────────────────────────────────
 
+/** Cancel metadata the routes stamp into jobs.settings at enqueue time. */
+interface CancelRowSettings {
+  flowChildCount?: number;
+  stepCount?: number;
+  clientJobId?: string;
+  pipelineFlowId?: string;
+}
+
+function isTerminal(status: string): boolean {
+  return status === "completed" || status === "failed" || status === "canceled";
+}
+
+/** Best-effort abort accelerant for active jobs; the cooperative flag is the
+ * durable mechanism, so one failed publish must not 500 a cancel that
+ * already committed. */
+async function publishCancel(id: string): Promise<void> {
+  await sharedRedis()
+    .publish(CANCEL_CHANNEL(), id)
+    .catch((err) => {
+      console.error("cancel publish failed", id, err);
+    });
+}
+
 /**
  * Attempt to cancel a job.
  *
- * Returns true if the job was removed (waiting/delayed) or a cancel
- * signal was published (active). Returns false if the job is already
- * terminal or not found in any queue.
+ * Returns true if the job was removed (waiting/delayed), a cancel signal
+ * was published (active), or a cooperative flag was committed (batch and
+ * pipeline runs). Returns false if the job is already terminal or not
+ * found in any queue.
  */
 export async function requestCancel(jobId: string): Promise<boolean> {
-  // Batch parents never match the single-job states below: they sit in
-  // waiting-children while their <parentId>-fN children run, so a cancel
-  // against the parent id used to cancel nothing (#767). Cancel them
-  // cooperatively instead: flag the batch (children consult the flag before
-  // doing any work), abort active children over the cancel channel, and let
-  // batch-finalize commit the canceled terminal state. Keyed off the DB row,
-  // not the queue job, so a cancel landing between the parent row insert and
-  // the flow enqueue still takes effect.
+  // Batch and pipeline parents never match the single-job states below:
+  // they sit in waiting-children while their children run, so a cancel
+  // against the parent id used to cancel nothing (#767, #771). Cancel them
+  // cooperatively instead: flag the run (steps and children consult the
+  // flag before doing any work), abort active jobs over the cancel channel,
+  // and let the finalize commit the canceled terminal state. Keyed off the
+  // DB row, not the queue job, so a cancel landing between the row insert
+  // and the flow enqueue still takes effect.
   const [row] = await db
     .select({
       type: schema.jobs.type,
@@ -92,32 +121,68 @@ export async function requestCancel(jobId: string): Promise<boolean> {
     .from(schema.jobs)
     .where(eq(schema.jobs.id, jobId));
   if (row?.type === "batch") {
-    // Pipeline-batch children are pipeline flows without a cooperative
-    // check; a flag would report canceled while every step keeps running.
-    if (row.toolId === "pipeline-batch") return false;
     // Custom batch sub-routes (pdf-to-image, svg-to-raster) process inline
     // and only publish progress frames; their rows are implicit inserts with
     // no settings and nothing reads the flag. Claiming canceled: true for
     // them would be a lie. Real batch parents write settings (with
     // flowChildCount) at insert time, before the enqueue window.
     if (!row.settings) return false;
-    if (row.status === "completed" || row.status === "failed" || row.status === "canceled") {
-      return false;
-    }
+    if (isTerminal(row.status)) return false;
     await markBatchCanceled(jobId);
-    const flowChildCount =
-      (row.settings as { flowChildCount?: number } | null)?.flowChildCount ?? 0;
-    for (let i = 0; i < flowChildCount; i++) {
-      // Best-effort accelerant for active children; the flag above is the
-      // durable mechanism, so one failed publish must not 500 a cancel that
-      // already committed.
-      await sharedRedis()
-        .publish(CANCEL_CHANNEL(), `${jobId}-f${i}`)
-        .catch((err) => {
-          console.error("batch child cancel publish failed", `${jobId}-f${i}`, err);
-        });
+    const settings = row.settings as CancelRowSettings;
+    const flowChildCount = settings.flowChildCount ?? 0;
+    if (row.toolId === "pipeline-batch") {
+      // Pipeline-batch children are per-file pipeline finalizes, which never
+      // register as cancelables; the abortable jobs are their steps (#771).
+      const stepCount = settings.stepCount ?? 0;
+      for (let i = 0; i < flowChildCount; i++) {
+        for (let j = 0; j < stepCount; j++) {
+          await publishCancel(`${jobId}-f${i}-s${j}`);
+        }
+      }
+    } else {
+      for (let i = 0; i < flowChildCount; i++) {
+        await publishCancel(`${jobId}-f${i}`);
+      }
     }
     return true;
+  }
+
+  // Single-run pipeline flow row (#771). The cooperative flag must be keyed
+  // by the id the steps carry in data.clientJobId (the client-facing id,
+  // stamped into settings at enqueue); rows from before the stamp existed
+  // can only be no-alias runs, where that id is the flow id itself.
+  if (row?.type === "pipeline") {
+    if (isTerminal(row.status)) return false;
+    const settings = (row.settings ?? {}) as CancelRowSettings;
+    await markBatchCanceled(settings.clientJobId ?? jobId);
+    const stepCount = settings.stepCount ?? 0;
+    for (let j = 0; j < stepCount; j++) {
+      await publishCancel(`${jobId}-s${j}`);
+    }
+    return true;
+  }
+
+  // Pipeline SSE alias (#771): the row the client-facing id lands on. The
+  // route stamps settings.pipelineFlowId at insert, before the flow rows
+  // exist, so a cancel in that window still commits the flag (the alias id
+  // is exactly the scope key the steps will consult). Plain single rows
+  // have no pointer and fall through to the queue scan unchanged.
+  if (row?.type === "single") {
+    const settings = (row.settings ?? {}) as CancelRowSettings;
+    if (settings.pipelineFlowId) {
+      if (isTerminal(row.status)) return false;
+      await markBatchCanceled(jobId);
+      const [flowRow] = await db
+        .select({ settings: schema.jobs.settings })
+        .from(schema.jobs)
+        .where(eq(schema.jobs.id, settings.pipelineFlowId));
+      const stepCount = ((flowRow?.settings ?? {}) as CancelRowSettings).stepCount ?? 0;
+      for (let j = 0; j < stepCount; j++) {
+        await publishCancel(`${settings.pipelineFlowId}-s${j}`);
+      }
+      return true;
+    }
   }
 
   for (const pool of POOLS) {

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -64,6 +64,7 @@ import { timeoutMessage } from "../lib/timeout.js";
 import { InputValidationError } from "../modality/contract.js";
 import {
   cancelBatchJob,
+  cancelSingleJobGuarded,
   completeBatchJob,
   failBatchJob,
   failSingleJobGuarded,
@@ -658,6 +659,45 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
 async function processPipelineStep(job: Job<ToolJobData>): Promise<ToolJobResult> {
   const data = job.data;
 
+  // Cooperative pipeline cancel (#771): steps queued behind the cancel do
+  // no work at all. The scope key is the batch parent for pipeline-batch
+  // steps and the client-facing id for single runs (data.clientJobId is
+  // clientJobId ?? flowId, the same key requestCancel flags). Active steps
+  // are aborted over the cancel channel instead and land in the catch below
+  // via processToolJob's own cancel handling. A fault here must fall through
+  // to normal processing, not wedge the row (attempts: 1, and nothing else
+  // revisits it); the run then finishes as a too-late cancel.
+  const cancelScope = data.parentId ?? data.clientJobId;
+  if (cancelScope) {
+    try {
+      if (await isBatchCanceled(cancelScope)) {
+        await db
+          .update(schema.jobs)
+          .set({ status: "canceled", completedAt: new Date(), error: { message: "Canceled" } })
+          .where(
+            and(
+              eq(schema.jobs.id, data.jobId),
+              notInArray(schema.jobs.status, ["completed", "failed", "canceled"]),
+            ),
+          );
+        jobsTotal.inc({ pool: data.pool, status: "canceled" });
+        return {
+          outputRefs: [],
+          filename: data.filename,
+          contentType: "",
+          originalSize: 0,
+          processedSize: 0,
+          resultPayload: { failed: true, canceled: true, error: "Canceled" },
+        };
+      }
+    } catch (err) {
+      logger.warn(
+        { err, jobId: data.jobId, cancelScope },
+        "pipeline cancel skip failed; processing the step normally",
+      );
+    }
+  }
+
   // Resolve inputRefs at run time: step 0 already has them from the
   // route; later steps read the previous step's output from the DB.
   if (data.stepIndex !== undefined && data.stepIndex > 0 && data.prevJobId) {
@@ -784,7 +824,7 @@ export function pipelineExecutedProps(
   totalSteps: number,
   toolIds: string[],
   durationMs: number,
-  status: "completed" | "failed",
+  status: "completed" | "failed" | "canceled",
 ) {
   // `satisfies` (not a return-type annotation) validates the shape against
   // PipelineExecutedProperties while keeping the inferred anonymous type, which
@@ -810,6 +850,7 @@ async function processPipelineFinalize(job: Job<ToolJobData>): Promise<ToolJobRe
   let lastOutputRef = "";
   let lastBytesOut = 0;
   let failedAtStep: number | null = null;
+  let failedStepCanceled = false;
   let failError = "";
 
   for (let i = 0; i < totalSteps; i++) {
@@ -824,6 +865,7 @@ async function processPipelineFinalize(job: Job<ToolJobData>): Promise<ToolJobRe
 
     if (row.status !== "completed") {
       failedAtStep = i;
+      failedStepCanceled = row.status === "canceled";
       failError = (row.error as { message?: string } | null)?.message ?? `Step ${i + 1} failed`;
       break;
     }
@@ -842,6 +884,58 @@ async function processPipelineFinalize(job: Job<ToolJobData>): Promise<ToolJobRe
   }
 
   const progressJobId = data.clientJobId ?? data.jobId;
+
+  // ── Cancel path (#771) ──────────────────────────────────────
+  // Cancel requires both halves (#770's too-late rule): the flag proves a
+  // cancel was requested, a canceled step proves it landed before the work
+  // finished. A flag with zero canceled steps means every step completed
+  // first; that pipeline completes normally, matching a too-late cancel on
+  // a single run. Intermediate step outputs are internal artifacts (a
+  // half-processed frame is not a deliverable), so a canceled pipeline
+  // returns nothing.
+  const cancelScope = data.parentId ?? data.clientJobId ?? data.jobId;
+  const canceled =
+    failedAtStep !== null && failedStepCanceled && (await isBatchCanceled(cancelScope));
+
+  if (canceled) {
+    // Guarded dual write (#766): the SSE channel (clientJobId) and the
+    // authoritative flow row can differ; both must settle canceled or a
+    // reconnecting client replays a live row forever.
+    await cancelSingleJobGuarded({ jobId: data.jobId });
+    if (progressJobId !== data.jobId) {
+      await cancelSingleJobGuarded({ jobId: progressJobId });
+    }
+
+    // Batch progress (pipeline-batch only): the canceled file counts like a
+    // failed one; batch-finalize turns the canceled rows into #767's
+    // partial-ZIP semantics.
+    if (data.parentId && data.totalFiles !== undefined) {
+      await recordChildOutcome(data.parentId, data.totalFiles, data.filename, "Canceled");
+    }
+
+    if (analyticsEnabled()) {
+      void trackEvent(
+        ANALYTICS_EVENTS.PIPELINE_EXECUTED,
+        pipelineExecutedProps(
+          data,
+          totalSteps,
+          steps.map((s) => s.toolId),
+          Date.now() - startTime,
+          "canceled",
+        ),
+        data.analyticsDistinctId,
+      );
+    }
+
+    return {
+      outputRefs: [],
+      filename: data.filename,
+      contentType: "",
+      originalSize: firstBytesIn,
+      processedSize: 0,
+      resultPayload: { error: "Canceled", canceled: true, stepsCompleted: steps.length, steps },
+    };
+  }
 
   // ── Failure path ────────────────────────────────────────────
   if (failedAtStep !== null) {

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -890,7 +890,10 @@ async function processPipelineFinalize(job: Job<ToolJobData>): Promise<ToolJobRe
   // cancel was requested, a canceled step proves it landed before the work
   // finished. A flag with zero canceled steps means every step completed
   // first; that pipeline completes normally, matching a too-late cancel on
-  // a single run. Intermediate step outputs are internal artifacts (a
+  // a single run. The flag's 1h TTL means a cancel on a pipeline that runs
+  // longer than that settles as a failure whose message still reads
+  // "Canceled": the same accepted tradeoff batch finalize inherited from
+  // #770. Intermediate step outputs are internal artifacts (a
   // half-processed frame is not a deliverable), so a canceled pipeline
   // returns nothing.
   const cancelScope = data.parentId ?? data.clientJobId ?? data.jobId;
@@ -1515,7 +1518,9 @@ export function startWorkers(): void {
       // SSE channel (clientJobId) and the authoritative flow row can differ,
       // so both get the guarded write; a committed completion is never
       // downgraded, and the frame is announced only for a transition this
-      // call owned.
+      // call owned. A finalize that dies inside its own cancel dual-write
+      // (#771) lands here too and gets labeled a failure; once that write
+      // threw, the net cannot know the run was canceled.
       if (data?.kind === "pipeline-finalize") {
         const netFail = (jobId: string) =>
           failSingleJobGuarded({ jobId, message: "Pipeline processing failed" }).catch((netErr) => {

--- a/apps/api/src/routes/pipeline.ts
+++ b/apps/api/src/routes/pipeline.ts
@@ -191,6 +191,9 @@ function buildPipelineFlowTree(opts: {
   // forever and no terminal frame ever reaches the client. With it, the
   // parent step runs, sees the predecessor has no output, and propagates a
   // clean failure up to the finalize (#766).
+  // Steps carry parentId (#771): pipeline-batch steps key their cooperative
+  // cancel check on the batch parent; single-run steps key it on
+  // clientJobId instead.
   let currentNode: FlowJob = {
     name: parsedSteps[0].resolvedToolId,
     queueName: queueName(parsedSteps[0].pool),
@@ -204,6 +207,7 @@ function buildPipelineFlowTree(opts: {
       totalSteps,
       prevJobId: undefined,
       clientJobId,
+      parentId,
       inputRefs: [uploadKey],
       filename,
       settings: parsedSteps[0].parsedSettings,
@@ -226,6 +230,7 @@ function buildPipelineFlowTree(opts: {
         totalSteps,
         prevJobId: stepJobIds[i - 1],
         clientJobId,
+        parentId,
         inputRefs: [],
         filename,
         settings: parsedSteps[i].parsedSettings,
@@ -609,12 +614,39 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
             await putObject(uploadKey, processBuffer);
           }
 
-          // Report initial progress. Awaited: this insert creates the
-          // client-facing row the SSE replays, which is the evidence a
-          // degraded client's fresh connection relies on (#766). Dropped
-          // fire-and-forget, a failed insert would fabricate "the server
-          // never confirmed the job" for a flow that is queued and fine.
+          // Derive the pipeline's pool from the first step's modality so the
+          // finalize job and parent row land on the correct queue.
+          const firstModality =
+            TOOLS.find((t) => t.id === parsedSteps[0].resolvedToolId)?.modality ?? "image";
+          const pipelinePool: Pool = MODALITY_POOL[firstModality];
+
           if (clientJobId) {
+            // Pre-insert the client-facing alias row with the flow pointer
+            // and owner (#771). The progress persist layer would otherwise
+            // create it lazily with neither, leaving requestCancel unable to
+            // resolve the alias to the flow and the cancel route unable to
+            // authorize the run's own starter. Insert-first also closes the
+            // window where a cancel lands before the flow rows exist: the
+            // pointer is durable from the first moment the id is known. A
+            // reused id keeps the old lazy-create semantics.
+            await db
+              .insert(schema.jobs)
+              .values({
+                id: clientJobId,
+                userId,
+                pool: pipelinePool,
+                type: "single",
+                status: "queued",
+                inputRefs: [],
+                settings: { pipelineFlowId: jobId },
+              })
+              .onConflictDoNothing();
+
+            // Report initial progress. Awaited: this write settles the
+            // client-facing row the SSE replays, which is the evidence a
+            // degraded client's fresh connection relies on (#766). Dropped
+            // fire-and-forget, a failed write would fabricate "the server
+            // never confirmed the job" for a flow that is queued and fine.
             await updateSingleFileProgress({
               jobId: clientJobId,
               phase: "processing",
@@ -622,12 +654,6 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
               stage: "Preparing pipeline...",
             });
           }
-
-          // Derive the pipeline's pool from the first step's modality so the
-          // finalize job and parent row land on the correct queue.
-          const firstModality =
-            TOOLS.find((t) => t.id === parsedSteps[0].resolvedToolId)?.modality ?? "image";
-          const pipelinePool: Pool = MODALITY_POOL[firstModality];
 
           // Build the nested FlowJob tree
           const { tree, stepJobIds } = buildPipelineFlowTree({
@@ -665,7 +691,10 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
             type: "pipeline",
             status: "queued",
             inputRefs: [],
-            settings: {},
+            // Cancel metadata (#771): requestCancel keys the cooperative
+            // flag by clientJobId (the id the steps carry) and publishes
+            // stepCount step ids for the active abort.
+            settings: { stepCount: parsedSteps.length, clientJobId: clientJobId ?? jobId },
           });
 
           // Inject OTel trace context into every node of the flow tree
@@ -686,11 +715,14 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
               return reply.status(202).send({ jobId: clientJobId ?? jobId, async: true });
             }
 
-            // Check for step failure reported by the finalize handler
+            // Check for step failure reported by the finalize handler. A
+            // canceled run keeps the same 422 shape plus the structural
+            // marker the web client settles on (#771), mirroring batch.ts.
             if (result.resultPayload?.error) {
               return reply.status(422).send({
                 error: result.resultPayload.error as string,
                 completedSteps: result.resultPayload.steps,
+                ...(result.resultPayload.canceled === true ? { canceled: true } : {}),
               });
             }
 
@@ -1094,7 +1126,9 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
             type: "batch",
             status: "queued",
             inputRefs: [],
-            settings: { flowChildCount: 0 },
+            // stepCount from the first write (#771): a cancel landing while
+            // files are still validating resolves through this row.
+            settings: { flowChildCount: 0, stepCount: parsedSteps.length },
           });
 
           // Emit initial batch progress
@@ -1339,7 +1373,13 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
           // Update the parent row with the final flow child count
           await db
             .update(schema.jobs)
-            .set({ settings: { flowChildCount: perFileChildren.length, fileIndexMap } })
+            .set({
+              settings: {
+                flowChildCount: perFileChildren.length,
+                fileIndexMap,
+                stepCount: parsedSteps.length,
+              },
+            })
             .where(eq(schema.jobs.id, parentId));
 
           // Inject OTel trace context into every node of the batch flow tree
@@ -1366,6 +1406,7 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
                   outputRef?: string;
                   error?: string;
                 }>;
+                canceled?: boolean;
                 zip?: {
                   key: string;
                   filename: string;
@@ -1377,11 +1418,15 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
 
           const zip = payload?.zip;
           if (!zip) {
-            // Every file failed; the finalize already published the terminal
-            // failed frame. Mirror it on the HTTP contract.
+            // Every file failed (or a full cancel kept anything from
+            // finishing); the finalize already published the terminal frame.
+            // Mirror it on the HTTP contract: a canceled batch is not a
+            // processing failure, and the structural marker is what the web
+            // client settles on instead of string-matching (#771, mirroring
+            // batch.ts).
             const manifestFailures = (payload?.manifest ?? []).filter((m) => !m.outputRef);
             return reply.status(422).send({
-              error: "All files failed processing",
+              error: payload?.canceled ? "Batch canceled" : "All files failed processing",
               errors: [
                 ...preFailures.map((f) => ({ filename: f.filename, error: f.error })),
                 ...manifestFailures.map((f) => ({
@@ -1389,6 +1434,7 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
                   error: f.error ?? "Failed",
                 })),
               ],
+              ...(payload?.canceled ? { canceled: true } : {}),
             });
           }
 

--- a/apps/api/src/routes/pipeline.ts
+++ b/apps/api/src/routes/pipeline.ts
@@ -627,8 +627,10 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
             // resolve the alias to the flow and the cancel route unable to
             // authorize the run's own starter. Insert-first also closes the
             // window where a cancel lands before the flow rows exist: the
-            // pointer is durable from the first moment the id is known. A
-            // reused id keeps the old lazy-create semantics.
+            // pointer is durable from the first moment the id is known. On a
+            // reused id the pointer and owner follow the newest flow, so a
+            // cancel resolves the live run instead of the finished one
+            // (frames were always latest-run-wins on a shared channel).
             await db
               .insert(schema.jobs)
               .values({
@@ -640,7 +642,10 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
                 inputRefs: [],
                 settings: { pipelineFlowId: jobId },
               })
-              .onConflictDoNothing();
+              .onConflictDoUpdate({
+                target: schema.jobs.id,
+                set: { userId, settings: { pipelineFlowId: jobId } },
+              });
 
             // Report initial progress. Awaited: this write settles the
             // client-facing row the SSE replays, which is the evidence a

--- a/apps/api/src/routes/pipeline.ts
+++ b/apps/api/src/routes/pipeline.ts
@@ -628,9 +628,13 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
             // authorize the run's own starter. Insert-first also closes the
             // window where a cancel lands before the flow rows exist: the
             // pointer is durable from the first moment the id is known. On a
-            // reused id the pointer and owner follow the newest flow, so a
-            // cancel resolves the live run instead of the finished one
-            // (frames were always latest-run-wins on a shared channel).
+            // reused id the pointer follows the newest flow, so a cancel
+            // resolves the live run instead of the finished one, but ONLY
+            // for the row's own user (setWhere): re-pointing a row someone
+            // else owns would transfer it and strip their cancel
+            // authorization. A foreign or pre-#771 ownerless row is left
+            // alone, the old lazy-create semantics, with no 409 so the
+            // response cannot become an id-existence oracle.
             await db
               .insert(schema.jobs)
               .values({
@@ -644,7 +648,8 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
               })
               .onConflictDoUpdate({
                 target: schema.jobs.id,
-                set: { userId, settings: { pipelineFlowId: jobId } },
+                set: { settings: { pipelineFlowId: jobId } },
+                setWhere: eq(schema.jobs.userId, userId),
               });
 
             // Report initial progress. Awaited: this write settles the

--- a/apps/api/src/routes/progress.ts
+++ b/apps/api/src/routes/progress.ts
@@ -634,6 +634,47 @@ export async function failSingleJobGuarded(args: FailSingleJobArgs): Promise<voi
   if (applied) announce(frame);
 }
 
+export interface CancelSingleJobArgs {
+  jobId: string;
+}
+
+/**
+ * Terminal single-run cancellation (#771), failSingleJobGuarded's sibling.
+ * The authoritative row becomes "canceled"; the announced frame reuses the
+ * failed-with-"Canceled" wire vocabulary the worker's single-run cancel path
+ * already speaks, so clients need no new terminal type. Used by the pipeline
+ * finalize, where the SSE channel id (clientJobId) and the authoritative
+ * flow row can differ; call it per row id.
+ */
+export async function cancelSingleJobGuarded(args: CancelSingleJobArgs): Promise<void> {
+  const frame: SingleFileProgress = {
+    jobId: args.jobId,
+    type: "single",
+    phase: "failed",
+    percent: 0,
+    error: "Canceled",
+  };
+  let applied = false;
+  await enqueuePersist(args.jobId, async () => {
+    const res = await db
+      .update(schema.jobs)
+      .set({
+        status: "canceled",
+        completedAt: new Date(),
+        progress: { percent: 0 },
+        error: { message: "Canceled" },
+      })
+      .where(
+        and(
+          eq(schema.jobs.id, args.jobId),
+          notInArray(schema.jobs.status, ["completed", "failed", "canceled"]),
+        ),
+      );
+    applied = ((res as { rowCount?: number | null } | undefined)?.rowCount ?? 0) > 0;
+  });
+  if (applied) announce(frame);
+}
+
 /**
  * Publish a progress event to Redis pub/sub and set the terminal replay
  * key, but do NOT persist to the durable DB row. Used by the worker's

--- a/apps/web/src/hooks/use-pipeline-processor.ts
+++ b/apps/web/src/hooks/use-pipeline-processor.ts
@@ -54,8 +54,16 @@ const JOB_EVIDENCE_TIMEOUT_MS = 30_000;
  * result; the batch frame carries the durable ZIP's download URL).
  */
 export function usePipelineProcessor() {
-  const { processing, error, processedUrl, originalSize, processedSize, setProcessing, setError } =
-    useFileStore();
+  const {
+    processing,
+    error,
+    processedUrl,
+    originalSize,
+    processedSize,
+    setProcessing,
+    setError,
+    setActiveJob,
+  } = useFileStore();
 
   const [progress, setProgress] = useState<PipelineProgress>(IDLE_PROGRESS);
   const elapsedRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -67,6 +75,10 @@ export function usePipelineProcessor() {
   const activeEntryIndexRef = useRef<number | null>(null);
   const asyncModeRef = useRef(false);
   const sawJobEvidenceRef = useRef(false);
+  // Set on the user's cancel click once the server acknowledged it (#771).
+  // Drives batch labeling: files missing from a partial result read
+  // "Canceled" instead of a lookup failure. Reset at every run start.
+  const canceledByUserRef = useRef(false);
   // Installed by processAll so the SSE handler can settle a degraded batch
   // run from its terminal frame. Null outside batch runs.
   const batchRunRef = useRef<{ onTerminal: (frame: BatchProgressFrame) => void } | null>(null);
@@ -86,6 +98,12 @@ export function usePipelineProcessor() {
     },
     [],
   );
+
+  const clearActiveJob = useCallback(() => {
+    activeJobIdRef.current = null;
+    activeEntryIndexRef.current = null;
+    setActiveJob(null, null);
+  }, [setActiveJob]);
 
   const clearStallTimer = useCallback(() => {
     if (stallTimerRef.current) {
@@ -121,7 +139,7 @@ export function usePipelineProcessor() {
         eventSourceRef.current.close();
         eventSourceRef.current = null;
       }
-      activeJobIdRef.current = null;
+      clearActiveJob();
       batchRunRef.current = null;
       setError(
         "Processing was interrupted and the server never confirmed the job. Retry when reconnected.",
@@ -129,7 +147,50 @@ export function usePipelineProcessor() {
       setProcessing(false);
       setProgress(IDLE_PROGRESS);
     }, JOB_EVIDENCE_TIMEOUT_MS);
-  }, [clearJobEvidenceTimer, clearStallTimer, setError, setProcessing]);
+  }, [clearJobEvidenceTimer, clearStallTimer, clearActiveJob, setError, setProcessing]);
+
+  // The pipeline twin of use-tool-processor's cancelCurrentJob (#771): POST
+  // the cancel under the run's client-facing id, record intent only once the
+  // server acknowledged it, and settle locally when the server never saw the
+  // job at all (the degraded #722 state: nothing will ever emit a frame).
+  const cancelCurrentJob = useCallback(async () => {
+    const jobId = activeJobIdRef.current;
+    if (!jobId) return;
+    try {
+      const res = await fetch(`/api/v1/jobs/${jobId}/cancel`, {
+        method: "POST",
+        headers: formatHeaders(),
+      });
+      // Record intent only on an acknowledged cancel: a failed or refused
+      // POST must not repaint the run's real outcome as canceled (#767).
+      if (res.ok) {
+        const body = (await res.json().catch(() => null)) as { canceled?: boolean } | null;
+        if (body?.canceled === true && activeJobIdRef.current === jobId) {
+          canceledByUserRef.current = true;
+        }
+      }
+      // 404 means no job exists server-side. Nothing will ever emit a
+      // frame, so settle locally as canceled instead of blaming the network
+      // 30 seconds later.
+      if (res.status === 404 && activeJobIdRef.current === jobId) {
+        xhrRef.current?.abort();
+        clearJobEvidenceTimer();
+        clearStallTimer();
+        if (elapsedRef.current) clearInterval(elapsedRef.current);
+        if (eventSourceRef.current) {
+          eventSourceRef.current.close();
+          eventSourceRef.current = null;
+        }
+        batchRunRef.current = null;
+        clearActiveJob();
+        setError("Canceled");
+        setProcessing(false);
+        setProgress(IDLE_PROGRESS);
+      }
+    } catch {
+      // Cancel request failed; the SSE handler owns cleanup
+    }
+  }, [clearJobEvidenceTimer, clearStallTimer, clearActiveJob, setError, setProcessing]);
 
   const reconnectSSE = useCallback(
     (force = false) => {
@@ -199,7 +260,7 @@ export function usePipelineProcessor() {
                 // leaving the run in silent limbo.
                 clearJobEvidenceTimer();
                 if (elapsedRef.current) clearInterval(elapsedRef.current);
-                activeJobIdRef.current = null;
+                clearActiveJob();
                 setError("Processing was interrupted. Retry when reconnected.");
                 setProcessing(false);
                 setProgress(IDLE_PROGRESS);
@@ -233,8 +294,7 @@ export function usePipelineProcessor() {
                 processedSize: result.processedSize,
                 ...(result.savedFileId ? { serverFileId: result.savedFileId } : {}),
               });
-              activeJobIdRef.current = null;
-              activeEntryIndexRef.current = null;
+              clearActiveJob();
               batchRunRef.current = null;
               setProcessing(false);
               setProgress(IDLE_PROGRESS);
@@ -247,8 +307,7 @@ export function usePipelineProcessor() {
               es.close();
               eventSourceRef.current = null;
               xhrRef.current?.abort();
-              activeJobIdRef.current = null;
-              activeEntryIndexRef.current = null;
+              clearActiveJob();
               batchRunRef.current = null;
               setError(data.error || "Processing failed");
               setProcessing(false);
@@ -282,7 +341,14 @@ export function usePipelineProcessor() {
         // EventSource creation failed
       }
     },
-    [clearStallTimer, clearJobEvidenceTimer, resetStallTimer, setError, setProcessing],
+    [
+      clearStallTimer,
+      clearJobEvidenceTimer,
+      clearActiveJob,
+      resetStallTimer,
+      setError,
+      setProcessing,
+    ],
   );
 
   useEffect(() => {
@@ -331,6 +397,7 @@ export function usePipelineProcessor() {
       clearJobEvidenceTimer();
       sawJobEvidenceRef.current = false;
       asyncModeRef.current = false;
+      canceledByUserRef.current = false;
       batchRunRef.current = null;
 
       const startTime = Date.now();
@@ -344,6 +411,9 @@ export function usePipelineProcessor() {
       const clientJobId = generateId();
       activeJobIdRef.current = clientJobId;
       activeEntryIndexRef.current = capturedIndex;
+      // Arm the ProgressCard cancel button for the whole run (#771); every
+      // settle path disarms it through clearActiveJob.
+      setActiveJob(clientJobId, cancelCurrentJob);
 
       // Open SSE for real-time progress from the server
       reconnectSSE(true);
@@ -469,8 +539,7 @@ export function usePipelineProcessor() {
 
         setProcessing(false);
         setProgress(IDLE_PROGRESS);
-        activeJobIdRef.current = null;
-        activeEntryIndexRef.current = null;
+        clearActiveJob();
       };
 
       xhr.onerror = () => {
@@ -487,8 +556,7 @@ export function usePipelineProcessor() {
         setError("Processing was interrupted. Retry when reconnected.");
         setProcessing(false);
         setProgress(IDLE_PROGRESS);
-        activeJobIdRef.current = null;
-        activeEntryIndexRef.current = null;
+        clearActiveJob();
       };
 
       xhr.ontimeout = () => {
@@ -503,8 +571,7 @@ export function usePipelineProcessor() {
         setError("Request timed out - the server may be overloaded. Try again.");
         setProcessing(false);
         setProgress(IDLE_PROGRESS);
-        activeJobIdRef.current = null;
-        activeEntryIndexRef.current = null;
+        clearActiveJob();
       };
 
       xhr.open("POST", "/api/v1/pipeline/execute");
@@ -516,6 +583,9 @@ export function usePipelineProcessor() {
     [
       setProcessing,
       setError,
+      setActiveJob,
+      cancelCurrentJob,
+      clearActiveJob,
       clearJobEvidenceTimer,
       clearStallTimer,
       reconnectSSE,
@@ -544,6 +614,7 @@ export function usePipelineProcessor() {
       clearJobEvidenceTimer();
       sawJobEvidenceRef.current = false;
       asyncModeRef.current = false;
+      canceledByUserRef.current = false;
 
       const startTime = Date.now();
       elapsedRef.current = setInterval(() => {
@@ -553,6 +624,8 @@ export function usePipelineProcessor() {
       const clientJobId = generateId();
       activeJobIdRef.current = clientJobId;
       activeEntryIndexRef.current = null;
+      // Arm the ProgressCard cancel button for the whole run (#771).
+      setActiveJob(clientJobId, cancelCurrentJob);
 
       // Tear down the run without touching the outcome state; callers set
       // the result or error first.
@@ -565,7 +638,7 @@ export function usePipelineProcessor() {
           eventSourceRef.current = null;
         }
         batchRunRef.current = null;
-        activeJobIdRef.current = null;
+        clearActiveJob();
         setProcessing(false);
         setProgress(IDLE_PROGRESS);
       };
@@ -596,7 +669,12 @@ export function usePipelineProcessor() {
               error: null,
             });
           } else {
-            updateEntry(i, { status: "failed", error: "File not found in batch results" });
+            // After a user cancel, a missing result is the cancel doing its
+            // job, not a lookup failure (#771).
+            updateEntry(i, {
+              status: "failed",
+              error: canceledByUserRef.current ? "Canceled" : "File not found in batch results",
+            });
           }
         }
 
@@ -766,6 +844,12 @@ export function usePipelineProcessor() {
           let errorMsg: string;
           try {
             const body = JSON.parse(text);
+            // The route marks a canceled batch structurally (#771); the
+            // per-file error list would otherwise read as a failure report.
+            if ((body as { canceled?: boolean } | null)?.canceled === true) {
+              failRun("Canceled");
+              return;
+            }
             if (body.errors && Array.isArray(body.errors) && body.errors.length > 0) {
               // Show the first file's step-level error (all files typically fail at the same step)
               const first = body.errors[0];
@@ -818,6 +902,9 @@ export function usePipelineProcessor() {
       processSingle,
       setProcessing,
       setError,
+      setActiveJob,
+      cancelCurrentJob,
+      clearActiveJob,
       clearJobEvidenceTimer,
       clearStallTimer,
       reconnectSSE,
@@ -830,6 +917,7 @@ export function usePipelineProcessor() {
   return {
     processSingle,
     processAll,
+    cancelCurrentJob,
     processing,
     error,
     downloadUrl: processedUrl,

--- a/apps/web/src/hooks/use-pipeline-processor.ts
+++ b/apps/web/src/hooks/use-pipeline-processor.ts
@@ -524,13 +524,20 @@ export function usePipelineProcessor() {
         } else {
           try {
             const body = JSON.parse(xhr.responseText);
-            const parsed = parseApiError(body, xhr.status);
-            if (typeof parsed === "object" && parsed.type === "feature_not_installed") {
-              setError(
-                `The "${parsed.featureName}" feature is not installed. Enable it in Settings → AI Features.`,
-              );
+            // The route marks a canceled run structurally (#771); keying on
+            // the marker instead of the error text keeps the single and
+            // batch paths agreeing on what a cancel looks like.
+            if ((body as { canceled?: boolean } | null)?.canceled === true) {
+              setError("Canceled");
             } else {
-              setError(parsed as string);
+              const parsed = parseApiError(body, xhr.status);
+              if (typeof parsed === "object" && parsed.type === "feature_not_installed") {
+                setError(
+                  `The "${parsed.featureName}" feature is not installed. Enable it in Settings → AI Features.`,
+                );
+              } else {
+                setError(parsed as string);
+              }
             }
           } catch {
             setError(`Processing failed: ${xhr.status}`);

--- a/packages/shared/src/analytics/events.ts
+++ b/packages/shared/src/analytics/events.ts
@@ -71,7 +71,7 @@ export interface PipelineExecutedProperties {
   is_batch: boolean;
   file_count?: number;
   duration_ms: number;
-  status: "completed" | "failed";
+  status: "completed" | "failed" | "canceled";
 }
 
 export interface AiBundleActionProperties {

--- a/tests/integration/platform/batch-cancel.test.ts
+++ b/tests/integration/platform/batch-cancel.test.ts
@@ -297,10 +297,29 @@ describe("requestCancel on a batch parent", () => {
     expect(await isBatchCanceled(id)).toBe(false);
   });
 
-  it("returns false for a pipeline-batch parent", async () => {
-    const id = await seedParent({ toolId: "pipeline-batch" });
-    expect(await requestCancel(id)).toBe(false);
-    expect(await isBatchCanceled(id)).toBe(false);
+  it("cancels a pipeline-batch parent cooperatively, publishing per-file step ids", async () => {
+    // #770 refused these (a flag would have claimed canceled while every
+    // step kept running); #771 gave steps the cooperative check, so the
+    // refusal flipped. The abortable jobs are the per-file pipeline steps,
+    // not the per-file finalizes.
+    const id = await seedParent({
+      toolId: "pipeline-batch",
+      settings: { flowChildCount: 2, stepCount: 2 },
+    });
+    const received: string[] = [];
+    const sub = createRedisSubscriberConnection();
+    await sub.subscribe(`${bullPrefix()}:cancel`);
+    sub.on("message", (_ch: string, msg: string) => received.push(msg));
+
+    try {
+      expect(await requestCancel(id)).toBe(true);
+      expect(await isBatchCanceled(id)).toBe(true);
+      await vi.waitFor(() => {
+        expect(received).toEqual([`${id}-f0-s0`, `${id}-f0-s1`, `${id}-f1-s0`, `${id}-f1-s1`]);
+      });
+    } finally {
+      await sub.quit();
+    }
   });
 
   it("returns false for an implicit batch row with no cooperative machinery", async () => {

--- a/tests/integration/platform/pipeline-cancel-http.test.ts
+++ b/tests/integration/platform/pipeline-cancel-http.test.ts
@@ -223,6 +223,45 @@ describe("HTTP cancel on route-created pipeline rows", () => {
     });
     expect(res.statusCode).toBe(404);
   });
+
+  it("does not let a second user take over an alias row by reusing its id", async () => {
+    const clientJobId = randomUUID();
+    await runPipeline(clientJobId);
+    const before = await jobRow(clientJobId);
+    const ownerBefore = before?.userId;
+    const pointerBefore = ((before?.settings ?? {}) as { pipelineFlowId?: string }).pipelineFlowId;
+    expect(ownerBefore).not.toBeNull();
+
+    // A second user submits their own pipeline under the first user's id.
+    // The run may proceed (colliding channels were always latest-run-wins),
+    // but the alias row's owner and pointer must survive: transferring them
+    // would hand the second user the row and strip the first user's own
+    // cancel authorization.
+    const attacker = await createUserAndLogin(app, `alias-reuse-${Date.now()}`);
+    await sharedRedis().del(`${bullPrefix()}:terminal:${clientJobId}`);
+    const { body, contentType } = createMultipartPayload([
+      { name: "file", filename: "photo.png", contentType: "image/png", content: PNG },
+      {
+        name: "pipeline",
+        content: JSON.stringify({ steps: [{ toolId: "resize", settings: { width: 50 } }] }),
+      },
+      { name: "clientJobId", content: clientJobId },
+    ]);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/pipeline/execute",
+      headers: { "content-type": contentType, authorization: `Bearer ${attacker.token}` },
+      body,
+    });
+    expect([200, 202]).toContain(res.statusCode);
+    await waitForTerminalFrame(clientJobId);
+
+    const after = await jobRow(clientJobId);
+    expect(after?.userId).toBe(ownerBefore);
+    expect(((after?.settings ?? {}) as { pipelineFlowId?: string }).pipelineFlowId).toBe(
+      pointerBefore,
+    );
+  });
 });
 
 describe("sync responses for canceled runs", () => {

--- a/tests/integration/platform/pipeline-cancel-http.test.ts
+++ b/tests/integration/platform/pipeline-cancel-http.test.ts
@@ -127,6 +127,27 @@ describe("route-stamped cancel metadata (#771)", () => {
     expect(flowSettings.clientJobId).toBe(clientJobId);
   });
 
+  it("re-stamps the alias pointer at the newest flow when a clientJobId is reused", async () => {
+    const clientJobId = randomUUID();
+    await runPipeline(clientJobId);
+    const first = await jobRow(clientJobId);
+    const firstFlow = ((first?.settings ?? {}) as { pipelineFlowId?: string }).pipelineFlowId;
+    expect(typeof firstFlow).toBe("string");
+
+    // Clear run 1's terminal frame so runPipeline waits on run 2's own.
+    await sharedRedis().del(`${bullPrefix()}:terminal:${clientJobId}`);
+    await runPipeline(clientJobId);
+
+    // The reused id must not 500, and its pointer must follow the newest
+    // flow so a cancel resolves the live run, not the finished one.
+    const reused = await jobRow(clientJobId);
+    const secondFlow = ((reused?.settings ?? {}) as { pipelineFlowId?: string }).pipelineFlowId;
+    expect(typeof secondFlow).toBe("string");
+    expect(secondFlow).not.toBe(firstFlow);
+    const flow = await jobRow(secondFlow as string);
+    expect(flow?.type).toBe("pipeline");
+  });
+
   it("stamps stepCount on the pipeline-batch parent", async () => {
     const clientJobId = randomUUID();
     const { body, contentType } = createMultipartPayload([

--- a/tests/integration/platform/pipeline-cancel-http.test.ts
+++ b/tests/integration/platform/pipeline-cancel-http.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Pipeline cancel over the real HTTP surface (#771).
+ *
+ * The worker-harness suite (pipeline-cancel.test.ts) hand-builds flows with
+ * the cancel metadata the routes are supposed to stamp; this file pins the
+ * stamping itself plus the HTTP cancel contract on route-created rows: the
+ * alias row carries {pipelineFlowId} and the owner (so plain users can
+ * cancel their own runs), the flow row carries {stepCount, clientJobId},
+ * the batch parent carries stepCount, and the sync responses answer the
+ * structural canceled shape the web client settles on.
+ *
+ * Mid-run timing is deliberately absent here (a tiny resize completes in
+ * milliseconds; a reliably-slow tool needs binaries the CI shards lack), so
+ * requestCancel's live behavior stays in the worker-harness suite. The one
+ * synthetic trick: rows are reset to nonterminal before the cancel POST, so
+ * resolution runs against genuinely route-stamped shapes without a race.
+ */
+
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+// Canned sync-wait results, keyed by pool: lets the route's post-wait
+// branches (the 422 canceled shapes) run deterministically. Null entries
+// keep the real waitForJob.
+const enqueueMock = vi.hoisted(() => ({
+  cannedByPool: new Map<string, Record<string, unknown>>(),
+}));
+
+vi.mock("../../../apps/api/src/jobs/enqueue.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../apps/api/src/jobs/enqueue.js")>();
+  return {
+    ...actual,
+    waitForJob: async (...args: Parameters<typeof actual.waitForJob>) => {
+      const canned = enqueueMock.cannedByPool.get(args[0]);
+      if (canned) return canned;
+      return actual.waitForJob(...args);
+    },
+  };
+});
+
+const { eq } = await import("drizzle-orm");
+const { db, schema } = await import("../../../apps/api/src/db/index.js");
+const { isBatchCanceled } = await import("../../../apps/api/src/jobs/batch-progress.js");
+const { sharedRedis } = await import("../../../apps/api/src/jobs/connection.js");
+const { bullPrefix } = await import("../../../apps/api/src/jobs/types.js");
+const { fixtures, readFixture } = await import("../../fixtures/index.js");
+const { buildTestApp, createMultipartPayload, createUserAndLogin, loginAsAdmin } = await import(
+  "../test-server.js"
+);
+
+const PNG = readFixture(fixtures.image.base.png200);
+
+let testApp: Awaited<ReturnType<typeof buildTestApp>>;
+let app: (typeof testApp)["app"];
+let adminToken: string;
+
+type JobRow = typeof schema.jobs.$inferSelect;
+
+async function jobRow(jobId: string): Promise<JobRow | undefined> {
+  const [row] = await db.select().from(schema.jobs).where(eq(schema.jobs.id, jobId));
+  return row;
+}
+
+/** Poll the Redis terminal replay key until the terminal frame appears. */
+async function waitForTerminalFrame(
+  jobId: string,
+  timeoutMs = 30_000,
+): Promise<Record<string, unknown>> {
+  const key = `${bullPrefix()}:terminal:${jobId}`;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const raw = await sharedRedis().get(key);
+    if (raw) return JSON.parse(raw) as Record<string, unknown>;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`No terminal frame for ${jobId} within ${timeoutMs}ms`);
+}
+
+/** Run a one-step resize pipeline to completion under a fresh clientJobId. */
+async function runPipeline(clientJobId: string): Promise<void> {
+  const { body, contentType } = createMultipartPayload([
+    { name: "file", filename: "photo.png", contentType: "image/png", content: PNG },
+    {
+      name: "pipeline",
+      content: JSON.stringify({ steps: [{ toolId: "resize", settings: { width: 50 } }] }),
+    },
+    { name: "clientJobId", content: clientJobId },
+  ]);
+  const res = await app.inject({
+    method: "POST",
+    url: "/api/v1/pipeline/execute",
+    headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+    body,
+  });
+  expect([200, 202]).toContain(res.statusCode);
+  await waitForTerminalFrame(clientJobId);
+}
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  app = testApp.app;
+  adminToken = await loginAsAdmin(app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+describe("route-stamped cancel metadata (#771)", () => {
+  it("stamps the alias pointer, owner, and flow-row step count on /execute", async () => {
+    const clientJobId = randomUUID();
+    await runPipeline(clientJobId);
+
+    const alias = await jobRow(clientJobId);
+    expect(alias?.type).toBe("single");
+    const aliasSettings = (alias?.settings ?? {}) as { pipelineFlowId?: string };
+    expect(typeof aliasSettings.pipelineFlowId).toBe("string");
+    // The owner lands on the alias so the cancel route's ownership check
+    // passes for the user who started the run.
+    expect(alias?.userId).not.toBeNull();
+
+    const flow = await jobRow(aliasSettings.pipelineFlowId as string);
+    expect(flow?.type).toBe("pipeline");
+    expect(flow?.userId).toBe(alias?.userId);
+    const flowSettings = (flow?.settings ?? {}) as { stepCount?: number; clientJobId?: string };
+    expect(flowSettings.stepCount).toBe(1);
+    expect(flowSettings.clientJobId).toBe(clientJobId);
+  });
+
+  it("stamps stepCount on the pipeline-batch parent", async () => {
+    const clientJobId = randomUUID();
+    const { body, contentType } = createMultipartPayload([
+      { name: "file", filename: "a.png", contentType: "image/png", content: PNG },
+      { name: "file", filename: "b.png", contentType: "image/png", content: PNG },
+      {
+        name: "pipeline",
+        content: JSON.stringify({ steps: [{ toolId: "resize", settings: { width: 50 } }] }),
+      },
+      { name: "clientJobId", content: clientJobId },
+    ]);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/pipeline/batch",
+      headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+      body,
+    });
+    expect([200, 202]).toContain(res.statusCode);
+    await waitForTerminalFrame(clientJobId);
+
+    const parent = await jobRow(clientJobId);
+    expect(parent?.type).toBe("batch");
+    const settings = (parent?.settings ?? {}) as { flowChildCount?: number; stepCount?: number };
+    expect(settings.flowChildCount).toBe(2);
+    expect(settings.stepCount).toBe(1);
+  });
+});
+
+describe("HTTP cancel on route-created pipeline rows", () => {
+  it("resolves the alias to the flow and flags the run", async () => {
+    const clientJobId = randomUUID();
+    await runPipeline(clientJobId);
+
+    // Terminal cancels are refused through the whole stack.
+    const refused = await app.inject({
+      method: "POST",
+      url: `/api/v1/jobs/${clientJobId}/cancel`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(refused.statusCode).toBe(200);
+    expect(JSON.parse(refused.body)).toEqual({ canceled: false });
+
+    // Reset the run's rows to nonterminal so resolution runs against the
+    // exact shapes the route stamped, without racing a live flow.
+    const alias = await jobRow(clientJobId);
+    const flowId = ((alias?.settings ?? {}) as { pipelineFlowId?: string }).pipelineFlowId;
+    for (const id of [clientJobId, flowId as string, `${flowId}-s0`]) {
+      await db
+        .update(schema.jobs)
+        .set({ status: "queued", completedAt: null })
+        .where(eq(schema.jobs.id, id));
+    }
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/jobs/${clientJobId}/cancel`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ canceled: true });
+    expect(await isBatchCanceled(clientJobId)).toBe(true);
+  });
+
+  it("blocks a non-owner from canceling a pipeline via its alias (404)", async () => {
+    const clientJobId = randomUUID();
+    await runPipeline(clientJobId);
+    const attacker = await createUserAndLogin(app, `pipe-cancel-attacker-${Date.now()}`);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/jobs/${clientJobId}/cancel`,
+      headers: { authorization: `Bearer ${attacker.token}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("sync responses for canceled runs", () => {
+  it("execute answers the structural canceled 422", async () => {
+    enqueueMock.cannedByPool.set("image", {
+      outputRefs: [],
+      filename: "input.png",
+      contentType: "",
+      originalSize: 0,
+      processedSize: 0,
+      resultPayload: { error: "Canceled", canceled: true, stepsCompleted: 0, steps: [] },
+    });
+    try {
+      const { body, contentType } = createMultipartPayload([
+        { name: "file", filename: "photo.png", contentType: "image/png", content: PNG },
+        {
+          name: "pipeline",
+          content: JSON.stringify({ steps: [{ toolId: "resize", settings: { width: 50 } }] }),
+        },
+        { name: "clientJobId", content: randomUUID() },
+      ]);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/pipeline/execute",
+        headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+        body,
+      });
+      expect(res.statusCode).toBe(422);
+      const parsed = JSON.parse(res.body) as { error: string; canceled?: boolean };
+      expect(parsed.error).toBe("Canceled");
+      expect(parsed.canceled).toBe(true);
+    } finally {
+      enqueueMock.cannedByPool.delete("image");
+    }
+  });
+
+  it("batch answers the structural Batch canceled 422 on a full cancel", async () => {
+    enqueueMock.cannedByPool.set("system", {
+      outputRefs: [],
+      filename: "",
+      contentType: "application/json",
+      originalSize: 0,
+      processedSize: 0,
+      resultPayload: {
+        manifest: [
+          { index: 0, filename: "a.png", error: "Canceled" },
+          { index: 1, filename: "b.png", error: "Canceled" },
+        ],
+        canceled: true,
+        allFailed: true,
+      },
+    });
+    try {
+      const { body, contentType } = createMultipartPayload([
+        { name: "file", filename: "a.png", contentType: "image/png", content: PNG },
+        { name: "file", filename: "b.png", contentType: "image/png", content: PNG },
+        {
+          name: "pipeline",
+          content: JSON.stringify({ steps: [{ toolId: "resize", settings: { width: 50 } }] }),
+        },
+        { name: "clientJobId", content: randomUUID() },
+      ]);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/pipeline/batch",
+        headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+        body,
+      });
+      expect(res.statusCode).toBe(422);
+      const parsed = JSON.parse(res.body) as { error: string; canceled?: boolean };
+      expect(parsed.error).toBe("Batch canceled");
+      expect(parsed.canceled).toBe(true);
+    } finally {
+      enqueueMock.cannedByPool.delete("system");
+    }
+  });
+});

--- a/tests/integration/platform/pipeline-cancel.test.ts
+++ b/tests/integration/platform/pipeline-cancel.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Pipeline cancel (#771): requestCancel's pipeline resolution (flow row,
+ * SSE alias, pipeline-batch parent), the step-level cooperative skip, and
+ * the finalize's canceled terminal paths.
+ *
+ * Follows the batch-cancel.test.ts harness: no HTTP app is built. The test
+ * tool is registered directly in the process registry, flows are enqueued
+ * the same way routes/pipeline.ts builds them (nested step chain under a
+ * pipeline-finalize parent, plus the cancel metadata the route stamps), and
+ * the real workers drain them against this fork's Postgres + Redis.
+ */
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
+import AdmZip from "adm-zip";
+import type { FlowJob } from "bullmq";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { ToolJobData } from "../../../apps/api/src/jobs/types.js";
+import type { ToolProcessCtx } from "../../../apps/api/src/routes/tool-factory.js";
+
+// Injects a fault into the step skip's flag read so the fall-through
+// contract (a failing skip must not wedge the step) is testable.
+const flagReadFault = vi.hoisted(() => ({ scope: null as string | null }));
+
+vi.mock("../../../apps/api/src/jobs/batch-progress.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../apps/api/src/jobs/batch-progress.js")>();
+  return {
+    ...actual,
+    isBatchCanceled: async (parentId: string) => {
+      if (parentId === flagReadFault.scope) {
+        throw new Error("injected flag-read outage");
+      }
+      return actual.isBatchCanceled(parentId);
+    },
+  };
+});
+
+const { eq } = await import("drizzle-orm");
+const { db, schema } = await import("../../../apps/api/src/db/index.js");
+const { runMigrations } = await import("../../../apps/api/src/db/migrate.js");
+const { isBatchCanceled, markBatchCanceled } = await import(
+  "../../../apps/api/src/jobs/batch-progress.js"
+);
+const { requestCancel, startCancelListener, stopCancelListener } = await import(
+  "../../../apps/api/src/jobs/cancel.js"
+);
+const { createRedisSubscriberConnection, sharedRedis } = await import(
+  "../../../apps/api/src/jobs/connection.js"
+);
+const { getFlowProducer } = await import("../../../apps/api/src/jobs/enqueue.js");
+const { closeQueues, getQueue } = await import("../../../apps/api/src/jobs/queues.js");
+const { bullPrefix, queueName } = await import("../../../apps/api/src/jobs/types.js");
+const { closeWorkers, startWorkers } = await import("../../../apps/api/src/jobs/worker.js");
+const { getObjectBuffer, putObject } = await import("../../../apps/api/src/lib/object-storage.js");
+const { registerToolProcessFn } = await import("../../../apps/api/src/routes/tool-factory.js");
+
+const passthroughSchema = { parse: (v: unknown) => v } as never;
+
+interface StepSettings {
+  mode: "fast" | "slow";
+  tag: string;
+}
+
+// Behavior keyed on per-step settings: fast returns instantly, slow waits on
+// the worker's abort signal, so a cancel mid-pipeline has a real running
+// target. Every invocation records its tag, so "this step never ran" is a
+// positive assertion instead of a timing guess.
+const invoked: string[] = [];
+registerToolProcessFn({
+  toolId: "wt-pipeline-cancel",
+  settingsSchema: passthroughSchema,
+  process: async (
+    inputBuffer: Buffer,
+    settings: unknown,
+    filename: string,
+    ctx?: ToolProcessCtx,
+  ) => {
+    const { mode, tag } = settings as StepSettings;
+    invoked.push(tag);
+    if (mode === "slow") {
+      await new Promise<void>((resolve, reject) => {
+        const signal = ctx?.signal;
+        if (!signal) {
+          reject(new Error("wt-pipeline-cancel requires an abort signal"));
+          return;
+        }
+        if (signal.aborted) {
+          reject(new Error("aborted before start"));
+          return;
+        }
+        const timer = setTimeout(resolve, 20_000);
+        signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            reject(new Error("aborted by signal"));
+          },
+          { once: true },
+        );
+      });
+    }
+    return { buffer: inputBuffer, filename, contentType: "image/png" };
+  },
+});
+
+mkdirSync(process.env.WORKSPACE_PATH ?? "", { recursive: true });
+await runMigrations();
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+type JobRow = typeof schema.jobs.$inferSelect;
+
+async function waitFor<T>(probe: () => Promise<T | undefined>, timeoutMs = 20_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await probe();
+    if (value !== undefined) return value;
+    if (Date.now() > deadline) throw new Error(`condition not met within ${timeoutMs}ms`);
+    await delay(150);
+  }
+}
+
+async function jobRow(jobId: string): Promise<JobRow | undefined> {
+  const [row] = await db.select().from(schema.jobs).where(eq(schema.jobs.id, jobId));
+  return row;
+}
+
+async function terminalRow(jobId: string, timeoutMs = 25_000): Promise<JobRow> {
+  return waitFor(async () => {
+    const row = await jobRow(jobId);
+    return row && row.status !== "queued" && row.status !== "processing" ? row : undefined;
+  }, timeoutMs);
+}
+
+async function terminalFrame(jobId: string): Promise<Record<string, unknown>> {
+  const raw = await waitFor(async () => {
+    const value = await sharedRedis().get(`${bullPrefix()}:terminal:${jobId}`);
+    return value ?? undefined;
+  }, 25_000);
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+/** Collect ids published on the cancel channel for the duration of `fn`. */
+async function collectCancelPublishes(fn: () => Promise<void>): Promise<string[]> {
+  const received: string[] = [];
+  const sub = createRedisSubscriberConnection();
+  await sub.subscribe(`${bullPrefix()}:cancel`);
+  sub.on("message", (_ch: string, msg: string) => received.push(msg));
+  try {
+    await fn();
+    // Publishes are awaited inside requestCancel, but delivery to this
+    // subscriber is async; give the frames a beat to arrive.
+    await delay(300);
+    return received;
+  } finally {
+    await sub.quit();
+  }
+}
+
+interface PipelineFlowOpts {
+  /** Per-step tool settings; length defines the step count. */
+  steps: StepSettings[];
+  /** Client-facing id; when set an alias row is inserted route-style. */
+  clientJobId?: string;
+  /** Pipeline-batch wiring: parent id + total files for the per-file tree. */
+  parentId?: string;
+  totalFiles?: number;
+  filename?: string;
+  beforeEnqueue?: (flowId: string) => Promise<void>;
+  /** Skip the FlowProducer add (for pure requestCancel resolution tests). */
+  skipEnqueue?: boolean;
+}
+
+/**
+ * Insert the rows and build the nested flow exactly the way
+ * routes/pipeline.ts does after #771: step rows + flow row with the cancel
+ * metadata ({stepCount, clientJobId}), an alias row carrying the
+ * {pipelineFlowId} pointer when a clientJobId is used, steps nested under a
+ * pipeline-finalize parent with step 0 deepest.
+ */
+async function enqueuePipelineFlow(
+  opts: PipelineFlowOpts,
+): Promise<{ flowId: string; stepIds: string[] }> {
+  const flowId = opts.parentId ? `${opts.parentId}-f0` : randomUUID();
+  return enqueuePipelineFlowAt(flowId, opts);
+}
+
+async function enqueuePipelineFlowAt(
+  flowId: string,
+  opts: PipelineFlowOpts,
+): Promise<{ flowId: string; stepIds: string[] }> {
+  const filename = opts.filename ?? "input.png";
+  const totalSteps = opts.steps.length;
+  const stepIds = opts.steps.map((_, i) => `${flowId}-s${i}`);
+  const progressId = opts.clientJobId ?? flowId;
+  const uploadKey = `uploads/${flowId}-s0/${filename}`;
+  await putObject(uploadKey, Buffer.from("payload"));
+
+  if (opts.clientJobId) {
+    await db.insert(schema.jobs).values({
+      id: opts.clientJobId,
+      type: "single",
+      status: "queued",
+      inputRefs: [],
+      settings: { pipelineFlowId: flowId },
+    });
+  }
+
+  for (let i = 0; i < totalSteps; i++) {
+    await db.insert(schema.jobs).values({
+      id: stepIds[i],
+      type: "pipeline-step",
+      toolId: "wt-pipeline-cancel",
+      pool: "image",
+      status: "queued",
+      inputRefs: i === 0 ? [uploadKey] : [],
+      settings: opts.steps[i] as unknown as Record<string, unknown>,
+    });
+  }
+
+  await db.insert(schema.jobs).values({
+    id: flowId,
+    type: opts.parentId ? "pipeline-finalize" : "pipeline",
+    toolId: "pipeline",
+    pool: "image",
+    status: "queued",
+    inputRefs: [],
+    settings: { stepCount: totalSteps, clientJobId: progressId },
+  });
+
+  let node: FlowJob = {
+    name: "wt-pipeline-cancel",
+    queueName: queueName("image"),
+    data: {
+      kind: "pipeline-step",
+      jobId: stepIds[0],
+      toolId: "wt-pipeline-cancel",
+      userId: null,
+      pool: "image",
+      stepIndex: 0,
+      totalSteps,
+      prevJobId: undefined,
+      clientJobId: progressId,
+      parentId: opts.parentId,
+      inputRefs: [uploadKey],
+      filename,
+      settings: opts.steps[0],
+    } satisfies ToolJobData,
+    opts: { jobId: stepIds[0], attempts: 1, ignoreDependencyOnFailure: true },
+  };
+  for (let i = 1; i < totalSteps; i++) {
+    node = {
+      name: "wt-pipeline-cancel",
+      queueName: queueName("image"),
+      data: {
+        kind: "pipeline-step",
+        jobId: stepIds[i],
+        toolId: "wt-pipeline-cancel",
+        userId: null,
+        pool: "image",
+        stepIndex: i,
+        totalSteps,
+        prevJobId: stepIds[i - 1],
+        clientJobId: progressId,
+        parentId: opts.parentId,
+        inputRefs: [],
+        filename,
+        settings: opts.steps[i],
+      } satisfies ToolJobData,
+      opts: { jobId: stepIds[i], attempts: 1, ignoreDependencyOnFailure: true },
+      children: [node],
+    };
+  }
+
+  const tree: FlowJob = {
+    name: "pipeline-finalize",
+    queueName: queueName("image"),
+    data: {
+      kind: "pipeline-finalize",
+      jobId: flowId,
+      toolId: "pipeline",
+      userId: null,
+      pool: "image",
+      totalSteps,
+      clientJobId: progressId,
+      parentId: opts.parentId,
+      totalFiles: opts.totalFiles,
+      inputRefs: [],
+      filename,
+      settings: {},
+    } satisfies ToolJobData,
+    opts: {
+      jobId: flowId,
+      attempts: 1,
+      ...(opts.parentId ? { ignoreDependencyOnFailure: true } : {}),
+    },
+    children: [node],
+  };
+
+  await opts.beforeEnqueue?.(flowId);
+  if (!opts.skipEnqueue) await getFlowProducer().add(tree);
+  return { flowId, stepIds };
+}
+
+/** The finalize's BullMQ return value, what routes/pipeline.ts branches on. */
+async function finalizeReturnValue(flowId: string): Promise<Record<string, unknown>> {
+  const job = await waitFor(async () => {
+    const j = await getQueue("image").getJob(flowId);
+    return j?.returnvalue ? j : undefined;
+  });
+  return job.returnvalue as Record<string, unknown>;
+}
+
+beforeAll(async () => {
+  await startCancelListener();
+  startWorkers();
+}, 30_000);
+
+afterAll(async () => {
+  await closeWorkers();
+  await stopCancelListener();
+  await closeQueues();
+  await sharedRedis().quit();
+}, 20_000);
+
+// ── requestCancel resolution ────────────────────────────────────
+
+describe("requestCancel on a pipeline flow row", () => {
+  it("flags the scope key from settings and publishes every step id", async () => {
+    const clientJobId = randomUUID();
+    const { flowId, stepIds } = await enqueuePipelineFlow({
+      steps: [
+        { mode: "fast", tag: "r0" },
+        { mode: "fast", tag: "r1" },
+      ],
+      clientJobId,
+      skipEnqueue: true,
+    });
+
+    const received = await collectCancelPublishes(async () => {
+      expect(await requestCancel(flowId)).toBe(true);
+    });
+
+    // The flag is keyed by the id steps carry in data.clientJobId, not the
+    // flow row id, so queued steps can actually see it.
+    expect(await isBatchCanceled(clientJobId)).toBe(true);
+    expect(await isBatchCanceled(flowId)).toBe(false);
+    expect(received).toEqual(stepIds);
+  });
+
+  it("flags the flow id itself when the run has no alias", async () => {
+    const { flowId, stepIds } = await enqueuePipelineFlow({
+      steps: [{ mode: "fast", tag: "n0" }],
+      skipEnqueue: true,
+    });
+
+    const received = await collectCancelPublishes(async () => {
+      expect(await requestCancel(flowId)).toBe(true);
+    });
+
+    expect(await isBatchCanceled(flowId)).toBe(true);
+    expect(received).toEqual(stepIds);
+  });
+
+  it("leaves the flow row alone: the finalize owns terminal state", async () => {
+    const { flowId } = await enqueuePipelineFlow({
+      steps: [{ mode: "fast", tag: "row0" }],
+      skipEnqueue: true,
+    });
+    expect(await requestCancel(flowId)).toBe(true);
+    const row = await jobRow(flowId);
+    expect(row?.status).toBe("queued");
+    expect(row?.completedAt).toBeNull();
+  });
+
+  it("returns false for a terminal flow row and does not flag it", async () => {
+    const clientJobId = randomUUID();
+    const { flowId } = await enqueuePipelineFlow({
+      steps: [{ mode: "fast", tag: "t0" }],
+      clientJobId,
+      skipEnqueue: true,
+    });
+    await db
+      .update(schema.jobs)
+      .set({ status: "completed", completedAt: new Date() })
+      .where(eq(schema.jobs.id, flowId));
+
+    expect(await requestCancel(flowId)).toBe(false);
+    expect(await isBatchCanceled(clientJobId)).toBe(false);
+  });
+});
+
+describe("requestCancel on a pipeline SSE alias row", () => {
+  it("resolves the pointer, flags the alias id, and publishes the flow's step ids", async () => {
+    const clientJobId = randomUUID();
+    const { flowId, stepIds } = await enqueuePipelineFlow({
+      steps: [
+        { mode: "fast", tag: "a0" },
+        { mode: "fast", tag: "a1" },
+        { mode: "fast", tag: "a2" },
+      ],
+      clientJobId,
+      skipEnqueue: true,
+    });
+
+    const received = await collectCancelPublishes(async () => {
+      expect(await requestCancel(clientJobId)).toBe(true);
+    });
+
+    expect(await isBatchCanceled(clientJobId)).toBe(true);
+    expect(received).toEqual(stepIds.map((id) => id));
+    expect(received.every((id) => id.startsWith(flowId))).toBe(true);
+  });
+
+  it("still flags when the flow rows are not inserted yet (pre-enqueue window)", async () => {
+    // The route inserts the alias (with its pointer) before the flow rows;
+    // a cancel landing in that window must still commit the flag.
+    const clientJobId = randomUUID();
+    const flowId = randomUUID();
+    await db.insert(schema.jobs).values({
+      id: clientJobId,
+      type: "single",
+      status: "queued",
+      inputRefs: [],
+      settings: { pipelineFlowId: flowId },
+    });
+
+    expect(await requestCancel(clientJobId)).toBe(true);
+    expect(await isBatchCanceled(clientJobId)).toBe(true);
+  });
+
+  it("returns false for a terminal alias row and does not flag it", async () => {
+    const clientJobId = randomUUID();
+    await enqueuePipelineFlow({
+      steps: [{ mode: "fast", tag: "ta0" }],
+      clientJobId,
+      skipEnqueue: true,
+    });
+    await db
+      .update(schema.jobs)
+      .set({ status: "canceled", completedAt: new Date() })
+      .where(eq(schema.jobs.id, clientJobId));
+
+    expect(await requestCancel(clientJobId)).toBe(false);
+    expect(await isBatchCanceled(clientJobId)).toBe(false);
+  });
+
+  it("does not treat a plain single row as a pipeline", async () => {
+    // No pipelineFlowId pointer: falls through to the queue scan and, with
+    // no queue job under this id, reports false (pre-#771 behavior).
+    const id = randomUUID();
+    await db.insert(schema.jobs).values({
+      id,
+      type: "single",
+      status: "processing",
+      inputRefs: [],
+    });
+    expect(await requestCancel(id)).toBe(false);
+    expect(await isBatchCanceled(id)).toBe(false);
+  });
+});
+
+describe("requestCancel on a pipeline-batch parent", () => {
+  async function seedParent(
+    overrides: Partial<typeof schema.jobs.$inferInsert> = {},
+  ): Promise<string> {
+    const id = randomUUID();
+    await db.insert(schema.jobs).values({
+      id,
+      type: "batch",
+      toolId: "pipeline-batch",
+      status: "processing",
+      inputRefs: [],
+      settings: { flowChildCount: 2, stepCount: 2 },
+      ...overrides,
+    });
+    return id;
+  }
+
+  it("flags the batch and publishes a cancel for every per-file step id", async () => {
+    const id = await seedParent();
+
+    const received = await collectCancelPublishes(async () => {
+      expect(await requestCancel(id)).toBe(true);
+    });
+
+    expect(await isBatchCanceled(id)).toBe(true);
+    expect(received).toEqual([`${id}-f0-s0`, `${id}-f0-s1`, `${id}-f1-s0`, `${id}-f1-s1`]);
+  });
+
+  it("returns false for a terminal pipeline-batch parent", async () => {
+    const id = await seedParent({ status: "completed" });
+    expect(await requestCancel(id)).toBe(false);
+    expect(await isBatchCanceled(id)).toBe(false);
+  });
+});

--- a/tests/integration/platform/pipeline-cancel.test.ts
+++ b/tests/integration/platform/pipeline-cancel.test.ts
@@ -19,9 +19,11 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { ToolJobData } from "../../../apps/api/src/jobs/types.js";
 import type { ToolProcessCtx } from "../../../apps/api/src/routes/tool-factory.js";
 
-// Injects a fault into the step skip's flag read so the fall-through
-// contract (a failing skip must not wedge the step) is testable.
-const flagReadFault = vi.hoisted(() => ({ scope: null as string | null }));
+// Injects a bounded fault into the step skip's flag read so the fall-through
+// contract (a failing skip must not wedge the step) is testable. Bounded by
+// `remaining` so the finalize's own flag read behind the same scope runs
+// against the real implementation.
+const flagReadFault = vi.hoisted(() => ({ scope: null as string | null, remaining: 0 }));
 
 vi.mock("../../../apps/api/src/jobs/batch-progress.js", async (importOriginal) => {
   const actual =
@@ -29,7 +31,8 @@ vi.mock("../../../apps/api/src/jobs/batch-progress.js", async (importOriginal) =
   return {
     ...actual,
     isBatchCanceled: async (parentId: string) => {
-      if (parentId === flagReadFault.scope) {
+      if (parentId === flagReadFault.scope && flagReadFault.remaining > 0) {
+        flagReadFault.remaining--;
         throw new Error("injected flag-read outage");
       }
       return actual.isBatchCanceled(parentId);
@@ -183,18 +186,23 @@ interface PipelineFlowOpts {
 async function enqueuePipelineFlow(
   opts: PipelineFlowOpts,
 ): Promise<{ flowId: string; stepIds: string[] }> {
-  const flowId = opts.parentId ? `${opts.parentId}-f0` : randomUUID();
-  return enqueuePipelineFlowAt(flowId, opts);
+  const flowId = randomUUID();
+  const built = await buildPipelineFlow(flowId, opts);
+  await opts.beforeEnqueue?.(flowId);
+  if (!opts.skipEnqueue) await getFlowProducer().add(built.tree);
+  return { flowId, stepIds: built.stepIds };
 }
 
-async function enqueuePipelineFlowAt(
+async function buildPipelineFlow(
   flowId: string,
   opts: PipelineFlowOpts,
-): Promise<{ flowId: string; stepIds: string[] }> {
+): Promise<{ tree: FlowJob; stepIds: string[] }> {
   const filename = opts.filename ?? "input.png";
   const totalSteps = opts.steps.length;
   const stepIds = opts.steps.map((_, i) => `${flowId}-s${i}`);
-  const progressId = opts.clientJobId ?? flowId;
+  // Batch per-file trees carry no clientJobId (the batch channel is the
+  // parent id); single runs always carry the client-facing id.
+  const progressId = opts.parentId ? undefined : (opts.clientJobId ?? flowId);
   const uploadKey = `uploads/${flowId}-s0/${filename}`;
   await putObject(uploadKey, Buffer.from("payload"));
 
@@ -227,7 +235,9 @@ async function enqueuePipelineFlowAt(
     pool: "image",
     status: "queued",
     inputRefs: [],
-    settings: { stepCount: totalSteps, clientJobId: progressId },
+    // Cancel metadata is stamped on single-run flow rows only; per-file
+    // rows of a batch resolve through the parent instead.
+    settings: opts.parentId ? {} : { stepCount: totalSteps, clientJobId: progressId },
   });
 
   let node: FlowJob = {
@@ -299,9 +309,68 @@ async function enqueuePipelineFlowAt(
     children: [node],
   };
 
-  await opts.beforeEnqueue?.(flowId);
-  if (!opts.skipEnqueue) await getFlowProducer().add(tree);
-  return { flowId, stepIds };
+  return { tree, stepIds };
+}
+
+/**
+ * Insert the parent row and per-file pipeline chains and enqueue the batch
+ * flow exactly the way routes/pipeline.ts builds it: per-file trees as
+ * children of one batch-finalize parent on the system queue, the parent row
+ * carrying {flowChildCount, fileIndexMap, stepCount}.
+ */
+async function enqueuePipelineBatch(opts: {
+  files: Array<{ steps: StepSettings[]; filename: string }>;
+  beforeEnqueue?: (parentId: string) => Promise<void>;
+}): Promise<{ parentId: string; fileFlowIds: string[] }> {
+  const parentId = randomUUID();
+  const stepCount = opts.files[0]?.steps.length ?? 0;
+  const fileIndexMap = opts.files.map((_, i) => i);
+
+  await db.insert(schema.jobs).values({
+    id: parentId,
+    type: "batch",
+    toolId: "pipeline-batch",
+    pool: "system",
+    status: "queued",
+    inputRefs: [],
+    settings: { flowChildCount: opts.files.length, fileIndexMap, stepCount },
+  });
+
+  const children: FlowJob[] = [];
+  const fileFlowIds: string[] = [];
+  for (let i = 0; i < opts.files.length; i++) {
+    const flowId = `${parentId}-f${i}`;
+    const built = await buildPipelineFlow(flowId, {
+      steps: opts.files[i].steps,
+      parentId,
+      totalFiles: opts.files.length,
+      filename: opts.files[i].filename,
+    });
+    children.push(built.tree);
+    fileFlowIds.push(flowId);
+  }
+
+  const batchTree: FlowJob = {
+    name: "batch-finalize",
+    queueName: queueName("system"),
+    data: {
+      kind: "batch-finalize",
+      jobId: parentId,
+      toolId: "pipeline-batch",
+      userId: null,
+      pool: "system",
+      totalFiles: opts.files.length,
+      inputRefs: [],
+      filename: "",
+      settings: { flowChildCount: opts.files.length, fileIndexMap, stepCount },
+    } satisfies ToolJobData,
+    opts: { jobId: parentId, attempts: 1 },
+    children,
+  };
+
+  await opts.beforeEnqueue?.(parentId);
+  await getFlowProducer().add(batchTree);
+  return { parentId, fileFlowIds };
 }
 
 /** The finalize's BullMQ return value, what routes/pipeline.ts branches on. */
@@ -494,5 +563,237 @@ describe("requestCancel on a pipeline-batch parent", () => {
     const id = await seedParent({ status: "completed" });
     expect(await requestCancel(id)).toBe(false);
     expect(await isBatchCanceled(id)).toBe(false);
+  });
+});
+
+// ── Cooperative step skip and canceled finalize ─────────────────
+
+describe("cooperative step skip and canceled finalize", () => {
+  it("cancel mid-run aborts the active step, skips the queued step, and settles every surface", async () => {
+    const clientJobId = randomUUID();
+    const tag = `mid-${clientJobId.slice(0, 8)}`;
+    const { flowId, stepIds } = await enqueuePipelineFlow({
+      steps: [
+        { mode: "slow", tag: `${tag}-s0` },
+        { mode: "fast", tag: `${tag}-s1` },
+      ],
+      clientJobId,
+    });
+
+    // The slow step must be actively running so the abort-over-the-channel
+    // path is exercised deterministically (a queued step would take the
+    // flag-skip path, which has its own test below).
+    await waitFor(async () => {
+      const row = await jobRow(stepIds[0]);
+      return row?.status === "processing" ? true : undefined;
+    });
+
+    expect(await requestCancel(clientJobId)).toBe(true);
+
+    // Active step aborted, queued step skipped without ever running.
+    const s0 = await terminalRow(stepIds[0]);
+    expect(s0.status).toBe("canceled");
+    const s1 = await terminalRow(stepIds[1]);
+    expect(s1.status).toBe("canceled");
+    expect(invoked).not.toContain(`${tag}-s1`);
+
+    // Both the authoritative flow row and the client-facing alias settle
+    // canceled (#766's dual-write lesson).
+    const flow = await terminalRow(flowId);
+    expect(flow.status).toBe("canceled");
+    const alias = await terminalRow(clientJobId);
+    expect(alias.status).toBe("canceled");
+    expect((alias.error as { message?: string } | null)?.message).toBe("Canceled");
+
+    // Live SSE clients settle from the terminal frame on the alias channel;
+    // a reconnecting client replays the same canceled outcome.
+    const frame = await terminalFrame(clientJobId);
+    expect(frame.type).toBe("single");
+    expect(frame.phase).toBe("failed");
+    expect(frame.error).toBe("Canceled");
+
+    // routes/pipeline.ts branches its sync 422 on this payload.
+    const returned = await finalizeReturnValue(flowId);
+    const payload = returned.resultPayload as { canceled?: boolean; error?: string };
+    expect(payload.canceled).toBe(true);
+    expect(payload.error).toBe("Canceled");
+  });
+
+  it("a cancel that lands after every step finished completes normally", async () => {
+    const clientJobId = randomUUID();
+    const tag = `late-${clientJobId.slice(0, 8)}`;
+    const { flowId, stepIds } = await enqueuePipelineFlow({
+      steps: [
+        { mode: "fast", tag: `${tag}-s0` },
+        { mode: "fast", tag: `${tag}-s1` },
+      ],
+      clientJobId,
+    });
+
+    await waitFor(async () => {
+      const s0 = await jobRow(stepIds[0]);
+      const s1 = await jobRow(stepIds[1]);
+      return s0?.status === "completed" && s1?.status === "completed" ? true : undefined;
+    });
+    await markBatchCanceled(clientJobId);
+
+    const flow = await terminalRow(flowId);
+    expect(flow.status).toBe("completed");
+    const frame = await terminalFrame(clientJobId);
+    expect(frame.phase).toBe("complete");
+    expect((frame.result as Record<string, unknown>).downloadUrl).toContain(
+      `/api/v1/download/${flowId}/`,
+    );
+  });
+
+  it("a cancel flagged before enqueue skips every step", async () => {
+    const clientJobId = randomUUID();
+    const tag = `pre-${clientJobId.slice(0, 8)}`;
+    const { flowId, stepIds } = await enqueuePipelineFlow({
+      steps: [
+        { mode: "slow", tag: `${tag}-s0` },
+        { mode: "slow", tag: `${tag}-s1` },
+      ],
+      clientJobId,
+      beforeEnqueue: async () => {
+        await markBatchCanceled(clientJobId);
+      },
+    });
+
+    const flow = await terminalRow(flowId);
+    expect(flow.status).toBe("canceled");
+    for (const stepId of stepIds) {
+      const row = await jobRow(stepId);
+      expect(row?.status).toBe("canceled");
+    }
+    expect(invoked).not.toContain(`${tag}-s0`);
+    expect(invoked).not.toContain(`${tag}-s1`);
+
+    const alias = await terminalRow(clientJobId);
+    expect(alias.status).toBe("canceled");
+    const frame = await terminalFrame(clientJobId);
+    expect(frame.phase).toBe("failed");
+    expect(frame.error).toBe("Canceled");
+  });
+
+  it("a failing flag read falls through to normal processing instead of wedging the step", async () => {
+    const clientJobId = randomUUID();
+    const tag = `fault-${clientJobId.slice(0, 8)}`;
+    flagReadFault.scope = clientJobId;
+    flagReadFault.remaining = 2;
+
+    try {
+      const { flowId, stepIds } = await enqueuePipelineFlow({
+        steps: [
+          { mode: "fast", tag: `${tag}-s0` },
+          { mode: "fast", tag: `${tag}-s1` },
+        ],
+        clientJobId,
+        beforeEnqueue: async () => {
+          await markBatchCanceled(clientJobId);
+        },
+      });
+
+      // Both step-level flag reads hit the injected outage and must fall
+      // through to normal processing (a too-late cancel), never leave the
+      // step row wedged behind a hard-failed job. The finalize's own flag
+      // read then runs for real, sees no canceled step, and completes.
+      const flow = await terminalRow(flowId);
+      expect(flow.status).toBe("completed");
+      expect(invoked).toContain(`${tag}-s0`);
+      expect(invoked).toContain(`${tag}-s1`);
+      for (const stepId of stepIds) {
+        const row = await jobRow(stepId);
+        expect(row?.status).toBe("completed");
+      }
+    } finally {
+      flagReadFault.scope = null;
+      flagReadFault.remaining = 0;
+    }
+  });
+});
+
+// ── Pipeline-batch composition ──────────────────────────────────
+
+describe("pipeline-batch cancel", () => {
+  it("cancel mid-batch keeps finished files in a partial ZIP and cancels the rest", async () => {
+    const { parentId, fileFlowIds } = await enqueuePipelineBatch({
+      files: [
+        { steps: [{ mode: "fast", tag: "pb-fast" }], filename: "fast.png" },
+        { steps: [{ mode: "slow", tag: "pb-slow" }], filename: "slow.png" },
+      ],
+    });
+
+    // The fast file's step must be done before the cancel so the batch has
+    // real finished work to keep, and the slow file's step must be actively
+    // running so the abort path is exercised. Only jobs scheduled ahead of
+    // the slow step gate the condition (the pools run at concurrency 1).
+    await waitFor(async () => {
+      const fast = await jobRow(`${fileFlowIds[0]}-s0`);
+      const slow = await jobRow(`${fileFlowIds[1]}-s0`);
+      return fast?.status === "completed" && slow?.status === "processing" ? true : undefined;
+    });
+
+    expect(await requestCancel(parentId)).toBe(true);
+
+    const parent = await terminalRow(parentId);
+    expect(parent.status).toBe("canceled");
+    expect(parent.outputRefs?.length).toBe(1);
+    const zipKey = parent.outputRefs?.[0] as string;
+
+    // The finished file's whole pipeline completed, so it lands in the ZIP
+    // (#767's file-level partial semantics); the canceled file reads
+    // "Canceled".
+    const frame = await terminalFrame(parentId);
+    expect(frame.status).toBe("completed");
+    const result = frame.result as { downloadUrl?: string; fileResults?: Record<string, string> };
+    expect(result.downloadUrl).toContain(`/api/v1/download/${parentId}/`);
+    expect(Object.keys(result.fileResults ?? {})).toEqual(["0"]);
+
+    const zip = new AdmZip(await getObjectBuffer(zipKey));
+    const names = zip.getEntries().map((e) => e.entryName);
+    expect(names).toHaveLength(1);
+    expect(names[0]).toMatch(/^fast/);
+
+    const finishedFile = await terminalRow(fileFlowIds[0]);
+    expect(finishedFile.status).toBe("completed");
+    const canceledFile = await terminalRow(fileFlowIds[1]);
+    expect(canceledFile.status).toBe("canceled");
+    const canceledStep = await terminalRow(`${fileFlowIds[1]}-s0`);
+    expect(canceledStep.status).toBe("canceled");
+
+    const returned = await waitFor(async () => {
+      const j = await getQueue("system").getJob(parentId);
+      return j?.returnvalue ? (j.returnvalue as Record<string, unknown>) : undefined;
+    });
+    expect((returned.resultPayload as { canceled?: boolean }).canceled).toBe(true);
+  });
+
+  it("a full cancel before any step ran settles the batch with the Canceled synthetic", async () => {
+    const { parentId, fileFlowIds } = await enqueuePipelineBatch({
+      files: [
+        { steps: [{ mode: "slow", tag: "pbx-a" }], filename: "a.png" },
+        { steps: [{ mode: "slow", tag: "pbx-b" }], filename: "b.png" },
+      ],
+      beforeEnqueue: (id) => markBatchCanceled(id),
+    });
+
+    const parent = await terminalRow(parentId);
+    expect(parent.status).toBe("canceled");
+    expect(parent.outputRefs ?? []).toEqual([]);
+
+    const frame = await terminalFrame(parentId);
+    expect(frame.status).toBe("failed");
+    const errors = frame.errors as Array<{ filename: string; error: string }>;
+    expect(errors[0]).toEqual({ filename: "", error: "Canceled" });
+
+    for (const flowId of fileFlowIds) {
+      const row = await jobRow(flowId);
+      expect(row?.status).toBe("canceled");
+      const step = await jobRow(`${flowId}-s0`);
+      expect(step?.status).toBe("canceled");
+    }
+    expect(invoked).not.toContain("pbx-a");
+    expect(invoked).not.toContain("pbx-b");
   });
 });

--- a/tests/integration/platform/worker-branches.test.ts
+++ b/tests/integration/platform/worker-branches.test.ts
@@ -58,6 +58,7 @@ const { eq } = await import("drizzle-orm");
 const { env } = await import("../../../apps/api/src/config.js");
 const { db, schema } = await import("../../../apps/api/src/db/index.js");
 const { runMigrations } = await import("../../../apps/api/src/db/migrate.js");
+const { markBatchCanceled } = await import("../../../apps/api/src/jobs/batch-progress.js");
 const { requestCancel, startCancelListener, stopCancelListener } = await import(
   "../../../apps/api/src/jobs/cancel.js"
 );
@@ -556,6 +557,45 @@ describe("pipeline finalize", () => {
     expect(props.status).toBe("failed");
     expect(props.step_count).toBe(1);
     expect(props.tool_ids).toEqual([]);
+    expect(props.is_batch).toBe(false);
+    expect(props.file_count).toBe(1);
+  });
+
+  it("commits a canceled run and emits canceled analytics when a flagged step was canceled", async () => {
+    const jobId = `pf-${randomUUID()}`;
+    await db.insert(schema.jobs).values({
+      id: `${jobId}-s0`,
+      type: "pipeline-step",
+      status: "canceled",
+      toolId: "resize",
+      pool: "image",
+      inputRefs: [],
+      error: { message: "Canceled" },
+    });
+    // Both halves of #770's too-late rule: the flag plus the canceled step.
+    await markBatchCanceled(jobId);
+
+    await enqueueToolJob(
+      toolJob({
+        jobId,
+        toolId: "pipeline",
+        kind: "pipeline-finalize",
+        totalSteps: 1,
+        filename: "chain.png",
+      }),
+    );
+
+    const row = await terminalRow(jobId);
+    expect(row.status).toBe("canceled");
+    expect(row.error?.message).toBe("Canceled");
+
+    const frame = await terminalFrame(jobId);
+    expect(frame.phase).toBe("failed");
+    expect(frame.error).toBe("Canceled");
+
+    const events = await emittedEvents(ANALYTICS_EVENTS.PIPELINE_EXECUTED, jobId);
+    const props = events[0];
+    expect(props.status).toBe("canceled");
     expect(props.is_batch).toBe(false);
     expect(props.file_count).toBe(1);
   });

--- a/tests/unit/api/progress.test.ts
+++ b/tests/unit/api/progress.test.ts
@@ -276,6 +276,40 @@ describe("durable single-file terminal progress", () => {
       error: "Completed result is no longer available. Run the job again.",
     });
   });
+
+  it("replays a canceled durable row as the failed Canceled terminal (#771)", () => {
+    expect(
+      buildSingleFileReplayEvent({
+        jobId: "single-canceled",
+        status: "canceled",
+        progress: { percent: 0 },
+        error: { message: "Canceled" },
+      }),
+    ).toEqual({
+      jobId: "single-canceled",
+      type: "single",
+      phase: "failed",
+      percent: 0,
+      error: "Canceled",
+    });
+  });
+
+  it("falls back to Canceled for a canceled row without a stored message", () => {
+    expect(
+      buildSingleFileReplayEvent({
+        jobId: "single-canceled-bare",
+        status: "canceled",
+        progress: {},
+        error: null,
+      }),
+    ).toEqual({
+      jobId: "single-canceled-bare",
+      type: "single",
+      phase: "failed",
+      percent: 0,
+      error: "Canceled",
+    });
+  });
 });
 
 describe("JobProgress type shape", () => {

--- a/tests/unit/web/use-pipeline-processor-cancel.test.ts
+++ b/tests/unit/web/use-pipeline-processor-cancel.test.ts
@@ -1,0 +1,497 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import AdmZip from "adm-zip";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  formatHeaders: () => new Map<string, string>(),
+  parseApiError: (body: unknown) => (body as { error?: string } | null)?.error ?? "error",
+}));
+
+// Deterministic run ids. Tests that start a second run must queue a distinct
+// id, or run-identity guards degenerate into always-true comparisons.
+const generateIdMock = vi.hoisted(() => ({ queue: [] as string[] }));
+
+vi.mock("@/lib/utils", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  return {
+    ...actual,
+    generateId: () => generateIdMock.queue.shift() ?? "66666666-6666-4666-8666-666666666666",
+  };
+});
+
+import { usePipelineProcessor } from "@/hooks/use-pipeline-processor";
+import { useFileStore } from "@/stores/file-store";
+
+interface MockXhr {
+  status: number;
+  responseText: string;
+  responseType: string;
+  response: unknown;
+  timeout: number;
+  upload: { onprogress?: unknown; onload?: (() => void) | null };
+  onload?: () => void;
+  onerror?: (() => void) | null;
+  ontimeout?: (() => void) | null;
+  open: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  setRequestHeader: ReturnType<typeof vi.fn>;
+  getResponseHeader: ReturnType<typeof vi.fn>;
+  abort: ReturnType<typeof vi.fn>;
+}
+
+class MockEventSource {
+  static OPEN = 1;
+  static instances: MockEventSource[] = [];
+
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = MockEventSource.OPEN;
+  close = vi.fn(() => {
+    this.readyState = 2;
+  });
+
+  constructor(readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+}
+
+let xhrs: MockXhr[];
+
+const JOB_ID = "66666666-6666-4666-8666-666666666666";
+const STEPS = [{ id: "s1", toolId: "resize", settings: { width: 50 } }];
+
+// Only the first file finished before the cancel landed.
+const PARTIAL_NAMES = { "0": "first_resize.png" } as const;
+const PARTIAL_ZIP_BYTES = (() => {
+  const zip = new AdmZip();
+  zip.addFile("first_resize.png", Buffer.from([1, 2, 3, 4]));
+  return new Uint8Array(zip.toBuffer());
+})();
+const partialZipBlob = () =>
+  new Blob([PARTIAL_ZIP_BYTES.slice().buffer], { type: "application/zip" });
+
+function latestSse(): MockEventSource {
+  return MockEventSource.instances[MockEventSource.instances.length - 1];
+}
+
+function sendSingleFrame(frame: Record<string, unknown>) {
+  latestSse().onmessage?.({
+    data: JSON.stringify({ type: "single", jobId: JOB_ID, ...frame }),
+  } as MessageEvent);
+}
+
+function sendBatchFrame(frame: Record<string, unknown>) {
+  latestSse().onmessage?.({
+    data: JSON.stringify({ type: "batch", jobId: JOB_ID, ...frame }),
+  } as MessageEvent);
+}
+
+beforeEach(() => {
+  vi.stubGlobal("URL", {
+    ...globalThis.URL,
+    createObjectURL: vi.fn(() => "blob:fake-url"),
+    revokeObjectURL: vi.fn(),
+  });
+  useFileStore.getState().reset();
+  xhrs = [];
+  MockEventSource.instances = [];
+  vi.stubGlobal("EventSource", MockEventSource);
+  vi.stubGlobal(
+    "XMLHttpRequest",
+    vi.fn(() => {
+      const xhr: MockXhr = {
+        status: 0,
+        responseText: "",
+        responseType: "",
+        response: null,
+        timeout: 0,
+        upload: {},
+        open: vi.fn(),
+        send: vi.fn(),
+        setRequestHeader: vi.fn(),
+        getResponseHeader: vi.fn(() => null),
+        abort: vi.fn(),
+      };
+      xhrs.push(xhr);
+      return xhr;
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+function startSingleRun() {
+  const file = new File([new ArrayBuffer(16)], "photo.png", { type: "image/png" });
+  useFileStore.getState().setFiles([file]);
+  const hook = renderHook(() => usePipelineProcessor());
+  act(() => {
+    hook.result.current.processSingle(file, STEPS);
+  });
+  return hook;
+}
+
+function startBatchRun() {
+  const files = [
+    new File([new ArrayBuffer(16)], "first.png", { type: "image/png" }),
+    new File([new ArrayBuffer(16)], "second.jpg", { type: "image/jpeg" }),
+  ];
+  useFileStore.getState().setFiles(files);
+  const hook = renderHook(() => usePipelineProcessor());
+  act(() => {
+    void hook.result.current.processAll(files, STEPS);
+  });
+  return hook;
+}
+
+async function settled(check: () => void) {
+  await vi.waitFor(check, { timeout: 3_000 });
+}
+
+/**
+ * #771: pipeline runs are cancelable. The Automate page's ProgressCard
+ * renders its cancel button off the store's activeJob handle, a cancel
+ * settles single runs through the server's "Canceled" vocabulary, and batch
+ * runs keep the partial results with skipped files reading "Canceled".
+ */
+describe("usePipelineProcessor cancel (#771)", () => {
+  it("arms the progress-card cancel handle for a single pipeline run", () => {
+    const { unmount } = startSingleRun();
+
+    expect(useFileStore.getState().activeJobId).toBe(JOB_ID);
+    expect(typeof useFileStore.getState().cancelCurrentJob).toBe("function");
+
+    unmount();
+  });
+
+  it("arms the progress-card cancel handle for a pipeline batch run", () => {
+    const { unmount } = startBatchRun();
+
+    expect(useFileStore.getState().activeJobId).toBe(JOB_ID);
+    expect(typeof useFileStore.getState().cancelCurrentJob).toBe("function");
+
+    unmount();
+  });
+
+  it("POSTs the cancel to the run's client-facing id", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ canceled: true }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startSingleRun();
+
+    await act(async () => {
+      await useFileStore.getState().cancelCurrentJob?.();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/v1/jobs/${JOB_ID}/cancel`,
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    hook.unmount();
+  });
+
+  it("settles a canceled single run from the failed frame and disarms the handle", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ canceled: true }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 202;
+      xhrs[0].responseText = JSON.stringify({ jobId: JOB_ID, async: true });
+      xhrs[0].onload?.();
+    });
+
+    await act(async () => {
+      await useFileStore.getState().cancelCurrentJob?.();
+    });
+
+    act(() => {
+      sendSingleFrame({ phase: "failed", percent: 0, error: "Canceled" });
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().processing).toBe(false);
+    });
+    expect(useFileStore.getState().error).toBe("Canceled");
+    expect(useFileStore.getState().activeJobId).toBeNull();
+
+    hook.unmount();
+  });
+
+  it("cancel during a run the server never saw aborts the upload and settles locally", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ error: "Job not found" }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startSingleRun();
+
+    // Upload still in flight: no upload.onload, no server response yet.
+    await act(async () => {
+      await useFileStore.getState().cancelCurrentJob?.();
+    });
+
+    expect(xhrs[0].abort).toHaveBeenCalled();
+    expect(useFileStore.getState().error).toBe("Canceled");
+    expect(useFileStore.getState().processing).toBe(false);
+    expect(useFileStore.getState().activeJobId).toBeNull();
+
+    hook.unmount();
+  });
+
+  it("a canceled sync 422 reads Canceled and disarms the handle", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ canceled: true }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+    });
+
+    await act(async () => {
+      await useFileStore.getState().cancelCurrentJob?.();
+    });
+
+    act(() => {
+      xhrs[0].status = 422;
+      xhrs[0].responseText = JSON.stringify({
+        error: "Canceled",
+        completedSteps: [],
+        canceled: true,
+      });
+      xhrs[0].onload?.();
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().processing).toBe(false);
+    });
+    expect(useFileStore.getState().error).toBe("Canceled");
+    expect(useFileStore.getState().activeJobId).toBeNull();
+
+    hook.unmount();
+  });
+
+  it("labels files the cancel skipped when settling the partial ZIP from SSE", async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/cancel")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ canceled: true }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(partialZipBlob()),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 202;
+      xhrs[0].responseText = JSON.stringify({ jobId: JOB_ID, async: true });
+      xhrs[0].onload?.();
+    });
+
+    await act(async () => {
+      await useFileStore.getState().cancelCurrentJob?.();
+    });
+
+    act(() => {
+      sendBatchFrame({
+        status: "completed",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 1,
+        errors: [{ filename: "second.jpg", error: "Canceled" }],
+        result: {
+          jobId: JOB_ID,
+          downloadUrl: `/api/v1/download/${JOB_ID}/pipeline-batch-66666666.zip`,
+          zipFilename: "pipeline-batch-66666666.zip",
+          fileResults: PARTIAL_NAMES,
+          processedSize: PARTIAL_ZIP_BYTES.length,
+        },
+      });
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[0].status).toBe("completed");
+      expect(useFileStore.getState().entries[1].status).toBe("failed");
+    });
+    expect(useFileStore.getState().entries[1].error).toBe("Canceled");
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().processing).toBe(false);
+    expect(useFileStore.getState().activeJobId).toBeNull();
+
+    hook.unmount();
+  });
+
+  it("keeps the lookup-failure label when nothing was canceled by the user", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(partialZipBlob()),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 202;
+      xhrs[0].responseText = JSON.stringify({ jobId: JOB_ID, async: true });
+      xhrs[0].onload?.();
+    });
+
+    // No cancel click: a partial result with a missing file is a genuine
+    // lookup failure, not a cancellation.
+    act(() => {
+      sendBatchFrame({
+        status: "completed",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 1,
+        errors: [{ filename: "second.jpg", error: "Processing failed" }],
+        result: {
+          jobId: JOB_ID,
+          downloadUrl: `/api/v1/download/${JOB_ID}/pipeline-batch-66666666.zip`,
+          zipFilename: "pipeline-batch-66666666.zip",
+          fileResults: PARTIAL_NAMES,
+          processedSize: PARTIAL_ZIP_BYTES.length,
+        },
+      });
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[1].status).toBe("failed");
+    });
+    expect(useFileStore.getState().entries[1].error).toBe("File not found in batch results");
+
+    hook.unmount();
+  });
+
+  it("settles a full batch cancel from the failed frame's Canceled synthetic", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ canceled: true }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 202;
+      xhrs[0].responseText = JSON.stringify({ jobId: JOB_ID, async: true });
+      xhrs[0].onload?.();
+    });
+
+    await act(async () => {
+      await useFileStore.getState().cancelCurrentJob?.();
+    });
+
+    act(() => {
+      sendBatchFrame({
+        status: "failed",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 2,
+        errors: [
+          { filename: "", error: "Canceled" },
+          { filename: "first.png", error: "Canceled" },
+          { filename: "second.jpg", error: "Canceled" },
+        ],
+      });
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().processing).toBe(false);
+    });
+    expect(useFileStore.getState().error).toBe("Canceled");
+    expect(useFileStore.getState().activeJobId).toBeNull();
+
+    hook.unmount();
+  });
+
+  it("reports the batch canceled 422 as Canceled, not a per-file failure list", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ canceled: true }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+    });
+
+    await act(async () => {
+      await useFileStore.getState().cancelCurrentJob?.();
+    });
+
+    act(() => {
+      xhrs[0].status = 422;
+      xhrs[0].response = new Blob(
+        [
+          JSON.stringify({
+            error: "Batch canceled",
+            canceled: true,
+            errors: [
+              { filename: "first.png", error: "Canceled" },
+              { filename: "second.jpg", error: "Canceled" },
+            ],
+          }),
+        ],
+        { type: "application/json" },
+      );
+      xhrs[0].onload?.();
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().processing).toBe(false);
+    });
+    expect(useFileStore.getState().error).toBe("Canceled");
+    expect(useFileStore.getState().activeJobId).toBeNull();
+
+    hook.unmount();
+  });
+});

--- a/tests/unit/web/use-pipeline-processor-cancel.test.ts
+++ b/tests/unit/web/use-pipeline-processor-cancel.test.ts
@@ -301,6 +301,100 @@ describe("usePipelineProcessor cancel (#771)", () => {
     hook.unmount();
   });
 
+  it("settles a canceled sync 422 structurally, not by matching the error string", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ canceled: true }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startSingleRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+    });
+
+    await act(async () => {
+      await useFileStore.getState().cancelCurrentJob?.();
+    });
+
+    // The canceled marker is the contract; the error text may drift.
+    act(() => {
+      xhrs[0].status = 422;
+      xhrs[0].responseText = JSON.stringify({
+        error: "Pipeline run was canceled",
+        completedSteps: [],
+        canceled: true,
+      });
+      xhrs[0].onload?.();
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().processing).toBe(false);
+    });
+    expect(useFileStore.getState().error).toBe("Canceled");
+
+    hook.unmount();
+  });
+
+  it("keeps the lookup-failure label when the cancel was refused", async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/cancel")) {
+        // Too late: the server found the run already terminal.
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ canceled: false }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(partialZipBlob()),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const hook = startBatchRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].status = 202;
+      xhrs[0].responseText = JSON.stringify({ jobId: JOB_ID, async: true });
+      xhrs[0].onload?.();
+    });
+
+    await act(async () => {
+      await useFileStore.getState().cancelCurrentJob?.();
+    });
+
+    // The refused click must not repaint a genuine lookup failure.
+    act(() => {
+      sendBatchFrame({
+        status: "completed",
+        totalFiles: 2,
+        completedFiles: 2,
+        failedFiles: 1,
+        errors: [{ filename: "second.jpg", error: "Processing failed" }],
+        result: {
+          jobId: JOB_ID,
+          downloadUrl: `/api/v1/download/${JOB_ID}/pipeline-batch-66666666.zip`,
+          zipFilename: "pipeline-batch-66666666.zip",
+          fileResults: PARTIAL_NAMES,
+          processedSize: PARTIAL_ZIP_BYTES.length,
+        },
+      });
+    });
+
+    await settled(() => {
+      expect(useFileStore.getState().entries[1].status).toBe("failed");
+    });
+    expect(useFileStore.getState().entries[1].error).toBe("File not found in batch results");
+
+    hook.unmount();
+  });
+
   it("labels files the cancel skipped when settling the partial ZIP from SSE", async () => {
     const fetchMock = vi.fn((url: string) => {
       if (url.endsWith("/cancel")) {


### PR DESCRIPTION
Fixes #771.

Pipelines were the one run type a user could not stop. The Automate UI had no cancel control, `POST /jobs/:id/cancel` answered `{canceled: false}` for every pipeline id shape, and #770 deliberately refused pipeline-batch parents: flagging a batch whose steps never check the flag would report "Canceled" while every step kept burning CPU. Since #769 pipelines also ride SSE across dead connections, so killing the tab stopped nothing.

The pieces, all on #770's machinery. `requestCancel` now resolves the three pipeline row shapes: a flow row flags the run under the id its steps actually consult (`settings.clientJobId`, stamped at enqueue) and publishes every step id so the active step aborts; the SSE alias row follows a `settings.pipelineFlowId` pointer the route now stamps; pipeline-batch parents lost the refusal, publishing `flowChildCount x stepCount` per-file step ids instead. `processPipelineStep` checks the flag before any work, inside the same no-throw contract `processBatchChild` keeps, so a fault falls through to normal processing rather than wedging a row that nothing revisits. The finalize commits the canceled terminal through a new guarded writer (`cancelSingleJobGuarded`) to both the authoritative flow row and the alias, the #766 dual-write lesson, with #770's too-late rule intact: flag plus at least one canceled step, otherwise the run completes normally.

A canceled single pipeline returns nothing. Intermediates are internal artifacts, not deliverables. Pipeline-batch composes without new code in the batch finalize: canceled per-file rows are exactly what `processBatchFinalize` already counts, so the partial ZIP keeps files whose whole pipeline finished and the rest read "Canceled".

One ownership fix rode along by necessity: the cancel route authorizes by `jobs.userId`, and the lazily-created alias row had none, so a plain user could never cancel their own run. The route now pre-inserts the alias with the owner and the flow pointer before anything else, which also closes the cancel-before-enqueue window.

On the web side, `use-pipeline-processor` arms the file-store's activeJob handle, so the ProgressCard the Automate page already renders grows its cancel button. No new UI surface, no new i18n strings. Canceled runs settle through the existing "Canceled" vocabulary on every transport; after a user cancel, batch files missing from the partial ZIP read "Canceled" instead of a lookup failure, and the structural canceled 422s (mirrored from batch.ts) settle as "Canceled" rather than a per-file failure list.

`pipeline_executed` gains status `"canceled"`.

## Verification

- `tests/integration/platform/pipeline-cancel.test.ts` (new, 16 tests, worker-harness like batch-cancel's): resolution for all three row shapes, mid-run abort where the queued step provably never runs, the too-late rule, the pre-enqueue window, flag-read fault fall-through, pipeline-batch partial ZIP and full cancel.
- `tests/integration/platform/pipeline-cancel-http.test.ts` (new, 7 tests): route stamping shapes, HTTP cancel against route-created rows, non-owner 404, both canceled 422 shapes.
- The #770 refusal test in `batch-cancel.test.ts` flips to pin the cooperative behavior.
- `tests/unit/web/use-pipeline-processor-cancel.test.ts` (new, 12 tests): handle arming, POST target, SSE and 422 settles, 404 local settle, "Canceled" labeling only after an acknowledged cancel.
- Local runs, all green: typecheck, lint, license boundary, unit (8455 tests), integration platform (1688) and security (660).

Three review agents (silent-failure, test coverage, code review) went over the diff before this went up and surfaced no bugs. Their low-severity items landed as a hardening commit: a reused clientJobId re-points the alias at the newest flow so a cancel resolves the live run, the single-run 422 settle keys on the structural canceled marker like the batch path already did, and coverage closed three gaps (the pipeline_executed canceled emission, the canceled DB-row replay after the Redis terminal key expires, refused-cancel labeling). A security pass then caught that the re-point wrote the requester's userId into any conflicting row, which would let a second user take over an alias and strip the owner's cancel authorization; the conflict update is now scoped to the row's own user (setWhere), pinned by a takeover regression test, with no 409 on the foreign case so the response cannot become an id-existence oracle.

Residual gaps, both deliberate: no e2e drives the mid-run cancel over real HTTP, because a reliably slow tool needs ffmpeg and the CI shards do not have it (that path lives at the worker-harness level); and the 1h cancel-flag TTL means a cancel on a pipeline that outlives it settles as a failure whose message still reads "Canceled", the same tradeoff #770 shipped for batches (#809).
