### PR TITLE
fix(auth): fail closed when the MFA policy read fails during login

### DIFF
--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -25,6 +25,7 @@ import {
   isDisabledRole,
   requirePermission,
 } from "../permissions.js";
+import type { ExternalMfaOutcome, MfaPolicy } from "./mfa.js";
 
 const scryptAsync = promisify(scrypt);
 
@@ -476,13 +477,34 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(403).send({ error: "User is disabled", code: "USER_DISABLED" });
       }
 
+      // Two failures used to share one silent catch here and they want
+      // opposite defaults (#815). The import failing means the MFA plugin
+      // isn't part of this build at all, so logins stay policy-free (an
+      // enrolled user still gets the TOTP challenge below). A loaded module
+      // whose policy READ fails is different: the stored policy may well be
+      // "required", so the read failure maps to the "unavailable" sentinel
+      // and unenrolled users fail closed instead of skipping the policy.
+      let mfaOutcome: ExternalMfaOutcome = user.totpEnabled ? "challenge" : "proceed";
       let mfaRequiredByPolicy = false;
+      let mfaModule: typeof import("./mfa.js") | undefined;
       try {
-        const { getMfaPolicy, isMfaRequiredForUser } = await import("./mfa.js");
-        const policy = await getMfaPolicy();
-        mfaRequiredByPolicy = isMfaRequiredForUser(policy, user.role);
+        mfaModule = await import("./mfa.js");
       } catch {
         // MFA plugin not loaded
+      }
+      if (mfaModule) {
+        let policy: MfaPolicy | "unavailable" = "unavailable";
+        try {
+          policy = await mfaModule.getMfaPolicy();
+        } catch (err) {
+          request.log.error({ err, userId: user.id }, "login: failed to read the MFA policy");
+        }
+        mfaOutcome = mfaModule.resolveExternalLoginMfaOutcome(policy, user.role, user.totpEnabled);
+        // Informational flag for the challenge response below; when the read
+        // failed it stays false, which only affects display -- enforcement
+        // for enrolled users is the challenge itself.
+        mfaRequiredByPolicy =
+          policy !== "unavailable" && mfaModule.isMfaRequiredForUser(policy, user.role);
       }
 
       // ── MFA challenge ──────────────────────────────────────────
@@ -500,7 +522,23 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         });
       }
 
-      if (mfaRequiredByPolicy) {
+      if (mfaOutcome === "policy_unavailable") {
+        // Only unenrolled users land here (enrolled ones were challenged
+        // above). Denying with a distinct retryable code beats minting a
+        // policy-exempt session off a transient settings fault (#815).
+        authAttempts.inc({ method: "password", result: "failure" });
+        await audit("LOGIN_FAILED", {
+          userId: user.id,
+          username: user.username,
+          reason: "mfa_policy_unavailable",
+        });
+        return reply.status(503).send({
+          error: "The MFA policy could not be checked. Please try again.",
+          code: "MFA_POLICY_UNAVAILABLE",
+        });
+      }
+
+      if (mfaOutcome === "enrollment_required") {
         // Licensed instances walk the user through enrollment right here instead
         // of hard-blocking, so a required policy cannot strand a not-yet-enrolled
         // user (snapotter-hq/SnapOtter#811). Unlicensed instances (a policy stored

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -9,6 +9,7 @@ import { db, schema } from "../db/index.js";
 import { sharedRedis } from "../jobs/connection.js";
 import { trackEvent } from "../lib/analytics.js";
 import { auditFromRequest, sanitizeAuditInput } from "../lib/audit.js";
+import { reportError } from "../lib/error-report.js";
 import {
   checkLoginThrottle,
   clearLoginFailures,
@@ -478,19 +479,23 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       }
 
       // Two failures used to share one silent catch here and they want
-      // opposite defaults (#815). The import failing means the MFA plugin
-      // isn't part of this build at all, so logins stay policy-free (an
-      // enrolled user still gets the TOTP challenge below). A loaded module
-      // whose policy READ fails is different: the stored policy may well be
-      // "required", so the read failure maps to the "unavailable" sentinel
-      // and unenrolled users fail closed instead of skipping the policy.
+      // opposite defaults (#815). A missing MFA module keeps logins
+      // policy-free (an enrolled user still gets the TOTP challenge below).
+      // A loaded module whose policy READ fails is different: the stored
+      // policy may well be "required", so the read failure maps to the
+      // "unavailable" sentinel and unenrolled users fail closed instead of
+      // skipping the policy.
       let mfaOutcome: ExternalMfaOutcome = user.totpEnabled ? "challenge" : "proceed";
       let mfaRequiredByPolicy = false;
       let mfaModule: typeof import("./mfa.js") | undefined;
       try {
         mfaModule = await import("./mfa.js");
-      } catch {
-        // MFA plugin not loaded
+      } catch (err) {
+        // Unreachable today: index.ts imports mfa.js statically at boot, so a
+        // broken module means the server never started. Kept as a guard for a
+        // future conditional registration; if it ever fires, logins proceed
+        // policy-free, which must never be silent.
+        request.log.error({ err }, "login: MFA module failed to load; proceeding without policy");
       }
       if (mfaModule) {
         let policy: MfaPolicy | "unavailable" = "unavailable";
@@ -498,6 +503,16 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
           policy = await mfaModule.getMfaPolicy();
         } catch (err) {
           request.log.error({ err, userId: user.id }, "login: failed to read the MFA policy");
+          // request.log has no Sentry bridge, and by catching here the error
+          // never reaches the global handler's reportError. Report explicitly
+          // so a settings fault denying logins is visible in triage.
+          void reportError(err, {
+            source: "http",
+            route: request.routeOptions?.url,
+            method: request.method,
+            statusCode: 503,
+            subsystem: "mfa-policy",
+          });
         }
         mfaOutcome = mfaModule.resolveExternalLoginMfaOutcome(policy, user.role, user.totpEnabled);
         // Informational flag for the challenge response below; when the read
@@ -522,22 +537,6 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         });
       }
 
-      if (mfaOutcome === "policy_unavailable") {
-        // Only unenrolled users land here (enrolled ones were challenged
-        // above). Denying with a distinct retryable code beats minting a
-        // policy-exempt session off a transient settings fault (#815).
-        authAttempts.inc({ method: "password", result: "failure" });
-        await audit("LOGIN_FAILED", {
-          userId: user.id,
-          username: user.username,
-          reason: "mfa_policy_unavailable",
-        });
-        return reply.status(503).send({
-          error: "The MFA policy could not be checked. Please try again.",
-          code: "MFA_POLICY_UNAVAILABLE",
-        });
-      }
-
       if (mfaOutcome === "enrollment_required") {
         // Licensed instances walk the user through enrollment right here instead
         // of hard-blocking, so a required policy cannot strand a not-yet-enrolled
@@ -559,6 +558,26 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(403).send({
           error: "MFA enrollment is required before login",
           code: "MFA_ENROLLMENT_REQUIRED",
+        });
+      }
+
+      if (mfaOutcome !== "proceed") {
+        // "policy_unavailable" today, and by construction any future outcome
+        // variant nobody wires up here: only an explicit "proceed" reaches
+        // session creation, so drift fails closed instead of recreating
+        // #815's fail-open. Only unenrolled users can land here (enrolled
+        // ones were challenged above); the distinct retryable code beats
+        // minting a policy-exempt session off a transient settings fault.
+        authAttempts.inc({ method: "password", result: "failure" });
+        void trackEvent(ANALYTICS_EVENTS.AUTH_LOGIN_FAILED, { method: "password" });
+        await audit("LOGIN_FAILED", {
+          userId: user.id,
+          username: user.username,
+          reason: "mfa_policy_unavailable",
+        });
+        return reply.status(503).send({
+          error: "The MFA policy could not be checked. Please try again.",
+          code: "MFA_POLICY_UNAVAILABLE",
         });
       }
 

--- a/apps/api/src/plugins/mfa.ts
+++ b/apps/api/src/plugins/mfa.ts
@@ -8,6 +8,7 @@ import { db, schema } from "../db/index.js";
 import { sharedRedis } from "../jobs/connection.js";
 import { auditFromRequest } from "../lib/audit.js";
 import { decrypt, encrypt } from "../lib/encryption.js";
