### PR TITLE
fix(api): check the password before revealing a disabled account on login

### DIFF
--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -369,15 +369,6 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
 
       const audit = auditFromRequest(request);
 
-      if (user && isDisabledRole(user.role)) {
-        authAttempts.inc({ method: "password", result: "failure" });
-        await audit("LOGIN_FAILED", {
-          username: sanitizeAuditInput(body.username),
-          reason: "disabled_user",
-        });
-        return reply.status(403).send({ error: "User is disabled", code: "USER_DISABLED" });
-      }
-
       if (!user?.passwordHash) {
         // Pay the same scrypt cost a real password check would take, so
         // response timing doesn't reveal whether the username exists.
@@ -386,7 +377,10 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         void trackEvent(ANALYTICS_EVENTS.AUTH_LOGIN_FAILED, { method: "password" });
         await audit("LOGIN_FAILED", {
           username: sanitizeAuditInput(body.username),
-          reason: "unknown_user",
+          // An SSO-provisioned account that was later disabled has no local
+          // hash and lands here too; keep the precise audit reason while the
+          // response stays the generic 401.
+          reason: user && isDisabledRole(user.role) ? "disabled_user" : "unknown_user",
         });
         return reply.status(401).send({ error: "Invalid credentials" });
       }
@@ -397,9 +391,21 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         void trackEvent(ANALYTICS_EVENTS.AUTH_LOGIN_FAILED, { method: "password" });
         await audit("LOGIN_FAILED", {
           username: sanitizeAuditInput(body.username),
-          reason: "bad_password",
+          reason: isDisabledRole(user.role) ? "disabled_user" : "bad_password",
         });
         return reply.status(401).send({ error: "Invalid credentials" });
+      }
+
+      // Only reveal the disabled state to a caller who proved password
+      // knowledge; without it, disabled accounts must be indistinguishable
+      // from unknown ones (issue #818).
+      if (isDisabledRole(user.role)) {
+        authAttempts.inc({ method: "password", result: "failure" });
+        await audit("LOGIN_FAILED", {
+          username: sanitizeAuditInput(body.username),
+          reason: "disabled_user",
+        });
+        return reply.status(403).send({ error: "User is disabled", code: "USER_DISABLED" });
       }
 
       let mfaRequiredByPolicy = false;

--- a/tests/integration/platform/auth-edge-cases.test.ts
+++ b/tests/integration/platform/auth-edge-cases.test.ts
@@ -6,6 +6,7 @@
 import { asc, eq } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { db, schema } from "../../../apps/api/src/db/index.js";
+import { authAttempts } from "../../../apps/api/src/lib/metrics.js";
 import { buildTestApp, loginAsAdmin, type TestApp } from "../test-server.js";
 
 let testApp: TestApp;
