### PR TITLE
fix(api): classify page-spec and capacity errors instead of reporting them as bugs

### DIFF
--- a/apps/api/src/lib/object-storage.ts
+++ b/apps/api/src/lib/object-storage.ts
@@ -53,6 +53,7 @@ function isS3Enabled(): boolean {
 }
 
 import type { S3StorageModule } from "@snapotter/enterprise";
+import { SafeError } from "@snapotter/shared";
 
 let s3Mod: S3StorageModule | null = null;
 // Concurrent first calls may double-configure; configureS3 is idempotent.
@@ -146,9 +147,13 @@ async function assertWorkspaceSizeCap(root: string): Promise<void> {
     workspaceSizeCache = { bytes: used, at: now };
   }
   if (isOverWorkspaceCap(used, maxGb)) {
-    const error = new Error("Workspace storage limit reached; try again shortly");
-    (error as Error & { statusCode: number }).statusCode = 503;
-    throw error;
+    // "Disk full" is the canonical operational condition (error-report.ts);
+    // as a plain Error this reported to Sentry as a bug (NODE-5Y).
+    throw new SafeError("Workspace storage limit reached; try again shortly", {
+      kind: "operational",
+      code: "workspace-cap",
+      statusCode: 503,
+    });
   }
 }
 
@@ -170,9 +175,11 @@ export async function assertLocalCapacity(): Promise<void> {
   }
   const freeBytes = fsStats.bavail * fsStats.bsize;
   if (isBelowCapacity(freeBytes)) {
-    const error = new Error("Insufficient disk space for processing");
-    (error as Error & { statusCode: number }).statusCode = 503;
-    throw error;
+    throw new SafeError("Insufficient disk space for processing", {
+      kind: "operational",
+      code: "disk-free-floor",
+      statusCode: 503,
+    });
   }
 }
 

--- a/packages/ai/src/tesseract-pdf.ts
+++ b/packages/ai/src/tesseract-pdf.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, realpath, rm, stat, statfs } from "node:fs/promises";
 import { join } from "node:path";
 import { performance } from "node:perf_hooks";
+import { ToolInputError } from "@snapotter/shared";
 import sharp from "sharp";
 import {
   type RunTesseractOptions,
@@ -87,15 +88,22 @@ function validatePositiveInteger(value: number, label: string, maximum?: number)
   return value;
 }
 
-/** Parse a strict 1-based page list such as `all`, `1-3,5`, or `2,4-6`. */
+/**
+ * Parse a strict 1-based page list such as `all`, `1-3,5`, or `2,4-6`.
+ *
+ * Rejections are ToolInputError: the spec is user-typed and only checkable
+ * against the real page count here in the worker, long after Zod. As plain
+ * Errors these were reported to Sentry as bug-class events and reached the
+ * user as opaque failures (NODE-55).
+ */
 export function parsePdfPageSpec(spec: string, totalPages: number): number[] {
   validatePositiveInteger(totalPages, "PDF page count");
   const normalized = spec.trim();
-  if (!normalized) throw new Error("No pages specified");
+  if (!normalized) throw new ToolInputError("No pages specified");
 
   if (normalized.toLowerCase() === "all") {
     if (totalPages > MAX_PDF_OCR_PAGES) {
-      throw new Error(`Too many pages for OCR (max ${MAX_PDF_OCR_PAGES})`);
+      throw new ToolInputError(`Too many pages for OCR (max ${MAX_PDF_OCR_PAGES})`);
     }
     return Array.from({ length: totalPages }, (_, index) => index + 1);
   }
@@ -103,32 +111,36 @@ export function parsePdfPageSpec(spec: string, totalPages: number): number[] {
   const selected = new Set<number>();
   for (const rawPart of normalized.split(",")) {
     const part = rawPart.trim();
-    if (!part) throw new Error(`Invalid page selection: "${spec}"`);
+    if (!part) throw new ToolInputError(`Invalid page selection: "${spec}"`);
 
     const match = /^(\d+)(?:\s*-\s*(\d+))?$/.exec(part);
-    if (!match) throw new Error(`Invalid page selection: "${part}"`);
+    if (!match) throw new ToolInputError(`Invalid page selection: "${part}"`);
 
     const start = Number(match[1]);
     const end = match[2] === undefined ? start : Number(match[2]);
     if (start < 1 || end < 1) {
-      throw new Error(`Invalid page selection: "${part}" (pages start at 1)`);
+      throw new ToolInputError(`Invalid page selection: "${part}" (pages start at 1)`);
     }
     if (start > end) {
-      throw new Error(`Invalid page selection: "${part}" (range start is after range end)`);
+      throw new ToolInputError(
+        `Invalid page selection: "${part}" (range start is after range end)`,
+      );
     }
     if (end > totalPages) {
-      throw new Error(`Invalid page selection: "${part}" (document has ${totalPages} pages)`);
+      throw new ToolInputError(
+        `Invalid page selection: "${part}" (document has ${totalPages} pages)`,
+      );
     }
 
     for (let page = start; page <= end; page += 1) {
       selected.add(page);
       if (selected.size > MAX_PDF_OCR_PAGES) {
-        throw new Error(`Too many pages for OCR (max ${MAX_PDF_OCR_PAGES})`);
+        throw new ToolInputError(`Too many pages for OCR (max ${MAX_PDF_OCR_PAGES})`);
       }
     }
   }
 
-  if (selected.size === 0) throw new Error("No pages specified");
+  if (selected.size === 0) throw new ToolInputError("No pages specified");
   return [...selected].sort((left, right) => left - right);
 }
 

--- a/tests/unit/ai/tesseract-pdf.test.ts
+++ b/tests/unit/ai/tesseract-pdf.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { performance } from "node:perf_hooks";
 import { PassThrough } from "node:stream";
+import { isToolInputError } from "@snapotter/shared";
 import sharp from "sharp";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -127,6 +128,22 @@ describe("parsePdfPageSpec", () => {
     expect(() => parsePdfPageSpec("1-51", 100)).toThrow("Too many pages for OCR (max 50)");
     expect(() => parsePdfPageSpec("all", 51)).toThrow("Too many pages for OCR (max 50)");
   });
+
+  // The spec is user-typed and only checkable against the real page count, deep
+  // in the worker. As plain Errors these landed in Sentry as bug-class events
+  // and reached the user as opaque failures (NODE-55). ToolInputError is the
+  // repo's class for exactly this: user input, never reported, message shown.
+  it.each(["", "0", "3-1", "1-a", "1,11", "1-51"])(
+    "throws a ToolInputError for user-facing rejection %j",
+    (spec) => {
+      try {
+        parsePdfPageSpec(spec, 10);
+        expect.unreachable("spec should have been rejected");
+      } catch (err) {
+        expect(isToolInputError(err)).toBe(true);
+      }
+    },
+  );
 });
 
 describe("runTesseractPdf", () => {

--- a/tests/unit/api/object-storage-workspace-cap.test.ts
+++ b/tests/unit/api/object-storage-workspace-cap.test.ts
@@ -116,6 +116,23 @@ describe("assertLocalCapacity capacity guard", () => {
     });
   });
 