+import { logger } from "../lib/logger.js";
 import { clearUserMfa } from "../lib/user-mfa.js";
 import {
   canManageTargetRole,
@@ -120,6 +121,15 @@ export async function getMfaPolicy(): Promise<MfaPolicy> {
     .limit(1);
   const raw = result[0]?.value;
   if (raw === "required" || raw === "admins_only") return raw;
+  if (raw !== undefined && raw !== "optional") {
+    // Writes are Zod-validated, so an unrecognized stored value means the DB
+    // was modified out of band. Treating it as "optional" disarms the policy,
+    // which must at least be loud (it is indistinguishable from tampering).
+    logger.warn(
+      { value: raw },
+      "mfaPolicy setting holds an unrecognized value; treating as optional",
+    );
+  }
   return "optional";
 }
 

--- a/apps/api/src/plugins/mfa.ts
+++ b/apps/api/src/plugins/mfa.ts
@@ -8,7 +8,6 @@ import { db, schema } from "../db/index.js";
 import { sharedRedis } from "../jobs/connection.js";
 import { auditFromRequest } from "../lib/audit.js";
 import { decrypt, encrypt } from "../lib/encryption.js";
-import { getSettingString } from "../lib/settings-helpers.js";
 import { clearUserMfa } from "../lib/user-mfa.js";
 import {
   canManageTargetRole,
@@ -110,7 +109,16 @@ async function decryptSecret(stored: string): Promise<string | null> {
 export type MfaPolicy = "optional" | "admins_only" | "required";
 
 export async function getMfaPolicy(): Promise<MfaPolicy> {
-  const raw = await getSettingString("mfaPolicy", "optional");
+  // Deliberately not getSettingString: that helper swallows DB errors into
+  // its default, which would silently disarm a required policy whenever the
+  // settings read fails (#815). A missing row legitimately means "optional";
+  // a failed read must throw so login paths can fail closed.
+  const result = await db
+    .select({ value: schema.settings.value })
+    .from(schema.settings)
+    .where(eq(schema.settings.key, "mfaPolicy"))
+    .limit(1);
+  const raw = result[0]?.value;
   if (raw === "required" || raw === "admins_only") return raw;
   return "optional";
 }
@@ -125,14 +133,26 @@ export function isMfaRequiredForUser(policy: MfaPolicy, userRole: string): boole
 // password, OIDC, SAML) so a new auth method can't silently diverge from the
 // others the way OIDC/SAML once did (they blocked on policy alone, with no
 // totpEnabled check and no challenge step -- snapotter-hq/SnapOtter#533).
-export type ExternalMfaOutcome = "proceed" | "challenge" | "enrollment_required";
+//
+// "unavailable" is the fail-closed sentinel for a failed policy READ (#815):
+// callers map a getMfaPolicy() rejection to it instead of guessing a policy.
+// An unenrolled user is then denied ("policy_unavailable"), because the
+// stored policy may well be "required". An enrolled user still gets the
+// challenge: TOTP is at least as strict as any policy, so a flaky settings
+// read can't lock out enrolled users (including the admin, mid-incident).
+export type ExternalMfaOutcome =
+  | "proceed"
+  | "challenge"
+  | "enrollment_required"
+  | "policy_unavailable";
 
 export function resolveExternalLoginMfaOutcome(
-  policy: MfaPolicy,
+  policy: MfaPolicy | "unavailable",
   userRole: string,
   totpEnabled: boolean,
 ): ExternalMfaOutcome {
   if (totpEnabled) return "challenge";
+  if (policy === "unavailable") return "policy_unavailable";
   if (isMfaRequiredForUser(policy, userRole)) return "enrollment_required";
   return "proceed";
 }

--- a/apps/api/src/plugins/oidc.ts
+++ b/apps/api/src/plugins/oidc.ts
@@ -9,6 +9,7 @@ import { db, schema } from "../db/index.js";
 import { sharedRedis } from "../jobs/connection.js";
 import { trackEvent } from "../lib/analytics.js";
 import { auditFromRequest, sanitizeAuditInput } from "../lib/audit.js";
+import { reportError } from "../lib/error-report.js";
 import { resolveExternalUser, sanitizeUsername } from "../lib/external-auth-resolver.js";
 import { authAttempts } from "../lib/metrics.js";
 import { isSecureRequest } from "../lib/secure-cookie.js";
@@ -322,19 +323,26 @@ export async function oidcRoutes(app: FastifyInstance): Promise<void> {
       }
 
       // Two failures used to share one silent catch here and they want
-      // opposite defaults (#815). The import failing means the MFA plugin
-      // isn't part of this build at all, so the login stays policy-free (an
-      // enrolled user still gets the challenge below). A loaded module whose
-      // policy READ fails maps to the "unavailable" sentinel instead: the
-      // stored policy may well be "required", so unenrolled users fail
-      // closed rather than silently skipping the policy.
+      // opposite defaults (#815). A missing MFA module keeps the login
+      // policy-free (an enrolled user still gets the challenge below). A
+      // loaded module whose policy READ fails maps to the "unavailable"
+      // sentinel instead: the stored policy may well be "required", so
+      // unenrolled users fail closed rather than silently skipping the
+      // policy.
       const totpEnabled = dbUser?.totpEnabled ?? false;
       let mfaOutcome: ExternalMfaOutcome = totpEnabled ? "challenge" : "proceed";
       let mfaModule: typeof import("./mfa.js") | undefined;
       try {
         mfaModule = await import("./mfa.js");
-      } catch {
-        // MFA plugin not loaded
+      } catch (err) {
+        // Unreachable today: index.ts imports mfa.js statically at boot, so a
+        // broken module means the server never started. Kept as a guard for a
+        // future conditional registration; if it ever fires, logins proceed
+        // policy-free, which must never be silent.
+        request.log.error(
+          { err },
+          "OIDC callback: MFA module failed to load; proceeding without policy",
+        );
       }
       if (mfaModule) {
         let policy: MfaPolicy | "unavailable" = "unavailable";
@@ -345,22 +353,22 @@ export async function oidcRoutes(app: FastifyInstance): Promise<void> {
             { err, userId: resolvedUser.id },
             "OIDC callback: failed to read the MFA policy",
           );
+          // request.log has no Sentry bridge, and by catching here the error
+          // never reaches the global handler's reportError. Report explicitly
+          // so a settings fault denying logins is visible in triage.
+          void reportError(err, {
+            source: "http",
+            route: request.routeOptions?.url,
+            method: request.method,
+            statusCode: 503,
+            subsystem: "mfa-policy",
+          });
         }
         mfaOutcome = mfaModule.resolveExternalLoginMfaOutcome(
           policy,
           resolvedUser.role,
           totpEnabled,
         );
-      }
-
-      if (mfaOutcome === "policy_unavailable") {
-        recordOidcFailure();
-        await audit("OIDC_LOGIN_FAILED", {
-          userId: resolvedUser.id,
-          username: resolvedUser.username,
-          reason: "mfa_policy_unavailable",
-        });
-        return redirectToLogin(reply, "mfa_policy_unavailable");
       }
 
       if (mfaOutcome === "challenge") {
@@ -382,6 +390,20 @@ export async function oidcRoutes(app: FastifyInstance): Promise<void> {
           reason: "mfa_enrollment_required",
         });
         return redirectToLogin(reply, "mfa_enrollment_required");
+      }
+
+      if (mfaOutcome !== "proceed") {
+        // "policy_unavailable" today, and by construction any future outcome
+        // variant nobody wires up here: only an explicit "proceed" reaches
+        // session creation, so drift fails closed instead of recreating
+        // #815's fail-open.
+        recordOidcFailure();
+        await audit("OIDC_LOGIN_FAILED", {
+          userId: resolvedUser.id,
+          username: resolvedUser.username,
+          reason: "mfa_policy_unavailable",
+        });
+        return redirectToLogin(reply, "mfa_policy_unavailable");
       }
 
       // 5. Create session

--- a/apps/api/src/plugins/oidc.ts
+++ b/apps/api/src/plugins/oidc.ts
@@ -13,6 +13,7 @@ import { resolveExternalUser, sanitizeUsername } from "../lib/external-auth-reso
 import { authAttempts } from "../lib/metrics.js";
 import { isSecureRequest } from "../lib/secure-cookie.js";
 import { createSessionToken } from "./auth.js";
+import type { ExternalMfaOutcome, MfaPolicy } from "./mfa.js";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -320,17 +321,46 @@ export async function oidcRoutes(app: FastifyInstance): Promise<void> {
         return redirectToLogin(reply, "oidc_auth_failed");
       }
 
-      let mfaOutcome: "proceed" | "challenge" | "enrollment_required" = "proceed";
+      // Two failures used to share one silent catch here and they want
+      // opposite defaults (#815). The import failing means the MFA plugin
+      // isn't part of this build at all, so the login stays policy-free (an
+      // enrolled user still gets the challenge below). A loaded module whose
+      // policy READ fails maps to the "unavailable" sentinel instead: the
+      // stored policy may well be "required", so unenrolled users fail
+      // closed rather than silently skipping the policy.
+      const totpEnabled = dbUser?.totpEnabled ?? false;
+      let mfaOutcome: ExternalMfaOutcome = totpEnabled ? "challenge" : "proceed";
+      let mfaModule: typeof import("./mfa.js") | undefined;
       try {
-        const { getMfaPolicy, resolveExternalLoginMfaOutcome } = await import("./mfa.js");
-        const policy = await getMfaPolicy();
-        mfaOutcome = resolveExternalLoginMfaOutcome(
-          policy,
-          resolvedUser.role,
-          dbUser?.totpEnabled ?? false,
-        );
+        mfaModule = await import("./mfa.js");
       } catch {
         // MFA plugin not loaded
+      }
+      if (mfaModule) {
+        let policy: MfaPolicy | "unavailable" = "unavailable";
+        try {
+          policy = await mfaModule.getMfaPolicy();
+        } catch (err) {
+          request.log.error(
+            { err, userId: resolvedUser.id },
+            "OIDC callback: failed to read the MFA policy",
+          );
+        }
+        mfaOutcome = mfaModule.resolveExternalLoginMfaOutcome(
+          policy,
+          resolvedUser.role,
+          totpEnabled,
+        );
+      }
+
+      if (mfaOutcome === "policy_unavailable") {
+        recordOidcFailure();
+        await audit("OIDC_LOGIN_FAILED", {
+          userId: resolvedUser.id,
+          username: resolvedUser.username,
+          reason: "mfa_policy_unavailable",
+        });
+        return redirectToLogin(reply, "mfa_policy_unavailable");
       }
 
       if (mfaOutcome === "challenge") {

--- a/apps/api/src/plugins/saml.ts
+++ b/apps/api/src/plugins/saml.ts
@@ -8,6 +8,7 @@ import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { sharedRedis } from "../jobs/connection.js";
 import { auditFromRequest } from "../lib/audit.js";
+import { reportError } from "../lib/error-report.js";
 import {
   findUniqueUsername,
   resolveExternalUser,
@@ -202,19 +203,26 @@ export async function registerSaml(app: FastifyInstance): Promise<void> {
       }
 
       // Two failures used to share one silent catch here and they want
-      // opposite defaults (#815). The import failing means the MFA plugin
-      // isn't part of this build at all, so the login stays policy-free (an
-      // enrolled user still gets the challenge below). A loaded module whose
-      // policy READ fails maps to the "unavailable" sentinel instead: the
-      // stored policy may well be "required", so unenrolled users fail
-      // closed rather than silently skipping the policy.
+      // opposite defaults (#815). A missing MFA module keeps the login
+      // policy-free (an enrolled user still gets the challenge below). A
+      // loaded module whose policy READ fails maps to the "unavailable"
+      // sentinel instead: the stored policy may well be "required", so
+      // unenrolled users fail closed rather than silently skipping the
+      // policy.
       const totpEnabled = dbUser?.totpEnabled ?? false;
       let mfaOutcome: ExternalMfaOutcome = totpEnabled ? "challenge" : "proceed";
       let mfaModule: typeof import("./mfa.js") | undefined;
       try {
         mfaModule = await import("./mfa.js");
-      } catch {
-        // MFA plugin not loaded
+      } catch (err) {
+        // Unreachable today: index.ts imports mfa.js statically at boot, so a
+        // broken module means the server never started. Kept as a guard for a
+        // future conditional registration; if it ever fires, logins proceed
+        // policy-free, which must never be silent.
+        request.log.error(
+          { err },
+          "SAML callback: MFA module failed to load; proceeding without policy",
+        );
       }
       if (mfaModule) {
         let policy: MfaPolicy | "unavailable" = "unavailable";
@@ -225,22 +233,22 @@ export async function registerSaml(app: FastifyInstance): Promise<void> {
             { err, userId: resolvedUser.id },
             "SAML callback: failed to read the MFA policy",
           );
+          // request.log has no Sentry bridge, and by catching here the error
+          // never reaches the global handler's reportError. Report explicitly
+          // so a settings fault denying logins is visible in triage.
+          void reportError(err, {
+            source: "http",
+            route: request.routeOptions?.url,
+            method: request.method,
+            statusCode: 503,
+            subsystem: "mfa-policy",
+          });
         }
         mfaOutcome = mfaModule.resolveExternalLoginMfaOutcome(
           policy,
           resolvedUser.role,
           totpEnabled,
         );
-      }
-
-      if (mfaOutcome === "policy_unavailable") {
-        authAttempts.inc({ method: "saml", result: "failure" });
-        await audit("SAML_LOGIN_FAILED", {
-          userId: resolvedUser.id,
-          username: resolvedUser.username,
-          reason: "mfa_policy_unavailable",
-        });
-        return redirectToLogin(reply, "mfa_policy_unavailable");
       }
 
       if (mfaOutcome === "challenge") {
@@ -262,6 +270,20 @@ export async function registerSaml(app: FastifyInstance): Promise<void> {
           reason: "mfa_enrollment_required",
         });
         return redirectToLogin(reply, "mfa_enrollment_required");
+      }
+
+      if (mfaOutcome !== "proceed") {
+        // "policy_unavailable" today, and by construction any future outcome
+        // variant nobody wires up here: only an explicit "proceed" reaches
+        // session creation, so drift fails closed instead of recreating
+        // #815's fail-open.
+        authAttempts.inc({ method: "saml", result: "failure" });
+        await audit("SAML_LOGIN_FAILED", {
+          userId: resolvedUser.id,
+          username: resolvedUser.username,
+          reason: "mfa_policy_unavailable",
+        });
+        return redirectToLogin(reply, "mfa_policy_unavailable");
       }
 
       // Create session (same pattern as OIDC)

--- a/apps/api/src/plugins/saml.ts
+++ b/apps/api/src/plugins/saml.ts
@@ -17,6 +17,7 @@ import { authAttempts } from "../lib/metrics.js";
 import { makeRedisSamlCacheProvider } from "../lib/saml-cache.js";
 import { isSecureRequest } from "../lib/secure-cookie.js";
 import { createSessionToken } from "./auth.js";
+import type { ExternalMfaOutcome, MfaPolicy } from "./mfa.js";
 
 // -- SAML instance factory ----------------------------------------------------
 
@@ -200,17 +201,46 @@ export async function registerSaml(app: FastifyInstance): Promise<void> {
         return redirectToLogin(reply, "saml_auth_failed");
       }
 
-      let mfaOutcome: "proceed" | "challenge" | "enrollment_required" = "proceed";
+      // Two failures used to share one silent catch here and they want
+      // opposite defaults (#815). The import failing means the MFA plugin
+      // isn't part of this build at all, so the login stays policy-free (an
+      // enrolled user still gets the challenge below). A loaded module whose
+      // policy READ fails maps to the "unavailable" sentinel instead: the
+      // stored policy may well be "required", so unenrolled users fail
+      // closed rather than silently skipping the policy.
+      const totpEnabled = dbUser?.totpEnabled ?? false;
+      let mfaOutcome: ExternalMfaOutcome = totpEnabled ? "challenge" : "proceed";
+      let mfaModule: typeof import("./mfa.js") | undefined;
       try {
-        const { getMfaPolicy, resolveExternalLoginMfaOutcome } = await import("./mfa.js");
-        const policy = await getMfaPolicy();
-        mfaOutcome = resolveExternalLoginMfaOutcome(
-          policy,
-          resolvedUser.role,
-          dbUser?.totpEnabled ?? false,
-        );
+        mfaModule = await import("./mfa.js");
       } catch {
         // MFA plugin not loaded
+      }
+      if (mfaModule) {
+        let policy: MfaPolicy | "unavailable" = "unavailable";
+        try {
+          policy = await mfaModule.getMfaPolicy();
+        } catch (err) {
+          request.log.error(
+            { err, userId: resolvedUser.id },
+            "SAML callback: failed to read the MFA policy",
+          );
+        }
+        mfaOutcome = mfaModule.resolveExternalLoginMfaOutcome(
+          policy,
+          resolvedUser.role,
+          totpEnabled,
+        );
+      }
+
+      if (mfaOutcome === "policy_unavailable") {
+        authAttempts.inc({ method: "saml", result: "failure" });
+        await audit("SAML_LOGIN_FAILED", {
+          userId: resolvedUser.id,
+          username: resolvedUser.username,
+          reason: "mfa_policy_unavailable",
+        });
+        return redirectToLogin(reply, "mfa_policy_unavailable");
       }
 
       if (mfaOutcome === "challenge") {

--- a/apps/web/src/pages/login-page.tsx
+++ b/apps/web/src/pages/login-page.tsx
@@ -214,6 +214,7 @@ export function LoginPage() {
         saml_user_not_authorized: t.auth.samlUserNotAuthorized,
         saml_user_limit_reached: t.auth.samlUserLimitReached,
         mfa_enrollment_required: t.auth.mfaEnrollmentRequired,
+        mfa_policy_unavailable: t.auth.mfaPolicyUnavailable,
       };
       setError(errorMessages[authError] || t.auth.oidcGenericError);
       setSearchParams({}, { replace: true });
@@ -232,11 +233,13 @@ export function LoginPage() {
       });
       if (!res.ok) {
         const failure = await res.json().catch(() => null);
-        setError(
-          failure?.code === "MFA_ENROLLMENT_REQUIRED"
-            ? t.auth.mfaEnrollmentRequired
-            : t.auth.invalidCredentials,
-        );
+        if (failure?.code === "MFA_ENROLLMENT_REQUIRED") {
+          setError(t.auth.mfaEnrollmentRequired);
+        } else if (failure?.code === "MFA_POLICY_UNAVAILABLE") {
+          setError(t.auth.mfaPolicyUnavailable);
+        } else {
+          setError(t.auth.invalidCredentials);
+        }
         return;
       }
       const data = await res.json();

--- a/apps/web/src/pages/login-page.tsx
+++ b/apps/web/src/pages/login-page.tsx
@@ -237,6 +237,11 @@ export function LoginPage() {
           setError(t.auth.mfaEnrollmentRequired);
         } else if (failure?.code === "MFA_POLICY_UNAVAILABLE") {
           setError(t.auth.mfaPolicyUnavailable);
+        } else if (res.status >= 500) {
+          // A 5xx (a proxy answering with HTML mid-restart, a handler crash)
+          // is not a credentials problem; claiming "invalid credentials"
+          // invites password resets during an outage.
+          setError(t.auth.connectionError);
         } else {
           setError(t.auth.invalidCredentials);
         }

--- a/packages/shared/src/i18n/ar.ts
+++ b/packages/shared/src/i18n/ar.ts
@@ -3685,6 +3685,7 @@ export const ar: TranslationKeys = {
     mfaInvalidCode: "رمز غير صالح. يرجى المحاولة مرة أخرى.",
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired: "تتطلب مؤسستك المصادقة متعددة العوامل. يرجى إعداد MFA في إعدادات حسابك.",
+    mfaPolicyUnavailable: "تعذّر التحقق من سياسة MFA. يرجى المحاولة مرة أخرى بعد قليل.",
     methodSaml: "SAML",
     passwordManagedByProvider: "يتم إدارة تغيير كلمة المرور بواسطة مزود الهوية الخاص بك.",
     enterUsername: "أدخل اسم المستخدم",

--- a/packages/shared/src/i18n/de.ts
+++ b/packages/shared/src/i18n/de.ts
@@ -3737,6 +3737,8 @@ export const de: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Ihre Organisation erfordert Multi-Faktor-Authentifizierung. Bitte richten Sie MFA in Ihren Kontoeinstellungen ein.",
+    mfaPolicyUnavailable:
+      "Die MFA-Richtlinie konnte nicht überprüft werden. Bitte versuchen Sie es gleich erneut.",
     methodSaml: "SAML",
     passwordManagedByProvider: "Passwortänderungen werden von Ihrem Identitätsanbieter verwaltet.",
     enterUsername: "Benutzernamen eingeben",

--- a/packages/shared/src/i18n/en.ts
+++ b/packages/shared/src/i18n/en.ts
@@ -3658,6 +3658,7 @@ export const en = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Your organization requires multi-factor authentication. Please set up MFA in your account settings.",
+    mfaPolicyUnavailable: "The MFA policy could not be checked. Please try again in a moment.",
     methodSaml: "SAML",
     passwordManagedByProvider: "Password changes are managed by your identity provider.",
     enterUsername: "Enter username",

--- a/packages/shared/src/i18n/es.ts
+++ b/packages/shared/src/i18n/es.ts
@@ -3716,6 +3716,8 @@ export const es: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Tu organización requiere autenticación multifactor. Configura MFA en los ajustes de tu cuenta.",
+    mfaPolicyUnavailable:
+      "No se pudo comprobar la política de MFA. Inténtalo de nuevo en un momento.",
     methodSaml: "SAML",
     passwordManagedByProvider:
       "Los cambios de contraseña son administrados por tu proveedor de identidad.",

--- a/packages/shared/src/i18n/fr.ts
+++ b/packages/shared/src/i18n/fr.ts
@@ -3741,6 +3741,8 @@ export const fr: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Votre organisation exige l'authentification multifacteur. Veuillez configurer le MFA dans les paramètres de votre compte.",
+    mfaPolicyUnavailable:
+      "Impossible de vérifier la politique MFA. Veuillez réessayer dans un instant.",
     methodSaml: "SAML",
     passwordManagedByProvider:
       "Les modifications de mot de passe sont gérées par votre fournisseur d'identité.",

--- a/packages/shared/src/i18n/hi.ts
+++ b/packages/shared/src/i18n/hi.ts
@@ -3514,6 +3514,7 @@ export const hi: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "आपके संगठन को मल्टी-फ़ैक्टर प्रमाणीकरण आवश्यक है। कृपया अपनी खाता सेटिंग्स में MFA सेट अप करें।",
+    mfaPolicyUnavailable: "MFA नीति की जाँच नहीं हो सकी। कृपया थोड़ी देर बाद फिर से प्रयास करें।",
     methodSaml: "SAML",
     passwordManagedByProvider: "पासवर्ड बदलाव आपके आइडेंटिटी प्रोवाइडर द्वारा प्रबंधित किए जाते हैं।",
     enterUsername: "यूज़रनेम दर्ज करें",

--- a/packages/shared/src/i18n/id.ts
+++ b/packages/shared/src/i18n/id.ts
@@ -3715,6 +3715,7 @@ export const id: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Organisasi Anda mewajibkan autentikasi multi-faktor. Silakan atur MFA di pengaturan akun Anda.",
+    mfaPolicyUnavailable: "Kebijakan MFA tidak dapat diperiksa. Silakan coba lagi sebentar lagi.",
     methodSaml: "SAML",
     passwordManagedByProvider: "Perubahan kata sandi dikelola oleh penyedia identitas Anda.",
     enterUsername: "Masukkan nama pengguna",

--- a/packages/shared/src/i18n/it.ts
+++ b/packages/shared/src/i18n/it.ts
@@ -3731,6 +3731,7 @@ export const it: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "La tua organizzazione richiede l'autenticazione a più fattori. Configura l'MFA nelle impostazioni del tuo account.",
+    mfaPolicyUnavailable: "Impossibile verificare la policy MFA. Riprova tra qualche istante.",
     methodSaml: "SAML",
     passwordManagedByProvider:
       "Le modifiche alla password sono gestite dal tuo provider di identità.",

--- a/packages/shared/src/i18n/ja.ts
+++ b/packages/shared/src/i18n/ja.ts
@@ -3663,6 +3663,8 @@ export const ja: TranslationKeys = {
     mfaInvalidCode: "無効なコードです。もう一度お試しください。",
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired: "組織で多要素認証が必須です。アカウント設定で MFA を設定してください。",
+    mfaPolicyUnavailable:
+      "MFA ポリシーを確認できませんでした。しばらくしてからもう一度お試しください。",
     methodSaml: "SAML",
     passwordManagedByProvider: "パスワードはIDプロバイダーで管理されています。",
     enterUsername: "ユーザー名を入力",

--- a/packages/shared/src/i18n/ko.ts
+++ b/packages/shared/src/i18n/ko.ts
@@ -3642,6 +3642,7 @@ export const ko: TranslationKeys = {
     mfaInvalidCode: "잘못된 코드입니다. 다시 시도해 주세요.",
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired: "조직에서 다단계 인증을 요구합니다. 계정 설정에서 MFA를 설정해 주세요.",
+    mfaPolicyUnavailable: "MFA 정책을 확인할 수 없습니다. 잠시 후 다시 시도해 주세요.",
     methodSaml: "SAML",
     passwordManagedByProvider: "비밀번호는 ID 제공자에서 관리됩니다.",
     enterUsername: "사용자명 입력",

--- a/packages/shared/src/i18n/nl.ts
+++ b/packages/shared/src/i18n/nl.ts
@@ -3724,6 +3724,8 @@ export const nl: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Uw organisatie vereist meerfactorauthenticatie. Stel MFA in via uw accountinstellingen.",
+    mfaPolicyUnavailable:
+      "Het MFA-beleid kon niet worden gecontroleerd. Probeer het over enkele ogenblikken opnieuw.",
     methodSaml: "SAML",
     passwordManagedByProvider: "Wachtwoordwijzigingen worden beheerd door je identiteitsprovider.",
     enterUsername: "Voer gebruikersnaam in",

--- a/packages/shared/src/i18n/pl.ts
+++ b/packages/shared/src/i18n/pl.ts
@@ -3728,6 +3728,7 @@ export const pl: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Twoja organizacja wymaga uwierzytelniania wieloskładnikowego. Skonfiguruj MFA w ustawieniach konta.",
+    mfaPolicyUnavailable: "Nie udało się sprawdzić polityki MFA. Spróbuj ponownie za chwilę.",
     methodSaml: "SAML",
     passwordManagedByProvider: "Zarządzanie hasłem odbywa się przez dostawcę tożsamości.",
     enterUsername: "Wprowadź nazwę użytkownika",

--- a/packages/shared/src/i18n/pt-BR.ts
+++ b/packages/shared/src/i18n/pt-BR.ts
@@ -3723,6 +3723,8 @@ export const ptBR: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Sua organização exige autenticação multifator. Configure o MFA nas configurações da sua conta.",
+    mfaPolicyUnavailable:
+      "Não foi possível verificar a política de MFA. Tente novamente em instantes.",
     methodSaml: "SAML",
     passwordManagedByProvider:
       "Alterações de senha são gerenciadas pelo seu provedor de identidade.",

--- a/packages/shared/src/i18n/ru.ts
+++ b/packages/shared/src/i18n/ru.ts
@@ -3720,6 +3720,7 @@ export const ru: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Ваша организация требует многофакторную аутентификацию. Настройте MFA в параметрах учётной записи.",
+    mfaPolicyUnavailable: "Не удалось проверить политику MFA. Повторите попытку чуть позже.",
     methodSaml: "SAML",
     passwordManagedByProvider: "Управление паролем осуществляется Вашим провайдером идентификации.",
     enterUsername: "Введите имя пользователя",

--- a/packages/shared/src/i18n/sv.ts
+++ b/packages/shared/src/i18n/sv.ts
@@ -3713,6 +3713,7 @@ export const sv: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Din organisation kräver multifaktorautentisering. Konfigurera MFA i dina kontoinställningar.",
+    mfaPolicyUnavailable: "MFA-policyn kunde inte kontrolleras. Försök igen om en stund.",
     methodSaml: "SAML",
     passwordManagedByProvider: "Lösenordsändringar hanteras av din identitetsleverantör.",
     enterUsername: "Ange användarnamn",

--- a/packages/shared/src/i18n/th.ts
+++ b/packages/shared/src/i18n/th.ts
@@ -3664,6 +3664,7 @@ export const th: TranslationKeys = {
     mfaInvalidCode: "รหัสไม่ถูกต้อง กรุณาลองอีกครั้ง",
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired: "องค์กรของคุณกำหนดให้ใช้การยืนยันตัวตนหลายปัจจัย กรุณาตั้งค่า MFA ในการตั้งค่าบัญชี",
+    mfaPolicyUnavailable: "ไม่สามารถตรวจสอบนโยบาย MFA ได้ กรุณาลองอีกครั้งในอีกสักครู่",
     methodSaml: "SAML",
     passwordManagedByProvider: "การเปลี่ยนรหัสผ่านจัดการโดยผู้ให้บริการยืนยันตัวตนของคุณ",
     enterUsername: "กรอกชื่อผู้ใช้",

--- a/packages/shared/src/i18n/tr.ts
+++ b/packages/shared/src/i18n/tr.ts
@@ -3722,6 +3722,7 @@ export const tr: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Kuruluşunuz çok faktörlü kimlik doğrulama gerektiriyor. Lütfen hesap ayarlarınızdan MFA kurulumunu yapın.",
+    mfaPolicyUnavailable: "MFA politikası kontrol edilemedi. Lütfen birazdan tekrar deneyin.",
     methodSaml: "SAML",
     passwordManagedByProvider:
       "Parola değişiklikleri kimlik sağlayıcınız tarafından yönetilmektedir.",

--- a/packages/shared/src/i18n/uk.ts
+++ b/packages/shared/src/i18n/uk.ts
@@ -3718,6 +3718,7 @@ export const uk: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Ваша організація вимагає багатофакторну автентифікацію. Налаштуйте MFA в параметрах облікового запису.",
+    mfaPolicyUnavailable: "Не вдалося перевірити політику MFA. Повторіть спробу трохи пізніше.",
     methodSaml: "SAML",
     passwordManagedByProvider: "Керування паролем здійснюється Вашим постачальником ідентифікації.",
     enterUsername: "Введіть ім'я користувача",

--- a/packages/shared/src/i18n/vi.ts
+++ b/packages/shared/src/i18n/vi.ts
@@ -3709,6 +3709,7 @@ export const vi: TranslationKeys = {
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired:
       "Tổ chức của bạn yêu cầu xác thực đa yếu tố. Vui lòng thiết lập MFA trong cài đặt tài khoản.",
+    mfaPolicyUnavailable: "Không thể kiểm tra chính sách MFA. Vui lòng thử lại sau giây lát.",
     methodSaml: "SAML",
     passwordManagedByProvider: "Việc đổi mật khẩu được quản lý bởi nhà cung cấp danh tính của bạn.",
     enterUsername: "Nhập tên đăng nhập",

--- a/packages/shared/src/i18n/zh-CN.ts
+++ b/packages/shared/src/i18n/zh-CN.ts
@@ -3448,6 +3448,7 @@ export const zhCN: TranslationKeys = {
     mfaInvalidCode: "验证码无效，请重试。",
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired: "您的组织要求启用多因素认证。请在账户设置中设置 MFA。",
+    mfaPolicyUnavailable: "无法检查 MFA 策略。请稍后重试。",
     methodSaml: "SAML",
     passwordManagedByProvider: "密码修改由您的身份提供商管理。",
     enterUsername: "输入用户名",

--- a/packages/shared/src/i18n/zh-TW.ts
+++ b/packages/shared/src/i18n/zh-TW.ts
@@ -3449,6 +3449,7 @@ export const zhTW: TranslationKeys = {
     mfaInvalidCode: "驗證碼無效，請再試一次。",
     mfaEnrollmentHeading: "Set up two-factor authentication to continue",
     mfaEnrollmentRequired: "您的組織要求啟用多因素驗證。請在帳戶設定中設定 MFA。",
+    mfaPolicyUnavailable: "無法檢查 MFA 政策。請稍後再試。",
     methodSaml: "SAML",
     passwordManagedByProvider: "密碼由您的身分提供者管理。",
     enterUsername: "輸入使用者名稱",

--- a/tests/integration/platform/mfa-forced-enrollment.test.ts
+++ b/tests/integration/platform/mfa-forced-enrollment.test.ts
@@ -237,6 +237,18 @@ describe("POST /api/auth/login MFA policy read failure (#815)", () => {
       .from(schema.sessions)
       .where(eq(schema.sessions.userId, userId));
     expect(sessionsAfter.length).toBe(sessionsBefore);
+
+    // The deny is auditable: audit writes are inserts, so they survive the
+    // broken settings reads.
+    const auditRows = await db
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "LOGIN_FAILED"));
+    const denyRow = auditRows.find((row) => {
+      const details = row.details as { username?: string; reason?: string } | null;
+      return details?.username === username && details?.reason === "mfa_policy_unavailable";
+    });
+    expect(denyRow).toBeDefined();
   });
 
   it("still challenges an enrolled user when the policy read throws (no admin lockout)", async () => {

--- a/tests/integration/platform/mfa-forced-enrollment.test.ts
+++ b/tests/integration/platform/mfa-forced-enrollment.test.ts
@@ -189,3 +189,83 @@ describe("POST /api/auth/login forced enrollment (licensed)", () => {
     expect(res.statusCode).toBe(400);
   });
 });
+
+describe("POST /api/auth/login MFA policy read failure (#815)", () => {
+  // Makes every settings-style select ({ value: ... } selection) throw while
+  // leaving full-row selects (users, sessions) untouched. getSettingString /
+  // getSettingNumber callers swallow the error internally and fall back to
+  // their defaults, so the only reader this breaks is the strict MFA policy
+  // read, which must NOT swallow it (#815).
+  function breakSettingsReads() {
+    const originalSelect = db.select.bind(db);
+    return vi.spyOn(db, "select").mockImplementation((...args: unknown[]) => {
+      const selection = args[0] as Record<string, unknown> | undefined;
+      if (selection && "value" in selection) {
+        throw new Error("simulated settings store failure");
+      }
+      // biome-ignore lint/suspicious/noExplicitAny: passthrough to the real overloaded implementation
+      return (originalSelect as any)(...args);
+    });
+  }
+
+  it("fails closed with 503 MFA_POLICY_UNAVAILABLE for an unenrolled user when the policy read throws", async () => {
+    const { username, password, userId } = await createUnenrolledUser();
+    await setMfaPolicy("required");
+    const sessionsBefore = (
+      await db.select().from(schema.sessions).where(eq(schema.sessions.userId, userId))
+    ).length;
+
+    const selectSpy = breakSettingsReads();
+    try {
+      const res = await login(username, password);
+
+      // Must NOT hand out a session, an enrollment, or a challenge: the
+      // stored policy may well be "required", so a failed read denies with a
+      // distinct retryable code instead of waving the user through.
+      expect(res.statusCode).toBe(503);
+      const body = JSON.parse(res.body);
+      expect(body.code).toBe("MFA_POLICY_UNAVAILABLE");
+      expect(body.token).toBeUndefined();
+      expect(body.requiresMfa).toBeUndefined();
+      expect(body.requiresMfaEnrollment).toBeUndefined();
+    } finally {
+      selectSpy.mockRestore();
+    }
+
+    const sessionsAfter = await db
+      .select()
+      .from(schema.sessions)
+      .where(eq(schema.sessions.userId, userId));
+    expect(sessionsAfter.length).toBe(sessionsBefore);
+  });
+
+  it("still challenges an enrolled user when the policy read throws (no admin lockout)", async () => {
+    const { username, password } = await createUnenrolledUser("admin");
+    await setMfaPolicy("required");
+
+    // Enroll for real via the forced-enrollment flow, before breaking reads.
+    const firstLogin = await login(username, password);
+    const { enrollmentToken, uri } = JSON.parse(firstLogin.body);
+    const completeRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/mfa/enroll-complete",
+      payload: { enrollmentToken, code: generateTotpCode(uri) },
+    });
+    expect(completeRes.statusCode).toBe(200);
+
+    const selectSpy = breakSettingsReads();
+    try {
+      const res = await login(username, password);
+
+      // The TOTP challenge is at least as strict as any policy, so a broken
+      // policy read must not turn into a lockout for enrolled users.
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.requiresMfa).toBe(true);
+      expect(body.mfaToken).toBeDefined();
+      expect(body.token).toBeUndefined();
+    } finally {
+      selectSpy.mockRestore();
+    }
+  });
+});

--- a/tests/integration/platform/oidc-callback-coverage.test.ts
+++ b/tests/integration/platform/oidc-callback-coverage.test.ts
@@ -378,12 +378,12 @@ describe("OIDC callback claim handling and resolver outcomes", () => {
     expect(await findUserByExternalId(sub)).toBeUndefined();
   });
 
-  it("logs the user in when the MFA policy lookup throws (optional plugin fails open)", async () => {
+  it("fails closed with a distinct error when the MFA policy lookup throws (#815)", async () => {
     // The dynamic import("./mfa.js") in the callback resolves to this same
     // module instance, so spying getMfaPolicy to reject drives the callback's
-    // MFA try/catch (oidc.ts:325-327). A thrown policy lookup must fail OPEN:
-    // MFA is an optional enterprise plugin, so login proceeds and a session is
-    // created rather than the user being blocked.
+    // policy-read catch. A thrown policy lookup must fail CLOSED for an
+    // unenrolled user: the stored policy may well be "required", so the
+    // login is denied with a retryable error param instead of a session.
     const spy = vi
       .spyOn(mfaModule, "getMfaPolicy")
       .mockRejectedValue(new Error("simulated MFA policy lookup failure"));
@@ -391,15 +391,16 @@ describe("OIDC callback claim handling and resolver outcomes", () => {
       const sub = `sub-mfathrow-${Math.random().toString(36).slice(2, 10)}`;
       const res = await callbackWithClaims({
         sub,
-        preferred_username: `mfaopen-${Math.random().toString(36).slice(2, 8)}`,
+        preferred_username: `mfaclosed-${Math.random().toString(36).slice(2, 8)}`,
       });
 
       expect(res.statusCode).toBe(302);
-      expect(res.headers.location).toBe("/");
+      expect(res.headers.location).toBe("/login?error=mfa_policy_unavailable");
       const setCookie = res.headers["set-cookie"];
-      expect(String(setCookie ?? "")).toContain("snapotter-session=");
+      expect(String(setCookie ?? "")).not.toContain("snapotter-session=");
 
-      // A real session row was written and the success analytics event fired.
+      // Provisioning happens before the MFA decision, so the user row may
+      // exist, but no session row was minted and no login success fired.
       const user = await findUserByExternalId(sub);
       expect(user).toBeDefined();
       const [session] = await db
@@ -407,8 +408,9 @@ describe("OIDC callback claim handling and resolver outcomes", () => {
         .from(schema.sessions)
         .where(eq(schema.sessions.userId, user?.id ?? ""))
         .limit(1);
-      expect(session).toBeDefined();
-      expect(trackEventSpy).toHaveBeenCalledWith("auth_login", { method: "oidc" });
+      expect(session).toBeUndefined();
+      expect(trackEventSpy).not.toHaveBeenCalledWith("auth_login", { method: "oidc" });
+      expect(trackEventSpy).toHaveBeenCalledWith("auth_login_failed", { method: "oidc" });
     } finally {
       spy.mockRestore();
     }

--- a/tests/integration/platform/oidc-mfa-callback.test.ts
+++ b/tests/integration/platform/oidc-mfa-callback.test.ts
@@ -334,4 +334,70 @@ describe("OIDC callback MFA outcomes", () => {
       selectSpy.mockRestore();
     }
   });
+
+  // Makes every settings-style select ({ value: ... } selection) throw while
+  // leaving full-row and totpEnabled selects untouched. getSettingString /
+  // getSettingNumber callers swallow the error internally, so the only reader
+  // this breaks is the strict MFA policy read (#815).
+  function breakSettingsReads() {
+    const originalSelect = db.select.bind(db);
+    return vi.spyOn(db, "select").mockImplementation((...args: unknown[]) => {
+      const selection = args[0] as Record<string, unknown> | undefined;
+      if (selection && "value" in selection) {
+        throw new Error("simulated settings store failure");
+      }
+      // biome-ignore lint/suspicious/noExplicitAny: passthrough to the real overloaded implementation
+      return (originalSelect as any)(...args);
+    });
+  }
+
+  it("fails closed with a distinct error when the MFA policy read throws and the user is not enrolled (#815)", async () => {
+    const { externalId } = await insertOidcUser({ role: "user", totpEnabled: false });
+    await setMfaPolicy("required");
+
+    const selectSpy = breakSettingsReads();
+    try {
+      const res = await callbackAsUser(externalId);
+
+      // The stored policy may well be "required", so a failed policy read
+      // must deny the login with a retryable, distinct error param instead
+      // of defaulting to "no policy" and minting a session.
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe("/login?error=mfa_policy_unavailable");
+      const setCookie = res.headers["set-cookie"];
+      expect(String(setCookie ?? "")).not.toContain("snapotter-session=");
+    } finally {
+      selectSpy.mockRestore();
+    }
+  });
+
+  it("still challenges an enrolled user when the MFA policy read throws, and the challenge is completable (#815)", async () => {
+    const { username, externalId, totpUri } = await insertAndEnrollOidcUser({ role: "user" });
+    await setMfaPolicy("required");
+
+    const selectSpy = breakSettingsReads();
+    let mfaToken: string;
+    try {
+      const res = await callbackAsUser(externalId);
+
+      // Enrollment beats policy: the TOTP challenge is at least as strict as
+      // any policy, so a broken policy read must not lock out enrolled users.
+      expect(res.statusCode).toBe(302);
+      const location = res.headers.location as string;
+      expect(location).toMatch(/^\/login\?mfaToken=/);
+      const setCookie = res.headers["set-cookie"];
+      expect(String(setCookie ?? "")).not.toContain("snapotter-session=");
+      mfaToken = location.split("mfaToken=")[1];
+    } finally {
+      selectSpy.mockRestore();
+    }
+
+    const completeRes = await oidcApp.app.inject({
+      method: "POST",
+      url: "/api/auth/mfa/complete",
+      payload: { mfaToken, code: generateTotpCode(totpUri) },
+    });
+    expect(completeRes.statusCode).toBe(200);
+    expect(JSON.parse(completeRes.body).user.username).toBe(username);
+  });
 });

--- a/tests/integration/platform/saml-auth.test.ts
+++ b/tests/integration/platform/saml-auth.test.ts
@@ -25,9 +25,10 @@ const samlMock = vi.hoisted(() => ({
 }));
 const mfaOutcomeMock = vi.hoisted(() => vi.fn(() => "proceed"));
 // A controllable handle for getMfaPolicy so a single test can make the MFA
-// policy lookup reject and drive saml.ts's `catch { /* MFA plugin not loaded */ }`
-// branch (the whole MFA block is best-effort: a policy-lookup failure must fall
-// back to "proceed", not fail the login).
+// policy lookup reject and drive saml.ts's policy-read catch. Since #815 a
+// failed policy read no longer falls back to "proceed": the caller passes the
+// "unavailable" sentinel to the outcome resolver, which denies unenrolled
+// users with a distinct retryable error instead of waving them through.
 const getMfaPolicyMock = vi.hoisted(() => vi.fn().mockResolvedValue({}));
 
 vi.mock("@node-saml/node-saml", () => ({
@@ -297,34 +298,42 @@ describe("SAML callback", () => {
     }
   });
 
-  it("still logs in when the MFA policy lookup fails (best-effort MFA block)", async () => {
-    // saml.ts wraps the getMfaPolicy/resolveExternalLoginMfaOutcome lookup in a
-    // try/catch that swallows failures and leaves the outcome at "proceed" (the
-    // MFA plugin may not be loaded). Make the policy lookup reject once and
-    // confirm the login still completes: session created, redirect to `/`.
+  it("fails closed when the MFA policy lookup fails and the user is not enrolled (#815)", async () => {
+    // Make the policy lookup reject once. saml.ts must map the failure to the
+    // "unavailable" sentinel and pass it to the outcome resolver instead of
+    // swallowing it into "proceed": the stored policy may well be "required",
+    // so an unenrolled user is denied with a distinct retryable error param.
     const email = `mfaerr-${randomUUID().slice(0, 8)}@example.com`;
     samlMock.validatePostResponseAsync.mockResolvedValue({ profile: { nameID: email, email } });
     getMfaPolicyMock.mockRejectedValueOnce(new Error("mfa policy store unavailable"));
+    // Mirror what the real resolver returns for ("unavailable", role, false);
+    // the pure mapping itself is covered exhaustively in tests/unit/api/mfa.test.ts.
+    mfaOutcomeMock.mockReturnValue("policy_unavailable");
 
     try {
       const res = await postCallback();
 
       expect(res.statusCode).toBe(302);
-      expect(res.headers.location).toBe("/");
+      expect(res.headers.location).toBe("/login?error=mfa_policy_unavailable");
       const setCookie = res.headers["set-cookie"];
       const cookieStr = Array.isArray(setCookie) ? setCookie.join("; ") : setCookie || "";
-      expect(cookieStr).toContain("snapotter-session=");
+      expect(cookieStr).not.toContain("snapotter-session=");
 
-      // A real session was still created despite the MFA lookup throwing.
+      // The caller fed the read failure to the resolver as the sentinel
+      // rather than skipping the MFA decision entirely.
+      expect(mfaOutcomeMock).toHaveBeenCalledWith("unavailable", expect.any(String), false);
+
+      // No session row was minted for the resolved user.
       const [user] = await db.select().from(schema.users).where(eq(schema.users.externalId, email));
       expect(user).toBeDefined();
       const sessions = await db
         .select()
         .from(schema.sessions)
         .where(eq(schema.sessions.userId, user?.id as string));
-      expect(sessions.length).toBeGreaterThan(0);
+      expect(sessions.length).toBe(0);
     } finally {
       getMfaPolicyMock.mockResolvedValue({});
+      mfaOutcomeMock.mockReturnValue("proceed");
     }
   });
 });

--- a/tests/integration/platform/saml-auth.test.ts
+++ b/tests/integration/platform/saml-auth.test.ts
@@ -336,4 +336,36 @@ describe("SAML callback", () => {
       mfaOutcomeMock.mockReturnValue("proceed");
     }
   });
+
+  it("still challenges an enrolled user when the MFA policy lookup fails (#815)", async () => {
+    const email = `mfaerr-enrolled-${randomUUID().slice(0, 8)}@example.com`;
+    samlMock.validatePostResponseAsync.mockResolvedValue({ profile: { nameID: email, email } });
+
+    // First login auto-creates the account, then mark it TOTP-enrolled.
+    mfaOutcomeMock.mockReturnValue("proceed");
+    expect((await postCallback()).statusCode).toBe(302);
+    await db
+      .update(schema.users)
+      .set({ totpEnabled: true })
+      .where(eq(schema.users.externalId, email));
+
+    getMfaPolicyMock.mockRejectedValueOnce(new Error("mfa policy store unavailable"));
+    // Mirror what the real resolver returns for ("unavailable", role, true).
+    mfaOutcomeMock.mockReturnValue("challenge");
+    try {
+      const res = await postCallback();
+
+      // A settings blip must not lock out enrolled users: the challenge is
+      // at least as strict as any policy, so it is issued as usual.
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toMatch(/^\/login\?mfaToken=/);
+      // The caller passed the sentinel with the REAL enrollment state; a
+      // regression that hardcodes totpEnabled=false on the failure path, or
+      // denies before consulting the resolver, trips this.
+      expect(mfaOutcomeMock).toHaveBeenLastCalledWith("unavailable", expect.any(String), true);
+    } finally {
+      getMfaPolicyMock.mockResolvedValue({});
+      mfaOutcomeMock.mockReturnValue("proceed");
+    }
+  });
 });

--- a/tests/unit/api/mfa.test.ts
+++ b/tests/unit/api/mfa.test.ts
@@ -191,9 +191,10 @@ describe("MFA", () => {
   });
 
   describe("resolveExternalLoginMfaOutcome", () => {
-    // Exhaustive over the full input space: 3 policies x 2 roles x 2
-    // totpEnabled states. Role only matters via isMfaRequiredForUser, which
-    // branches solely on role === "admin", so {admin, user} covers it.
+    // Exhaustive over the full input space: 3 policies plus the "unavailable"
+    // read-failure sentinel, x 2 roles x 2 totpEnabled states. Role only
+    // matters via isMfaRequiredForUser, which branches solely on
+    // role === "admin", so {admin, user} covers it.
     it.each([
       ["optional", "user", false, "proceed"],
       ["optional", "user", true, "challenge"],
@@ -210,6 +211,15 @@ describe("MFA", () => {
       ["required", "user", true, "challenge"],
       ["required", "admin", false, "enrollment_required"],
       ["required", "admin", true, "challenge"],
+      // "unavailable" is the #815 fail-closed sentinel: the policy read
+      // failed, so an unenrolled user must be denied (the stored policy may
+      // well be "required"), while an enrolled user still gets the TOTP
+      // challenge, which is at least as strict as any policy. That carve-out
+      // is what keeps a flaky settings read from locking out enrolled admins.
+      ["unavailable", "user", false, "policy_unavailable"],
+      ["unavailable", "user", true, "challenge"],
+      ["unavailable", "admin", false, "policy_unavailable"],
+      ["unavailable", "admin", true, "challenge"],
     ] as const)("policy=%s role=%s totpEnabled=%s -> %s", (policy, role, totpEnabled, expected) => {
       expect(resolveExternalLoginMfaOutcome(policy, role, totpEnabled)).toBe(expected);
     });
@@ -217,6 +227,15 @@ describe("MFA", () => {
     it("enrollment takes priority: an enrolled user is challenged even under a required policy", () => {
       expect(resolveExternalLoginMfaOutcome("required", "admin", true)).not.toBe(
         "enrollment_required",
+      );
+    });
+
+    it("never proceeds when the policy is unavailable and the user is not enrolled (#815)", () => {
+      expect(resolveExternalLoginMfaOutcome("unavailable", "user", false)).toBe(
+        "policy_unavailable",
+      );
+      expect(resolveExternalLoginMfaOutcome("unavailable", "admin", false)).toBe(
+        "policy_unavailable",
       );
     });
   });

--- a/tests/unit/web/login-page-mfa-error.test.tsx
+++ b/tests/unit/web/login-page-mfa-error.test.tsx
@@ -61,6 +61,51 @@ describe("LoginPage error messages", () => {
     expect(screen.queryByText(/invalid username or password/i)).not.toBeInTheDocument();
   });
 
+  it("shows the retryable policy message when the API returns MFA_POLICY_UNAVAILABLE", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({
+          error: "The MFA policy could not be checked. Please try again.",
+          code: "MFA_POLICY_UNAVAILABLE",
+        }),
+      }),
+    );
+
+    renderLoginPage();
+    await submitLogin();
+
+    // A DB blip must not read as "wrong password".
+    await waitFor(() => {
+      expect(screen.getByText(/mfa policy could not be checked/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/invalid username or password/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a connection error, not invalid credentials, for a 5xx with an unparseable body", async () => {
+    // A reverse proxy answering 502 with HTML mid-restart: json() rejects.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        json: async () => {
+          throw new Error("Unexpected token < in JSON");
+        },
+      }),
+    );
+
+    renderLoginPage();
+    await submitLogin();
+
+    await waitFor(() => {
+      expect(screen.getByText(/connection error/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/invalid username or password/i)).not.toBeInTheDocument();
+  });
+
   it("still shows a generic message for a plain invalid-credentials response", async () => {
     vi.stubGlobal(
       "fetch",

--- a/tests/unit/web/login-page-oidc-mfa-redirect.test.tsx
+++ b/tests/unit/web/login-page-oidc-mfa-redirect.test.tsx
@@ -50,6 +50,11 @@ describe("LoginPage OIDC/SAML MFA redirect handling", () => {
     expect(screen.getByText(/multi-factor authentication/i)).toBeInTheDocument();
   });
 
+  it("shows the retryable policy message for the mfa_policy_unavailable error code", () => {
+    renderLoginPage("/login?error=mfa_policy_unavailable");
+    expect(screen.getByText(/mfa policy could not be checked/i)).toBeInTheDocument();
+  });
+
   it("does not show the TOTP prompt for an empty mfaToken param", () => {
     renderLoginPage("/login?mfaToken=");
     expect(screen.queryByPlaceholderText("000000")).not.toBeInTheDocument();


### PR DESCRIPTION
Fixes #815.

A required MFA policy stopped being enforced whenever the `mfaPolicy` settings read failed. The issue describes the silent catch in each login path, but the bug ran a layer deeper: `getSettingString` swallows DB errors into its default, so a settings fault became `"optional"` before those catches ever saw it. On OIDC and SAML the same swallow also skipped the TOTP challenge for already-enrolled users.

`getMfaPolicy()` now reads the settings row directly. A missing row still means `optional`; a failed read throws.

The three login paths split the old catch in two, per the issue's recommended option. A failed import of the MFA module keeps the proceed-if-absent default. A failed policy read maps to an `"unavailable"` sentinel fed through the shared `resolveExternalLoginMfaOutcome` resolver, which denies unenrolled users: 503 `MFA_POLICY_UNAVAILABLE` on password login, `?error=mfa_policy_unavailable` on the SSO redirects, plus audit rows and failure metrics. Enrolled users still get their TOTP challenge. The challenge is at least as strict as any policy, so a flaky settings read can't lock an enrolled admin out mid-incident, which was the cost the issue weighed against failing closed.

The login page maps both new error shapes to a retryable message, added to all 21 locales.

One deviation from the issue's test sketch: no integration test for a genuine import failure. `index.ts` and the test server import `./mfa.js` statically at boot, so if that import failed there would be no running server to log in to. The defensive catch stays; the unlicensed-instance behavior next to it is already covered by `mfa-forced-enrollment-unlicensed`.

Tests (written first, watched fail):

- unit: resolver table extended with the `unavailable` rows
- password: a broken settings read gets an unenrolled user a 503 and no session; an enrolled user still gets the challenge
- OIDC: same two cases through the real strict-read path (a db spy that breaks `{ value }` selects, which the swallowing settings helpers shrug off), with the enrolled user's challenge completed by a real TOTP code
- the SAML and OIDC-coverage tests that codified the old fail-open are inverted

Verified locally: full unit suite (481 files / 8534 tests), all of `tests/integration/platform` (110 files / 1737 tests), typecheck, lint, license boundary. `i18n:check`'s [api] surface is OK; its landing-ui/docs failures reproduce on main and predate this change.

---

Second commit, from the pre-merge review pass (silent-failure-hunter and pr-test-analyzer):

- The policy-read catches report to Sentry via `reportError`. `request.log` has no Sentry bridge, so without this a settings fault denying logins would produce zero triage signal.
- The import-failure catches log instead of staying silent, with honest comments: the module is imported statically at boot, so that branch is a guard for future conditional registration, not a live path.
- `getMfaPolicy` warns when the stored value is unrecognized (only reachable through out-of-band DB edits, which should not silently disarm the policy).
- Session creation now requires an explicit `"proceed"` on all three paths. A future `ExternalMfaOutcome` variant that nobody wires up fails closed instead of falling through to a session.
- The login page shows a connection error for 5xx responses with unrecognized or unparseable bodies, instead of telling a user mid-outage their password is wrong.
- The password deny fires `auth_login_failed`, matching OIDC's `recordOidcFailure`.
- Added tests: SAML enrolled-user-during-outage (the one path that lacked the no-lockout proof), frontend mappings for the new error code and redirect param plus the 5xx fallback, and an audit-row assertion on the password 503.

Review findings that were real but out of this PR's scope are filed as #866, #867, and #868.
