### PR TITLE
refactor(auth): drop the dead mfaRequired plumbing

### DIFF
--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -486,7 +486,6 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       // "unavailable" sentinel and unenrolled users fail closed instead of
       // skipping the policy.
       let mfaOutcome: ExternalMfaOutcome = user.totpEnabled ? "challenge" : "proceed";
-      let mfaRequiredByPolicy = false;
       let mfaModule: typeof import("./mfa.js") | undefined;
       try {
         mfaModule = await import("./mfa.js");
@@ -515,11 +514,6 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
           });
         }
         mfaOutcome = mfaModule.resolveExternalLoginMfaOutcome(policy, user.role, user.totpEnabled);
-        // Informational flag for the challenge response below; when the read
-        // failed it stays false, which only affects display -- enforcement
-        // for enrolled users is the challenge itself.
-        mfaRequiredByPolicy =
-          policy !== "unavailable" && mfaModule.isMfaRequiredForUser(policy, user.role);
       }
 
       // ── MFA challenge ──────────────────────────────────────────
@@ -532,7 +526,6 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(200).send({
           requiresMfa: true,
           mfaToken,
-          mfaRequired: mfaRequiredByPolicy,
           message: "MFA verification required",
         });
       }

--- a/apps/demo/src/mock-api.ts
+++ b/apps/demo/src/mock-api.ts
@@ -953,7 +953,6 @@ export function matchDemoRoute(url: string, method: string, body?: unknown): Res
         role: "admin",
         permissions: PERMISSIONS,
         mustChangePassword: false,
-        mfaRequired: false,
         loginMethod: "local",
         hasLocalPassword: true,
       },

--- a/apps/docs/api/rest.md
+++ b/apps/docs/api/rest.md
@@ -77,7 +77,7 @@ Keys are prefixed `si_` and stored as scrypt hashes - the raw key is shown once 
 | `GET` | `/api/auth/saml/login` | Public | Start SAML login |
 | `POST` | `/api/auth/saml/callback` | Public | SAML assertion consumer service |
 
-When MFA is enabled for a user, `POST /api/auth/login` returns `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` instead of a session token. Send that `mfaToken` plus a TOTP or recovery code to `/api/auth/mfa/complete`.
+When MFA is enabled for a user, `POST /api/auth/login` returns `{"requiresMfa":true,"mfaToken":"..."}` instead of a session token. Send that `mfaToken` plus a TOTP or recovery code to `/api/auth/mfa/complete`.
 
 ### Permissions {#permissions}
 

--- a/apps/docs/ar/api/rest.md
+++ b/apps/docs/ar/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "مرجع REST API الكامل. نقاط نهاية الأدوات، والمعالجة الدفعية، وخطوط المعالجة، ومكتبة الملفات، والمصادقة، والفرق، وعمليات الإدارة."
 i18n_output_hash: 89f2ba5743eb
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ curl -X POST http://localhost:1349/api/v1/tools/image/resize \
 | `GET` | `/api/auth/saml/login` | عام | بدء تسجيل دخول SAML |
 | `POST` | `/api/auth/saml/callback` | عام | خدمة استهلاك تأكيدات SAML |
 
-عند تفعيل MFA لمستخدم، يُرجع `POST /api/auth/login` القيمة `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` بدلًا من رمز الجلسة. أرسل ذلك `mfaToken` إضافةً إلى رمز TOTP أو رمز استرداد إلى `/api/auth/mfa/complete`.
+عند تفعيل MFA لمستخدم، يُرجع `POST /api/auth/login` القيمة `{"requiresMfa":true,"mfaToken":"..."}` بدلًا من رمز الجلسة. أرسل ذلك `mfaToken` إضافةً إلى رمز TOTP أو رمز استرداد إلى `/api/auth/mfa/complete`.
 
 ### الأذونات {#permissions}
 

--- a/apps/docs/de/api/rest.md
+++ b/apps/docs/de/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Vollständige REST-API-Referenz. Tool-Endpunkte, Stapelverarbeitung, Pipelines, Dateibibliothek, Authentifizierung, Teams und Admin-Operationen."
 i18n_output_hash: 8efd33eca67a
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ Schlüssel erhalten das Präfix `si_` und werden als scrypt-Hashes gespeichert. 
 | `GET` | `/api/auth/saml/login` | Öffentlich | SAML-Login starten |
 | `POST` | `/api/auth/saml/callback` | Öffentlich | SAML Assertion Consumer Service |
 