@@ -530,20 +531,10 @@ describe("Forced password change gate", () => {
 // A user whose role is prefixed "disabled:" is treated as deactivated.
 // ═══════════════════════════════════════════════════════════════════════════
 describe("Disabled user paths", () => {
-  it("login is rejected with 403 USER_DISABLED before any password check", async () => {
-    const { username, password, id } = await createUser();
-    await db.update(schema.users).set({ role: `disabled:user` }).where(eq(schema.users.id, id));
-
-    const res = await testApp.app.inject({
-      method: "POST",
-      url: "/api/auth/login",
-      payload: { username, password },
-    });
-
-    expect(res.statusCode).toBe(403);
-    expect(JSON.parse(res.body).code).toBe("USER_DISABLED");
-
-    // The failed attempt is audited with the disabled_user reason.
+  // Fetch the LOGIN_FAILED audit entry for a (unique) username, if any.
+  async function findLoginFailedAudit(
+    username: string,
+  ): Promise<{ username?: string; reason?: string } | undefined> {
     const audit = await testApp.app.inject({
       method: "GET",
       url: "/api/v1/audit-log?action=LOGIN_FAILED&limit=100",
@@ -553,10 +544,116 @@ describe("Disabled user paths", () => {
       action: string;
       details?: { username?: string; reason?: string };
     }>;
-    const match = entries.find(
-      (e) => e.details?.username === username && e.details?.reason === "disabled_user",
+    return entries.find((e) => e.details?.username === username)?.details;
+  }
+
+  // Current failure count of the password-method authAttempts counter.
+  async function passwordFailureCount(): Promise<number> {
+    const metric = await authAttempts.get();
+    const row = metric.values.find(
+      (v) => v.labels.method === "password" && v.labels.result === "failure",
     );
-    expect(match).toBeDefined();
+    return row?.value ?? 0;
+  }
+
+  it("login with the CORRECT password on a disabled account returns 403 USER_DISABLED", async () => {
+    const { username, password, id } = await createUser();
+    await db.update(schema.users).set({ role: `disabled:user` }).where(eq(schema.users.id, id));
+
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username, password },
+    });
+
+    // The caller proved password knowledge, so revealing the disabled state
+    // leaks nothing an attacker could use for enumeration.
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).code).toBe("USER_DISABLED");
+
+    // The failed attempt is audited with the disabled_user reason.
+    const details = await findLoginFailedAudit(username);
+    expect(details?.reason).toBe("disabled_user");
+  });
+
+  it("login failures are byte-identical for unknown, wrong-password, and disabled accounts", async () => {
+    // Issue #818: a pre-password disabled check let an unauthenticated caller
+    // confirm a disabled username exists. Without password knowledge, all
+    // three cases must be indistinguishable.
+    const active = await createUser();
+    const disabled = await createUser();
+    await db
+      .update(schema.users)
+      .set({ role: `disabled:user` })
+      .where(eq(schema.users.id, disabled.id));
+
+    const payloads = [
+      { username: `nonexistent_${uid()}`, password: "WrongPass1" },
+      { username: active.username, password: "WrongPass1" },
+      { username: disabled.username, password: "WrongPass1" },
+    ];
+    const responses = [];
+    for (const payload of payloads) {
+      responses.push(await testApp.app.inject({ method: "POST", url: "/api/auth/login", payload }));
+    }
+
+    for (const res of responses) {
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toBe(JSON.stringify({ error: "Invalid credentials" }));
+    }
+  });
+
+  it("wrong-password login on a disabled account still audits reason disabled_user", async () => {
+    const { username, id } = await createUser();
+    await db.update(schema.users).set({ role: `disabled:user` }).where(eq(schema.users.id, id));
+
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username, password: "WrongPass1" },
+    });
+    expect(res.statusCode).toBe(401);
+
+    // Admins still see that the attempt targeted a disabled account.
+    const details = await findLoginFailedAudit(username);
+    expect(details?.reason).toBe("disabled_user");
+  });
+
+  it("a disabled passwordless (SSO-provisioned) account gets the generic 401, audited as disabled_user", async () => {
+    const { username, id } = await createUser();
+    await db
+      .update(schema.users)
+      .set({ role: `disabled:user`, passwordHash: null })
+      .where(eq(schema.users.id, id));
+
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username, password: "Whatever1" },
+    });
+
+    // No password on file means no way to prove ownership: the response must
+    // stay generic, but the audit trail keeps the more precise reason.
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toBe(JSON.stringify({ error: "Invalid credentials" }));
+    const details = await findLoginFailedAudit(username);
+    expect(details?.reason).toBe("disabled_user");
+  });
+
+  it("each failed login increments authAttempts exactly once", async () => {
+    const { username, password, id } = await createUser();
+    await db.update(schema.users).set({ role: `disabled:user` }).where(eq(schema.users.id, id));
+
+    const payloads = [
+      { username, password }, // correct password, disabled -> 403
+      { username, password: "WrongPass1" }, // wrong password, disabled -> 401
+      { username: `nonexistent_${uid()}`, password: "Whatever1" }, // unknown -> 401
+    ];
+    for (const payload of payloads) {
+      const before = await passwordFailureCount();
+      await testApp.app.inject({ method: "POST", url: "/api/auth/login", payload });
+      expect((await passwordFailureCount()) - before).toBe(1);
+    }
   });
 
   it("session endpoint denies and purges the session once the user is disabled", async () => {


### PR DESCRIPTION
An unauthenticated caller could enumerate disabled accounts: `POST /api/auth/login` returned `403 USER_DISABLED` before any password verification, while unknown usernames and wrong passwords both got the generic 401 with dummy-scrypt timing equalization. Sending any password was enough to learn a username exists and is disabled.

The disabled check now runs only after `verifyPassword` succeeds. A caller who proves the password still gets the truthful 403. Wrong-password and passwordless attempts (SSO-provisioned accounts that were later disabled) fall through to the generic 401, byte-identical to unknown accounts, with the dummy-scrypt cost still paid on the no-hash path. Audit rows keep `reason: "disabled_user"` on every disabled-account path so admins still see those attempts, and `authAttempts` increments once per failure as before. The disabled 403 also sits above the MFA block, so a disabled account is never issued an MFA challenge.

Verification: new tests in `tests/integration/platform/auth-edge-cases.test.ts` pin the parity property (unknown vs wrong-password vs disabled-wrong-password must produce identical status and body), the correct-password 403, the audit reasons, and single counter increments. They failed red against the old ordering (3 failed), then 49/49 green after the fix. The related suites (security-auth-hardening, sso-enforcement-login, mfa-endpoints, auth-routes unit) pass: 102/102. `pnpm typecheck` green. Nothing in `apps/web` or the e2e suites references `USER_DISABLED`, so no client change is needed.

Closes #818
