### PR TITLE
fix(web): make copy buttons work on plain-http installs instead of crashing

### DIFF
--- a/apps/web/src/components/editor/common/export-dialog.tsx
+++ b/apps/web/src/components/editor/common/export-dialog.tsx
@@ -16,7 +16,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { editorStageRefHolder } from "@/components/editor/editor-canvas";
 import { captureDocumentCanvas } from "@/components/editor/stage-capture";
 import { useTranslation } from "@/contexts/i18n-context";
-import { cn } from "@/lib/utils";
+import { cn, copyImageToClipboard } from "@/lib/utils";
 import { useEditorStore } from "@/stores/editor-store";
 import type {
   AdjustmentValues,
@@ -80,7 +80,7 @@ export function ExportDialog({ onClose }: { onClose: () => void }) {
   });
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [estimatedSize, setEstimatedSize] = useState<number | null>(null);
-  const [copyStatus, setCopyStatus] = useState<"idle" | "copied">("idle");
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "failed">("idle");
 
   const aspectRatio = canvasSize.width / canvasSize.height;
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -313,11 +313,14 @@ export function ExportDialog({ onClose }: { onClose: () => void }) {
     try {
       const res = await fetch(dataUrl);
       const blob = await res.blob();
-      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
-      setCopyStatus("copied");
+      // Image copy has no fallback on plain-http installs (no ClipboardItem
+      // there), so failure gets surfaced on the button instead of thrown.
+      setCopyStatus((await copyImageToClipboard(blob)) ? "copied" : "failed");
       setTimeout(() => setCopyStatus("idle"), 2000);
     } catch (err) {
       console.error("Copy to clipboard failed:", err);
+      setCopyStatus("failed");
+      setTimeout(() => setCopyStatus("idle"), 2000);
     }
   }, [settings, canvasSize]);
 
@@ -608,7 +611,11 @@ export function ExportDialog({ onClose }: { onClose: () => void }) {
               className="flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-medium bg-muted text-foreground rounded hover:bg-muted/80 transition-colors"
             >
               {copyStatus === "copied" ? <Check size={14} /> : <ClipboardCopy size={14} />}
-              {copyStatus === "copied" ? "Copied" : "Copy"}
+              {copyStatus === "copied"
+                ? "Copied"
+                : copyStatus === "failed"
+                  ? "Copy failed"
+                  : "Copy"}
             </button>
           </div>
 

--- a/apps/web/src/components/tools/image-to-base64-results.tsx
+++ b/apps/web/src/components/tools/image-to-base64-results.tsx
@@ -1,5 +1,6 @@
 import { Check, ClipboardCopy, Download, FileJson, FileText, Loader2 } from "lucide-react";
 import { useCallback, useState } from "react";
+import { copyToClipboard } from "@/lib/utils";
 import type { Base64Result } from "@/stores/base64-store";
 import { useBase64Store } from "@/stores/base64-store";
 import { useFileStore } from "@/stores/file-store";
@@ -66,12 +67,14 @@ function downloadFile(content: string, filename: string, type: string) {
 // -- CopyButton -------------------------------------------------------------
 
 function CopyButton({ text, label }: { text: string; label?: string }) {
-  const [copied, setCopied] = useState(false);
+  const [status, setStatus] = useState<"idle" | "copied" | "failed">("idle");
 
   const handleCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    // copyToClipboard falls back to execCommand on plain-http installs, where
+    // navigator.clipboard does not exist (Sentry WEB-G).
+    const ok = await copyToClipboard(text);
+    setStatus(ok ? "copied" : "failed");
+    setTimeout(() => setStatus("idle"), 2000);
   }, [text]);
 
   return (
@@ -80,8 +83,12 @@ function CopyButton({ text, label }: { text: string; label?: string }) {
       onClick={handleCopy}
       className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs font-medium hover:bg-primary/90 transition-colors"
     >
-      {copied ? <Check className="h-3.5 w-3.5" /> : <ClipboardCopy className="h-3.5 w-3.5" />}
-      {copied ? "Copied!" : (label ?? "Copy")}
+      {status === "copied" ? (
+        <Check className="h-3.5 w-3.5" />
+      ) : (
+        <ClipboardCopy className="h-3.5 w-3.5" />
+      )}
+      {status === "copied" ? "Copied!" : status === "failed" ? "Copy failed" : (label ?? "Copy")}
     </button>
   );
 }

--- a/apps/web/src/components/tools/ocr-pdf-view.tsx
+++ b/apps/web/src/components/tools/ocr-pdf-view.tsx
@@ -1,5 +1,6 @@
 import { Copy, FileText } from "lucide-react";
 import { useEffect, useState } from "react";
+import { copyToClipboard } from "@/lib/utils";
 import { useFileStore } from "@/stores/file-store";
 import { DocumentView } from "./document-view";
 
@@ -43,12 +44,11 @@ export function OcrPdfView() {
 
   const copy = async () => {
     if (!text) return;
-    try {
-      await navigator.clipboard.writeText(text);
+    // Falls back to execCommand on plain-http installs, where the async
+    // Clipboard API does not exist (Sentry WEB-G).
+    if (await copyToClipboard(text)) {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // clipboard unavailable; ignore
     }
   };
 

--- a/apps/web/src/hooks/use-editor-shortcuts.ts
+++ b/apps/web/src/hooks/use-editor-shortcuts.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { editorStageRefHolder } from "@/components/editor/editor-canvas";
+import { copyImageToClipboard } from "@/lib/utils";
 import { useEditorStore } from "@/stores/editor-store";
 import type { ToolType } from "@/types/editor";
 
@@ -477,13 +478,9 @@ export function useEditorShortcuts(callbacks?: {
       });
       fetch(dataUrl)
         .then((res) => res.blob())
-        .then(async (blob) => {
-          try {
-            await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
-          } catch {
-            // Clipboard API not available
-          }
-        })
+        // copyImageToClipboard resolves false (never throws) when the
+        // Clipboard API is unavailable, e.g. on plain-http installs.
+        .then((blob) => copyImageToClipboard(blob))
         .catch(() => {
           // Export failed silently
         });

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -30,3 +30,19 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     }
   }
 }