-Wenn MFA für einen Benutzer aktiviert ist, gibt `POST /api/auth/login` statt eines Sitzungs-Tokens `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` zurück. Senden Sie dieses `mfaToken` zusammen mit einem TOTP- oder Wiederherstellungscode an `/api/auth/mfa/complete`.
+Wenn MFA für einen Benutzer aktiviert ist, gibt `POST /api/auth/login` statt eines Sitzungs-Tokens `{"requiresMfa":true,"mfaToken":"..."}` zurück. Senden Sie dieses `mfaToken` zusammen mit einem TOTP- oder Wiederherstellungscode an `/api/auth/mfa/complete`.
 
 ### Berechtigungen {#permissions}
 

--- a/apps/docs/es/api/rest.md
+++ b/apps/docs/es/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Referencia completa de la API REST. Endpoints de herramientas, procesamiento por lotes, pipelines, biblioteca de archivos, autenticación, equipos y operaciones de administración."
 i18n_output_hash: a9129e12a29c
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ Las claves llevan el prefijo `si_` y se almacenan como hashes scrypt; la clave e
 | `GET` | `/api/auth/saml/login` | Público | Iniciar el inicio de sesión SAML |
 | `POST` | `/api/auth/saml/callback` | Público | Servicio consumidor de aserciones SAML |
 
-Cuando MFA está habilitado para un usuario, `POST /api/auth/login` devuelve `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` en lugar de un token de sesión. Envía ese `mfaToken` junto con un código TOTP o de recuperación a `/api/auth/mfa/complete`.
+Cuando MFA está habilitado para un usuario, `POST /api/auth/login` devuelve `{"requiresMfa":true,"mfaToken":"..."}` en lugar de un token de sesión. Envía ese `mfaToken` junto con un código TOTP o de recuperación a `/api/auth/mfa/complete`.
 
 ### Permisos {#permissions}
 

--- a/apps/docs/fr/api/rest.md
+++ b/apps/docs/fr/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Référence complète de l'API REST. Points de terminaison des outils, traitement par lots, pipelines, bibliothèque de fichiers, authentification, équipes et opérations d'administration."
 i18n_output_hash: 450fd529e479
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ Les clés sont préfixées par `si_` et stockées sous forme de hachages scrypt 
 | `GET` | `/api/auth/saml/login` | Public | Démarrer la connexion SAML |
 | `POST` | `/api/auth/saml/callback` | Public | Service consommateur d'assertions SAML |
 
-Lorsque l'authentification multifacteur est activée pour un utilisateur, `POST /api/auth/login` renvoie `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` au lieu d'un jeton de session. Envoyez ce `mfaToken` accompagné d'un code TOTP ou d'un code de récupération à `/api/auth/mfa/complete`.
+Lorsque l'authentification multifacteur est activée pour un utilisateur, `POST /api/auth/login` renvoie `{"requiresMfa":true,"mfaToken":"..."}` au lieu d'un jeton de session. Envoyez ce `mfaToken` accompagné d'un code TOTP ou d'un code de récupération à `/api/auth/mfa/complete`.
 
 ### Autorisations {#permissions}
 

--- a/apps/docs/hi/api/rest.md
+++ b/apps/docs/hi/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "संपूर्ण REST API संदर्भ। टूल एंडपॉइंट, बैच प्रोसेसिंग, पाइपलाइन, फ़ाइल लाइब्रेरी, प्रमाणीकरण, टीमें और एडमिन संचालन।"
 i18n_output_hash: 40efba210bee
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ curl -X POST http://localhost:1349/api/v1/tools/image/resize \
 | `GET` | `/api/auth/saml/login` | सार्वजनिक | SAML लॉगिन शुरू करें |
 | `POST` | `/api/auth/saml/callback` | सार्वजनिक | SAML असर्शन कंज़्यूमर सर्विस |
 
-जब किसी उपयोगकर्ता के लिए MFA सक्षम होता है, तो `POST /api/auth/login` सेशन टोकन के बजाय `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` लौटाता है। उस `mfaToken` के साथ एक TOTP या रिकवरी कोड `/api/auth/mfa/complete` को भेजें।
+जब किसी उपयोगकर्ता के लिए MFA सक्षम होता है, तो `POST /api/auth/login` सेशन टोकन के बजाय `{"requiresMfa":true,"mfaToken":"..."}` लौटाता है। उस `mfaToken` के साथ एक TOTP या रिकवरी कोड `/api/auth/mfa/complete` को भेजें।
 
 ### अनुमतियाँ {#permissions}
 

