### PR TITLE
chore(web): filter wallet/injected-global noise and fork dev-server traffic out of Sentry

### DIFF
--- a/apps/web/src/lib/sentry-scrub.ts
+++ b/apps/web/src/lib/sentry-scrub.ts
@@ -23,7 +23,35 @@ export const IGNORE_ERRORS: (string | RegExp)[] = [
   /getUrlAutofillTargetingRules/i,
   /onLongParse/i,
   /Java exception was raised during method invocation/i,
+  // Crypto-wallet extensions inject window.ethereum on every page (WEB-J);
+  // other injections reference globals that exist only in their bundle (WEB-M).
+  /window\.ethereum/i,
+  /EmptyRanges/,
 ];
+
+/**
+ * No production build of ours serves anything under /node_modules/.vite/deps/;
+ * only `vite dev` does. Events with such frames come from a fork or modified
+ * build running a dev server against our baked DSN (WEB-V/W/Y/Z), and they
+ * pollute release health under our own release tag. Not ours to triage.
+ */
+const DEV_SERVER_FRAME = "/node_modules/.vite/";
+
+function hasDevServerFrames(event: AnyEvent): boolean {
+  const values = asObj(event.exception)?.values;
+  if (!Array.isArray(values)) return false;
+  for (const entry of values) {
+    const frames = asObj(asObj(entry)?.stacktrace)?.frames;
+    if (!Array.isArray(frames)) continue;
+    for (const f of frames) {
+      const frame = asObj(f);
+      if (typeof frame?.filename === "string" && frame.filename.includes(DEV_SERVER_FRAME)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 export const DENY_URLS: RegExp[] = [
   /^chrome-extension:\/\//,
@@ -96,6 +124,8 @@ export function buildWebBeforeSend(isActive: () => boolean) {
       sentInWindow = 0;
     }
     if (++sentInWindow > CEILING_PER_HOUR) return null;
+
+    if (hasDevServerFrames(event)) return null;
 
     // Dropped: these surfaces can carry user data or PII.
     event.message = undefined;

--- a/tests/unit/web/sentry-scrub.test.ts
+++ b/tests/unit/web/sentry-scrub.test.ts
@@ -10,6 +10,63 @@ describe("static filter lists", () => {
   });
 });
 
+describe("noise filters for non-app code", () => {
+  const matchesIgnore = (message: string) =>
+    IGNORE_ERRORS.some((p) => (typeof p === "string" ? message.includes(p) : p.test(message)));
+
+  // Sentry WEB-J: crypto-wallet extensions poke window.ethereum into every page.
+  it("ignores wallet-extension injections", () => {
+    expect(
+      matchesIgnore("undefined is not an object (evaluating 'window.ethereum.selectedAddress')"),
+    ).toBe(true);
+  });
+
+  // Sentry WEB-M: injected code referencing globals that do not exist here.
+  it("ignores the EmptyRanges injected-global error", () => {
+    expect(matchesIgnore("Can't find variable: EmptyRanges")).toBe(true);
+  });
+
+  // Sentry WEB-V/W/Y/Z: a fork running `vite dev` with our baked DSN reports
+  // stacks through /node_modules/.vite/deps/, which no production build of
+  // ours ever produces. Their errors are not ours to triage.
+  it("drops events whose frames come from a vite dev server", () => {
+    const send = buildWebBeforeSend(() => true);
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "useMaterialStore.getState(...).setToken is not a function",
+            stacktrace: {
+              frames: [
+                { filename: "http://localhost:5173/node_modules/.vite/deps/react-dom_client.js" },
+                { filename: "/src/pages/home-page.tsx" },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    expect(send(event, { originalException: new TypeError("x") })).toBeNull();
+  });
+
+  it("keeps events whose frames come from our built bundle", () => {
+    const send = buildWebBeforeSend(() => true);
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "real bug",
+            stacktrace: { frames: [{ filename: "http://192.168.0.4:1349/assets/app.js" }] },
+          },
+        ],
+      },
+    };
+    expect(send(event, { originalException: new TypeError("x") })).not.toBeNull();
+  });
+});
+
 describe("buildWebBeforeSend", () => {
   const baseEvent = (over: Record<string, any> = {}): Record<string, any> => ({
     request: { url: "http://192.168.0.4:1349/image/resize" },


### PR DESCRIPTION
Follow-up to the extension filtering already on main (`IGNORE_ERRORS`/`DENY_URLS` in `sentry-scrub.ts`), closing the gaps the 2026-08-18 triage found:

- `window.ethereum` injections from crypto-wallet extensions (Sentry WEB-J)
- `EmptyRanges` injected-global lookups (WEB-M)
- events whose stack frames reference `/node_modules/.vite/`: only `vite dev` serves those paths, and our dev builds carry placeholder DSNs, so any such event is a fork or modified build running a dev server against our production DSN (WEB-V, WEB-W, WEB-Y, WEB-Z, all reporting `useMaterialStore`/`MaterialLibraryModal` code that doesn't exist in this repo, under our own 2.2.0 release tag)

Deliberately NOT filtered: the react `insertBefore`/`removeChild` NotFoundError cluster. Translate extensions cause most of it, but a real bug in our portal/modal code would look identical, so a message-based ignore would hide our own crashes. The frame-origin heuristic here only drops what our production build cannot produce.

Tests: four new cases in `tests/unit/web/sentry-scrub.test.ts` (both new ignore patterns, the dev-frame drop, and a keeps-our-bundle control). The sentry/analytics suites pass.

Fixes #845