+
+/**
+ * Copy an image blob to the clipboard. Unlike text, images have no
+ * execCommand fallback, so on insecure (plain-http) contexts, where
+ * navigator.clipboard and ClipboardItem do not exist, this reports failure
+ * instead of throwing (Sentry WEB-G).
+ */
+export async function copyImageToClipboard(blob: Blob): Promise<boolean> {
+  if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) return false;
+  try {
+    await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/unit/web/image-to-base64-copy-button.test.tsx
+++ b/tests/unit/web/image-to-base64-copy-button.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression coverage for Sentry WEB-G: on plain-http installs
+ * navigator.clipboard does not exist, and the copy button used to throw an
+ * unhandled TypeError instead of copying. The button must fall back to the
+ * execCommand path (which works in insecure contexts) and only claim
+ * "Copied!" when a copy actually happened.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ImageToBase64Results } from "@/components/tools/image-to-base64-results";
+import { useBase64Store } from "@/stores/base64-store";
+import { useFileStore } from "@/stores/file-store";
+
+const RESULT = {
+  filename: "otter.png",
+  mimeType: "image/png",
+  width: 2,
+  height: 2,
+  originalSize: 68,
+  encodedSize: 92,
+  overheadPercent: 35,
+  base64: "aGVsbG8=",
+  dataUri: "data:image/png;base64,aGVsbG8=",
+};
+
+describe("image-to-base64 copy button on insecure contexts", () => {
+  const originalClipboard = navigator.clipboard;
+  const originalExecCommand = document.execCommand;
+
+  beforeEach(() => {
+    // The component looks results up by the selected file's name, so the file
+    // store needs a matching entry. jsdom has no URL.createObjectURL.
+    vi.stubGlobal("URL", Object.assign(URL, { createObjectURL: () => "blob:otter" }));
+    useFileStore.getState().addFiles([new File(["png"], "otter.png", { type: "image/png" })]);
+    useBase64Store.setState({
+      results: [RESULT],
+      errors: [],
+      processing: false,
+      progress: null,
+      expandedIndex: 0,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    Object.assign(navigator, { clipboard: originalClipboard });
+    document.execCommand = originalExecCommand;
+    useBase64Store.getState().reset();
+    useFileStore.setState({ entries: [], files: [], selectedIndex: 0 });
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("copies via the execCommand fallback when navigator.clipboard is missing", async () => {
+    // Insecure context: the async Clipboard API does not exist at all.
+    Object.assign(navigator, { clipboard: undefined });
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand;
+
+    render(<ImageToBase64Results />);
+    const copyButtons = screen.getAllByRole("button", { name: /copy/i });
+    fireEvent.click(copyButtons[0]);
+
+    expect(await screen.findByText("Copied!")).toBeTruthy();
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("reports failure instead of claiming Copied! when no copy mechanism exists", async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    document.execCommand = vi.fn().mockReturnValue(false);
+
+    render(<ImageToBase64Results />);
+    const copyButtons = screen.getAllByRole("button", { name: /copy/i });
+    fireEvent.click(copyButtons[0]);
+
+    expect(await screen.findByText("Copy failed")).toBeTruthy();
+    expect(screen.queryByText("Copied!")).toBeNull();
+  });
+});

--- a/tests/unit/web/utils.test.ts
+++ b/tests/unit/web/utils.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { copyToClipboard, generateId } from "../../../apps/web/src/lib/utils";
+import { copyImageToClipboard, copyToClipboard, generateId } from "../../../apps/web/src/lib/utils";
 
 describe("generateId", () => {
   it("returns a valid UUID v4 string", () => {
@@ -45,5 +45,59 @@ describe("copyToClipboard", () => {
       throw new Error("not supported");
     });
     expect(await copyToClipboard("hello")).toBe(false);
+  });
+});
+
+describe("copyImageToClipboard", () => {
+  const originalClipboard = navigator.clipboard;
+  const originalClipboardItem = globalThis.ClipboardItem;
+
+  afterEach(() => {
+    Object.assign(navigator, { clipboard: originalClipboard });
+    if (originalClipboardItem === undefined) {
+      delete (globalThis as { ClipboardItem?: unknown }).ClipboardItem;
+    } else {
+      globalThis.ClipboardItem = originalClipboardItem;
+    }
+    vi.restoreAllMocks();
+  });
+
+  const blob = () => new Blob(["png-bytes"], { type: "image/png" });
+
+  it("returns false without throwing when navigator.clipboard is missing (insecure context)", async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    (globalThis as { ClipboardItem?: unknown }).ClipboardItem = class {};
+
+    await expect(copyImageToClipboard(blob())).resolves.toBe(false);
+  });
+
+  it("returns false without throwing when ClipboardItem is missing", async () => {
+    Object.assign(navigator, { clipboard: { write: vi.fn() } });
+    delete (globalThis as { ClipboardItem?: unknown }).ClipboardItem;
+
+    await expect(copyImageToClipboard(blob())).resolves.toBe(false);
+  });
+
+  it("writes the blob and returns true when the API is available", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { write } });
+    (globalThis as { ClipboardItem?: unknown }).ClipboardItem = class {
+      items: unknown;
+      constructor(items: unknown) {
+        this.items = items;
+      }
+    };
+
+    await expect(copyImageToClipboard(blob())).resolves.toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when the write itself rejects", async () => {
+    Object.assign(navigator, {
+      clipboard: { write: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    (globalThis as { ClipboardItem?: unknown }).ClipboardItem = class {};
+
+    await expect(copyImageToClipboard(blob())).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
Sentry WEB-G: `TypeError: Cannot read properties of undefined (reading 'writeText')`, 22 events across 2.1.0 and 2.2.0. `navigator.clipboard` only exists in secure contexts, and a LAN install served over plain http is a normal deployment for us (#4 was the same class of bug with `crypto.randomUUID`). The copy button on the image-to-base64 results threw an unhandled rejection and copied nothing.

The fix routes the four call sites that bypassed the existing `copyToClipboard` helper (which falls back to `execCommand("copy")`, and that works on http):

- image-to-base64 results `CopyButton`: uses the helper, only shows "Copied!" on success, shows "Copy failed" otherwise
- OCR PDF view copy: uses the helper
- editor export dialog and the mod+shift+C shortcut copy images, which have no execCommand fallback; they get a new `copyImageToClipboard` helper that resolves false instead of throwing when `ClipboardItem` or `clipboard.write` is missing, and the dialog now shows a failed state

Tests: new jsdom component test drives the real results component with `navigator.clipboard` removed, reproducing the exact WEB-G TypeError before the fix; four new unit cases cover `copyImageToClipboard`'s guards. Full `tests/unit/web`: 110 files, 1591 tests, all passing. `tsc --noEmit` clean.

Fixes #838