### PR TITLE
test(api): poll the queue state in the no-output retry test

### DIFF
--- a/tests/integration/platform/worker-branches.test.ts
+++ b/tests/integration/platform/worker-branches.test.ts
@@ -468,9 +468,14 @@ describe("tool job failure paths", () => {
     expect(props.execution_hint).toBe("fast");
 
     // The queue job is terminally failed (this is what fired the pool's
-    // failed-handler on the final attempt).
-    const queueJob = await getQueue("image").getJob(jobId);
-    expect(await queueJob?.getState()).toBe("failed");
+    // failed-handler on the final attempt). Poll for it: the durable row and
+    // analytics flip inside the processor's failure handling, before the
+    // rejection propagates into BullMQ's own active -> failed move.
+    await waitFor(async () => {
+      const queueJob = await getQueue("image").getJob(jobId);
+      if (!queueJob) return undefined;
+      return (await queueJob.getState()) === "failed" ? queueJob : undefined;
+    }, 10_000);
   }, 30_000);
 
   it("fails when an extra output has neither buffer nor scratchPath", async () => {


### PR DESCRIPTION
Fixes the flaky assertion that failed Integration (4/4) on main (run 32250234370): expected the BullMQ job state to read "failed", got "active".

Everything the test waits on before that read (the durable row via terminalRow, the terminal Redis frame, the analytics mock) is written inside the processor's failure handling, before the rejection propagates back into BullMQ's own active to failed move. On a starved runner that window stretched past the one-shot getState() read. The fix polls with the file's own waitFor idiom, the same shape the pipeline test at line 842 already uses, with the same 10s budget as the terminal-frame and analytics polls.

Test-only change, no product code touched. Verified locally: the changed test passes against dev Postgres/Redis, biome and typecheck clean.

Fixes #874