### PR TITLE
fix(shared): reject synthetic keydown events with no key instead of throwing

### DIFF
--- a/packages/shared/src/search/type-to-search.ts
+++ b/packages/shared/src/search/type-to-search.ts
@@ -44,6 +44,10 @@ export function isTypeToSearchKey(event: TypeToSearchKeyEvent): boolean {
   if (event.defaultPrevented) return false;
   if (event.isComposing) return false;
 
+  // Synthetic events (password-manager autofill, WebView bridges) can arrive
+  // with no key at all, whatever the type says. Nobody typed those.
+  if (typeof event.key !== "string") return false;
+
   // Every non-printable key reports a multi-character name: Enter, Tab, Escape,
   // ArrowDown, F1, Dead. A single character means a real character.
   if (event.key.length !== 1) return false;

--- a/tests/unit/shared/type-to-search.test.ts
+++ b/tests/unit/shared/type-to-search.test.ts
@@ -93,6 +93,15 @@ describe("isTypeToSearchKey", () => {
     expect(isTypeToSearchKey(ev({ key: " " }))).toBe(false);
   });
 
+  it("rejects a synthetic event whose key is undefined instead of throwing", () => {
+    // Password-manager and autofill extensions dispatch synthetic keydowns on
+    // document with no key at all (Sentry WEB-N). The type says `key: string`;
+    // the runtime disagrees.
+    const synthetic = { ...ev({ key: "x" }), key: undefined } as unknown as TypeToSearchKeyEvent;
+
+    expect(isTypeToSearchKey(synthetic)).toBe(false);
+  });
+
   it.each(["Enter", "Tab", "Escape", "ArrowDown", "Backspace", "F1", "Dead", "Shift"])(
     "rejects the non-printable key %s",
     (key) => {


### PR DESCRIPTION
Sentry WEB-N: 22 events of `TypeError: Cannot read properties of undefined (reading 'length')` from the document-level type-to-search listener. Password-manager autofill extensions and WebView bridges dispatch synthetic keydowns with no `key`, and `isTypeToSearchKey` read `event.key.length` unguarded.

One-line guard: a non-string `key` is rejected the same way any non-printable keystroke is. The `TypeToSearchKeyEvent` type still says `key: string`; the comment on the guard notes that the runtime disagrees, so nobody simplifies it away.

Tests: new case in `tests/unit/shared/type-to-search.test.ts` reproduces the exact production TypeError before the fix and passes after (48/48 in the suite, plus the full `tests/unit/web` run, 1585 tests, since both app surfaces share this module).

Fixes #839