### PR TITLE
fix(doc-engine): stop MuPDF stdout noise from failing completed doc conversions

### DIFF
--- a/packages/ai/python/doc_to_word.py
+++ b/packages/ai/python/doc_to_word.py
@@ -18,6 +18,16 @@ def main():
         print(json.dumps({"error": "pdf2docx not installed"}))
         sys.exit(1)
     try:
+        # PyMuPDF's message system writes to sys.stdout by default, and MuPDF
+        # errors ("error: No common ancestor in structure tree") are routed
+        # through it. This stdout is a one-JSON-line protocol; keep library
+        # diagnostics on stderr (issue #843, Sentry NODE-5M).
+        import pymupdf
+
+        pymupdf.set_messages(stream=sys.stderr)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
         install_pdf2docx_layout_fixes()
         cv = Converter(path)
         try:

--- a/packages/doc-engine/src/python-docs.ts
+++ b/packages/doc-engine/src/python-docs.ts
@@ -14,6 +14,21 @@ function parseDocsJson<T>(script: string, stdout: string): T {
   try {
     return JSON.parse(trimmed) as T;
   } catch {
+    // MuPDF's C-level printer writes "error: ..." lines to the same stdout the
+    // JSON contract uses (pdf2docx and the PyMuPDF scripts both drive MuPDF),
+    // ahead of the script's single JSON line. Walk the lines from the end and
+    // take the last one that parses, so library noise cannot turn a completed
+    // conversion into a failure (Sentry NODE-5M).
+    const lines = trimmed.split("\n");
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim();
+      if (!line.startsWith("{")) continue;
+      try {
+        return JSON.parse(line) as T;
+      } catch {
+        // fall through to the earlier lines
+      }
+    }
     throw new SafeError("Document tool returned non-JSON output", {
       kind: "bug",
       code: script,

--- a/tests/unit/doc-engine/python-docs-parse.test.ts
+++ b/tests/unit/doc-engine/python-docs-parse.test.ts
@@ -7,7 +7,11 @@ vi.mock("@snapotter/ai", () => ({
 }));
 
 import { isSafeMessageError } from "@snapotter/shared";
-import { pdfPageCountPy, pdfRedactPy } from "../../../packages/doc-engine/src/python-docs.js";
+import {
+  pdfPageCountPy,
+  pdfRedactPy,
+  pdfToWordPy,
+} from "../../../packages/doc-engine/src/python-docs.js";
 
 /** Flatten an error's message, code, and cause-chain messages into one string. */
 function errorText(err: unknown): string {
@@ -25,6 +29,29 @@ function errorText(err: unknown): string {
 describe("python-docs sidecar JSON parsing", () => {
   beforeEach(() => {
     runDocsScript.mockReset();
+  });
+
+  // MuPDF's C-level printer writes "error: ..." lines to stdout ahead of the
+  // script's one JSON line (pdf2docx drives PyMuPDF). Sentry NODE-5M: those
+  // lines broke the whole parse and a successful conversion reported as
+  // "Document tool returned non-JSON output".
+  it("finds the JSON line under library noise on stdout", async () => {
+    runDocsScript.mockResolvedValue(
+      "error: No common ancestor in structure tree\n" +
+        "error: No common ancestor in structure tree\n" +
+        JSON.stringify({ ok: true }),
+    );
+    await expect(pdfToWordPy("/in.pdf", "/out.docx")).resolves.toBeUndefined();
+  });
+
+  it("surfaces the script's real error line under library noise", async () => {
+    runDocsScript.mockResolvedValue(
+      "error: No common ancestor in structure tree\n" +
+        JSON.stringify({ error: "conversion failed on page 3" }),
+    );
+    await expect(pdfToWordPy("/in.pdf", "/out.docx")).rejects.toThrow(
+      "conversion failed on page 3",
+    );
   });
 
   it("parses valid JSON output normally", async () => {


### PR DESCRIPTION
Sentry NODE-5M: `SafeError: Document tool returned non-JSON output` from pdf-to-word, with the sidecar's stdout full of MuPDF's `error: No common ancestor in structure tree` lines. Root cause per PyMuPDF's docs: its message system defaults to `sys.stdout`, and MuPDF errors are displayed through it. Our docs-sidecar contract is one JSON line on stdout, so a PDF whose structure tree makes MuPDF complain corrupted the protocol even when the conversion itself completed.

Two layers:

- `parseDocsJson` (`packages/doc-engine/src/python-docs.ts`) now falls back to scanning stdout from the last line and parsing the last JSON object line. Every `doc_*` script prints its result as the final line, so this covers all ten scripts on both the dispatcher and per-request fallback paths. When no line parses, the existing SafeError with captured stdout is unchanged.
- `doc_to_word.py` calls `pymupdf.set_messages(stream=sys.stderr)` so the noise lands on the diagnostic channel to begin with (guarded try/except; verified against PyMuPDF's documented `set_messages` API, since the library isn't installed outside the container venv).

If a structure-tree PDF turns out to also hard-fail the pdf2docx conversion (the Sentry payload could not distinguish this), the failure now surfaces with the script's real error message instead of "non-JSON output", which makes a targeted follow-up debuggable.

Tests: two new cases pin JSON-under-noise for both the success and error line shapes (they reproduce the NODE-5M failure before the fix); `tests/unit/doc-engine` passes (14 tests) and the python file compiles.

Fixes #843