### PR TITLE
fix(api): mark session cookies Secure when the request arrived over HTTPS

### DIFF
--- a/apps/api/src/lib/secure-cookie.ts
+++ b/apps/api/src/lib/secure-cookie.ts
@@ -1,0 +1,21 @@
+import type { FastifyRequest } from "fastify";
+import { env } from "../config.js";
+
+/**
+ * Whether an auth cookie set on this request should carry the Secure
+ * attribute (issue #817).
+ *
+ * Two independent signals, OR-ed:
+ *  - EXTERNAL_URL starts with https: the operator declared an HTTPS origin.
+ *  - request.protocol is "https": the request actually arrived over HTTPS.
+ *    Fastify resolves this from X-Forwarded-Proto when the peer is trusted,
+ *    and the TRUST_PROXY default (loopback,linklocal,uniquelocal) already
+ *    trusts a reverse proxy on a private network, so HTTPS-behind-proxy
+ *    installs get Secure cookies without configuring EXTERNAL_URL.
+ *
+ * Never hardcode this to true: plain-HTTP LAN installs are supported, and
+ * browsers refuse to store Secure cookies over http.
+ */
+export function isSecureRequest(request: FastifyRequest): boolean {
+  return env.EXTERNAL_URL.startsWith("https") || request.protocol === "https";
+}

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -10,6 +10,7 @@ import { sharedRedis } from "../jobs/connection.js";
 import { trackEvent } from "../lib/analytics.js";
 import { auditFromRequest, sanitizeAuditInput } from "../lib/audit.js";
 import { authAttempts } from "../lib/metrics.js";
+import { isSecureRequest } from "../lib/secure-cookie.js";
 import { getSettingNumber, getSettingString } from "../lib/settings-helpers.js";
 import {
   canAssignRole,
@@ -481,7 +482,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
           path: "/",
           httpOnly: true,
           sameSite: "strict",
-          secure: env.EXTERNAL_URL.startsWith("https"),
+          secure: isSecureRequest(request),
           maxAge: SESSION_DURATION_MS / 1000,
         });
       }

--- a/apps/api/src/plugins/oidc.ts
+++ b/apps/api/src/plugins/oidc.ts
@@ -11,6 +11,7 @@ import { trackEvent } from "../lib/analytics.js";
 import { auditFromRequest, sanitizeAuditInput } from "../lib/audit.js";
 import { resolveExternalUser, sanitizeUsername } from "../lib/external-auth-resolver.js";
 import { authAttempts } from "../lib/metrics.js";
+import { isSecureRequest } from "../lib/secure-cookie.js";
 import { createSessionToken } from "./auth.js";
 
 // ── Types ─────────────────────────────────────────────────────────
@@ -47,7 +48,9 @@ async function getOrDiscoverConfig(): Promise<oidc.Configuration> {
     env.OIDC_CLIENT_SECRET,
     undefined,
     {
-      execute: isSecure() ? undefined : [oidc.allowInsecureRequests],
+      // No request in scope here; this gates plain-http issuer URLs for dev
+      // setups, so only the declared origin matters.
+      execute: env.EXTERNAL_URL.startsWith("https") ? undefined : [oidc.allowInsecureRequests],
     },
   );
 
