### PR TITLE
fix(api): tell the admin how to fix a world-accessible AI install lock instead of raw EPERM

### DIFF
--- a/apps/api/src/lib/feature-status.ts
+++ b/apps/api/src/lib/feature-status.ts
@@ -32,7 +32,12 @@ import {
   selectOcrRuntimeTarget,
 } from "@snapotter/ai";
 import type { FeatureBundleState, FeatureStatus } from "@snapotter/shared";
-import { FEATURE_BUNDLES, getRequiredBundlesForTool } from "@snapotter/shared";
+import {
+  FEATURE_BUNDLES,
+  getRequiredBundlesForTool,
+  isSafeMessageError,
+  SafeError,
+} from "@snapotter/shared";
 import * as tar from "tar";
 import { getQueuedBundleIds } from "./feature-install-queue.js";
 
@@ -368,8 +373,16 @@ function openKernelInstallLockFile(): number {
         // A permanent lock inode may have been created by another pod UID and
         // shared through fsGroup. Opening O_RDWR already proved this replica's
         // access; do not require ownership merely to reapply an identical-safe
-        // mode. Still fail closed if the inherited inode is world-accessible.
+        // mode. Still fail closed if the inherited inode is world-accessible,
+        // but say what to fix: the raw EPERM got retried blind (NODE-5E).
         if ((code !== "EPERM" && code !== "EACCES") || (mode & 0o007) !== 0) {
+          if (code === "EPERM" || code === "EACCES") {
+            throw new SafeError(
+              "The AI install lock file on the data volume is owned by another user and is world-accessible. " +
+                "Fix ownership on the data volume (match PUID/PGID to the app user, or delete <data>/ai/install.flock) and retry.",
+              { kind: "operational", code: "install-lock-perms", statusCode: 503, cause: error },
+            );
+          }
           throw error;
         }
       }
@@ -614,6 +627,9 @@ export function acquireInstallLock(bundleId: string): boolean {
         // Preserve the acquisition failure.
       }
     }
+    // A SafeError carries its own operator-facing message and classification;
+    // rewrapping it in a plain Error would demote it back to a bug-class blob.
+    if (isSafeMessageError(error)) throw error;
     throw new Error(
       `Unable to acquire the AI install lock: ${error instanceof Error ? error.message : String(error)}`,
       { cause: error },

--- a/tests/unit/features/feature-status.test.ts
+++ b/tests/unit/features/feature-status.test.ts
@@ -397,6 +397,30 @@ describe("Install lock", () => {
     expect(JSON.parse(readFileSync(lockPath, "utf-8")).bundleId).toBe("ocr");
   });
 
+  // The fail-closed policy for a world-accessible foreign inode is deliberate;
+  // what escaped was a raw "EPERM fchmod" the admin retried against 20 times
+  // in a day (Sentry NODE-5E). The rejection has to say what to fix.
+  it("rejects a world-accessible foreign kernel inode with an actionable operational error", () => {
+    writeFileSync(kernelLockPath, "", { mode: 0o666 });
+    chmodSync(kernelLockPath, 0o666);
+    fsFaults.denyOwnerOnlyMutationPath = kernelLockPath;
+
+    let thrown: unknown;
+    try {
+      mod.acquireInstallLock("ocr");
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toMatchObject({
+      isSafeMessage: true,
+      kind: "operational",
+      code: "install-lock-perms",
+    });
+    // The message must point the operator at the volume fix, not just EPERM.
+    expect((thrown as Error).message).toMatch(/data volume/i);
+    expect((thrown as Error).message).toMatch(/PUID|ownership/i);
+  });
+
   it("heartbeats an owned lease so a long install cannot be stolen", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(Date.now());


### PR DESCRIPTION
Sentry NODE-5E: 20 events from one install in a single day, all `Error: EPERM fchmod` out of the bundle-install route. That's an admin clicking Install repeatedly against a wall we never explained.

The wall itself is correct: `openKernelInstallLockFile` deliberately fails closed when the lock inode is owned by another UID AND world-accessible (the typical shape is /data populated as root with a permissive umask, container later run with PUID/PGID). This PR keeps the policy exactly and changes only what the failure says: an operational `SafeError` (`install-lock-perms`, 503) telling the operator to fix data-volume ownership or delete `<data>/ai/install.flock`. `acquireInstallLock`'s generic rewrap now passes SafeErrors through, since rewrapping demoted the classification back to a bug-class blob.

Tests: a new case in the install-lock suite creates a world-accessible lock inode with fchmod denied (the existing `fsFaults` harness) and pins the SafeError markers and the actionable message; the group-shared tolerance case still passes unchanged. Full `tests/unit/features`: 149 tests green.

Fixes #847