### PR TITLE
fix(api): attach error listeners to ioredis connections so a Redis blip can't crash the process

### DIFF
--- a/apps/api/src/jobs/connection.ts
+++ b/apps/api/src/jobs/connection.ts
@@ -46,16 +46,32 @@ const SOCKET_TIMEOUT_MS = 30_000;
 const SUBSCRIBER_PING_INTERVAL_MS = 10_000;
 
 /**
+ * ioredis emits "error" on every failed connect attempt. An EventEmitter
+ * "error" with no listener is escalated by Node to an uncaught exception,
+ * so without this handler a Redis restart kills the whole API process
+ * (Sentry NODE-30). Reconnecting is ioredis's job via its retryStrategy;
+ * the listener only has to exist and say what happened.
+ */
+function swallowConnectionErrors(connection: Redis): Redis {
+  connection.on("error", (err: Error) => {
+    console.error("[redis] connection error:", err.message);
+  });
+  return connection;
+}
+
+/**
  * Create a new ioredis connection from REDIS_URL.
  * Each caller gets an independent connection (BullMQ requires separate
  * connections for Queue, Worker, and QueueEvents).
  */
 export function createRedisConnection(): Redis {
-  return new Redis(env.REDIS_URL, {
-    maxRetriesPerRequest: null,
-    enableReadyCheck: true,
-    socketTimeout: SOCKET_TIMEOUT_MS,
-  });
+  return swallowConnectionErrors(
+    new Redis(env.REDIS_URL, {
+      maxRetriesPerRequest: null,
+      enableReadyCheck: true,
+      socketTimeout: SOCKET_TIMEOUT_MS,
+    }),
+  );
 }
 
 /**
@@ -64,11 +80,13 @@ export function createRedisConnection(): Redis {
  * ioredis ready checks that issue INFO during reconnects.
  */
 export function createRedisSubscriberConnection(): Redis {
-  const connection = new Redis(env.REDIS_URL, {
-    maxRetriesPerRequest: null,
-    enableReadyCheck: false,
-    socketTimeout: SOCKET_TIMEOUT_MS,
-  });
+  const connection = swallowConnectionErrors(
+    new Redis(env.REDIS_URL, {
+      maxRetriesPerRequest: null,
+      enableReadyCheck: false,
+      socketTimeout: SOCKET_TIMEOUT_MS,
+    }),
+  );
   keepSubscriberSocketProbed(connection);
   return connection;
 }

--- a/tests/unit/api/jobs/connection.test.ts
+++ b/tests/unit/api/jobs/connection.test.ts
@@ -5,14 +5,18 @@ type RedisStub = {
   quit: ReturnType<typeof vi.fn>;
   info: ReturnType<typeof vi.fn>;
   once: ReturnType<typeof vi.fn>;
-  /** Fires the handler registered for an event, as ioredis would. */
+  on: ReturnType<typeof vi.fn>;
+  /** Fires the handler registered via once(), as ioredis would. */
   emitOnce: (event: string) => void;
+  /** Fires every handler registered via on(). Throws if none exist, like an EventEmitter "error" would. */
+  emitOn: (event: string, ...args: unknown[]) => void;
 };
 
 const { RedisMock, stubs } = vi.hoisted(() => {
   const created: RedisStub[] = [];
   const mock = vi.fn(function RedisMock() {
     const handlers = new Map<string, () => void>();
+    const onHandlers = new Map<string, ((...args: unknown[]) => void)[]>();
     const stub: RedisStub = {
       ping: vi.fn().mockResolvedValue("PONG"),
       quit: vi.fn().mockResolvedValue("OK"),
@@ -21,7 +25,20 @@ const { RedisMock, stubs } = vi.hoisted(() => {
         handlers.set(event, handler);
         return stub;
       }),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        onHandlers.set(event, [...(onHandlers.get(event) ?? []), handler]);
+        return stub;
+      }),
       emitOnce: (event: string) => handlers.get(event)?.(),
+      emitOn: (event: string, ...args: unknown[]) => {
+        const listeners = onHandlers.get(event);
+        if (!listeners || listeners.length === 0) {
+          // Mirror Node's EventEmitter contract for "error": no listener
+          // means the process goes down. That is the bug under test.
+          throw args[0] instanceof Error ? args[0] : new Error(`unhandled ${event}`);
+        }
+        for (const listener of listeners) listener(...args);
+      },
     };
     created.push(stub);
     return stub;
@@ -165,6 +182,40 @@ describe("Redis connection factory", () => {
       process.off("unhandledRejection", unhandled);
       vi.useRealTimers();
     }
+  });
+
+  it("attaches an error listener to command connections so a Redis blip cannot crash the process", async () => {
+    const { createRedisConnection } = await freshModule();
+
+    const conn = createRedisConnection() as unknown as RedisStub;
+
+    // ioredis emits "error" on every failed connect attempt. With no listener,
+    // Node escalates it to an uncaught exception and kills the API (Sentry
+    // NODE-30: fatal ECONNREFUSED from installs whose Redis restarted).
+    expect(conn.on).toHaveBeenCalledWith("error", expect.any(Function));
+  });
+
+  it("attaches an error listener to subscriber connections", async () => {
+    const { createRedisSubscriberConnection } = await freshModule();
+
+    const conn = createRedisSubscriberConnection() as unknown as RedisStub;
+
+    expect(conn.on).toHaveBeenCalledWith("error", expect.any(Function));
+  });
+
+  it("logs and swallows connection errors, leaving reconnection to ioredis", async () => {
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { createRedisConnection } = await freshModule();
+
+    const conn = createRedisConnection() as unknown as RedisStub;
+
+    expect(() =>
+      conn.emitOn("error", new Error("connect ECONNREFUSED 127.0.0.1:6379")),
+    ).not.toThrow();
+    expect(errorLog).toHaveBeenCalledWith(
+      expect.stringContaining("[redis]"),
+      expect.stringContaining("ECONNREFUSED"),
+    );
   });
 
   it("sharedRedis memoizes a single connection across calls", async () => {


### PR DESCRIPTION
A Redis restart could take down the whole API. ioredis emits `error` on every failed connect attempt, and an EventEmitter `error` with no listener becomes an uncaught exception, so the process died with every in-flight job. BullMQ covers its own connections; the `sharedRedis()` singleton and bare subscriber connections were the exposed ones. This is Sentry NODE-30 (fatal ECONNREFUSED, 5 installs) and NODE-2F (fatal ETIMEDOUT).

The connection factory now attaches a logging `error` listener to every connection it builds, so no consumer can reintroduce the crash. Reconnection stays where it was, in ioredis's retryStrategy; the listener just has to exist.

Tested with three new cases in `tests/unit/api/jobs/connection.test.ts`: both factories register a listener, and an emitted ECONNREFUSED is logged instead of thrown (the mock mirrors Node's throw-on-unhandled-error contract, so the old code fails the test the same way it failed in production). Full `tests/unit/api/jobs/` plus the redis-preflight, queues-mutation, and analytics-gate suites pass: 196 tests.

Fixes #840