--- a/apps/docs/id/api/rest.md
+++ b/apps/docs/id/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Referensi REST API lengkap. Endpoint tool, pemrosesan batch, pipeline, pustaka file, autentikasi, tim, dan operasi admin."
 i18n_output_hash: 7793faea1aad
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ Kunci diberi awalan `si_` dan disimpan sebagai hash scrypt - kunci mentah ditamp
 | `GET` | `/api/auth/saml/login` | Publik | Mulai login SAML |
 | `POST` | `/api/auth/saml/callback` | Publik | Layanan konsumen asersi SAML |
 
-Ketika MFA diaktifkan untuk seorang pengguna, `POST /api/auth/login` mengembalikan `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` alih-alih token sesi. Kirim `mfaToken` tersebut ditambah kode TOTP atau kode pemulihan ke `/api/auth/mfa/complete`.
+Ketika MFA diaktifkan untuk seorang pengguna, `POST /api/auth/login` mengembalikan `{"requiresMfa":true,"mfaToken":"..."}` alih-alih token sesi. Kirim `mfaToken` tersebut ditambah kode TOTP atau kode pemulihan ke `/api/auth/mfa/complete`.
 
 ### Izin {#permissions}
 

--- a/apps/docs/it/api/rest.md
+++ b/apps/docs/it/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Riferimento completo dell'API REST. Endpoint degli strumenti, elaborazione batch, pipeline, libreria file, autenticazione, team e operazioni di amministrazione."
 i18n_output_hash: 1fa1fec30f47
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ Le chiavi hanno il prefisso `si_` e sono memorizzate come hash scrypt: la chiave
 | `GET` | `/api/auth/saml/login` | Pubblico | Avvia l'accesso SAML |
 | `POST` | `/api/auth/saml/callback` | Pubblico | Servizio consumer delle asserzioni SAML |
 
-Quando l'MFA è abilitato per un utente, `POST /api/auth/login` restituisce `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` invece di un token di sessione. Invia quel `mfaToken` più un codice TOTP o di recupero a `/api/auth/mfa/complete`.
+Quando l'MFA è abilitato per un utente, `POST /api/auth/login` restituisce `{"requiresMfa":true,"mfaToken":"..."}` invece di un token di sessione. Invia quel `mfaToken` più un codice TOTP o di recupero a `/api/auth/mfa/complete`.
 
 ### Permessi {#permissions}
 

--- a/apps/docs/ja/api/rest.md
+++ b/apps/docs/ja/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "完全な REST API リファレンス。ツールエンドポイント、バッチ処理、パイプライン、ファイルライブラリ、認証、チーム、管理者操作。"
 i18n_output_hash: aa42f6d4ddbe
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ curl -X POST http://localhost:1349/api/v1/tools/image/resize \
 | `GET` | `/api/auth/saml/login` | Public | SAML ログインを開始 |
 | `POST` | `/api/auth/saml/callback` | Public | SAML アサーションコンシューマーサービス |
 
-ユーザーに対して MFA が有効な場合、`POST /api/auth/login` はセッショントークンの代わりに `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` を返します。その `mfaToken` と TOTP またはリカバリコードを `/api/auth/mfa/complete` に送信してください。
+ユーザーに対して MFA が有効な場合、`POST /api/auth/login` はセッショントークンの代わりに `{"requiresMfa":true,"mfaToken":"..."}` を返します。その `mfaToken` と TOTP またはリカバリコードを `/api/auth/mfa/complete` に送信してください。
 
 ### パーミッション {#permissions}
 

--- a/apps/docs/ko/api/rest.md
+++ b/apps/docs/ko/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "전체 REST API 레퍼런스. 도구 엔드포인트, 배치 처리, 파이프라인, 파일 라이브러리, 인증, 팀, 관리 작업."
 i18n_output_hash: a4289adc1b56
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ curl -X POST http://localhost:1349/api/v1/tools/image/resize \
 | `GET` | `/api/auth/saml/login` | 공개 | SAML 로그인 시작 |
 | `POST` | `/api/auth/saml/callback` | 공개 | SAML 어설션 컨슈머 서비스 |
 