@@ -100,10 +103,6 @@ function deriveUsername(claims: Record<string, unknown>): string {
 
 // ── Helpers ───────────────────────────────────────────────────────
 
-function isSecure(): boolean {
-  return env.EXTERNAL_URL.startsWith("https");
-}
-
 const SESSION_DURATION_MS = env.SESSION_DURATION_HOURS * 60 * 60 * 1000;
 
 function redirectToLogin(reply: FastifyReply, errorCode: string): void {
@@ -152,7 +151,7 @@ export async function oidcRoutes(app: FastifyInstance): Promise<void> {
       reply.setCookie("oidc-state", cookieValue, {
         httpOnly: true,
         sameSite: "lax",
-        secure: isSecure(),
+        secure: isSecureRequest(request),
         path: "/api/auth/oidc",
         maxAge: 600, // 10 minutes
         signed: false, // already signed manually
@@ -188,7 +187,7 @@ export async function oidcRoutes(app: FastifyInstance): Promise<void> {
         path: "/api/auth/oidc",
         httpOnly: true,
         sameSite: "lax",
-        secure: isSecure(),
+        secure: isSecureRequest(request),
       });
 
       const unsigned = request.unsignCookie(rawCookie);
@@ -377,7 +376,7 @@ export async function oidcRoutes(app: FastifyInstance): Promise<void> {
       reply.setCookie("snapotter-session", token, {
         httpOnly: true,
         sameSite: "strict",
-        secure: isSecure(),
+        secure: isSecureRequest(request),
         path: "/",
         maxAge: env.SESSION_DURATION_HOURS * 3600,
       });

--- a/apps/api/src/plugins/saml.ts
+++ b/apps/api/src/plugins/saml.ts
@@ -15,6 +15,7 @@ import {
 } from "../lib/external-auth-resolver.js";
 import { authAttempts } from "../lib/metrics.js";
 import { makeRedisSamlCacheProvider } from "../lib/saml-cache.js";
+import { isSecureRequest } from "../lib/secure-cookie.js";
 import { createSessionToken } from "./auth.js";
 
 // -- SAML instance factory ----------------------------------------------------
@@ -42,10 +43,6 @@ function getSamlInstance(): SAML {
 }
 
 // -- Helpers ------------------------------------------------------------------
-
-function isSecure(): boolean {
-  return env.EXTERNAL_URL.startsWith("https");
-}
 
 const SESSION_DURATION_MS = env.SESSION_DURATION_HOURS * 60 * 60 * 1000;
 
@@ -257,7 +254,7 @@ export async function registerSaml(app: FastifyInstance): Promise<void> {
       reply.setCookie("snapotter-session", token, {
         httpOnly: true,
         sameSite: "strict",
-        secure: isSecure(),
+        secure: isSecureRequest(request),
         path: "/",
         maxAge: env.SESSION_DURATION_HOURS * 3600,
       });

--- a/tests/integration/platform/session-cookie-secure.test.ts
+++ b/tests/integration/platform/session-cookie-secure.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Session cookie Secure flag (issue #817).
+ *
+ * The Secure attribute must be derived from the actual connection, not only
+ * from EXTERNAL_URL: that env var defaults to "" and the shipped compose file
+ * comments it out, so an HTTPS-behind-proxy install would otherwise get a
+ * session cookie the browser also attaches to plain-http requests.
+ *
+ * Fastify resolves `request.protocol` from X-Forwarded-Proto when the peer is
+ * trusted. The test app mirrors production's trustProxy setting, and inject()
+ * requests originate from 127.0.0.1, which the default TRUST_PROXY policy
+ * (loopback,linklocal,uniquelocal) trusts. Prior art for this seam:
+ * tests/unit/security/trust-proxy-policy.test.ts.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { env } from "../../../apps/api/src/config.js";
+import { buildTestApp, type TestApp } from "../test-server.js";
+
+let testApp: TestApp;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+/** Log in and return the raw Set-Cookie header for the session cookie. */
+async function loginSetCookie(
+  opts: { headers?: Record<string, string>; remoteAddress?: string } = {},
+): Promise<string> {
+  const res = await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username: "admin", password: "Adminpass1" },
+    headers: opts.headers,
+    ...(opts.remoteAddress ? { remoteAddress: opts.remoteAddress } : {}),
+  });
+  expect(res.statusCode).toBe(200);
+  const raw = res.headers["set-cookie"];
+  const cookies = Array.isArray(raw) ? raw : raw ? [raw] : [];
+  const session = cookies.find((c) => c.startsWith("snapotter-session="));
+  expect(session, "login must set the snapotter-session cookie").toBeDefined();
+  return session as string;
+}
+
+const SECURE_ATTR = /;\s*Secure(;|$)/i;
+
+describe("session cookie Secure flag", () => {
+  it("stays non-Secure on a plain-http login with EXTERNAL_URL unset", async () => {
+    // Plain-HTTP LAN installs are supported; browsers refuse to store Secure
+    // cookies over http, so Secure here would break login outright.
+    expect(env.EXTERNAL_URL).toBe("");
+    const cookie = await loginSetCookie();
+    expect(cookie).not.toMatch(SECURE_ATTR);
+  });
+
+  it("sets Secure when a trusted proxy forwarded an https request", async () => {
+    const cookie = await loginSetCookie({ headers: { "x-forwarded-proto": "https" } });
+    expect(cookie).toMatch(SECURE_ATTR);
+  });
+
+  it("ignores x-forwarded-proto from an untrusted public peer", async () => {
+    const cookie = await loginSetCookie({
+      headers: { "x-forwarded-proto": "https" },
+      remoteAddress: "203.0.113.9",
+    });
+    expect(cookie).not.toMatch(SECURE_ATTR);
+  });
+
+  it("sets Secure from an https EXTERNAL_URL with no forwarded header", async () => {
+    const orig = env.EXTERNAL_URL;
+    (env as { EXTERNAL_URL: string }).EXTERNAL_URL = "https://snapotter.example.com";
+    try {
+      const cookie = await loginSetCookie();
+      expect(cookie).toMatch(SECURE_ATTR);
+    } finally {
+      (env as { EXTERNAL_URL: string }).EXTERNAL_URL = orig;
+    }
+  });
+});

--- a/tests/integration/test-server.ts
+++ b/tests/integration/test-server.ts
@@ -35,6 +35,7 @@ import { pingRedis } from "../../apps/api/src/jobs/connection.js";
 import { closeQueueEvents, warmQueueEvents } from "../../apps/api/src/jobs/enqueue.js";
 import { closeWorkers, startWorkers } from "../../apps/api/src/jobs/worker.js";
 import { posthogProxyEnabled } from "../../apps/api/src/lib/posthog-proxy.js";
+import { parseTrustProxy } from "../../apps/api/src/lib/trust-proxy.js";
 import { requirePermission } from "../../apps/api/src/permissions.js";
 import {
   authMiddleware,
@@ -138,6 +139,10 @@ export async function buildTestApp(): Promise<TestApp> {
   const app = Fastify({
     logger: false, // quiet during tests
     bodyLimit: env.MAX_UPLOAD_SIZE_MB * 1024 * 1024,
+    // Mirrors index.ts so forwarded-header behaviour (request.ip,
+    // request.protocol) matches production. inject() peers on 127.0.0.1 are
+    // trusted by the default policy; see tests/unit/security/trust-proxy-policy.test.ts.
+    trustProxy: parseTrustProxy(env.TRUST_PROXY),
   });
 
   // Plugins


### PR DESCRIPTION
The session cookie's `Secure` flag was computed from `EXTERNAL_URL.startsWith("https")` alone. `EXTERNAL_URL` defaults to empty, is only required when OIDC or SAML is enabled, and ships commented out in the compose file, so the common deployment shape (password auth behind an HTTPS reverse proxy) got a session cookie without `Secure`. Any plain-http request to the same host would carry it in cleartext, with HSTS only closing the window after the first successful HTTPS visit.

The flag is now `env.EXTERNAL_URL.startsWith("https") || request.protocol === "https"`, in a shared `isSecureRequest()` helper (`apps/api/src/lib/secure-cookie.ts`) used by the password-login, OIDC, and SAML session cookies plus the OIDC state cookie. Fastify resolves `request.protocol` from `X-Forwarded-Proto` when the peer is trusted, and the `TRUST_PROXY` default already trusts private-network proxies, so HTTPS-behind-proxy installs get `Secure` with zero configuration. Plain-HTTP LAN installs are unaffected: both signals stay false, which matters because browsers refuse to store `Secure` cookies over http. The OIDC discovery `allowInsecureRequests` gate keeps the env-only check on purpose; it gates the issuer URL and has no request in scope.

One test-infra change: `tests/integration/test-server.ts` now passes the same `trustProxy` value as `index.ts`, so forwarded-header behavior in tests matches production.

Verification: new `tests/integration/platform/session-cookie-secure.test.ts` covers plain-http (no Secure), forwarded https from a trusted peer (Secure), forwarded https from an untrusted public address 203.0.113.9 (ignored, no Secure), and `EXTERNAL_URL=https` alone (Secure). Red first on the forwarded-https case, then 4/4 green. Ten neighboring suites (trust-proxy-policy, auth, OIDC, SAML, posthog-proxy, rate-limiting): 141/141. Six unit files importing the touched plugins: 70/70. `pnpm typecheck` green.

Closes #817
