### PR TITLE
fix(web): reload once when a lazy chunk 404s after a container update

### DIFF
--- a/apps/web/src/lib/chunk-reload.ts
+++ b/apps/web/src/lib/chunk-reload.ts
@@ -1,0 +1,49 @@
+/**
+ * Self-heal for stale-deploy chunk failures (Sentry WEB-8/WEB-5/WEB-S/WEB-1).
+ *
+ * Every page component is lazy()-loaded with hashed filenames. When the
+ * container updates under an open tab, the tab's next route navigation
+ * requests a chunk that no longer exists, the dynamic import rejects, and
+ * the ErrorBoundary shows a crash screen until the user reloads by hand.
+ * Vite surfaces exactly this case as a window "vite:preloadError" event.
+ *
+ * The handler reloads the page once. The guard (persisted in sessionStorage
+ * so it survives the reload it triggers) makes a second failure inside the
+ * window fall through to the error boundary instead of looping: chunks that
+ * are still missing after a fresh load mean the server is broken, not
+ * updated.
+ */
+
+export const CHUNK_RELOAD_GUARD_KEY = "snapotter-chunk-reload-at";
+export const CHUNK_RELOAD_GUARD_MS = 30_000;
+
+function readLastReloadAt(): number {
+  try {
+    return Number(sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY) ?? 0);
+  } catch {
+    return 0; // storage blocked (private mode): reload without a guard record
+  }
+}
+
+function markReloadedNow(): void {
+  try {
+    sessionStorage.setItem(CHUNK_RELOAD_GUARD_KEY, String(Date.now()));
+  } catch {
+    // storage blocked: the reload still happens, only loop protection is lost
+  }
+}
+
+/** Returns an uninstall function (used by tests; the app installs once for its lifetime). */
+export function installChunkReloadHandler(
+  reload: () => void = () => window.location.reload(),
+): () => void {
+  const onPreloadError = (event: Event) => {
+    if (Date.now() - readLastReloadAt() < CHUNK_RELOAD_GUARD_MS) return;
+    markReloadedNow();
+    // Handled here: stop Vite from rethrowing into the error boundary.
+    event.preventDefault();
+    reload();
+  };
+  window.addEventListener("vite:preloadError", onPreloadError);
+  return () => window.removeEventListener("vite:preloadError", onPreloadError);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,12 +1,17 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { installChunkReloadHandler } from "./lib/chunk-reload";
 import { startEarlyErrorCapture } from "./lib/early-errors";
 import "./styles/globals.css";
 
 // Buffer crashes that happen before Sentry initializes (it inits late, after
 // the analytics config fetch); flushEarlyErrors replays them once it is ready.
 startEarlyErrorCapture();
+
+// A container update invalidates the hashed chunks an open tab still points
+// at; reload once instead of stranding the user on a crash screen.
+installChunkReloadHandler();
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element not found");

--- a/tests/unit/web/chunk-reload.test.ts
+++ b/tests/unit/web/chunk-reload.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression coverage for Sentry WEB-8/WEB-5/WEB-S/WEB-1: after a container
+ * update, an open tab's next lazy route import requests a chunk hash that no
+ * longer exists, the import rejects, and the app is dead until the user
+ * reloads by hand. Vite reports exactly this as a window "vite:preloadError"
+ * event; the handler reloads once, with a guard so a genuinely broken server
+ * cannot cause a reload loop.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CHUNK_RELOAD_GUARD_KEY,
+  CHUNK_RELOAD_GUARD_MS,
+  installChunkReloadHandler,
+} from "@/lib/chunk-reload";
+
+function fireChunkError(): Event {
+  const event = new Event("vite:preloadError", { cancelable: true });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe("installChunkReloadHandler", () => {
+  let reload: ReturnType<typeof vi.fn>;
+  let uninstall: () => void;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-18T12:00:00Z"));
+    reload = vi.fn();
+    uninstall = installChunkReloadHandler(reload);
+  });
+
+  afterEach(() => {
+    uninstall();
+    sessionStorage.clear();
+    vi.useRealTimers();
+  });
+
+  it("reloads once on a chunk preload error and marks the event handled", () => {
+    const event = fireChunkError();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    // preventDefault stops Vite from rethrowing the error into the boundary.
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does not reload again within the guard window (broken server, not an update)", () => {
+    fireChunkError();
+    vi.advanceTimersByTime(1000);
+    const second = fireChunkError();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    // The second failure is left to propagate so the error boundary shows.
+    expect(second.defaultPrevented).toBe(false);
+  });
+
+  it("reloads again after the guard window has passed (a later, separate update)", () => {
+    fireChunkError();
+    vi.advanceTimersByTime(CHUNK_RELOAD_GUARD_MS + 1000);
+    fireChunkError();
+
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it("persists the guard across the reload via sessionStorage", () => {
+    fireChunkError();
+    expect(sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).not.toBeNull();
+
+    // Simulate the post-reload page: a fresh handler, same sessionStorage.
+    uninstall();
+    const reloadAfter = vi.fn();
+    uninstall = installChunkReloadHandler(reloadAfter);
+    fireChunkError();
+
+    expect(reloadAfter).not.toHaveBeenCalled();
+  });
+
+  it("still reloads when sessionStorage is unavailable (Safari private mode)", () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+
+    fireChunkError();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    setItem.mockRestore();
+    getItem.mockRestore();
+  });
+});


### PR DESCRIPTION
Sentry WEB-8 (10 events), WEB-5, WEB-S (`error loading dynamically imported module`) and WEB-1 (17 events, preload-helper failures): a tab left open across a `docker compose pull` requests old chunk hashes on its next lazy route load, the import rejects, and the app sits on the ErrorBoundary crash screen until a manual reload. Routine for self-hosted updates, and the most frequent web issue in Sentry that's actually ours.

Vite emits `vite:preloadError` on window for exactly this. `installChunkReloadHandler()` (wired in `main.tsx`) calls `preventDefault()` and reloads once. A sessionStorage timestamp guard (30s, persists across the reload it triggers) means a second failure inside the window falls through to the error boundary instead of reload-looping when the server is down rather than updated. Storage-blocked browsers (Safari private mode) still get the reload, just without loop protection.

Tests: five jsdom cases in `tests/unit/web/chunk-reload.test.ts` cover the reload, the loop guard, guard expiry, persistence across the reload, and the storage-blocked path.

Fixes #844