### PR TITLE
chore: close out the small security-audit leftovers (docs, landing headers, multipart limits)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,8 +72,8 @@ The following headers are set on all responses:
 | `X-XSS-Protection` | `0` (modern best practice) |
 | `Referrer-Policy` | `strict-origin-when-cross-origin` |
 | `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` |
-| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` (production only) |
-| `Content-Security-Policy` | Restrictive policy with `default-src 'self'` (production only) |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` (sent in all environments; browsers ignore it over plain HTTP) |
+| `Content-Security-Policy` | Restrictive policy with `default-src 'self'` |
 
 ### Rate Limiting
 

--- a/apps/api/src/lib/multipart-parts.ts
+++ b/apps/api/src/lib/multipart-parts.ts
@@ -20,6 +20,15 @@ export interface MultipartFieldPart {
 
 export type MultipartPart = MultipartFilePart | MultipartFieldPart;
 
+/**
+ * Caps on multipart text fields, shared with the plugin registration in
+ * plugins/upload.ts so the two limit sets cannot drift. fieldSize restates
+ * busboy's implicit 1 MB per-field default; fields bounds the per-request
+ * field count, which busboy otherwise leaves unlimited (issue #821).
+ */
+export const MULTIPART_FIELD_SIZE_BYTES = 1024 * 1024;
+export const MULTIPART_MAX_FIELDS = 100;
+
 const DONE = Symbol("multipart-done");
 
 /**
@@ -50,6 +59,8 @@ export async function* multipartParts(
         limits.fileSize ??
         (env.MAX_UPLOAD_SIZE_MB > 0 ? env.MAX_UPLOAD_SIZE_MB * 1024 * 1024 : undefined),
       files: limits.files ?? (env.MAX_BATCH_SIZE > 0 ? env.MAX_BATCH_SIZE : undefined),
+      fieldSize: MULTIPART_FIELD_SIZE_BYTES,
+      fields: MULTIPART_MAX_FIELDS,
     },
   });
 
@@ -88,8 +99,17 @@ export async function* multipartParts(
       file: stream,
     });
   });
-  bb.on("field", (fieldname, value) => push({ type: "field", fieldname, value }));
+  bb.on("field", (fieldname, value, _fieldnameTruncated, valueTruncated) => {
+    // Busboy clips a field value at fieldSize and keeps going; a clipped
+    // settings payload must fail loudly here, not parse as garbage downstream.
+    if (valueTruncated) {
+      push(new Error(`field value too large: ${fieldname}`));
+      return;
+    }
+    push({ type: "field", fieldname, value });
+  });
   bb.on("filesLimit", () => push(new Error("reached files limit")));
+  bb.on("fieldsLimit", () => push(new Error("reached fields limit")));
   bb.on("partsLimit", () => push(new Error("reached parts limit")));
   bb.on("error", (err: unknown) => push(err instanceof Error ? err : new Error(String(err))));
   bb.on("finish", () => push(DONE));

--- a/apps/api/src/plugins/upload.ts
+++ b/apps/api/src/plugins/upload.ts
@@ -1,13 +1,19 @@
 import multipart from "@fastify/multipart";
 import type { FastifyInstance } from "fastify";
 import { env } from "../config.js";
-import { multipartParts } from "../lib/multipart-parts.js";
+import {
+  MULTIPART_FIELD_SIZE_BYTES,
+  MULTIPART_MAX_FIELDS,
+  multipartParts,
+} from "../lib/multipart-parts.js";
 
 export async function registerUpload(app: FastifyInstance): Promise<void> {
   await app.register(multipart, {
     limits: {
       fileSize: env.MAX_UPLOAD_SIZE_MB > 0 ? env.MAX_UPLOAD_SIZE_MB * 1024 * 1024 : undefined,
       files: env.MAX_BATCH_SIZE > 0 ? env.MAX_BATCH_SIZE : undefined,
+      fieldSize: MULTIPART_FIELD_SIZE_BYTES,
+      fields: MULTIPART_MAX_FIELDS,
     },
   });
 

--- a/apps/docs/guide/deployment.md
+++ b/apps/docs/guide/deployment.md
@@ -486,10 +486,15 @@ Two things to know before you go measuring client IPs. Docker Desktop on macOS a
 
 Two things matter for every proxy below: allow large request bodies (uploads), and do not buffer responses. A response-buffering proxy breaks SSE progress and, more visibly, makes a large file download "start but never finish", because the proxy holds the whole file before passing it on. SnapOtter sends `X-Accel-Buffering: no` on downloads so nginx streams them even if buffering is left on elsewhere, but proxies other than nginx need response buffering disabled explicitly (shown in each config below). If a download stalls partway, a buffering proxy in front is the first thing to check.
 
+A note on HSTS: the API sends `Strict-Transport-Security` on every response itself, so a proxy that passes response headers through (all of the configs below do) needs no HSTS setup of its own. Only if your proxy is configured to strip or override upstream response headers do you need to preserve the header or re-add it at the edge.
+
 ### Nginx {#nginx}
 
 ```nginx
 server {
+    # Plain HTTP shown for brevity. Terminate TLS in your own `listen 443 ssl`
+    # server block; the Strict-Transport-Security header the API sends passes
+    # through with every proxied response, so no add_header is needed there.
     listen 80;
     server_name images.example.com;
 
@@ -522,6 +527,8 @@ server {
 4. Enable WebSocket support
 5. Under Advanced, add: `client_max_body_size 500M;` and `proxy_buffering off;`
 
+The API's `Strict-Transport-Security` header passes through NPM as-is; the HSTS toggle on the SSL tab is optional on top of it.
+
 ### Traefik {#traefik}
 
 ```yaml
@@ -537,6 +544,8 @@ labels:
   - "traefik.http.routers.snapotter.middlewares=snapotter-body"
 ```
 
+Traefik forwards upstream response headers unchanged, so the API's `Strict-Transport-Security` header reaches browsers without a `headers` middleware. If you already run one that rewrites response headers, make sure it leaves that header intact.
+
 ### Caddy {#caddy}
 
 ```txt
@@ -551,7 +560,7 @@ images.example.com {
 }
 ```
 
-`flush_interval -1` disables response buffering, which is required for SSE progress events (batch processing, AI tools, feature installs) and for large file downloads to stream through instead of stalling. The extended timeouts allow large file uploads to complete without Caddy closing the connection early.
+`flush_interval -1` disables response buffering, which is required for SSE progress events (batch processing, AI tools, feature installs) and for large file downloads to stream through instead of stalling. The extended timeouts allow large file uploads to complete without Caddy closing the connection early. Caddy also passes the API's `Strict-Transport-Security` header through untouched, so no `header` directive is needed for HSTS.
 
 ### Cloudflare Tunnels {#cloudflare-tunnels}
 
@@ -560,6 +569,8 @@ cloudflared tunnel --url http://localhost:1349
 ```
 
 Note: Cloudflare has a 100 MB upload limit on free plans. Set `MAX_UPLOAD_SIZE_MB=100` to match.
+
+The tunnel forwards the API's response headers, `Strict-Transport-Security` included, so no dashboard HSTS configuration is required (Cloudflare's own edge HSTS setting is optional on top).
 
 ## Troubleshooting {#troubleshooting}
 

--- a/apps/landing/public/_headers
+++ b/apps/landing/public/_headers
@@ -1,3 +1,8 @@
+/*
+  Strict-Transport-Security: max-age=31536000
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+
 /_next/static/*
   X-Robots-Tag: noindex, nofollow
 

--- a/tests/unit/api/multipart-parts.test.ts
+++ b/tests/unit/api/multipart-parts.test.ts
@@ -129,6 +129,30 @@ describe("multipartParts", () => {
     await generator.return(undefined);
   });
 
+  it("rejects a request with more than 100 text fields", async () => {
+    const body = multipartBody(
+      Array.from({ length: 101 }, (_, i) => ({ name: `field${i}`, content: "x" })),
+    );
+
+    await expect(async () => {
+      for await (const part of multipartParts(fakeRequest(body))) {
+        if (part.type === "file") await drain(part.file);
+      }
+    }).rejects.toThrow("fields limit");
+  });
+
+  it("rejects a text field over the 1 MB cap instead of silently truncating it", async () => {
+    const body = multipartBody([
+      { name: "settings", content: Buffer.alloc(1024 * 1024 + 1, 0x61) },
+    ]);
+
+    await expect(async () => {
+      for await (const part of multipartParts(fakeRequest(body))) {
+        if (part.type === "file") await drain(part.file);
+      }
+    }).rejects.toThrow("field value too large");
+  });
+
   it("honors a route-specific two-file limit", async () => {
     const body = multipartBody([
       { name: "index", filename: "ocr-runtime-index.json", content: "index" },

--- a/tests/unit/api/static-upload.test.ts
+++ b/tests/unit/api/static-upload.test.ts
@@ -14,7 +14,8 @@ const mockMultipartPlugin = vi.fn();
 vi.mock("@fastify/multipart", () => ({ default: mockMultipartPlugin }));
 
 const multipartPartsMock = vi.hoisted(() => vi.fn());
-vi.mock("../../../apps/api/src/lib/multipart-parts.js", () => ({
+vi.mock("../../../apps/api/src/lib/multipart-parts.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../apps/api/src/lib/multipart-parts.js")>()),
   multipartParts: multipartPartsMock,
 }));
 
@@ -130,6 +131,8 @@ describe("registerUpload", () => {
       limits: {
         fileSize: 10 * 1024 * 1024,
         files: 5,
+        fieldSize: 1024 * 1024,
+        fields: 100,
       },
     });
   });
@@ -144,6 +147,8 @@ describe("registerUpload", () => {
       limits: {
         fileSize: undefined,
         files: 5,
+        fieldSize: 1024 * 1024,
+        fields: 100,
       },
     });
   });
@@ -158,6 +163,8 @@ describe("registerUpload", () => {
       limits: {
         fileSize: 10 * 1024 * 1024,
         files: undefined,
+        fieldSize: 1024 * 1024,
+        fields: 100,
       },
     });
   });
@@ -172,6 +179,8 @@ describe("registerUpload", () => {
       limits: {
         fileSize: undefined,
         files: undefined,
+        fieldSize: 1024 * 1024,
+        fields: 100,
       },
     });
   });


### PR DESCRIPTION
Items 1 to 4 of #821. Item 5 (Postgres least-privilege split) needs its own design pass and stays open, so this PR does not close the issue.

1. `SECURITY.md` no longer claims HSTS and CSP are "production only"; both have been sent unconditionally since the global onSend hook. The HSTS row now notes browsers ignore the header over plain HTTP.

2. The reverse-proxy guide gets one intro paragraph on HSTS (the API sends the header itself, so pass-through proxies need nothing; header-stripping proxies must preserve or re-add it) plus a sentence per proxy: an nginx comment pointing TLS at the operator's own `listen 443 ssl` block, and notes for NPM, Traefik, Caddy, and Cloudflare Tunnels. Headings and anchors untouched.

3. `apps/landing/public/_headers` adds a `/*` block: `Strict-Transport-Security: max-age=31536000`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`. Deliberately no `includeSubDomains` and no `preload`: the landing site must not force-commit demo, docs, or the ingest proxy subdomains to HSTS. The existing `X-Robots-Tag` rules are unchanged. Nothing in `tests/e2e-landing/` asserts response headers from `_headers` (the worker spec's header assertions are worker-synthesized responses), so no baseline breaks.

4. Multipart text-field limits are now explicit and shared: `MULTIPART_FIELD_SIZE_BYTES` (1 MB, restating busboy's implicit default) and `MULTIPART_MAX_FIELDS` (100, previously unbounded) live in `lib/multipart-parts.ts` and are imported by the `@fastify/multipart` registration so the two limit sets can't drift. Two behavior hardenings came with it: a truncated field value now rejects with "field value too large" instead of silently yielding clipped data downstream, and the `fieldsLimit` busboy event maps to an error like the existing `filesLimit`/`partsLimit` handlers. Checked that no route carries large text fields (sign-pdf signatures travel as file parts), so the hard reject is safe.

Verification: new tests red first (6 failed against the old behavior), then `tests/unit/api/multipart-parts.test.ts` and `tests/unit/api/static-upload.test.ts` at 15/15, a sweep of six multipart-adjacent unit files at 51/51, `pnpm typecheck` green, biome clean.

Part of #821
