### PR TITLE
fix(api): stream tool outputs over 1.5 GiB instead of crashing on the 2 GiB read cap

### DIFF
--- a/apps/api/src/jobs/output-resolve.ts
+++ b/apps/api/src/jobs/output-resolve.ts
@@ -20,7 +20,7 @@ export type ResolvedOutput =
 
 export async function resolveOutputSource(
   out: { buffer?: Buffer; scratchPath?: string },
-  label: string,
+  missingSourceMessage: string,
   opts: { maxBufferedBytes?: number } = {},
 ): Promise<ResolvedOutput> {
   if (out.buffer) {
@@ -33,5 +33,7 @@ export async function resolveOutputSource(
     }
     return { kind: "buffer", buffer: await readFile(out.scratchPath), size };
   }
-  throw new Error(`${label} returned neither buffer nor scratchPath`);
+  // The caller supplies its full historical message; integration tests and
+  // logs pin these strings per call site.
+  throw new Error(missingSourceMessage);
 }

--- a/apps/api/src/jobs/output-resolve.ts
+++ b/apps/api/src/jobs/output-resolve.ts
@@ -1,0 +1,37 @@
+/**
+ * Decide how a tool's output travels to object storage.
+ *
+ * Node's fs.readFile refuses single reads at 2 GiB (ERR_FS_FILE_TOO_LARGE),
+ * so buffering every scratchPath result crashed long video jobs after the
+ * encode itself had succeeded (Sentry NODE-2Z). Anything over the cap stays
+ * on disk and is streamed with putObjectStream; everything under it buffers
+ * exactly as before, keeping previews, PDF scrubbing, and library auto-save
+ * untouched for the sizes they actually serve.
+ */
+
+import { readFile, stat } from "node:fs/promises";
+
+/** 1.5 GiB: safely under Node's 2 GiB single-read limit, with margin. */
+export const MAX_BUFFERED_OUTPUT_BYTES = 1.5 * 1024 ** 3;
+
+export type ResolvedOutput =
+  | { kind: "buffer"; buffer: Buffer; size: number }
+  | { kind: "stream"; scratchPath: string; size: number };
+
+export async function resolveOutputSource(
+  out: { buffer?: Buffer; scratchPath?: string },
+  label: string,
+  opts: { maxBufferedBytes?: number } = {},
+): Promise<ResolvedOutput> {
+  if (out.buffer) {
+    return { kind: "buffer", buffer: out.buffer, size: out.buffer.length };
+  }
+  if (out.scratchPath) {
+    const size = (await stat(out.scratchPath)).size;
+    if (size > (opts.maxBufferedBytes ?? MAX_BUFFERED_OUTPUT_BYTES)) {
+      return { kind: "stream", scratchPath: out.scratchPath, size };
+    }
+    return { kind: "buffer", buffer: await readFile(out.scratchPath), size };
+  }
+  throw new Error(`${label} returned neither buffer nor scratchPath`);
+}

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -21,7 +21,8 @@
  * are deferred until the final attempt so intermediate retries stay
  * invisible to the client.
  */
-import { mkdir, readFile, rm } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
@@ -88,6 +89,7 @@ import { isBatchCanceled, readBatchCounters, recordChildOutcome } from "./batch-
 import { registerCancelable, unregisterCancelable } from "./cancel.js";
 import { createBullMQConnection } from "./connection.js";
 import { createMonotonicReporter } from "./monotonic-progress.js";
+import { resolveOutputSource } from "./output-resolve.js";
 import { autoSaveToLibrary, buildOutputName, generatePreview } from "./postprocess.js";
 import { runSystemJob } from "./system-jobs.js";
 import { POOLS, type Pool, queueName, type ToolJobData, type ToolJobResult } from "./types.js";
@@ -333,16 +335,23 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
       const ctx: ToolProcessCtx = { signal, scratchDir, report };
 
       // Dispatch: AI handler or standard tool registry
-      let resultBuffer: Buffer;
+      let resultBuffer: Buffer | null = null;
+      // Set instead of resultBuffer when the output exceeds the buffering cap
+      // (Sentry NODE-2Z): the scratch file streams to storage untouched.
+      let resultStreamPath: string | null = null;
+      let resultSize = 0;
       let resultFilename: string;
       let resultContentType: string;
       let resultPayload: Record<string, unknown> | undefined;
