### PR TITLE
fix(auth): report a failed MFA policy read in snapotter-admin status

### DIFF
--- a/apps/api/src/scripts/mfa-recover.ts
+++ b/apps/api/src/scripts/mfa-recover.ts
@@ -3,8 +3,9 @@ import { eq } from "drizzle-orm";
 import type { FastifyBaseLogger } from "fastify";
 import { closeDb, db, schema } from "../db/index.js";
 import { auditLog } from "../lib/audit.js";
-import { getSettingString, upsertSetting } from "../lib/settings-helpers.js";
+import { upsertSetting } from "../lib/settings-helpers.js";
 import { clearUserMfa } from "../lib/user-mfa.js";
+import { getMfaPolicy, type MfaPolicy } from "../plugins/mfa.js";
 
 // auditLog's first parameter is a FastifyBaseLogger, but a CLI has no request.
 // It only calls .info(obj, msg) and .warn(obj, msg), so a console-backed shim
@@ -46,13 +47,42 @@ export async function disableUserMfa(username: string): Promise<DisableMfaResult
 }
 
 /** Read-only snapshot for diagnosing which login gate is blocking someone. */
-export async function mfaStatus(): Promise<{ policy: string; enrolled: string[] }> {
-  const policy = await getSettingString("mfaPolicy", "optional");
-  const rows = await db
-    .select({ username: schema.users.username })
-    .from(schema.users)
-    .where(eq(schema.users.totpEnabled, true));
-  return { policy, enrolled: rows.map((r) => r.username) };
+export async function mfaStatus(): Promise<{
+  policy: MfaPolicy | null;
+  policyError?: string;
+  enrolled: string[];
+  enrolledError?: string;
+}> {
+  // The two login gates (the policy, and whether the user is enrolled) are read
+  // independently, and each read is reported on its own. This command runs
+  // mid-incident against a possibly-degraded DB, so a failed read must surface
+  // as a failed read, never be swallowed. That is the #867 fix: getMfaPolicy
+  // reads the settings row directly and throws on a DB fault, where the old
+  // getSettingString path returned "optional". Reporting "optional" over a
+  // stored "required" sends the operator to the wrong wall. A read that fails
+  // leaves its value empty and records the cause; the other gate is still read
+  // and reported, so a partial fault still tells the operator something useful.
+  let policy: MfaPolicy | null = null;
+  let policyError: string | undefined;
+  try {
+    policy = await getMfaPolicy();
+  } catch (err) {
+    policyError = err instanceof Error ? err.message : String(err);
+  }
+
+  let enrolled: string[] = [];
+  let enrolledError: string | undefined;
+  try {
+    const rows = await db
+      .select({ username: schema.users.username })
+      .from(schema.users)
+      .where(eq(schema.users.totpEnabled, true));
+    enrolled = rows.map((r) => r.username);
+  } catch (err) {
+    enrolledError = err instanceof Error ? err.message : String(err);
+  }
+
+  return { policy, policyError, enrolled, enrolledError };
 }
 
 const USAGE = `snapotter-admin: offline MFA recovery
@@ -67,14 +97,24 @@ export async function runRecoveryCli(argv: string[]): Promise<number> {
   const [command, ...rest] = argv;
   switch (command) {
     case "status": {
-      const { policy, enrolled } = await mfaStatus();
-      console.log(`MFA policy: ${policy}`);
-      console.log(
-        enrolled.length
-          ? `Enrolled users (${enrolled.length}): ${enrolled.join(", ")}`
-          : "Enrolled users: none",
-      );
-      return 0;
+      const { policy, policyError, enrolled, enrolledError } = await mfaStatus();
+      // A failed read goes loud on stderr with a non-zero exit below, so it can
+      // never read as "this gate is fine, look elsewhere" (#867).
+      if (policyError) {
+        console.error(`MFA policy: could not read (${policyError})`);
+      } else {
+        console.log(`MFA policy: ${policy}`);
+      }
+      if (enrolledError) {
+        console.error(`Enrolled users: could not read (${enrolledError})`);
+      } else {
+        console.log(
+          enrolled.length
+            ? `Enrolled users (${enrolled.length}): ${enrolled.join(", ")}`
+            : "Enrolled users: none",
+        );
+      }
+      return policyError || enrolledError ? 1 : 0;
     }
     case "reset-mfa-policy": {
       await resetMfaPolicy();

--- a/tests/integration/platform/mfa-recovery.test.ts
+++ b/tests/integration/platform/mfa-recovery.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { db, schema } from "../../../apps/api/src/db/index.js";
 import {
   disableUserMfa,
@@ -138,8 +138,21 @@ describe("runRecoveryCli", () => {
     expect(await readPolicy()).toBe("optional");
   });
 
-  it("returns 0 for status", async () => {
-    expect(await runRecoveryCli(["status"])).toBe(0);
+  it("returns 0 for status and prints the policy to stdout", async () => {
+    await db
+      .insert(schema.settings)
+      .values({ key: "mfaPolicy", value: "required" })
+      .onConflictDoUpdate({ target: schema.settings.key, set: { value: "required" } });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(await runRecoveryCli(["status"])).toBe(0);
+      expect(logSpy).toHaveBeenCalledWith("MFA policy: required");
+      expect(errSpy).not.toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+    }
   });
 
   it("returns 1 for disable-mfa with no username", async () => {
@@ -156,5 +169,109 @@ describe("runRecoveryCli", () => {
 
   it("returns 0 for help", async () => {
     expect(await runRecoveryCli(["help"])).toBe(0);
+  });
+});
+
+// #867: the status diagnostic must never report a failed policy read as
+// "optional". An operator runs this mid-incident against a possibly-degraded
+// DB; a swallowed read that prints "optional" over a stored "required" sends
+// them to the wrong login wall.
+describe("mfaStatus when the policy read fails (#867)", () => {
+  // Fail only the settings {value} read (what getMfaPolicy issues); the
+  // enrolled-users {username} read must still reach the real DB.
+  function failSettingsRead(): ReturnType<typeof vi.spyOn> {
+    const originalSelect = db.select.bind(db);
+    return vi.spyOn(db, "select").mockImplementation((...args: unknown[]) => {
+      const selection = args[0] as Record<string, unknown> | undefined;
+      if (selection && "value" in selection) {
+        throw new Error("simulated settings read failure");
+      }
+      // biome-ignore lint/suspicious/noExplicitAny: passthrough to the real overloaded implementation
+      return (originalSelect as any)(...args);
+    });
+  }
+
+  it("reports the read failure instead of defaulting to optional, and still lists enrolled users", async () => {
+    // Arm a required policy: a swallowed read would masquerade as "optional".
+    await db
+      .insert(schema.settings)
+      .values({ key: "mfaPolicy", value: "required" })
+      .onConflictDoUpdate({ target: schema.settings.key, set: { value: "required" } });
+    const { username } = await insertUser({ totpEnabled: true, totpSecret: "s" });
+
+    const selectSpy = failSettingsRead();
+    try {
+      const status = await mfaStatus();
+      expect(status.policy).toBeNull();
+      expect(status.policyError).toContain("simulated settings read failure");
+      // The independent enrollment gate is still reported.
+      expect(status.enrolled).toContain(username);
+    } finally {
+      selectSpy.mockRestore();
+    }
+  });
+
+  it("runRecoveryCli status exits 1 and prints a 'could not read' line when the policy read fails", async () => {
+    await db
+      .insert(schema.settings)
+      .values({ key: "mfaPolicy", value: "required" })
+      .onConflictDoUpdate({ target: schema.settings.key, set: { value: "required" } });
+
+    const selectSpy = failSettingsRead();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const code = await runRecoveryCli(["status"]);
+      expect(code).toBe(1);
+      // The underlying cause must ride along, not just the "could not read"
+      // label: the whole point is the operator sees WHY, so they don't read it
+      // as "MFA is fine."
+      expect(errSpy).toHaveBeenCalledWith(
+        expect.stringContaining("MFA policy: could not read (simulated settings read failure)"),
+      );
+    } finally {
+      selectSpy.mockRestore();
+      errSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+
+  // The recovery CLI's whole job is to run mid-incident against a degraded DB,
+  // and a full outage is the most likely one. Both reads must then degrade to a
+  // reported failure with a clean non-zero exit, never an unhandled rejection or
+  // a masqueraded "optional".
+  it("mfaStatus reports both reads as failed, without throwing, when the whole DB is down", async () => {
+    const selectSpy = vi.spyOn(db, "select").mockImplementation(() => {
+      throw new Error("whole DB down");
+    });
+    try {
+      const status = await mfaStatus();
+      expect(status.policy).toBeNull();
+      expect(status.policyError).toContain("whole DB down");
+      expect(status.enrolled).toEqual([]);
+      expect(status.enrolledError).toContain("whole DB down");
+    } finally {
+      selectSpy.mockRestore();
+    }
+  });
+
+  it("runRecoveryCli status resolves to 1 (never rejects) and reports both gates when the whole DB is down", async () => {
+    const selectSpy = vi.spyOn(db, "select").mockImplementation(() => {
+      throw new Error("whole DB down");
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const code = await runRecoveryCli(["status"]);
+      expect(code).toBe(1);
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("MFA policy: could not read"));
+      expect(errSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Enrolled users: could not read"),
+      );
+    } finally {
+      selectSpy.mockRestore();
+      errSpy.mockRestore();
+      logSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## What was wrong

`snapotter-admin status` is the offline diagnostic an operator runs mid-incident to see which login gate is locking people out (the "Which wall am I hitting?" step in the account-recovery guide). It read the MFA policy through `getSettingString("mfaPolicy", "optional")`, which catches any DB error and returns the default. So a failed settings read printed `MFA policy: optional` even when the stored policy was `required`. A DB fault is exactly when this gets run, and the misreport points the operator away from the real gate.

## The fix

`mfaStatus()` now reads the policy through the strict `getMfaPolicy()` added in #865, which reads the settings row directly and throws on a fault instead of swallowing it. The `status` command reads both gates (the policy, and the enrolled-users list) independently and reports each one. A readable gate prints as before; a failed read prints `could not read (<error>)` on stderr and forces exit 1. Neither gate can show a clean value when its read failed.

A partial fault (settings read fails, users table fine) still reports the gate that is readable. A full outage reports both as unreadable and exits 1 instead of dumping a raw query error.

## Tests

Four new integration tests in `mfa-recovery.test.ts` drive `db.select` failures:

- policy read fails in isolation: `mfaStatus()` returns `policy: null` plus a `policyError` and still lists enrolled users; `runRecoveryCli(["status"])` exits 1 with the cause on stderr
- whole DB down: both reads report a failure, `mfaStatus()` resolves instead of rejecting, and `runRecoveryCli(["status"])` resolves to 1 instead of throwing out of the CLI

The existing "status returns 0" test now also asserts the healthy path prints `MFA policy: <value>` to stdout. All four new tests fail against the pre-fix code. Full file green (18 tests), typecheck and biome clean. I also confirmed the CLI exits cleanly with the added `mfa.ts` import, via a real run against an unreachable DB.

Fixes #867