-사용자에 대해 MFA가 활성화되면 `POST /api/auth/login`는 세션 토큰 대신 `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}`를 반환합니다. 해당 `mfaToken`와 함께 TOTP 또는 복구 코드를 `/api/auth/mfa/complete`로 전송하세요.
+사용자에 대해 MFA가 활성화되면 `POST /api/auth/login`는 세션 토큰 대신 `{"requiresMfa":true,"mfaToken":"..."}`를 반환합니다. 해당 `mfaToken`와 함께 TOTP 또는 복구 코드를 `/api/auth/mfa/complete`로 전송하세요.
 
 ### 권한 {#permissions}
 

--- a/apps/docs/nl/api/rest.md
+++ b/apps/docs/nl/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Volledige REST API-referentie. Tool-endpoints, batchverwerking, pipelines, bestandsbibliotheek, authenticatie, teams en beheerbewerkingen."
 i18n_output_hash: 8f6eabc592c0
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ Sleutels krijgen het voorvoegsel `si_` en worden opgeslagen als scrypt-hashes. D
 | `GET` | `/api/auth/saml/login` | Publiek | SAML-login starten |
 | `POST` | `/api/auth/saml/callback` | Publiek | SAML assertion consumer service |
 
-Wanneer MFA is ingeschakeld voor een gebruiker, retourneert `POST /api/auth/login` een `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` in plaats van een sessietoken. Stuur die `mfaToken` samen met een TOTP- of herstelcode naar `/api/auth/mfa/complete`.
+Wanneer MFA is ingeschakeld voor een gebruiker, retourneert `POST /api/auth/login` een `{"requiresMfa":true,"mfaToken":"..."}` in plaats van een sessietoken. Stuur die `mfaToken` samen met een TOTP- of herstelcode naar `/api/auth/mfa/complete`.
 
 ### Permissies {#permissions}
 

--- a/apps/docs/pl/api/rest.md
+++ b/apps/docs/pl/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Kompletna dokumentacja API REST. Punkty końcowe narzędzi, przetwarzanie wsadowe, potoki, biblioteka plików, uwierzytelnianie, zespoły i operacje administracyjne."
 i18n_output_hash: 4b25a4ffd694
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ Klucze są poprzedzone przedrostkiem `si_` i przechowywane jako skróty scrypt -
 | `GET` | `/api/auth/saml/login` | Publiczny | Rozpoczęcie logowania SAML |
 | `POST` | `/api/auth/saml/callback` | Publiczny | Usługa konsumenta asercji SAML |
 
-Gdy MFA jest włączone dla użytkownika, `POST /api/auth/login` zwraca `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` zamiast tokena sesji. Wyślij ten `mfaToken` wraz z kodem TOTP lub kodem odzyskiwania do `/api/auth/mfa/complete`.
+Gdy MFA jest włączone dla użytkownika, `POST /api/auth/login` zwraca `{"requiresMfa":true,"mfaToken":"..."}` zamiast tokena sesji. Wyślij ten `mfaToken` wraz z kodem TOTP lub kodem odzyskiwania do `/api/auth/mfa/complete`.
 
 ### Uprawnienia {#permissions}
 

--- a/apps/docs/pt-BR/api/rest.md
+++ b/apps/docs/pt-BR/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Referência completa da API REST. Endpoints de ferramentas, processamento em lote, pipelines, biblioteca de arquivos, autenticação, times e operações administrativas."
 i18n_output_hash: cf7876adfe84
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ As chaves têm o prefixo `si_` e são armazenadas como hashes scrypt. A chave br
 | `GET` | `/api/auth/saml/login` | Público | Iniciar o login SAML |
 | `POST` | `/api/auth/saml/callback` | Público | Serviço consumidor de asserções SAML |
 
-Quando o MFA está habilitado para um usuário, `POST /api/auth/login` retorna `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` em vez de um token de sessão. Envie esse `mfaToken` junto com um código TOTP ou de recuperação para `/api/auth/mfa/complete`.
+Quando o MFA está habilitado para um usuário, `POST /api/auth/login` retorna `{"requiresMfa":true,"mfaToken":"..."}` em vez de um token de sessão. Envie esse `mfaToken` junto com um código TOTP ou de recuperação para `/api/auth/mfa/complete`.
 
 ### Permissões {#permissions}
 