-      let extraOutputs: Array<{ name: string; buffer: Buffer; contentType: string }> | undefined;
+      let extraOutputs:
+        | Array<{ name: string; buffer?: Buffer; scratchPath?: string; contentType: string }>
+        | undefined;
 
       if (hasAiPathJobHandler(data.toolId)) {
         if (!pathInput) throw new Error(`No path-backed input for ${data.toolId}`);
         const aiResult = await runAiPathToolJob(data, pathInput, ctx);
         resultBuffer = aiResult.buffer;
+        resultSize = aiResult.buffer.length;
         resultFilename = aiResult.filename;
         resultContentType = aiResult.contentType;
         resultPayload = aiResult.resultPayload;
@@ -351,6 +360,7 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
         if (!inputBuffer) throw new Error(`No buffered input for ${data.toolId}`);
         const aiResult = await runAiToolJob(data, inputBuffer, ctx);
         resultBuffer = aiResult.buffer;
+        resultSize = aiResult.buffer.length;
         resultFilename = aiResult.filename;
         resultContentType = aiResult.contentType;
         resultPayload = aiResult.resultPayload;
@@ -369,14 +379,15 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
           report,
         });
 
-        // Resolve buffer OR scratchPath for the primary output
-        if (result.buffer) {
-          resultBuffer = result.buffer;
-        } else if (result.scratchPath) {
-          resultBuffer = await readFile(result.scratchPath);
+        // Resolve buffer OR scratchPath for the primary output. Over-cap
+        // scratch files stay on disk and stream to storage below.
+        const primary = await resolveOutputSource(result, `Tool ${data.toolId}`);
+        if (primary.kind === "buffer") {
+          resultBuffer = primary.buffer;
         } else {
-          throw new Error(`Tool ${data.toolId} returned neither buffer nor scratchPath`);
+          resultStreamPath = primary.scratchPath;
         }
+        resultSize = primary.size;
         resultFilename = result.filename;
         resultContentType = result.contentType;
         resultPayload = result.resultPayload;
@@ -385,15 +396,14 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
         if (result.extraOutputs) {
           extraOutputs = await Promise.all(
             result.extraOutputs.map(async (extra) => {
-              let buf: Buffer;
-              if (extra.buffer) {
-                buf = extra.buffer;
-              } else if (extra.scratchPath) {
-                buf = await readFile(extra.scratchPath);
-              } else {
-                throw new Error(`Extra output "${extra.name}" has neither buffer nor scratchPath`);
-              }
-              return { name: extra.name, buffer: buf, contentType: extra.contentType };
+              const source = await resolveOutputSource(extra, `Extra output "${extra.name}"`);
+              return source.kind === "buffer"
+                ? { name: extra.name, buffer: source.buffer, contentType: extra.contentType }
+                : {
+                    name: extra.name,
+                    scratchPath: source.scratchPath,
+                    contentType: extra.contentType,
+                  };
             }),
           );
         }
@@ -410,45 +420,74 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
       // Generated PDFs carry the conversion engine's name as Producer/Creator
       // (LibreOffice, Ghostscript, pdfcpu, ...); stamp SnapOtter instead.
       // Best effort: a failed scrub keeps the original bytes.
-      if (SCRUB_PDF_PRODUCER_TOOLS.has(data.toolId) && outName.toLowerCase().endsWith(".pdf")) {
+      if (
+        SCRUB_PDF_PRODUCER_TOOLS.has(data.toolId) &&
+        outName.toLowerCase().endsWith(".pdf") &&
+        resultBuffer
+      ) {
         resultBuffer = await scrubPdfProducer(resultBuffer);
+        resultSize = resultBuffer.length;
       }
 
       // Write primary output to object storage
       const primaryKey = `outputs/${jobId}/${outName}`;
-      await putObject(primaryKey, resultBuffer);
+      if (resultBuffer) {
+        await putObject(primaryKey, resultBuffer);
+      } else if (resultStreamPath) {
+        resultSize = await putObjectStream(primaryKey, createReadStream(resultStreamPath), {
+          signal,
+        });
+      }
       const outputRefs: string[] = [primaryKey];
 
       // Write extra outputs (AI tools may produce multiple files)
       if (extraOutputs) {
         for (const extra of extraOutputs) {
           const extraKey = `outputs/${jobId}/${extra.name}`;
-          const body =
-            SCRUB_PDF_PRODUCER_TOOLS.has(data.toolId) && extra.name.toLowerCase().endsWith(".pdf")
-              ? await scrubPdfProducer(extra.buffer)
-              : extra.buffer;
-          await putObject(extraKey, body);
+          if (extra.buffer) {
+            const body =
+              SCRUB_PDF_PRODUCER_TOOLS.has(data.toolId) && extra.name.toLowerCase().endsWith(".pdf")
+                ? await scrubPdfProducer(extra.buffer)
+                : extra.buffer;
+            await putObject(extraKey, body);
+          } else if (extra.scratchPath) {
+            // Over-cap extra: streamed as-is. The producer scrub needs bytes in
+            // memory, and no real PDF reaches the buffering cap.
+            await putObjectStream(extraKey, createReadStream(extra.scratchPath), { signal });
+          }
           outputRefs.push(extraKey);
         }
       }
 
-      // Generate preview for non-browser-previewable formats
-      const previewRef = await generatePreview(resultBuffer, resultContentType, jobId);
+      // Generate preview for non-browser-previewable formats. A streamed
+      // over-cap output ships without one: the poster pipeline needs the bytes
+      // in memory, and no preview beats no result.
+      const previewRef = resultBuffer
+        ? await generatePreview(resultBuffer, resultContentType, jobId)
+        : undefined;
 
       // Auto-save when the input came from the user's library (data.fileId is
       // set by the route when the upload referenced a library file). saveMode
       // picks between an independent new file (default) and a superseding
       // version. Without a fileId this is a no-op, so tool-first uploads are
       // not auto-saved.
-      const savedFileId = await autoSaveToLibrary({
-        fileId: data.fileId,
-        saveMode: data.saveMode,
-        userId: data.userId,
-        buffer: resultBuffer,
-        outName,
-        contentType: resultContentType,
-        toolId: data.toolId,
-      });
+      let savedFileId: string | undefined;
+      if (resultBuffer) {
+        savedFileId = await autoSaveToLibrary({
+          fileId: data.fileId,
+          saveMode: data.saveMode,
+          userId: data.userId,
+          buffer: resultBuffer,
+          outName,
+          contentType: resultContentType,
+          toolId: data.toolId,
+        });
+      } else if (data.fileId) {
+        logger.info(
+          { jobId, toolId: data.toolId, bytes: resultSize },
+          "output exceeds the buffering cap; skipping library auto-save",
+        );
+      }
 
       const durationMs = Date.now() - startTime;
 
@@ -458,7 +497,7 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
         filename: outName,
         contentType: resultContentType,
         originalSize,
-        processedSize: resultBuffer.length,
+        processedSize: resultSize,
         previewRef,
         savedFileId,
         resultPayload,
@@ -484,7 +523,7 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
               completedAt: new Date(),
               durationMs,
               bytesIn: originalSize,
-              bytesOut: resultBuffer.length,
+              bytesOut: resultSize,
               outputRefs,
               progress: { percent: 100, stage: "complete", result: legacyResult },
             })