+  it("classifies the cap error as an operational SafeError, not a bug", async () => {
+    root = await mkdtemp(join(tmpdir(), "snapotter-cap-class-"));
+    await mkdir(join(root, "outputs", "job1"), { recursive: true });
+    await writeFile(join(root, "outputs", "job1", "big.bin"), Buffer.alloc(2 * 1024 * 1024));
+    (env as { WORKSPACE_PATH: string }).WORKSPACE_PATH = root;
+    (env as { MAX_WORKSPACE_SIZE_GB: number }).MAX_WORKSPACE_SIZE_GB = 0.001;
+    vi.spyOn(Date, "now").mockReturnValue(nowBase);
+
+    // "Disk full" is the canonical operational condition in error-report.ts.
+    // As a plain Error it lands in Sentry as a bug-class event (NODE-5Y).
+    await expect(assertLocalCapacity()).rejects.toMatchObject({
+      isSafeMessage: true,
+      kind: "operational",
+      statusCode: 503,
+    });
+  });
+
   it("reuses the cached workspace total within the cache window", async () => {
     root = await mkdtemp(join(tmpdir(), "snapotter-cap-cache-"));
     await mkdir(join(root, "outputs", "job1"), { recursive: true });


### PR DESCRIPTION
Two flavors of plain `Error` thrown where the taxonomy in `tool-errors.ts` / `error-report.ts` already has the right class.

**OCR page selections (Sentry NODE-55, 6 events from 6 different installs).** `parsePdfPageSpec` rejects user-typed ranges like `5-12` on a 3-page PDF, and that can only happen in the worker where the page count is known. The plain throws classified as bug-class Sentry events and surfaced as generic job failures. Now `ToolInputError`: the worker already special-cases it (worker.ts input-failure path), the message reaches the user, and nothing is reported. The messages were user-quality all along.

**Storage capacity guards (Sentry NODE-5Y).** `assertWorkspaceSizeCap` and `assertLocalCapacity` threw plain Errors with a bolted-on 503. Disk-full is the doc-comment example of operational in `error-report.ts`, so these are now operational `SafeError`s with stable codes (`workspace-cap`, `disk-free-floor`), same 503, same messages (constant strings, per the SafeError rule).

Tests: six new `it.each` cases pin `isToolInputError` on every page-spec rejection shape, and a new capacity-guard case pins `isSafeMessage`/`kind: operational`/503. Full `tests/unit/ai` (39 files, 1218 tests) plus the object-storage suites pass.

Fixes #842