--- a/apps/docs/ru/api/rest.md
+++ b/apps/docs/ru/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Полный справочник REST API. Эндпоинты инструментов, пакетная обработка, конвейеры, файловая библиотека, аутентификация, команды и административные операции."
 i18n_output_hash: b2ec4e36cb9f
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ curl -X POST http://localhost:1349/api/v1/tools/image/resize \
 | `GET` | `/api/auth/saml/login` | Публичный | Начало входа через SAML |
 | `POST` | `/api/auth/saml/callback` | Публичный | Служба потребителя утверждений SAML |
 
-Когда для пользователя включён MFA, `POST /api/auth/login` возвращает `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` вместо токена сессии. Отправьте этот `mfaToken` вместе с кодом TOTP или кодом восстановления на `/api/auth/mfa/complete`.
+Когда для пользователя включён MFA, `POST /api/auth/login` возвращает `{"requiresMfa":true,"mfaToken":"..."}` вместо токена сессии. Отправьте этот `mfaToken` вместе с кодом TOTP или кодом восстановления на `/api/auth/mfa/complete`.
 
 ### Разрешения {#permissions}
 

--- a/apps/docs/sv/api/rest.md
+++ b/apps/docs/sv/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Fullständig REST API-referens. Verktygsslutpunkter, batchbearbetning, pipelines, filbibliotek, autentisering, team och adminåtgärder."
 i18n_output_hash: 4756237a0bdc
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ Nycklar har prefixet `si_` och lagras som scrypt-hashar - den råa nyckeln visas
 | `GET` | `/api/auth/saml/login` | Publik | Starta SAML-inloggning |
 | `POST` | `/api/auth/saml/callback` | Publik | SAML assertion consumer service |
 
-När MFA är aktiverat för en användare returnerar `POST /api/auth/login` `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` istället för en sessionstoken. Skicka den `mfaToken` plus en TOTP- eller återställningskod till `/api/auth/mfa/complete`.
+När MFA är aktiverat för en användare returnerar `POST /api/auth/login` `{"requiresMfa":true,"mfaToken":"..."}` istället för en sessionstoken. Skicka den `mfaToken` plus en TOTP- eller återställningskod till `/api/auth/mfa/complete`.
 
 ### Behörigheter {#permissions}
 

--- a/apps/docs/th/api/rest.md
+++ b/apps/docs/th/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "เอกสารอ้างอิง REST API ฉบับสมบูรณ์ เอนด์พอยต์ของเครื่องมือ การประมวลผลแบบแบตช์ ไปป์ไลน์ คลังไฟล์ การยืนยันตัวตน ทีม และการดำเนินงานของผู้ดูแลระบบ"
 i18n_output_hash: 34c52fe6305e
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ curl -X POST http://localhost:1349/api/v1/tools/image/resize \
 | `GET` | `/api/auth/saml/login` | สาธารณะ | เริ่มการลงชื่อเข้าใช้ SAML |
 | `POST` | `/api/auth/saml/callback` | สาธารณะ | บริการ SAML assertion consumer |
 
-เมื่อเปิดใช้งาน MFA สำหรับผู้ใช้ `POST /api/auth/login` จะคืนค่า `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` แทนโทเคนเซสชัน ส่ง `mfaToken` นั้นพร้อมรหัส TOTP หรือรหัสกู้คืนไปยัง `/api/auth/mfa/complete`
+เมื่อเปิดใช้งาน MFA สำหรับผู้ใช้ `POST /api/auth/login` จะคืนค่า `{"requiresMfa":true,"mfaToken":"..."}` แทนโทเคนเซสชัน ส่ง `mfaToken` นั้นพร้อมรหัส TOTP หรือรหัสกู้คืนไปยัง `/api/auth/mfa/complete`
 
 ### สิทธิ์ {#permissions}
 

--- a/apps/docs/tr/api/rest.md
+++ b/apps/docs/tr/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Eksiksiz REST API başvurusu. Araç uç noktaları, toplu işleme, işlem hatları, dosya kitaplığı, kimlik doğrulama, ekipler ve yönetici işlemleri."
 i18n_output_hash: 4ae115bf377e
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ Anahtarlar `si_` ön ekiyle işaretlenir ve scrypt karma değerleri olarak sakla
 | `GET` | `/api/auth/saml/login` | Herkese açık | SAML oturum açmayı başlat |
 | `POST` | `/api/auth/saml/callback` | Herkese açık | SAML doğrulama tüketici hizmeti |
 