@@ -505,7 +544,7 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
             status: "completed",
             output_format: safeFormatTag(outName) ?? "unknown",
             bytes_in: originalSize,
-            bytes_out: resultBuffer.length,
+            bytes_out: resultSize,
           },
           data.analyticsDistinctId,
         );

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -381,7 +381,10 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
 
         // Resolve buffer OR scratchPath for the primary output. Over-cap
         // scratch files stay on disk and stream to storage below.
-        const primary = await resolveOutputSource(result, `Tool ${data.toolId}`);
+        const primary = await resolveOutputSource(
+          result,
+          `Tool ${data.toolId} returned neither buffer nor scratchPath`,
+        );
         if (primary.kind === "buffer") {
           resultBuffer = primary.buffer;
         } else {
@@ -396,7 +399,10 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
         if (result.extraOutputs) {
           extraOutputs = await Promise.all(
             result.extraOutputs.map(async (extra) => {
-              const source = await resolveOutputSource(extra, `Extra output "${extra.name}"`);
+              const source = await resolveOutputSource(
+                extra,
+                `Extra output "${extra.name}" has neither buffer nor scratchPath`,
+              );
               return source.kind === "buffer"
                 ? { name: extra.name, buffer: source.buffer, contentType: extra.contentType }
                 : {

--- a/tests/unit/api/jobs/output-resolve.test.ts
+++ b/tests/unit/api/jobs/output-resolve.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  MAX_BUFFERED_OUTPUT_BYTES,
+  resolveOutputSource,
+} from "../../../../apps/api/src/jobs/output-resolve.js";
+
+/**
+ * Regression coverage for Sentry NODE-2Z: tool outputs over Node's 2 GiB
+ * fs.readFile cap crashed the job with ERR_FS_FILE_TOO_LARGE after the actual
+ * processing had already succeeded. Oversized scratch files must resolve to a
+ * streamable source instead of a buffer.
+ */
+describe("resolveOutputSource", () => {
+  let dir = "";
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+    dir = "";
+  });
+
+  async function scratchFile(bytes: number): Promise<string> {
+    dir = await mkdtemp(join(tmpdir(), "snapotter-output-resolve-"));
+    const p = join(dir, "out.bin");
+    await writeFile(p, Buffer.alloc(bytes, 7));
+    return p;
+  }
+
+  it("passes an in-memory buffer through untouched", async () => {
+    const buffer = Buffer.from("result-bytes");
+    const out = await resolveOutputSource({ buffer }, "tool x");
+
+    expect(out).toEqual({ kind: "buffer", buffer, size: buffer.length });
+  });
+
+  it("buffers a scratch file under the cap, as before", async () => {
+    const p = await scratchFile(4096);
+    const out = await resolveOutputSource({ scratchPath: p }, "tool x");
+
+    expect(out.kind).toBe("buffer");
+    expect(out.size).toBe(4096);
+    expect(out.kind === "buffer" && out.buffer.length).toBe(4096);
+  });
+
+  it("resolves an over-cap scratch file to a streamable source instead of buffering", async () => {
+    const p = await scratchFile(4096);
+    const out = await resolveOutputSource({ scratchPath: p }, "tool x", { maxBufferedBytes: 1024 });
+
+    expect(out).toEqual({ kind: "stream", scratchPath: p, size: 4096 });
+  });
+
+  it("throws a named error when neither buffer nor scratchPath is present", async () => {
+    await expect(resolveOutputSource({}, "tool x")).rejects.toThrow(
+      "tool x returned neither buffer nor scratchPath",
+    );
+  });
+
+  it("keeps the default cap under Node's 2 GiB single-read limit", () => {
+    expect(MAX_BUFFERED_OUTPUT_BYTES).toBeLessThan(2 ** 31);
+    // With margin: a result at the cap still has to survive readFile.
+    expect(MAX_BUFFERED_OUTPUT_BYTES).toBeLessThanOrEqual(1.5 * 1024 ** 3);
+  });
+});

--- a/tests/unit/api/jobs/output-resolve.test.ts
+++ b/tests/unit/api/jobs/output-resolve.test.ts
@@ -30,14 +30,14 @@ describe("resolveOutputSource", () => {
 
   it("passes an in-memory buffer through untouched", async () => {
     const buffer = Buffer.from("result-bytes");
-    const out = await resolveOutputSource({ buffer }, "tool x");
+    const out = await resolveOutputSource({ buffer }, "unused message");
 
     expect(out).toEqual({ kind: "buffer", buffer, size: buffer.length });
   });
 
   it("buffers a scratch file under the cap, as before", async () => {
     const p = await scratchFile(4096);
-    const out = await resolveOutputSource({ scratchPath: p }, "tool x");
+    const out = await resolveOutputSource({ scratchPath: p }, "unused message");
 
     expect(out.kind).toBe("buffer");
     expect(out.size).toBe(4096);
@@ -46,15 +46,19 @@ describe("resolveOutputSource", () => {
 
   it("resolves an over-cap scratch file to a streamable source instead of buffering", async () => {
     const p = await scratchFile(4096);
-    const out = await resolveOutputSource({ scratchPath: p }, "tool x", { maxBufferedBytes: 1024 });
+    const out = await resolveOutputSource({ scratchPath: p }, "unused message", {
+      maxBufferedBytes: 1024,
+    });
 
     expect(out).toEqual({ kind: "stream", scratchPath: p, size: 4096 });
   });
 
-  it("throws a named error when neither buffer nor scratchPath is present", async () => {
-    await expect(resolveOutputSource({}, "tool x")).rejects.toThrow(
-      "tool x returned neither buffer nor scratchPath",
-    );
+  it("throws the caller's exact message when neither buffer nor scratchPath is present", async () => {
+    // Call sites pass their full historical strings; worker-branches
+    // integration tests pin them verbatim.
+    await expect(
+      resolveOutputSource({}, "Tool x returned neither buffer nor scratchPath"),
+    ).rejects.toThrow("Tool x returned neither buffer nor scratchPath");
   });
 
   it("keeps the default cap under Node's 2 GiB single-read limit", () => {


### PR DESCRIPTION
Sentry NODE-2Z: `RangeError: ERR_FS_FILE_TOO_LARGE` at the worker's `readFile(result.scratchPath)`. A 4K transcode clears Node's 2 GiB single-read cap without trying, so the job did all the encoding work and then failed at the copy step.

The decision lives in a new `resolveOutputSource` (`apps/api/src/jobs/output-resolve.ts`): a scratchPath result under 1.5 GiB buffers exactly as before, so previews, the PDF producer scrub, and library auto-save are untouched for every size that used to work. Over the cap, the file stays on disk and streams to object storage through the existing `putObjectStream` (which already runs the capacity guards and returns the byte count, used for `processedSize`/`bytesOut`). Applies to the primary output and `extraOutputs` both.

Streamed outputs ship without a poster preview and skip library auto-save: both paths need the bytes in memory, and these jobs previously could not complete at all. The auto-save skip logs with jobId and size. Multi-GiB intermediates inside pipelines are unchanged by this PR (separate buffering path).

Tests: five unit cases on `resolveOutputSource` (buffer passthrough, under-cap buffering, over-cap streaming with a lowered cap injected, the neither-source error, and a pin that the default cap stays under 2^31). `tests/unit/api/jobs/` all pass (156 tests), `tsc --noEmit` clean, and the resize + trim-video integration specs run green through the real worker (23 tests, exercising both the buffer and scratchPath flows end-to-end).

Fixes #841