### PR TITLE
fix(web): stop a non-array permissions value from killing the settings dialog

### DIFF
--- a/apps/api/src/db/migrate-from-sqlite.ts
+++ b/apps/api/src/db/migrate-from-sqlite.ts
@@ -77,7 +77,7 @@ export function columnsEngineCanFill(table: string, sourceColumns: string[]): Se
   return out;
 }
 
-function convertRow(table: string, row: SqliteRow): SqliteRow {
+export function convertRow(table: string, row: SqliteRow): SqliteRow {
   const out: SqliteRow = {};
   const rename = RENAMES[table] ?? {};
   for (const [rawCol, raw] of Object.entries(row)) {
@@ -126,6 +126,15 @@ function convertRow(table: string, row: SqliteRow): SqliteRow {
         throw new Error(
           `Invalid JSON in ${table}.${col} (row id=${String(row.id)}): ${(e as Error).message}`,
         );
+      }
+      // A double-encoded 1.x permissions cell parses to a jsonb string, which
+      // the settings UI then chokes on forever (issue #846). Only a string
+      // array may cross; api_keys.permissions is nullable, roles.permissions
+      // is NOT NULL, so their fallbacks differ.
+      if (col === "permissions") {
+        const parsed = out[col];
+        const clean = Array.isArray(parsed) ? parsed.filter((p) => typeof p === "string") : null;
+        out[col] = clean ?? (table === "roles" ? [] : null);
       }
     } else {
       out[col] = raw;

--- a/apps/web/src/components/settings/settings-dialog.tsx
+++ b/apps/web/src/components/settings/settings-dialog.tsx
@@ -2087,7 +2087,7 @@ function PeopleSection() {
 
 /* ────────────────────── API Keys ────────────────────── */
 
-function ApiKeysSection() {
+export function ApiKeysSection() {
   const { t } = useTranslation();
   const [keys, setKeys] = useState<ApiKeyEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -2309,7 +2309,7 @@ function ApiKeysSection() {
                 <p className="text-xs text-muted-foreground font-mono">
                   {k.prefix}... &middot; Created {new Date(k.createdAt).toLocaleDateString()}
                 </p>
-                {k.permissions && (
+                {Array.isArray(k.permissions) && k.permissions.length > 0 && (
                   <p className="text-xs text-muted-foreground font-mono mt-0.5">
                     Scoped: {k.permissions.join(", ")}
                   </p>
@@ -3111,7 +3111,9 @@ function RolesSection() {
                         setEditingRole(role);
                         setEditName(role.name);
                         setEditDescription(role.description);
-                        setEditPermissions([...role.permissions]);
+                        setEditPermissions(
+                          Array.isArray(role.permissions) ? [...role.permissions] : [],
+                        );
                       }}
                       className="p-1.5 rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                       title="Edit role"
@@ -3135,7 +3137,7 @@ function RolesSection() {
                 <p className="text-xs text-muted-foreground">{role.description}</p>
               )}
               <div className="flex flex-wrap gap-1.5">
-                {role.permissions.map((perm) => (
+                {(Array.isArray(role.permissions) ? role.permissions : []).map((perm) => (
                   <span
                     key={perm}
                     className="inline-block px-2 py-0.5 rounded-full bg-muted text-xs font-mono text-muted-foreground"

--- a/tests/unit/api/migrate-sqlite-permissions.test.ts
+++ b/tests/unit/api/migrate-sqlite-permissions.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { convertRow } from "../../../apps/api/src/db/migrate-from-sqlite.js";
+
+/**
+ * A 1.x SQLite cell can hold a double-encoded permissions value like
+ * '"images:process,files:read"'. JSON.parse turns that into a plain string,
+ * the ::jsonb cast stores it as a jsonb string, and the settings dialog then
+ * dies on `.join is not a function` forever (Sentry WEB-C, issue #846).
+ * The import has to normalize permissions to an array or drop them.
+ */
+describe("convertRow permissions normalization", () => {
+  it("coerces a double-encoded api_keys.permissions string to null", () => {
+    const out = convertRow("api_keys", {
+      id: 1,
+      permissions: '"images:process,files:read"',
+    });
+    expect(out.permissions).toBeNull();
+  });
+
+  it("coerces a JSON object in api_keys.permissions to null", () => {
+    const out = convertRow("api_keys", { id: 2, permissions: '{"images": true}' });
+    expect(out.permissions).toBeNull();
+  });
+
+  it("keeps a well-formed api_keys.permissions array, dropping non-string members", () => {
+    const out = convertRow("api_keys", {
+      id: 3,
+      permissions: '["images:process", 7, "files:read"]',
+    });
+    expect(out.permissions).toEqual(["images:process", "files:read"]);
+  });
+
+  it("coerces a non-array roles.permissions to an empty array (column is NOT NULL)", () => {
+    const out = convertRow("roles", { id: "r1", permissions: '"images:process"' });
+    expect(out.permissions).toEqual([]);
+  });
+
+  it("keeps a well-formed roles.permissions array", () => {
+    const out = convertRow("roles", { id: "r2", permissions: '["images:process"]' });
+    expect(out.permissions).toEqual(["images:process"]);
+  });
+
+  it("leaves null api_keys.permissions as null", () => {
+    const out = convertRow("api_keys", { id: 4, permissions: null });
+    expect(out.permissions).toBeNull();
+  });
+});

--- a/tests/unit/web/api-keys-section-permissions.test.tsx
+++ b/tests/unit/web/api-keys-section-permissions.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression coverage for Sentry WEB-C: an API key row whose `permissions`
+ * came back as a non-array (a 1.x import can leave a jsonb string in the
+ * column) crashed the whole settings dialog through the ErrorBoundary with
+ * `t.permissions.join is not a function`. The list must render the key and
+ * just skip the scoped line.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiKeysSection } from "@/components/settings/settings-dialog";
+
+const apiGet = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  return { ...actual, apiGet };
+});
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    permissions: [],
+    hasPermission: () => true,
+    authEnabled: true,
+    role: "admin",
+  }),
+}));
+
+function key(overrides: Record<string, unknown>) {
+  return {
+    id: 1,
+    name: "legacy key",
+    prefix: "si_abc",
+    createdAt: "2026-01-01T00:00:00Z",
+    permissions: null,
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  apiGet.mockReset();
+});
+
+describe("ApiKeysSection permissions rendering", () => {
+  it("renders a key whose permissions is a jsonb string instead of crashing", async () => {
+    apiGet.mockResolvedValue({ apiKeys: [key({ permissions: "images:process,files:read" })] });
+
+    render(<ApiKeysSection />);
+
+    expect(await screen.findByText("legacy key")).toBeTruthy();
+    // The malformed value must not be presented as a scoped list.
+    expect(screen.queryByText(/Scoped:/)).toBeNull();
+  });
+
+  it("still renders the scoped list for a well-formed permissions array", async () => {
+    apiGet.mockResolvedValue({
+      apiKeys: [key({ id: 2, name: "scoped key", permissions: ["images:process"] })],
+    });
+
+    render(<ApiKeysSection />);
+
+    expect(await screen.findByText("scoped key")).toBeTruthy();
+    expect(await screen.findByText(/Scoped: images:process/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Sentry WEB-C: `TypeError: t.permissions.join is not a function` out of the API keys list, caught by the dialog-root ErrorBoundary, so Settings was dead for that user on every open. Three events, all 2.1.0, likely one install.

How a non-array gets into a `jsonb` column typed `string[]`: the 1.x SQLite import. A double-encoded 1.x cell like `'"a,b"'` survives `JSON.parse` as a plain string and the `::jsonb` cast stores it forever. 2.x writes are Zod-validated and can't produce it.

Two layers:

- `ApiKeysSection` renders the scoped line only for `Array.isArray(k.permissions)`, and the roles list gets the same guard on `role.permissions` (also a jsonb column fed by the same import path)
- `convertRow` in the SQLite import normalizes `permissions`: string arrays pass through (non-string members dropped), anything else becomes `null` for `api_keys` and `[]` for `roles` (NOT NULL column)

Tests: a jsdom test renders `ApiKeysSection` (now exported, same precedent as `AdminSecuritySettings`) with a string `permissions` and reproduced the exact WEB-C TypeError before the fix; six unit cases pin `convertRow`'s normalization. The legacy-sqlite fixture suite and the settings tests pass (27 tests across the four related files).

Fixes #846