-Bir kullanıcı için MFA etkinleştirildiğinde, `POST /api/auth/login` bir oturum belirteci yerine `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` döndürür. Bu `mfaToken` değerini bir TOTP veya kurtarma kodu ile birlikte `/api/auth/mfa/complete` adresine gönderin.
+Bir kullanıcı için MFA etkinleştirildiğinde, `POST /api/auth/login` bir oturum belirteci yerine `{"requiresMfa":true,"mfaToken":"..."}` döndürür. Bu `mfaToken` değerini bir TOTP veya kurtarma kodu ile birlikte `/api/auth/mfa/complete` adresine gönderin.
 
 ### İzinler {#permissions}
 

--- a/apps/docs/uk/api/rest.md
+++ b/apps/docs/uk/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Повний довідник REST API. Кінцеві точки інструментів, пакетна обробка, конвеєри, бібліотека файлів, автентифікація, команди й адміністративні операції."
 i18n_output_hash: 20d37040e8ea
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ curl -X POST http://localhost:1349/api/v1/tools/image/resize \
 | `GET` | `/api/auth/saml/login` | Публічний | Початок входу SAML |
 | `POST` | `/api/auth/saml/callback` | Публічний | Служба споживача твердження SAML |
 
-Коли для користувача ввімкнено MFA, `POST /api/auth/login` повертає `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` замість токена сесії. Надішліть цей `mfaToken` разом із кодом TOTP або кодом відновлення на `/api/auth/mfa/complete`.
+Коли для користувача ввімкнено MFA, `POST /api/auth/login` повертає `{"requiresMfa":true,"mfaToken":"..."}` замість токена сесії. Надішліть цей `mfaToken` разом із кодом TOTP або кодом відновлення на `/api/auth/mfa/complete`.
 
 ### Дозволи {#permissions}
 

--- a/apps/docs/vi/api/rest.md
+++ b/apps/docs/vi/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "Tài liệu tham khảo REST API đầy đủ. Endpoint công cụ, xử lý hàng loạt, pipeline, thư viện tệp, xác thực, nhóm và các thao tác quản trị."
 i18n_output_hash: a2d3795ef769
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ Khóa có tiền tố `si_` và được lưu dưới dạng hash scrypt - khóa
 | `GET` | `/api/auth/saml/login` | Công khai | Bắt đầu đăng nhập SAML |
 | `POST` | `/api/auth/saml/callback` | Công khai | Dịch vụ tiêu thụ khẳng định SAML |
 
-Khi MFA được bật cho một người dùng, `POST /api/auth/login` trả về `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` thay vì token phiên. Gửi `mfaToken` đó cùng mã TOTP hoặc mã khôi phục tới `/api/auth/mfa/complete`.
+Khi MFA được bật cho một người dùng, `POST /api/auth/login` trả về `{"requiresMfa":true,"mfaToken":"..."}` thay vì token phiên. Gửi `mfaToken` đó cùng mã TOTP hoặc mã khôi phục tới `/api/auth/mfa/complete`.
 
 ### Quyền hạn {#permissions}
 

--- a/apps/docs/zh-CN/api/rest.md
+++ b/apps/docs/zh-CN/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "完整的 REST API 参考。工具端点、批处理、流水线、文件库、身份验证、团队以及管理操作。"
 i18n_output_hash: c43973438a42
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ curl -X POST http://localhost:1349/api/v1/tools/image/resize \
 | `GET` | `/api/auth/saml/login` | 公开 | 开始 SAML 登录 |
 | `POST` | `/api/auth/saml/callback` | 公开 | SAML 断言消费者服务 |
 
-当用户启用了 MFA 时，`POST /api/auth/login` 会返回 `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` 而不是会话令牌。将该 `mfaToken` 连同 TOTP 或恢复码一起发送到 `/api/auth/mfa/complete`。
+当用户启用了 MFA 时，`POST /api/auth/login` 会返回 `{"requiresMfa":true,"mfaToken":"..."}` 而不是会话令牌。将该 `mfaToken` 连同 TOTP 或恢复码一起发送到 `/api/auth/mfa/complete`。
 
 ### 权限 {#permissions}
 

