### PR TITLE
fix(landing): slide the mobile CTA bar away while scrolling

### DIFF
--- a/apps/landing/src/components/StickyMobileCta.astro
+++ b/apps/landing/src/components/StickyMobileCta.astro
@@ -4,8 +4,13 @@
 // Persistent bottom CTA for phones. The navbar's CTAs live in its md:flex
 // desktop cluster and are hidden below md, so without this a phone visitor has
 // no call to action until they open the hamburger. Hidden again at md+, where
-// the navbar CTAs reappear. CSS-only, no client JS: it is always-visible while
-// mounted, so the responsive breakpoint alone decides when it shows.
+// the navbar CTAs reappear.
+//
+// A small scroll script slides the bar away while scrolling down and back on
+// scroll up or after scrolling stops. Mobile browsers re-anchor fixed bottom
+// elements when the URL bar collapses (and Android Chrome toggles
+// safe-area-inset-bottom with it), so an always-visible bar hops around
+// mid-scroll; keeping it off-screen during the scroll hides that.
 //
 // Actions mirror what the hero and navbar already offer, reusing their i18n
 // keys so no new strings are needed: "Try the live demo" (lowest friction) and
@@ -30,7 +35,7 @@ const { locale = "en" } = Astro.props;
       during the URL-bar collapse animation (guarded by e2e). */}
   <div
     id="mobile-cta"
-    class="fixed inset-x-0 bottom-0 z-40 flex gap-2 border-t border-border bg-surface px-4 py-3"
+    class="fixed inset-x-0 bottom-0 z-40 flex gap-2 border-t border-border bg-surface px-4 py-3 transition-transform duration-300 motion-reduce:transition-none"
     style="padding-bottom: max(0.75rem, env(safe-area-inset-bottom));"
   >
     <a
@@ -51,3 +56,28 @@ const { locale = "en" } = Astro.props;
     </a>
   </div>
 </div>
+
+<script>
+  const bar = document.getElementById("mobile-cta");
+  if (bar) {
+    let lastY = window.scrollY;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    const show = () => bar.classList.remove("translate-y-full");
+    const hide = () => bar.classList.add("translate-y-full");
+    window.addEventListener(
+      "scroll",
+      () => {
+        const y = window.scrollY;
+        const delta = y - lastY;
+        lastY = y;
+        clearTimeout(idleTimer);
+        idleTimer = setTimeout(show, 1000);
+        // Small deltas are jitter from the URL-bar resize itself; reacting
+        // to them would re-trigger the exact hop this script exists to hide.
+        if (y <= 0 || delta < -4) show();
+        else if (delta > 4) hide();
+      },
+      { passive: true },
+    );
+  }
+</script>

--- a/tests/e2e-landing/sticky-mobile-cta.spec.ts
+++ b/tests/e2e-landing/sticky-mobile-cta.spec.ts
@@ -48,6 +48,48 @@ test.describe("Sticky mobile CTA", () => {
     expect(alpha).toBe(1);
   });
 
+  // The bar auto-hides while scrolling down so the browser's URL-bar
+  // collapse (which re-anchors every fixed bottom element and toggles
+  // safe-area-inset-bottom on Android Chrome) never moves it in view.
+  // Shown/hidden is judged by bounding box, not class names: hidden means
+  // the bar's top is at or below the viewport's bottom edge.
+  const barTop = (page: import("@playwright/test").Page) =>
+    page
+      .locator("#mobile-cta")
+      .boundingBox()
+      .then((box) => box?.y ?? Number.POSITIVE_INFINITY);
+
+  test("slides away while scrolling down and back on scroll up", async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await page.goto("/");
+    await expect(page.locator("#mobile-cta")).toBeVisible();
+
+    // Two spaced scroll steps keep the idle-reveal timer from firing while
+    // we assert the hidden state.
+    await page.evaluate(() => window.scrollBy(0, 900));
+    await page.waitForTimeout(200);
+    await page.evaluate(() => window.scrollBy(0, 300));
+    await expect
+      .poll(() => barTop(page), { timeout: 2000 })
+      .toBeGreaterThanOrEqual(PHONE.height - 1);
+
+    await page.evaluate(() => window.scrollBy(0, -300));
+    await expect.poll(() => barTop(page), { timeout: 2000 }).toBeLessThan(PHONE.height);
+  });
+
+  test("slides back on its own once scrolling stops", async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await page.goto("/");
+
+    await page.evaluate(() => window.scrollBy(0, 1200));
+    await expect
+      .poll(() => barTop(page), { timeout: 2000 })
+      .toBeGreaterThanOrEqual(PHONE.height - 1);
+
+    // No further scrolling: the idle timer should bring the bar back.
+    await expect.poll(() => barTop(page), { timeout: 4000 }).toBeLessThan(PHONE.height);
+  });
+
   test("is hidden on desktop where the navbar CTAs are already visible", async ({ page }) => {
     await page.setViewportSize(DESKTOP);
     await page.goto("/");


### PR DESCRIPTION
## What

Follow-up to #860. The bar no longer flickers, but it still hops on phones: mobile browsers re-anchor fixed bottom elements when the URL bar collapses or returns, and newer Android Chrome toggles `safe-area-inset-bottom` between those two states, so the bar jumps and its bottom padding changes height mid-scroll. Screenshots from a Galaxy on Chrome show the buttons at two different heights depending on toolbar state. No CSS pins an element to the glass through that animation; the browser owns the bottom edge.

So the bar gets out of the way instead. A small scroll script (same inline-script pattern as HeroSearch) slides it off-screen while scrolling down and back in on scroll up, or one second after scrolling stops. The browser's re-anchoring happens while the bar is out of view. Sub-4px scroll deltas are ignored because the URL-bar resize itself fires scroll events, which would otherwise re-trigger the exact hop this hides. Reduced-motion users get an instant toggle instead of the 300ms slide.

## Verification

- Two new e2e tests in `tests/e2e-landing/sticky-mobile-cta.spec.ts`: hide on scroll down plus return on scroll up, and the idle reveal. Written first, both failing before the script existed. Shown/hidden is judged by bounding box, not class names.
- Ran the spec with `--repeat-each=3` to check the timing-sensitive tests for flake: 18/18.
- Full landing suite green: 132 passed. `biome check` clean on both files.