### PR TITLE
fix(landing): stop the sticky mobile CTA bar flickering on phones

### DIFF
--- a/apps/landing/src/components/StickyMobileCta.astro
+++ b/apps/landing/src/components/StickyMobileCta.astro
@@ -25,9 +25,12 @@ const { locale = "en" } = Astro.props;
       Generous by a hair on purpose; a small gap beats clipping content. */}
   <div style="height: calc(4.5rem + env(safe-area-inset-bottom));" aria-hidden="true"></div>
 
+  {/* Opaque on purpose, no backdrop-filter: blur on a bottom-fixed bar
+      flickers and stutters on phones while the browser repositions it
+      during the URL-bar collapse animation (guarded by e2e). */}
   <div
     id="mobile-cta"
-    class="fixed inset-x-0 bottom-0 z-40 flex gap-2 border-t border-border bg-surface/95 px-4 py-3 backdrop-blur-xl"
+    class="fixed inset-x-0 bottom-0 z-40 flex gap-2 border-t border-border bg-surface px-4 py-3"
     style="padding-bottom: max(0.75rem, env(safe-area-inset-bottom));"
   >
     <a

--- a/tests/e2e-landing/sticky-mobile-cta.spec.ts
+++ b/tests/e2e-landing/sticky-mobile-cta.spec.ts
@@ -24,6 +24,30 @@ test.describe("Sticky mobile CTA", () => {
     );
   });
 
+  test("stays cheap to composite: no backdrop blur, opaque background", async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await page.goto("/");
+
+    // Regression guard: backdrop-filter on a bottom-fixed bar flickers and lags
+    // on phones while the browser repositions it during URL-bar collapse. The
+    // bar must stay a plain opaque layer so the compositor can keep it glued
+    // to the bottom edge.
+    const bar = page.locator("#mobile-cta");
+    const { backdropFilter, alpha } = await bar.evaluate((el) => {
+      const style = getComputedStyle(el);
+      const bg = style.backgroundColor;
+      const slash = bg.match(/\/\s*([\d.]+)\s*\)$/);
+      const rgba = bg.match(/^rgba\([^,]+,[^,]+,[^,]+,\s*([\d.]+)\s*\)$/);
+      const parsed = slash ?? rgba;
+      return {
+        backdropFilter: style.backdropFilter,
+        alpha: parsed ? Number.parseFloat(parsed[1]) : 1,
+      };
+    });
+    expect(backdropFilter).toBe("none");
+    expect(alpha).toBe(1);
+  });
+
   test("is hidden on desktop where the navbar CTAs are already visible", async ({ page }) => {
     await page.setViewportSize(DESKTOP);
     await page.goto("/");


### PR DESCRIPTION
## What

The sticky mobile CTA bar from #806 flickered and stuttered on phones, seen on more than one device. The culprit was `backdrop-blur-xl` on the fixed bar: a 24px backdrop blur makes the GPU re-sample everything behind the bar on every frame while the page scrolls under it, and again while the browser repositions the bar during the URL-bar collapse animation. The background was already 95% opaque, so the blur was paying that cost for close to no visible effect.

Two class changes: `backdrop-blur-xl` is gone and `bg-surface/95` is now solid `bg-surface`. The bar composites as a plain opaque layer the browser can keep glued to the bottom edge. It still rides with the browser toolbar as it collapses (every fixed bottom bar does), but the flicker and stutter go with the blur. A comment on the element records why, so the blur doesn't come back for looks.

## Verification

- New e2e in `tests/e2e-landing/sticky-mobile-cta.spec.ts` asserting the bar has no backdrop-filter and a fully opaque background. Written first, watched it fail on the old classes.
- Full landing suite green: 130 passed. `biome check` clean on both files.
- Eyeballed at 390px against dev: visually near-identical, footer still clears the bar.