### PR TITLE
feat(auth): enroll users into MFA at login instead of hard-blocking (#811)

### DIFF
--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -428,6 +428,17 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       }
 
       if (mfaRequiredByPolicy) {
+        // Licensed instances walk the user through enrollment right here instead
+        // of hard-blocking, so a required policy cannot strand a not-yet-enrolled
+        // user (snapotter-hq/SnapOtter#811). Unlicensed instances (a policy stored
+        // before the v2.2.0 license gate) cannot enroll, so keep the 403; the
+        // offline recovery CLI is the escape there.
+        const { beginForcedEnrollment } = await import("./mfa.js");
+        const enrollment = await beginForcedEnrollment(user);
+        if (enrollment) {
+          await audit("MFA_ENROLLMENT_STARTED", { userId: user.id, username: user.username });
+          return reply.status(200).send({ requiresMfaEnrollment: true, ...enrollment });
+        }
         authAttempts.inc({ method: "password", result: "failure" });
         await audit("LOGIN_FAILED", {
           userId: user.id,

--- a/apps/api/src/plugins/mfa.ts
+++ b/apps/api/src/plugins/mfa.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import * as OTPAuth from "otpauth";
@@ -34,6 +34,11 @@ const verifyCodeSchema = z.object({
 
 const completeSchema = z.object({
   mfaToken: z.string().uuid("Invalid MFA token"),
+  code: z.string().min(1, "Code is required").max(20, "Code too long"),
+});
+
+const enrollCompleteSchema = z.object({
+  enrollmentToken: z.string().uuid("Invalid enrollment token"),
   code: z.string().min(1, "Code is required").max(20, "Code too long"),
 });
 
@@ -129,6 +134,45 @@ export function resolveExternalLoginMfaOutcome(
   if (totpEnabled) return "challenge";
   if (isMfaRequiredForUser(policy, userRole)) return "enrollment_required";
   return "proceed";
+}
+
+/**
+ * Start a forced TOTP enrollment for a user who just passed password auth but
+ * is blocked by a required MFA policy without an enrollment. Mirrors the enroll
+ * route's pending-secret storage, but keyed by a short-lived redis token so it
+ * can complete without a session. Returns null when MFA is not licensed (the
+ * caller keeps the hard 403 in that case).
+ */
+export async function beginForcedEnrollment(user: {
+  id: string;
+  username: string;
+}): Promise<{ enrollmentToken: string; uri: string; recoveryCodes: string[] } | null> {
+  let mfaLicensed = false;
+  try {
+    const { isFeatureEnabled } = await import("@snapotter/enterprise");
+    mfaLicensed = isFeatureEnabled("mfa");
+  } catch {
+    // Enterprise package not available.
+  }
+  if (!mfaLicensed) return null;
+
+  const totp = createTotp(user.username);
+  const recoveryCodes = generateRecoveryCodes();
+  const encryptedSecret = await encryptSecret(totp.secret.base32);
+
+  await db
+    .update(schema.users)
+    .set({
+      totpSecret: encryptedSecret,
+      totpEnabled: false,
+      recoveryCodesHash: hashRecoveryCodes(recoveryCodes),
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.users.id, user.id));
+
+  const enrollmentToken = randomUUID();
+  await sharedRedis().setex(`mfa:enroll:${enrollmentToken}`, MFA_CHALLENGE_TTL_SECONDS, user.id);
+  return { enrollmentToken, uri: totp.toString(), recoveryCodes };
 }
 
 // ── MFA plugin registration ───────────────────────────────────────
@@ -366,6 +410,116 @@ export async function registerMfa(app: FastifyInstance): Promise<void> {
         userId: dbUser.id,
         username: dbUser.username,
       });
+
+      const [teamRow] = await db
+        .select()
+        .from(schema.teams)
+        .where(eq(schema.teams.id, dbUser.team));
+
+      return reply.send({
+        token,
+        user: {
+          id: dbUser.id,
+          username: dbUser.username,
+          role: dbUser.role,
+          mustChangePassword: env.SKIP_MUST_CHANGE_PASSWORD ? false : dbUser.mustChangePassword,
+          permissions: await getPermissions(dbUser.role),
+          teamName: teamRow?.name ?? dbUser.team,
+        },
+        expiresAt: expiresAt.toISOString(),
+      });
+    },
+  );
+
+  // POST /api/auth/mfa/enroll-complete confirms a forced enrollment started at
+  // login (snapotter-hq/SnapOtter#811) and mints a session. Not session-gated:
+  // the whole point is that the user has no session yet. Keyed on a short-lived
+  // redis enroll token instead. Only a TOTP code is accepted for the initial
+  // confirmation (never a recovery code), same as the self-service verify route.
+  app.post(
+    "/api/auth/mfa/enroll-complete",
+    {
+      config: { rateLimit: { max: 15, timeWindow: "1 minute" } },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const parsed = enrollCompleteSchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.status(400).send({
+          error: "Enrollment token and code are required",
+          code: "VALIDATION_ERROR",
+        });
+      }
+      const { enrollmentToken, code } = parsed.data;
+
+      const redis = sharedRedis();
+      const userId = await redis.get(`mfa:enroll:${enrollmentToken}`);
+      if (!userId) {
+        return reply.status(401).send({
+          error: "Enrollment challenge expired or invalid",
+          code: "MFA_EXPIRED",
+        });
+      }
+
+      const [dbUser] = await db.select().from(schema.users).where(eq(schema.users.id, userId));
+      if (!dbUser?.totpSecret || isDisabledRole(dbUser.role)) {
+        return reply.status(401).send({
+          error: "User not found or MFA not configured",
+          code: "MFA_NOT_CONFIGURED",
+        });
+      }
+      if (dbUser.totpEnabled) {
+        // Defensive: the pending secret should be inactive at this point.
+        return reply.status(409).send({
+          error: "MFA is already verified and active",
+          code: "MFA_ALREADY_ENABLED",
+        });
+      }
+
+      const secretBase32 = await decryptSecret(dbUser.totpSecret);
+      if (!secretBase32) {
+        return reply.status(500).send({
+          error: "Failed to decrypt TOTP secret",
+          code: "DECRYPTION_FAILED",
+        });
+      }
+
+      const audit = auditFromRequest(request);
+
+      if (!verifyTotpCode(secretBase32, code)) {
+        // Burn the enrollment after a few wrong codes so an attacker who already
+        // holds valid credentials cannot grind TOTP guesses within the window.
+        // The counter shares the enrollment token's lifetime.
+        const attemptsKey = `mfa:enroll:attempts:${enrollmentToken}`;
+        const attempts = await redis.incr(attemptsKey);
+        if (attempts === 1) await redis.expire(attemptsKey, MFA_CHALLENGE_TTL_SECONDS);
+        if (attempts >= MFA_MAX_FAILED_ATTEMPTS) {
+          await redis.del(`mfa:enroll:${enrollmentToken}`, attemptsKey);
+        }
+        await audit("MFA_VERIFY_FAILED", { userId, username: dbUser.username });
+        return reply.status(401).send({
+          error: "Invalid TOTP code",
+          code: "INVALID_CODE",
+        });
+      }
+
+      // Activate MFA and clear the enrollment token + any failed-attempt counter.
+      await db
+        .update(schema.users)
+        .set({ totpEnabled: true, updatedAt: new Date() })
+        .where(eq(schema.users.id, userId));
+      await redis.del(`mfa:enroll:${enrollmentToken}`, `mfa:enroll:attempts:${enrollmentToken}`);
+
+      // Create a session, same as the complete route's login completion.
+      const token = createSessionToken();
+      const expiresAt = new Date(Date.now() + SESSION_DURATION_MS);
+      await db.insert(schema.sessions).values({
+        id: token,
+        userId: dbUser.id,
+        expiresAt,
+      });
+
+      await audit("MFA_ENROLLED", { userId: dbUser.id, username: dbUser.username });
+      await audit("LOGIN_SUCCESS", { userId: dbUser.id, username: dbUser.username });
 
       const [teamRow] = await db
         .select()

--- a/apps/web/src/pages/login-page.tsx
+++ b/apps/web/src/pages/login-page.tsx
@@ -1,10 +1,47 @@
 import { KeyRound } from "lucide-react";
+import QRCodeStyling from "qr-code-styling";
 import { type FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useAuth } from "@/hooks/use-auth";
 import { setToken } from "@/lib/api";
 import { format } from "@/lib/format";
+import { copyToClipboard } from "@/lib/utils";
+
+function parseManualSecret(uri: string): string {
+  try {
+    return new URL(uri).searchParams.get("secret") ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function QrCode({ uri }: { uri: string }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const qr = new QRCodeStyling({
+      width: 200,
+      height: 200,
+      data: uri,
+      margin: 8,
+      dotsOptions: { type: "square", color: "#000000" },
+      backgroundOptions: { color: "#ffffff" },
+    } as never);
+    const el = containerRef.current;
+    if (el) {
+      while (el.firstChild) el.removeChild(el.firstChild);
+      qr.append(el);
+    }
+  }, [uri]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex items-center justify-center rounded-xl border border-border p-4 bg-white w-fit"
+    />
+  );
+}
 
 function RotatingPhrase() {
   const { t } = useTranslation();
@@ -139,6 +176,13 @@ export function LoginPage() {
   const [mfaCode, setMfaCode] = useState("");
   const [mfaLoading, setMfaLoading] = useState(false);
   const mfaInputRef = useRef<HTMLInputElement>(null);
+  const [showMfaEnrollment, setShowMfaEnrollment] = useState(false);
+  const [enrollmentToken, setEnrollmentToken] = useState("");
+  const [enrollmentUri, setEnrollmentUri] = useState("");
+  const [enrollmentRecoveryCodes, setEnrollmentRecoveryCodes] = useState<string[]>([]);
+  const [enrollmentCode, setEnrollmentCode] = useState("");
+  const [enrollmentLoading, setEnrollmentLoading] = useState(false);
+  const [enrollmentCodesCopied, setEnrollmentCodesCopied] = useState(false);
 
   useEffect(() => {
     // A successful OIDC/SAML login for an already-enrolled user redirects
@@ -196,6 +240,19 @@ export function LoginPage() {
         return;
       }
       const data = await res.json();
+      if (data.requiresMfaEnrollment) {
+        // A licensed instance with a required MFA policy walks an unenrolled
+        // user through TOTP setup at login instead of blocking them. The
+        // secret is fresh per response, so once the panel is up we keep the
+        // token and URI in state and never re-submit the form underneath the
+        // user (that would rotate the secret out from under a scanned QR).
+        setEnrollmentToken(data.enrollmentToken);
+        setEnrollmentUri(data.uri);
+        setEnrollmentRecoveryCodes(data.recoveryCodes ?? []);
+        setShowMfaEnrollment(true);
+        setTimeout(() => mfaInputRef.current?.focus(), 100);
+        return;
+      }
       if (data.requiresMfa) {
         setMfaToken(data.mfaToken);
         setShowMfaPrompt(true);
@@ -245,6 +302,44 @@ export function LoginPage() {
     }
   };
 
+  const handleEnrollComplete = async () => {
+    setEnrollmentLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/api/auth/mfa/enroll-complete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enrollmentToken, code: enrollmentCode }),
+      });
+      if (!res.ok) {
+        setError(t.auth.mfaInvalidCode);
+        setEnrollmentCode("");
+        return;
+      }
+      const data = await res.json();
+      setToken(data.token);
+      localStorage.setItem("snapotter-username", data.user?.username || username);
+      if (data.user?.mustChangePassword) {
+        window.location.href = "/change-password";
+      } else {
+        window.location.href = "/";
+      }
+    } catch {
+      setError(t.auth.connectionError);
+    } finally {
+      setEnrollmentLoading(false);
+    }
+  };
+
+  const handleCopyRecoveryCodes = async () => {
+    if (enrollmentRecoveryCodes.length === 0) return;
+    const ok = await copyToClipboard(enrollmentRecoveryCodes.join("\n"));
+    if (ok) {
+      setEnrollmentCodesCopied(true);
+      setTimeout(() => setEnrollmentCodesCopied(false), 2000);
+    }
+  };
+
   return (
     <main id="main-content" tabIndex={-1} className="flex h-dvh bg-background">
       <div className="flex-1 flex items-center justify-center p-8">
@@ -285,7 +380,101 @@ export function LoginPage() {
               </p>
             </div>
           )}
-          {showMfaPrompt ? (
+          {showMfaEnrollment ? (
+            <div className="space-y-4">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="text-primary"
+                    role="img"
+                    aria-hidden="true"
+                  >
+                    <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+                    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    {t.auth.mfaEnrollmentHeading}
+                  </p>
+                </div>
+              </div>
+              <p className="text-sm text-foreground">{t.settings.security.twoFactorScanQr}</p>
+              {enrollmentUri && <QrCode uri={enrollmentUri} />}
+              <div>
+                <p className="text-xs text-muted-foreground mb-1">
+                  {t.settings.security.twoFactorManualEntry}
+                </p>
+                <code className="block text-xs bg-muted rounded-md px-3 py-2 break-all">
+                  {parseManualSecret(enrollmentUri)}
+                </code>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-foreground">
+                  {t.settings.security.twoFactorRecoveryCodesHeading}
+                </p>
+                <p className="text-xs text-muted-foreground mt-1 mb-2">
+                  {t.settings.security.twoFactorRecoveryCodesDescription}
+                </p>
+                <div className="grid grid-cols-2 gap-1 rounded-md border border-border p-3 font-mono text-xs">
+                  {enrollmentRecoveryCodes.map((rc) => (
+                    <span key={rc}>{rc}</span>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  onClick={handleCopyRecoveryCodes}
+                  className="mt-2 text-xs text-primary-ink hover:underline"
+                >
+                  {enrollmentCodesCopied
+                    ? t.settings.security.twoFactorCodesCopied
+                    : t.settings.security.twoFactorCopyRecoveryCodes}
+                </button>
+              </div>
+              <div>
+                <label
+                  htmlFor="enrollment-code"
+                  className="block text-sm font-medium mb-1 text-foreground"
+                >
+                  {t.settings.security.twoFactorEnterCode}
+                </label>
+                <input
+                  id="enrollment-code"
+                  ref={mfaInputRef}
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  maxLength={6}
+                  autoComplete="one-time-code"
+                  placeholder={t.settings.security.twoFactorCodePlaceholder}
+                  value={enrollmentCode}
+                  onChange={(e) => setEnrollmentCode(e.target.value.replace(/[^0-9]/g, ""))}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && enrollmentCode.length >= 6) handleEnrollComplete();
+                  }}
+                  className="w-full px-4 py-3 rounded-lg border border-border bg-background text-foreground text-center text-2xl font-mono tracking-[0.5em] focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              {error && <p className="text-sm text-destructive">{error}</p>}
+              <button
+                type="button"
+                onClick={handleEnrollComplete}
+                disabled={enrollmentLoading || enrollmentCode.length < 6}
+                className="w-full py-3 rounded-lg bg-primary/80 text-primary-foreground font-medium hover:bg-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {enrollmentLoading ? t.auth.verifying : t.settings.security.twoFactorConfirmButton}
+              </button>
+            </div>
+          ) : showMfaPrompt ? (
             <div className="space-y-4">
               <div className="flex items-center gap-3">
                 <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">

--- a/packages/shared/src/i18n/ar.ts
+++ b/packages/shared/src/i18n/ar.ts
@@ -3683,6 +3683,7 @@ export const ar: TranslationKeys = {
     verify: "تحقق",
     verifying: "جارٍ التحقق...",
     mfaInvalidCode: "رمز غير صالح. يرجى المحاولة مرة أخرى.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired: "تتطلب مؤسستك المصادقة متعددة العوامل. يرجى إعداد MFA في إعدادات حسابك.",
     methodSaml: "SAML",
     passwordManagedByProvider: "يتم إدارة تغيير كلمة المرور بواسطة مزود الهوية الخاص بك.",

--- a/packages/shared/src/i18n/de.ts
+++ b/packages/shared/src/i18n/de.ts
@@ -3734,6 +3734,7 @@ export const de: TranslationKeys = {
     verify: "Bestätigen",
     verifying: "Wird überprüft...",
     mfaInvalidCode: "Ungültiger Code. Bitte versuchen Sie es erneut.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Ihre Organisation erfordert Multi-Faktor-Authentifizierung. Bitte richten Sie MFA in Ihren Kontoeinstellungen ein.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/en.ts
+++ b/packages/shared/src/i18n/en.ts
@@ -3655,6 +3655,7 @@ export const en = {
     verify: "Verify",
     verifying: "Verifying...",
     mfaInvalidCode: "Invalid code. Please try again.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Your organization requires multi-factor authentication. Please set up MFA in your account settings.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/es.ts
+++ b/packages/shared/src/i18n/es.ts
@@ -3713,6 +3713,7 @@ export const es: TranslationKeys = {
     verify: "Verificar",
     verifying: "Verificando...",
     mfaInvalidCode: "Código no válido. Inténtalo de nuevo.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Tu organización requiere autenticación multifactor. Configura MFA en los ajustes de tu cuenta.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/fr.ts
+++ b/packages/shared/src/i18n/fr.ts
@@ -3738,6 +3738,7 @@ export const fr: TranslationKeys = {
     verify: "Vérifier",
     verifying: "Vérification...",
     mfaInvalidCode: "Code invalide. Veuillez réessayer.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Votre organisation exige l'authentification multifacteur. Veuillez configurer le MFA dans les paramètres de votre compte.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/hi.ts
+++ b/packages/shared/src/i18n/hi.ts
@@ -3511,6 +3511,7 @@ export const hi: TranslationKeys = {
     verify: "सत्यापित करें",
     verifying: "सत्यापित हो रहा है...",
     mfaInvalidCode: "अमान्य कोड। कृपया पुनः प्रयास करें।",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "आपके संगठन को मल्टी-फ़ैक्टर प्रमाणीकरण आवश्यक है। कृपया अपनी खाता सेटिंग्स में MFA सेट अप करें।",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/id.ts
+++ b/packages/shared/src/i18n/id.ts
@@ -3712,6 +3712,7 @@ export const id: TranslationKeys = {
     verify: "Verifikasi",
     verifying: "Memverifikasi...",
     mfaInvalidCode: "Kode tidak valid. Silakan coba lagi.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Organisasi Anda mewajibkan autentikasi multi-faktor. Silakan atur MFA di pengaturan akun Anda.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/it.ts
+++ b/packages/shared/src/i18n/it.ts
@@ -3728,6 +3728,7 @@ export const it: TranslationKeys = {
     verify: "Verifica",
     verifying: "Verifica in corso...",
     mfaInvalidCode: "Codice non valido. Riprova.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "La tua organizzazione richiede l'autenticazione a più fattori. Configura l'MFA nelle impostazioni del tuo account.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/ja.ts
+++ b/packages/shared/src/i18n/ja.ts
@@ -3661,6 +3661,7 @@ export const ja: TranslationKeys = {
     verify: "確認",
     verifying: "確認中...",
     mfaInvalidCode: "無効なコードです。もう一度お試しください。",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired: "組織で多要素認証が必須です。アカウント設定で MFA を設定してください。",
     methodSaml: "SAML",
     passwordManagedByProvider: "パスワードはIDプロバイダーで管理されています。",

--- a/packages/shared/src/i18n/ko.ts
+++ b/packages/shared/src/i18n/ko.ts
@@ -3640,6 +3640,7 @@ export const ko: TranslationKeys = {
     verify: "확인",
     verifying: "확인 중...",
     mfaInvalidCode: "잘못된 코드입니다. 다시 시도해 주세요.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired: "조직에서 다단계 인증을 요구합니다. 계정 설정에서 MFA를 설정해 주세요.",
     methodSaml: "SAML",
     passwordManagedByProvider: "비밀번호는 ID 제공자에서 관리됩니다.",

--- a/packages/shared/src/i18n/nl.ts
+++ b/packages/shared/src/i18n/nl.ts
@@ -3721,6 +3721,7 @@ export const nl: TranslationKeys = {
     verify: "Verifieer",
     verifying: "Verifieren...",
     mfaInvalidCode: "Ongeldige code. Probeer het opnieuw.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Uw organisatie vereist meerfactorauthenticatie. Stel MFA in via uw accountinstellingen.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/pl.ts
+++ b/packages/shared/src/i18n/pl.ts
@@ -3725,6 +3725,7 @@ export const pl: TranslationKeys = {
     verify: "Zweryfikuj",
     verifying: "Weryfikowanie...",
     mfaInvalidCode: "Nieprawidłowy kod. Spróbuj ponownie.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Twoja organizacja wymaga uwierzytelniania wieloskładnikowego. Skonfiguruj MFA w ustawieniach konta.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/pt-BR.ts
+++ b/packages/shared/src/i18n/pt-BR.ts
@@ -3720,6 +3720,7 @@ export const ptBR: TranslationKeys = {
     verify: "Verificar",
     verifying: "Verificando...",
     mfaInvalidCode: "Código inválido. Tente novamente.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Sua organização exige autenticação multifator. Configure o MFA nas configurações da sua conta.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/ru.ts
+++ b/packages/shared/src/i18n/ru.ts
@@ -3717,6 +3717,7 @@ export const ru: TranslationKeys = {
     verify: "Подтвердить",
     verifying: "Проверка...",
     mfaInvalidCode: "Неверный код. Попробуйте ещё раз.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Ваша организация требует многофакторную аутентификацию. Настройте MFA в параметрах учётной записи.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/sv.ts
+++ b/packages/shared/src/i18n/sv.ts
@@ -3710,6 +3710,7 @@ export const sv: TranslationKeys = {
     verify: "Verifiera",
     verifying: "Verifierar...",
     mfaInvalidCode: "Ogiltig kod. Försök igen.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Din organisation kräver multifaktorautentisering. Konfigurera MFA i dina kontoinställningar.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/th.ts
+++ b/packages/shared/src/i18n/th.ts
@@ -3662,6 +3662,7 @@ export const th: TranslationKeys = {
     verify: "ยืนยัน",
     verifying: "กำลังยืนยัน...",
     mfaInvalidCode: "รหัสไม่ถูกต้อง กรุณาลองอีกครั้ง",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired: "องค์กรของคุณกำหนดให้ใช้การยืนยันตัวตนหลายปัจจัย กรุณาตั้งค่า MFA ในการตั้งค่าบัญชี",
     methodSaml: "SAML",
     passwordManagedByProvider: "การเปลี่ยนรหัสผ่านจัดการโดยผู้ให้บริการยืนยันตัวตนของคุณ",

--- a/packages/shared/src/i18n/tr.ts
+++ b/packages/shared/src/i18n/tr.ts
@@ -3719,6 +3719,7 @@ export const tr: TranslationKeys = {
     verify: "Doğrula",
     verifying: "Doğrulanıyor...",
     mfaInvalidCode: "Geçersiz kod. Lütfen tekrar deneyin.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Kuruluşunuz çok faktörlü kimlik doğrulama gerektiriyor. Lütfen hesap ayarlarınızdan MFA kurulumunu yapın.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/uk.ts
+++ b/packages/shared/src/i18n/uk.ts
@@ -3715,6 +3715,7 @@ export const uk: TranslationKeys = {
     verify: "Перевірити",
     verifying: "Перевірка...",
     mfaInvalidCode: "Невірний код. Спробуйте ще раз.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Ваша організація вимагає багатофакторну автентифікацію. Налаштуйте MFA в параметрах облікового запису.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/vi.ts
+++ b/packages/shared/src/i18n/vi.ts
@@ -3706,6 +3706,7 @@ export const vi: TranslationKeys = {
     verify: "Xác minh",
     verifying: "Đang xác minh...",
     mfaInvalidCode: "Mã không hợp lệ. Vui lòng thử lại.",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Tổ chức của bạn yêu cầu xác thực đa yếu tố. Vui lòng thiết lập MFA trong cài đặt tài khoản.",
     methodSaml: "SAML",

--- a/packages/shared/src/i18n/zh-CN.ts
+++ b/packages/shared/src/i18n/zh-CN.ts
@@ -3446,6 +3446,7 @@ export const zhCN: TranslationKeys = {
     verify: "验证",
     verifying: "验证中...",
     mfaInvalidCode: "验证码无效，请重试。",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired: "您的组织要求启用多因素认证。请在账户设置中设置 MFA。",
     methodSaml: "SAML",
     passwordManagedByProvider: "密码修改由您的身份提供商管理。",

--- a/packages/shared/src/i18n/zh-TW.ts
+++ b/packages/shared/src/i18n/zh-TW.ts
@@ -3447,6 +3447,7 @@ export const zhTW: TranslationKeys = {
     verify: "驗證",
     verifying: "驗證中...",
     mfaInvalidCode: "驗證碼無效，請再試一次。",
+    mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired: "您的組織要求啟用多因素驗證。請在帳戶設定中設定 MFA。",
     methodSaml: "SAML",
     passwordManagedByProvider: "密碼由您的身分提供者管理。",

--- a/tests/integration/platform/mfa-endpoints.test.ts
+++ b/tests/integration/platform/mfa-endpoints.test.ts
@@ -779,18 +779,21 @@ async function setMfaPolicy(value: "optional" | "admins_only" | "required"): Pro
     .onConflictDoUpdate({ target: schema.settings.key, set: { value } });
 }
 
-// This is the actual fix for #515/#529: exercises the real /api/auth/login
-// route end to end, not a mocked response. Everything else in this repo that
-// covers this bug (the license gate on saving the setting, the frontend's
-// handling of a stubbed 403) would still pass if this exact backend branch
-// were reverted or its response code were renamed.
+// Exercises the real /api/auth/login MFA-policy branch end to end, not a mocked
+// response. Originally the fix for #515/#529 (an unenrolled user under a
+// required policy was hard-blocked with 403). Since #811, a LICENSED instance
+// (this file mocks mfa as licensed) no longer hard-blocks: it starts a forced
+// enrollment at login and returns 200 requiresMfaEnrollment. The hard 403 now
+// only survives on an unlicensed instance, covered by
+// mfa-forced-enrollment-unlicensed.test.ts. This block would still catch a
+// revert or a renamed response code on the licensed branch.
 describe("POST /api/auth/login with mfaPolicy enforcement", () => {
   afterEach(async () => {
     await setMfaPolicy("optional");
     await clearMfaState("admin");
   });
 
-  it("blocks an unenrolled admin with 403 MFA_ENROLLMENT_REQUIRED when policy is required", async () => {
+  it("starts a forced enrollment (200 requiresMfaEnrollment) for an unenrolled admin when policy is required", async () => {
     await setMfaPolicy("required");
 
     const res = await testApp.app.inject({
@@ -799,13 +802,15 @@ describe("POST /api/auth/login with mfaPolicy enforcement", () => {
       payload: { username: "admin", password: "Adminpass1" },
     });
 
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
-    expect(body.code).toBe("MFA_ENROLLMENT_REQUIRED");
+    expect(body.requiresMfaEnrollment).toBe(true);
+    expect(body.enrollmentToken).toBeDefined();
+    // No session is handed out until enroll-complete confirms a TOTP code.
     expect(body.token).toBeUndefined();
   });
 
-  it("blocks an unenrolled admin under an admins_only policy", async () => {
+  it("starts a forced enrollment for an unenrolled admin under an admins_only policy", async () => {
     await setMfaPolicy("admins_only");
 
     const res = await testApp.app.inject({
@@ -814,8 +819,8 @@ describe("POST /api/auth/login with mfaPolicy enforcement", () => {
       payload: { username: "admin", password: "Adminpass1" },
     });
 
-    expect(res.statusCode).toBe(403);
-    expect(JSON.parse(res.body).code).toBe("MFA_ENROLLMENT_REQUIRED");
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).requiresMfaEnrollment).toBe(true);
   });
 
   it("does not block a non-admin user under an admins_only policy", async () => {

--- a/tests/integration/platform/mfa-forced-enrollment-unlicensed.test.ts
+++ b/tests/integration/platform/mfa-forced-enrollment-unlicensed.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Forced-enrollment escape hatch on an UNLICENSED instance
+ * (snapotter-hq/SnapOtter#811).
+ *
+ * MFA enrollment is enterprise-gated, so an unlicensed instance cannot walk a
+ * user through enrollment at login. The only way a required policy exists here
+ * is if it was stored before v2.2.0 added the license gate on saving it. In
+ * that case login must keep the hard `403 MFA_ENROLLMENT_REQUIRED`; the offline
+ * recovery CLI is the escape.
+ *
+ * This file deliberately mocks enterprise as absent (`mockNoEnterprise()`) and
+ * lives apart from the licensed suite because the enterprise mock is per-file
+ * all-or-nothing. The required policy is written straight to the DB, since the
+ * PUT /settings gate would (correctly) reject saving it on an unlicensed
+ * instance -- which is exactly why this legacy pre-gate state has to be seeded
+ * directly.
+ */
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.resetModules();
+const { mockNoEnterprise } = await import("../../helpers/enterprise-mock.js");
+mockNoEnterprise();
+
+const { buildTestApp, createUserAndLogin } = await import("../test-server.js");
+const { db, schema } = await import("../../../apps/api/src/db/index.js");
+
+import type { TestApp } from "../test-server.js";
+
+let testApp: TestApp;
+
+async function setMfaPolicy(value: "optional" | "admins_only" | "required"): Promise<void> {
+  await db
+    .insert(schema.settings)
+    .values({ key: "mfaPolicy", value })
+    .onConflictDoUpdate({ target: schema.settings.key, set: { value } });
+}
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+}, 30_000);
+
+afterEach(async () => {
+  await db.delete(schema.settings).where(eq(schema.settings.key, "mfaPolicy"));
+});
+
+afterAll(async () => {
+  await db.delete(schema.settings).where(eq(schema.settings.key, "mfaPolicy"));
+  await testApp.cleanup();
+}, 10_000);
+
+describe("POST /api/auth/login forced enrollment (unlicensed)", () => {
+  it("still returns 403 MFA_ENROLLMENT_REQUIRED for an unenrolled user under a required policy", async () => {
+    const username = `mfa_unlicensed_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+    const password = "Userpass1";
+    await createUserAndLogin(testApp.app, username, "user", password);
+    // Seed the pre-gate required policy directly (the PUT gate would reject it).
+    await setMfaPolicy("required");
+
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username, password },
+    });
+
+    expect(res.statusCode).toBe(403);
+    const body = JSON.parse(res.body);
+    expect(body.code).toBe("MFA_ENROLLMENT_REQUIRED");
+    expect(body.token).toBeUndefined();
+    expect(body.requiresMfaEnrollment).toBeUndefined();
+  });
+
+  it("enroll-complete is a dead end here: an unknown token returns 401 MFA_EXPIRED (no enrollment was ever begun)", async () => {
+    // Even though the route exists, no forced enrollment is started on an
+    // unlicensed instance, so there is never a live enroll token to complete.
+    const { randomUUID } = await import("node:crypto");
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/mfa/enroll-complete",
+      payload: { enrollmentToken: randomUUID(), code: "123456" },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body).code).toBe("MFA_EXPIRED");
+  });
+});

--- a/tests/integration/platform/mfa-forced-enrollment-unlicensed.test.ts
+++ b/tests/integration/platform/mfa-forced-enrollment-unlicensed.test.ts
@@ -12,7 +12,7 @@
  * lives apart from the licensed suite because the enterprise mock is per-file
  * all-or-nothing. The required policy is written straight to the DB, since the
  * PUT /settings gate would (correctly) reject saving it on an unlicensed
- * instance -- which is exactly why this legacy pre-gate state has to be seeded
+ * instance, which is exactly why this legacy pre-gate state has to be seeded
  * directly.
  */
 import { eq } from "drizzle-orm";

--- a/tests/integration/platform/mfa-forced-enrollment.test.ts
+++ b/tests/integration/platform/mfa-forced-enrollment.test.ts
@@ -153,8 +153,10 @@ describe("POST /api/auth/login forced enrollment (licensed)", () => {
         url: "/api/auth/mfa/enroll-complete",
         payload: { enrollmentToken, code: "000000" },
       });
+      const badBody = JSON.parse(bad.body);
       expect(bad.statusCode).toBe(401);
-      expect(JSON.parse(bad.body).code).toBe("INVALID_CODE");
+      expect(badBody.code).toBe("INVALID_CODE");
+      expect(badBody.token).toBeUndefined();
     }
 
     // The 6th attempt finds a burned token: it now reads as expired.

--- a/tests/integration/platform/mfa-forced-enrollment.test.ts
+++ b/tests/integration/platform/mfa-forced-enrollment.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Forced TOTP enrollment at login (snapotter-hq/SnapOtter#811).
+ *
+ * Before the fix, a user under an MFA-required policy who had never enrolled
+ * TOTP got a hard `403 MFA_ENROLLMENT_REQUIRED` from `POST /api/auth/login`
+ * with no session, and the enrollment UI needs a session, so they were
+ * stranded. On a LICENSED instance we now walk them through enrollment right
+ * at login: login hands back an enrollment token + secret + recovery codes,
+ * and a not-session-gated `POST /api/auth/mfa/enroll-complete` confirms a real
+ * TOTP code and mints the session.
+ *
+ * This file covers the licensed path end to end with real TOTP codes. The
+ * unlicensed path (still a 403) lives in the sibling
+ * `mfa-forced-enrollment-unlicensed.test.ts`, which must not load the
+ * enterprise mock, since the mock is per-file all-or-nothing.
+ */
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import * as OTPAuth from "otpauth";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.resetModules();
+const { mockEnterpriseFeatures } = await import("../../helpers/enterprise-mock.js");
+mockEnterpriseFeatures(["mfa"]);
+
+const { buildTestApp, createUserAndLogin } = await import("../test-server.js");
+const { db, schema } = await import("../../../apps/api/src/db/index.js");
+
+import type { TestApp } from "../test-server.js";
+
+let testApp: TestApp;
+
+function generateTotpCode(uri: string): string {
+  const totp = OTPAuth.URI.parse(uri) as OTPAuth.TOTP;
+  return totp.generate();
+}
+
+async function setMfaPolicy(value: "optional" | "admins_only" | "required"): Promise<void> {
+  await db
+    .insert(schema.settings)
+    .values({ key: "mfaPolicy", value })
+    .onConflictDoUpdate({ target: schema.settings.key, set: { value } });
+}
+
+// Register a fresh unenrolled user with a known password and clear the
+// first-login password-change gate so login reaches the MFA decision.
+async function createUnenrolledUser(
+  role = "user",
+): Promise<{ username: string; password: string; userId: string }> {
+  const username = `mfa_forced_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+  const password = "Userpass1";
+  const { userId } = await createUserAndLogin(testApp.app, username, role, password);
+  return { username, password, userId };
+}
+
+async function login(username: string, password: string) {
+  return testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username, password },
+  });
+}
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+}, 30_000);
+
+afterEach(async () => {
+  // Never let a required policy bleed into sibling tests in the fork.
+  await db.delete(schema.settings).where(eq(schema.settings.key, "mfaPolicy"));
+});
+
+afterAll(async () => {
+  await db.delete(schema.settings).where(eq(schema.settings.key, "mfaPolicy"));
+  await testApp.cleanup();
+}, 10_000);
+
+describe("POST /api/auth/login forced enrollment (licensed)", () => {
+  it("returns 200 requiresMfaEnrollment with a token, uri, and recovery codes for an unenrolled user under a required policy", async () => {
+    const { username, password, userId } = await createUnenrolledUser();
+    await setMfaPolicy("required");
+
+    const res = await login(username, password);
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.requiresMfaEnrollment).toBe(true);
+    expect(typeof body.enrollmentToken).toBe("string");
+    expect(body.enrollmentToken.length).toBeGreaterThan(0);
+    expect(body.uri).toContain("otpauth://totp/");
+    expect(Array.isArray(body.recoveryCodes)).toBe(true);
+    expect(body.recoveryCodes.length).toBeGreaterThan(0);
+    // No session was handed out yet -- that only happens after enroll-complete.
+    expect(body.token).toBeUndefined();
+
+    // A real pending secret now sits on the row, still inactive.
+    const [dbUser] = await db.select().from(schema.users).where(eq(schema.users.id, userId));
+    expect(dbUser.totpSecret).toBeTruthy();
+    expect(dbUser.totpEnabled).toBe(false);
+  });
+
+  it("enroll-complete with a valid TOTP code activates MFA and mints a session, and the next login is a normal MFA challenge", async () => {
+    const { username, password, userId } = await createUnenrolledUser();
+    await setMfaPolicy("required");
+
+    const loginRes = await login(username, password);
+    const { enrollmentToken, uri } = JSON.parse(loginRes.body);
+
+    const completeRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/mfa/enroll-complete",
+      payload: { enrollmentToken, code: generateTotpCode(uri) },
+    });
+    expect(completeRes.statusCode).toBe(200);
+    const body = JSON.parse(completeRes.body);
+    expect(typeof body.token).toBe("string");
+    expect(body.user.username).toBe(username);
+    expect(body.expiresAt).toBeDefined();
+
+    // MFA is now genuinely active.
+    const [dbUser] = await db.select().from(schema.users).where(eq(schema.users.id, userId));
+    expect(dbUser.totpEnabled).toBe(true);
+
+    // The session token is real: it authenticates a session lookup.
+    const sessionRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${body.token}` },
+    });
+    expect(sessionRes.statusCode).toBe(200);
+
+    // Logging in again is now the ordinary enrolled-user challenge, not another
+    // forced enrollment.
+    const nextLogin = await login(username, password);
+    expect(nextLogin.statusCode).toBe(200);
+    const nextBody = JSON.parse(nextLogin.body);
+    expect(nextBody.requiresMfa).toBe(true);
+    expect(nextBody.mfaToken).toBeDefined();
+    expect(nextBody.requiresMfaEnrollment).toBeUndefined();
+  });
+
+  it("enroll-complete rejects an invalid code with 401 INVALID_CODE and burns the token after 5 wrong attempts", async () => {
+    const { username, password } = await createUnenrolledUser();
+    await setMfaPolicy("required");
+
+    const loginRes = await login(username, password);
+    const { enrollmentToken } = JSON.parse(loginRes.body);
+
+    // Five wrong codes, each a 401 INVALID_CODE.
+    for (let i = 0; i < 5; i++) {
+      const bad = await testApp.app.inject({
+        method: "POST",
+        url: "/api/auth/mfa/enroll-complete",
+        payload: { enrollmentToken, code: "000000" },
+      });
+      expect(bad.statusCode).toBe(401);
+      expect(JSON.parse(bad.body).code).toBe("INVALID_CODE");
+    }
+
+    // The 6th attempt finds a burned token: it now reads as expired.
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/mfa/enroll-complete",
+      payload: { enrollmentToken, code: "000000" },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body).code).toBe("MFA_EXPIRED");
+  });
+
+  it("enroll-complete with an unknown enrollment token returns 401 MFA_EXPIRED", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/mfa/enroll-complete",
+      // Valid uuid shape so Zod passes, but no Redis entry backs it.
+      payload: { enrollmentToken: randomUUID(), code: "123456" },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body).code).toBe("MFA_EXPIRED");
+  });
+
+  it("enroll-complete with a non-uuid token returns 400", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/mfa/enroll-complete",
+      payload: { enrollmentToken: "not-a-uuid", code: "123456" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/tests/integration/platform/mfa-forced-enrollment.test.ts
+++ b/tests/integration/platform/mfa-forced-enrollment.test.ts
@@ -90,7 +90,7 @@ describe("POST /api/auth/login forced enrollment (licensed)", () => {
     expect(body.uri).toContain("otpauth://totp/");
     expect(Array.isArray(body.recoveryCodes)).toBe(true);
     expect(body.recoveryCodes.length).toBeGreaterThan(0);
-    // No session was handed out yet -- that only happens after enroll-complete.
+    // No session was handed out yet; that only happens after enroll-complete.
     expect(body.token).toBeUndefined();
 
     // A real pending secret now sits on the row, still inactive.

--- a/tests/unit/web/login-page-mfa-enrollment.test.tsx
+++ b/tests/unit/web/login-page-mfa-enrollment.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const useAuth = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/use-auth", () => ({ useAuth }));
+
+// qr-code-styling reaches for canvas/DOM APIs jsdom doesn't implement, and the
+// QR image itself isn't what we're asserting on. Stub it so the enrollment
+// panel renders and we can check the recovery codes, manual secret, and code
+// input instead.
+vi.mock("qr-code-styling", () => ({
+  default: class {
+    append() {}
+  },
+}));
+
+import { LoginPage } from "@/pages/login-page";
+
+afterEach(() => {
+  cleanup();
+  useAuth.mockReset();
+  vi.unstubAllGlobals();
+});
+
+const ENROLLMENT_URI = "otpauth://totp/SnapOtter:admin?secret=JBSWY3DPEHPK3PXP&issuer=SnapOtter";
+
+function renderLoginPage() {
+  useAuth.mockReturnValue({
+    oidcEnabled: false,
+    oidcProviderName: null,
+    samlEnabled: false,
+    samlProviderName: null,
+    ssoEnforced: false,
+  });
+  return render(
+    <MemoryRouter initialEntries={["/login"]}>
+      <LoginPage />
+    </MemoryRouter>,
+  );
+}
+
+async function submitLogin() {
+  fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "admin" } });
+  fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "correct-password" } });
+  fireEvent.click(screen.getByRole("button", { name: /^login$/i }));
+}
+
+describe("LoginPage forced MFA enrollment", () => {
+  it("shows the enrollment panel when login returns requiresMfaEnrollment", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          requiresMfaEnrollment: true,
+          enrollmentToken: "enroll-token-1",
+          uri: ENROLLMENT_URI,
+          recoveryCodes: ["AAAA-1111", "BBBB-2222"],
+        }),
+      }),
+    );
+
+    renderLoginPage();
+    await submitLogin();
+
+    // Recovery codes and the manual secret from the URI are rendered.
+    await waitFor(() => {
+      expect(screen.getByText("AAAA-1111")).toBeInTheDocument();
+    });
+    expect(screen.getByText("BBBB-2222")).toBeInTheDocument();
+    expect(screen.getByText("JBSWY3DPEHPK3PXP")).toBeInTheDocument();
+    // The 6-digit confirmation input is present, the password form is gone.
+    expect(screen.getByLabelText(/6-digit code/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^password$/i)).not.toBeInTheDocument();
+  });
+
+  it("POSTs to /api/auth/mfa/enroll-complete when the code is confirmed", async () => {
+    const fetchMock = vi
+      .fn()
+      // login -> forced enrollment
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          requiresMfaEnrollment: true,
+          enrollmentToken: "enroll-token-1",
+          uri: ENROLLMENT_URI,
+          recoveryCodes: ["AAAA-1111", "BBBB-2222"],
+        }),
+      })
+      // enroll-complete -> session issued
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          token: "session-token",
+          user: { username: "admin", mustChangePassword: false },
+          expiresAt: new Date().toISOString(),
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderLoginPage();
+    await submitLogin();
+
+    const codeInput = await screen.findByLabelText(/6-digit code/i);
+    fireEvent.change(codeInput, { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: /confirm and enable/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/auth/mfa/enroll-complete",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ enrollmentToken: "enroll-token-1", code: "123456" }),
+        }),
+      );
+    });
+  });
+
+  it("shows the invalid-code message and clears the field on a rejected code", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          requiresMfaEnrollment: true,
+          enrollmentToken: "enroll-token-1",
+          uri: ENROLLMENT_URI,
+          recoveryCodes: ["AAAA-1111"],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ code: "INVALID_CODE" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderLoginPage();
+    await submitLogin();
+
+    const codeInput = (await screen.findByLabelText(/6-digit code/i)) as HTMLInputElement;
+    fireEvent.change(codeInput, { target: { value: "000000" } });
+    fireEvent.click(screen.getByRole("button", { name: /confirm and enable/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid code/i)).toBeInTheDocument();
+    });
+    expect(codeInput.value).toBe("");
+  });
+});


### PR DESCRIPTION
Fixes #811. The other half of #515: PR #814 gives an operator a recovery CLI for an existing lockout, this stops the lockout from happening on a licensed instance in the first place.

Today a required MFA policy hard-blocks any user who has not enrolled TOTP. Login returns 403 with no session, and the enrollment screen needs a session, so the user is stuck (`apps/api/src/plugins/auth.ts`). This flips that. When a licensed instance requires MFA and the user is not enrolled, login starts enrollment right there and returns `200 { requiresMfaEnrollment, enrollmentToken, uri, recoveryCodes }` with no session. The login page shows a QR, recovery codes, and a code field, and `POST /api/auth/mfa/enroll-complete` confirms a TOTP code and mints the session. On an unlicensed instance (a policy stored before v2.2.0's license gate) the 403 stays, since there is no way to enroll without a license; #814's recovery CLI is the escape there.

The backend mirrors the existing challenge flow. `beginForcedEnrollment` stores the pending secret encrypted (same as the self-service enroll route), hashes the recovery codes, and issues a short-lived `mfa:enroll:<token>` in Redis holding only the userId, in a namespace disjoint from the `mfa:*` challenge tokens. `enroll-complete` mirrors `/mfa/complete`: TOTP-only confirmation, the same five-wrong-codes burn, and a session only after a verified code. No partially-privileged session ever exists. The call sits outside a try/catch on purpose, so a DB or Redis fault fails closed to a 500 rather than letting anyone through.

The frontend reuses the existing `settings.security.twoFactor*` strings and the Settings QR component, so the only new string is one heading, added across all 21 locales.

### Verified

- Backend integration: a licensed instance with a required policy and an unenrolled user returns 200 `requiresMfaEnrollment` with a real pending secret on the row and no session; a TOTP generated from the returned `uri` completes enrollment, mints a session, and the next login is a normal challenge; five wrong codes burn the token (the sixth reads `MFA_EXPIRED`); an unknown token is 401. An unlicensed instance still returns 403, in a separate test file with enterprise absent.
- The 40 existing `mfa-endpoints` tests still pass. Two of their assertions moved from 403 to 200 for the licensed contract and still assert no token is issued.
- Frontend unit tests: the panel appears on `requiresMfaEnrollment`, confirm POSTs to `enroll-complete`, an invalid code surfaces the error and clears the field. The existing login-page tests stay green, and locale key parity passes.
- typecheck and lint clean on api and web. A security and silent-failure review of the full diff returned APPROVE.

Found and filed, not fixed here: #815 (all three login paths read the MFA policy inside a try/catch that fails open on a DB fault; pre-existing, and the fix needs a fail-closed-versus-lockout call).

#515 stays open until this and #814 both ship.