--- a/apps/docs/zh-TW/api/rest.md
+++ b/apps/docs/zh-TW/api/rest.md
@@ -1,7 +1,7 @@
 ---
 description: "完整的 REST API 參考。工具端點、批次處理、管線、檔案庫、驗證、團隊與管理操作。"
 i18n_output_hash: 9fa4a9a91996
-i18n_source_hash: 7e0a0db4abe0
+i18n_source_hash: 899149b272e4
 i18n_provenance: human
 ---
 
@@ -80,7 +80,7 @@ Key 以 `si_` 為前綴並以 scrypt 雜湊儲存，原始 key 只會顯示一�
 | `GET` | `/api/auth/saml/login` | Public | 啟動 SAML 登入 |
 | `POST` | `/api/auth/saml/callback` | Public | SAML assertion consumer service |
 
-當使用者啟用 MFA 時，`POST /api/auth/login` 會回傳 `{"requiresMfa":true,"mfaToken":"...","mfaRequired":true|false}` 而非 session token。將該 `mfaToken` 加上 TOTP 或復原代碼送至 `/api/auth/mfa/complete`。
+當使用者啟用 MFA 時，`POST /api/auth/login` 會回傳 `{"requiresMfa":true,"mfaToken":"..."}` 而非 session token。將該 `mfaToken` 加上 TOTP 或復原代碼送至 `/api/auth/mfa/complete`。
 
 ### 權限 {#permissions}
 

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -7,7 +7,6 @@ interface AuthState {
   authEnabled: boolean;
   isAuthenticated: boolean;
   mustChangePassword: boolean;
-  mfaRequired: boolean;
   role: string | null;
   permissions: string[];
   oidcEnabled: boolean;
@@ -70,7 +69,6 @@ export function useAuth() {
     authEnabled: false,
     isAuthenticated: false,
     mustChangePassword: false,
-    mfaRequired: false,
     role: null,
     permissions: [],
     oidcEnabled: false,
@@ -97,7 +95,6 @@ export function useAuth() {
               authEnabled: false,
               isAuthenticated: true,
               mustChangePassword: false,
-              mfaRequired: false,
               role: "admin",
               permissions: ANON_ADMIN_PERMISSIONS,
               oidcEnabled: false,
@@ -127,7 +124,6 @@ export function useAuth() {
               authEnabled: true,
               isAuthenticated: true,
               mustChangePassword: mustChange,
-              mfaRequired: session.user?.mfaRequired === true,
               role: session.user?.role ?? null,
               permissions: session.user?.permissions ?? [],
               oidcEnabled: config.oidcEnabled ?? false,
@@ -147,7 +143,6 @@ export function useAuth() {
               authEnabled: true,
               isAuthenticated: false,
               mustChangePassword: false,
-              mfaRequired: false,
               role: null,
               permissions: [],
               oidcEnabled: config.oidcEnabled ?? false,


### PR DESCRIPTION
Fixes #866.

`useAuth()` exposed an `mfaRequired` flag that read `session.user?.mfaRequired`, a field `GET /api/auth/session` has never returned, so it was always false. It also had zero consumers. The password-login challenge response carried a matching `mfaRequired` field no client read. Both predate #811's forced enrollment at login, which removed the audience for an in-app "enroll now" banner, so this deletes the plumbing rather than wiring it up.

Removed:

- the `AuthState` field and its four settings in `apps/web/src/hooks/use-auth.ts`
- the `mfaRequired` challenge-response field and the `mfaRequiredByPolicy` computation feeding it in `apps/api/src/plugins/auth.ts` (the #815 fail-closed flow around it is untouched)
- the mirroring `mfaRequired: false` in the demo mock's session response

The review pass caught that `apps/docs/api/rest.md` documented the removed response field, so the sentence is fixed in English and all 20 locale copies, with `i18n_source_hash` restamped so the docs parity check stays clean for that unit. The `t.auth.mfaRequired` i18n key stays: it is display text in the challenge UI, unrelated to the boolean.

Worth knowing for release notes: the login challenge response is public API surface, so an external consumer reading `mfaRequired` from `POST /api/auth/login` will no longer find it. Enrollment state is still available as `totpEnabled` on `GET /api/auth/session`. No test anywhere asserted on the removed field (checked before deleting).

Verified: typecheck, lint, full unit suite (481 files / 8537 tests), all of `tests/integration/platform` (1738 tests). A residual repo-wide grep finds no `mfaRequired` outside the i18n label.