### PR TITLE
ci: bound apt installs and fall back off a degraded Azure mirror

### DIFF
--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -1,0 +1,28 @@
+name: Install apt packages with a mirror fallback
+description: >-
+  apt-get install with every network step bounded by a timeout. The runner's
+  Azure apt mirror can degrade to kB/s and eat an entire job budget before
+  tests start (#876); when an attempt stalls or fails, sources are switched
+  to the canonical Ubuntu archive and the install is retried once.
+inputs:
+  packages:
+    description: Space-separated apt package list
+    required: true
+  update-timeout:
+    description: Seconds allowed for each apt-get update
+    required: false
+    default: "120"
+  install-timeout:
+    description: Seconds allowed for each apt-get install attempt
+    required: false
+    default: "420"
+runs:
+  using: composite
+  steps:
+    - name: apt-get install (Azure mirror, then archive.ubuntu.com)
+      shell: bash
+      env:
+        PACKAGES: ${{ inputs.packages }}
+        UPDATE_TIMEOUT: ${{ inputs.update-timeout }}
+        INSTALL_TIMEOUT: ${{ inputs.install-timeout }}
+      run: bash "${{ github.action_path }}/install.sh"

--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -9,13 +9,13 @@ inputs:
     description: Space-separated apt package list
     required: true
   update-timeout:
-    description: Seconds allowed for each apt-get update
+    description: Seconds allowed for the first apt-get update (the fallback retry gets 3x)
     required: false
     default: "120"
   install-timeout:
-    description: Seconds allowed for each apt-get install attempt
+    description: Seconds allowed for the first apt-get install (the fallback retry gets 2x)
     required: false
-    default: "420"
+    default: "360"
 runs:
   using: composite
   steps:

--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -9,13 +9,13 @@ inputs:
     description: Space-separated apt package list
     required: true
   update-timeout:
-    description: Seconds allowed for the first apt-get update (the fallback retry gets 3x)
+    description: Seconds allowed for each apt-get update attempt
     required: false
     default: "120"
   install-timeout:
-    description: Seconds allowed for the first apt-get install (the fallback retry gets 2x)
+    description: Seconds allowed for each apt-get install attempt (3 attempts; downloads resume across them)
     required: false
-    default: "360"
+    default: "300"
 runs:
   using: composite
   steps:

--- a/.github/actions/apt-install/install.sh
+++ b/.github/actions/apt-install/install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Bounded apt install with a mirror fallback (#876).
+#
+# Every network step runs under timeout(1): apt's own Acquire::http::Timeout
+# only catches dead connections, not a mirror that keeps trickling bytes at
+# kB/s. When the first attempt stalls or fails, swap the Azure mirror for the
+# canonical archive in the apt sources and retry once, so the worst case is
+# bounded instead of eating the job's whole timeout budget.
+set -euo pipefail
+
+read -r -a packages <<< "$PACKAGES"
+
+attempt() {
+  sudo timeout -k 30 "${UPDATE_TIMEOUT:-120}" apt-get update -qq &&
+    sudo timeout -k 30 "${INSTALL_TIMEOUT:-420}" apt-get install -y \
+      --no-install-recommends "${packages[@]}"
+}
+
+if attempt; then exit 0; fi
+
+echo "::warning::apt via the Azure mirror stalled or failed; retrying via archive.ubuntu.com"
+# A timed-out apt can leave packages unpacked but unconfigured.
+sudo dpkg --configure -a || true
+# Classic sources.list and deb822 ubuntu.sources both just name the host.
+sudo find /etc/apt/sources.list /etc/apt/sources.list.d -maxdepth 1 -type f \
+  -exec sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' {} + 2>/dev/null || true
+attempt

--- a/.github/actions/apt-install/install.sh
+++ b/.github/actions/apt-install/install.sh
@@ -3,16 +3,19 @@
 #
 # Every network step runs under timeout(1): apt's own Acquire::http::Timeout
 # only catches dead connections, not a mirror that keeps trickling bytes at
-# kB/s. The two halves degrade differently, so they recover differently:
+# kB/s. The pieces degrade differently, so they recover differently:
 #
-# - Index fetches (apt-get update) barely resume, and the mirror swap
-#   invalidates everything cached, so the post-swap update gets patient
-#   budgets instead of re-rolls (a 120s post-swap update died twice on a
-#   real degraded day).
 # - Package downloads resume across attempts and the degradation is
 #   per-connection (one runner pulled 154 MB at 3.7 MB/s from the same host
 #   that trickled kB/s to another), so installs get cheap re-rolls: each new
 #   attempt draws a new connection and keeps the bytes already fetched.
+# - Index fetches (apt-get update) barely resume, and the mirror swap
+#   invalidates the cache by hostname. When the Azure update succeeded,
+#   relabeling its just-fetched list files sidesteps the refresh entirely:
+#   the mirrors carry identical content and apt keys downloaded indexes by
+#   hostname-derived filename. Only when the Azure update itself failed is
+#   a real post-swap refresh needed, with patience instead of re-rolls
+#   (120s and 360s post-swap updates both died on a real degraded day).
 set -euo pipefail
 
 read -r -a packages <<< "$PACKAGES"
@@ -28,8 +31,12 @@ apt_install() {
     --no-install-recommends "${packages[@]}"
 }
 
-# One shot against the runner's default Azure mirror.
-if apt_update "$update_budget" && apt_install; then exit 0; fi
+azure_lists_ok=false
+if apt_update "$update_budget"; then
+  azure_lists_ok=true
+  if apt_install; then exit 0; fi
+fi
+
 echo "::warning::apt via the Azure mirror stalled or failed; swapping to archive.ubuntu.com"
 # A timed-out apt can leave packages unpacked but unconfigured.
 sudo dpkg --configure -a || true
@@ -37,7 +44,14 @@ sudo dpkg --configure -a || true
 sudo find /etc/apt/sources.list /etc/apt/sources.list.d -maxdepth 1 -type f \
   -exec sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' {} + 2>/dev/null || true
 
-apt_update "$((update_budget * 3))" || apt_update "$((update_budget * 3))"
+if $azure_lists_ok; then
+  for f in /var/lib/apt/lists/azure.archive.ubuntu.com_*; do
+    [ -e "$f" ] || continue
+    sudo mv "$f" "${f/azure.archive.ubuntu.com/archive.ubuntu.com}"
+  done
+else
+  apt_update "$((update_budget * 3))" || apt_update "$((update_budget * 3))"
+fi
 
 for i in 1 2 3; do
   if apt_install; then exit 0; fi

--- a/.github/actions/apt-install/install.sh
+++ b/.github/actions/apt-install/install.sh
@@ -11,12 +11,15 @@ set -euo pipefail
 read -r -a packages <<< "$PACKAGES"
 
 attempt() {
-  sudo timeout -k 30 "${UPDATE_TIMEOUT:-120}" apt-get update -qq &&
-    sudo timeout -k 30 "${INSTALL_TIMEOUT:-420}" apt-get install -y \
+  sudo timeout -k 30 "$1" apt-get update -qq &&
+    sudo timeout -k 30 "$2" apt-get install -y \
       --no-install-recommends "${packages[@]}"
 }
 
-if attempt; then exit 0; fi
+update_budget="${UPDATE_TIMEOUT:-120}"
+install_budget="${INSTALL_TIMEOUT:-360}"
+
+if attempt "$update_budget" "$install_budget"; then exit 0; fi
 
 echo "::warning::apt via the Azure mirror stalled or failed; retrying via archive.ubuntu.com"
 # A timed-out apt can leave packages unpacked but unconfigured.
@@ -24,4 +27,7 @@ sudo dpkg --configure -a || true
 # Classic sources.list and deb822 ubuntu.sources both just name the host.
 sudo find /etc/apt/sources.list /etc/apt/sources.list.d -maxdepth 1 -type f \
   -exec sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' {} + 2>/dev/null || true
-attempt
+# The retry is the last chance before the job fails, and the mirror swap
+# forces a full index refresh, so it gets patient budgets: a slow-but-flowing
+# mirror beats a dead job (a 120s retry update died on a real degraded day).
+attempt "$((update_budget * 3))" "$((install_budget * 2))"

--- a/.github/actions/apt-install/install.sh
+++ b/.github/actions/apt-install/install.sh
@@ -1,33 +1,36 @@
 #!/usr/bin/env bash
-# Bounded apt install with a mirror fallback (#876).
+# Bounded apt install with connection re-rolls and a mirror fallback (#876).
 #
 # Every network step runs under timeout(1): apt's own Acquire::http::Timeout
 # only catches dead connections, not a mirror that keeps trickling bytes at
-# kB/s. When the first attempt stalls or fails, swap the Azure mirror for the
-# canonical archive in the apt sources and retry once, so the worst case is
-# bounded instead of eating the job's whole timeout budget.
+# kB/s. Mirror degradation is per-connection (one runner pulled 154 MB at
+# 3.7 MB/s from the same host that trickled to another), and apt resumes
+# partial downloads, so several cheap attempts beat one patient one: each
+# new attempt re-rolls the connection and keeps the bytes already fetched.
+# The Azure mirror gets one shot, then sources swap to the canonical archive.
 set -euo pipefail
 
 read -r -a packages <<< "$PACKAGES"
 
+update_budget="${UPDATE_TIMEOUT:-120}"
+install_budget="${INSTALL_TIMEOUT:-300}"
+attempts="${ATTEMPTS:-3}"
+
 attempt() {
-  sudo timeout -k 30 "$1" apt-get update -qq &&
-    sudo timeout -k 30 "$2" apt-get install -y \
+  sudo timeout -k 30 "$update_budget" apt-get update -qq &&
+    sudo timeout -k 30 "$install_budget" apt-get install -y \
       --no-install-recommends "${packages[@]}"
 }
 
-update_budget="${UPDATE_TIMEOUT:-120}"
-install_budget="${INSTALL_TIMEOUT:-360}"
-
-if attempt "$update_budget" "$install_budget"; then exit 0; fi
-
-echo "::warning::apt via the Azure mirror stalled or failed; retrying via archive.ubuntu.com"
-# A timed-out apt can leave packages unpacked but unconfigured.
-sudo dpkg --configure -a || true
-# Classic sources.list and deb822 ubuntu.sources both just name the host.
-sudo find /etc/apt/sources.list /etc/apt/sources.list.d -maxdepth 1 -type f \
-  -exec sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' {} + 2>/dev/null || true
-# The retry is the last chance before the job fails, and the mirror swap
-# forces a full index refresh, so it gets patient budgets: a slow-but-flowing
-# mirror beats a dead job (a 120s retry update died on a real degraded day).
-attempt "$((update_budget * 3))" "$((install_budget * 2))"
+for i in $(seq 1 "$attempts"); do
+  if attempt; then exit 0; fi
+  echo "::warning::apt attempt ${i}/${attempts} stalled or failed"
+  # A timed-out apt can leave packages unpacked but unconfigured.
+  sudo dpkg --configure -a || true
+  if [ "$i" = 1 ]; then
+    # Classic sources.list and deb822 ubuntu.sources both just name the host.
+    sudo find /etc/apt/sources.list /etc/apt/sources.list.d -maxdepth 1 -type f \
+      -exec sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' {} + 2>/dev/null || true
+  fi
+done
+exit 1

--- a/.github/actions/apt-install/install.sh
+++ b/.github/actions/apt-install/install.sh
@@ -1,36 +1,47 @@
 #!/usr/bin/env bash
-# Bounded apt install with connection re-rolls and a mirror fallback (#876).
+# Bounded apt install with a mirror fallback (#876).
 #
 # Every network step runs under timeout(1): apt's own Acquire::http::Timeout
 # only catches dead connections, not a mirror that keeps trickling bytes at
-# kB/s. Mirror degradation is per-connection (one runner pulled 154 MB at
-# 3.7 MB/s from the same host that trickled to another), and apt resumes
-# partial downloads, so several cheap attempts beat one patient one: each
-# new attempt re-rolls the connection and keeps the bytes already fetched.
-# The Azure mirror gets one shot, then sources swap to the canonical archive.
+# kB/s. The two halves degrade differently, so they recover differently:
+#
+# - Index fetches (apt-get update) barely resume, and the mirror swap
+#   invalidates everything cached, so the post-swap update gets patient
+#   budgets instead of re-rolls (a 120s post-swap update died twice on a
+#   real degraded day).
+# - Package downloads resume across attempts and the degradation is
+#   per-connection (one runner pulled 154 MB at 3.7 MB/s from the same host
+#   that trickled kB/s to another), so installs get cheap re-rolls: each new
+#   attempt draws a new connection and keeps the bytes already fetched.
 set -euo pipefail
 
 read -r -a packages <<< "$PACKAGES"
 
 update_budget="${UPDATE_TIMEOUT:-120}"
 install_budget="${INSTALL_TIMEOUT:-300}"
-attempts="${ATTEMPTS:-3}"
 
-attempt() {
-  sudo timeout -k 30 "$update_budget" apt-get update -qq &&
-    sudo timeout -k 30 "$install_budget" apt-get install -y \
-      --no-install-recommends "${packages[@]}"
+apt_update() {
+  sudo timeout -k 30 "$1" apt-get update -qq
+}
+apt_install() {
+  sudo timeout -k 30 "$install_budget" apt-get install -y \
+    --no-install-recommends "${packages[@]}"
 }
 
-for i in $(seq 1 "$attempts"); do
-  if attempt; then exit 0; fi
-  echo "::warning::apt attempt ${i}/${attempts} stalled or failed"
-  # A timed-out apt can leave packages unpacked but unconfigured.
+# One shot against the runner's default Azure mirror.
+if apt_update "$update_budget" && apt_install; then exit 0; fi
+echo "::warning::apt via the Azure mirror stalled or failed; swapping to archive.ubuntu.com"
+# A timed-out apt can leave packages unpacked but unconfigured.
+sudo dpkg --configure -a || true
+# Classic sources.list and deb822 ubuntu.sources both just name the host.
+sudo find /etc/apt/sources.list /etc/apt/sources.list.d -maxdepth 1 -type f \
+  -exec sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' {} + 2>/dev/null || true
+
+apt_update "$((update_budget * 3))" || apt_update "$((update_budget * 3))"
+
+for i in 1 2 3; do
+  if apt_install; then exit 0; fi
+  echo "::warning::apt install re-roll ${i}/3 stalled or failed"
   sudo dpkg --configure -a || true
-  if [ "$i" = 1 ]; then
-    # Classic sources.list and deb822 ubuntu.sources both just name the host.
-    sudo find /etc/apt/sources.list /etc/apt/sources.list.d -maxdepth 1 -type f \
-      -exec sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' {} + 2>/dev/null || true
-  fi
 done
 exit 1

--- a/.github/actions/playwright-install/action.yml
+++ b/.github/actions/playwright-install/action.yml
@@ -1,0 +1,24 @@
+name: Install Playwright browsers with bounded system deps
+description: >-
+  Splits the browser download (Playwright CDN + actions/cache) from the
+  system-dependency apt install, and bounds the apt half with a timeout and
+  one retry. An unbounded "playwright install --with-deps" stalls for the
+  rest of the job budget when an apt mirror degrades (#876).
+inputs:
+  browsers:
+    description: Space-separated Playwright browser list
+    required: false
+    default: chromium
+  deps-timeout:
+    description: Seconds allowed for each install-deps attempt
+    required: false
+    default: "420"
+runs:
+  using: composite
+  steps:
+    - name: playwright install, then bounded install-deps
+      shell: bash
+      env:
+        BROWSERS: ${{ inputs.browsers }}
+        DEPS_TIMEOUT: ${{ inputs.deps-timeout }}
+      run: bash "${{ github.action_path }}/install.sh"

--- a/.github/actions/playwright-install/action.yml
+++ b/.github/actions/playwright-install/action.yml
@@ -10,9 +10,9 @@ inputs:
     required: false
     default: chromium
   deps-timeout:
-    description: Seconds allowed for each install-deps attempt
+    description: Seconds allowed for each install-deps attempt (3 attempts; downloads resume across them)
     required: false
-    default: "420"
+    default: "300"
 runs:
   using: composite
   steps:

--- a/.github/actions/playwright-install/install.sh
+++ b/.github/actions/playwright-install/install.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 # Browser binaries come from Playwright's CDN (usually a cache hit); only
 # install-deps talks to apt. Splitting them keeps a degraded apt mirror
-# (#876) from wasting the browser download, and the bounded retry keeps a
-# stalled mirror from eating the whole job budget.
+# (#876) from wasting the browser download. Mirror degradation is
+# per-connection and apt resumes partial downloads, so several bounded
+# attempts re-roll the connection while keeping the bytes already fetched.
 set -euo pipefail
 
 read -r -a browsers <<< "$BROWSERS"
 
 pnpm playwright install "${browsers[@]}"
 
-for attempt in 1 2; do
-  if timeout -k 30 "${DEPS_TIMEOUT:-420}" pnpm playwright install-deps "${browsers[@]}"; then
+attempts="${ATTEMPTS:-3}"
+for i in $(seq 1 "$attempts"); do
+  if timeout -k 30 "${DEPS_TIMEOUT:-300}" pnpm playwright install-deps "${browsers[@]}"; then
     exit 0
   fi
-  echo "::warning::playwright install-deps stalled or failed (attempt ${attempt}/2)"
+  echo "::warning::playwright install-deps stalled or failed (attempt ${i}/${attempts})"
   # timeout kills the pnpm tree, but the sudo apt-get underneath can survive
   # as an orphan and hold the dpkg lock into the retry.
   sudo pkill -9 -x apt-get 2>/dev/null || true

--- a/.github/actions/playwright-install/install.sh
+++ b/.github/actions/playwright-install/install.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Browser binaries come from Playwright's CDN (usually a cache hit); only
+# install-deps talks to apt. Splitting them keeps a degraded apt mirror
+# (#876) from wasting the browser download, and the bounded retry keeps a
+# stalled mirror from eating the whole job budget.
+set -euo pipefail
+
+read -r -a browsers <<< "$BROWSERS"
+
+pnpm playwright install "${browsers[@]}"
+
+for attempt in 1 2; do
+  if timeout -k 30 "${DEPS_TIMEOUT:-420}" pnpm playwright install-deps "${browsers[@]}"; then
+    exit 0
+  fi
+  echo "::warning::playwright install-deps stalled or failed (attempt ${attempt}/2)"
+  # timeout kills the pnpm tree, but the sudo apt-get underneath can survive
+  # as an orphan and hold the dpkg lock into the retry.
+  sudo pkill -9 -x apt-get 2>/dev/null || true
+  sudo pkill -9 -x dpkg 2>/dev/null || true
+  sleep 2
+  sudo dpkg --configure -a || true
+done
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,16 +121,21 @@ jobs:
   test-unit:
     name: Unit Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    # Headroom for a degraded-apt-mirror day: both bounded install attempts
+    # plus the tests still fit (#876).
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install system dependencies (HEIC + ExifTool + ImageMagick + exotic format tools)
+        uses: ./.github/actions/apt-install
+        with:
+          packages: libheif-examples libheif-plugin-x265 libheif-plugin-libde265 libimage-exiftool-perl libraw-bin imagemagick ghostscript libjxl-tools libopenjp2-tools
+
+      - name: Install the ImageMagick EXR coder and verify
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends libheif-examples libheif-plugin-x265 libheif-plugin-libde265 libimage-exiftool-perl libraw-bin imagemagick ghostscript libjxl-tools libopenjp2-tools
           if apt-cache show libmagickcore-6.q16-7-extra >/dev/null 2>&1; then
             sudo apt-get install -y --no-install-recommends libmagickcore-6.q16-7-extra
           elif apt-cache show libmagickcore-6.q16-6-extra >/dev/null 2>&1; then
@@ -158,7 +163,9 @@ jobs:
   test-integration:
     name: Integration (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Headroom for a degraded-apt-mirror day: both bounded install attempts
+    # plus the tests still fit (#876).
+    timeout-minutes: 40
     needs: changes
     if: needs.changes.outputs.code == 'true'
     strategy:
@@ -169,17 +176,19 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install system dependencies (image formats + docs + Fast OCR)
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
-            libheif-examples libheif-plugin-x265 libheif-plugin-libde265 \
-            libimage-exiftool-perl libraw-bin imagemagick ghostscript \
-            libjxl-tools libopenjp2-tools \
-            qpdf libreoffice-calc libreoffice-impress libreoffice-writer \
-            tesseract-ocr tesseract-ocr-eng tesseract-ocr-deu \
-            tesseract-ocr-fra tesseract-ocr-spa \
+        uses: ./.github/actions/apt-install
+        with:
+          packages: >-
+            libheif-examples libheif-plugin-x265 libheif-plugin-libde265
+            libimage-exiftool-perl libraw-bin imagemagick ghostscript
+            libjxl-tools libopenjp2-tools
+            qpdf libreoffice-calc libreoffice-impress libreoffice-writer
+            tesseract-ocr tesseract-ocr-eng tesseract-ocr-deu
+            tesseract-ocr-fra tesseract-ocr-spa
             tesseract-ocr-chi-sim tesseract-ocr-jpn
 
+      - name: Install the ImageMagick EXR coder and verify the format toolchain
+        run: |
           if apt-cache show libmagickcore-6.q16-7-extra >/dev/null 2>&1; then
             sudo apt-get install -y --no-install-recommends libmagickcore-6.q16-7-extra
           elif apt-cache show libmagickcore-6.q16-6-extra >/dev/null 2>&1; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,10 @@ jobs:
   test-unit:
     name: Unit Tests
     runs-on: ubuntu-latest
-    # Headroom for a degraded-apt-mirror day: both bounded install attempts
-    # plus the tests still fit (#876).
-    timeout-minutes: 15
+    # Headroom for a degraded-apt-mirror day: the full bounded recovery
+    # ladder (~27m worst case) plus the tests still fit (#876). A 15m cap
+    # killed this job mid-recovery on a real degraded day.
+    timeout-minutes: 35
     needs: changes
     if: needs.changes.outputs.code == 'true'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,9 @@ jobs:
   test-e2e-smoke:
     name: E2E Smoke (Chromium)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Headroom for a degraded-apt-mirror day (#876): bounded install-deps
+    # attempts plus the specs still fit.
+    timeout-minutes: 25
     needs: changes
     if: needs.changes.outputs.code == 'true'
     services:
@@ -285,7 +287,7 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright Chromium
-        run: pnpm playwright install --with-deps chromium
+        uses: ./.github/actions/playwright-install
       - name: Run smoke specs
         # tools-all.spec.ts is the full 240-tool per-tool render matrix (~250 tests)
         # -- a comprehensive check, not a PR-gate smoke test. It runs in the nightly
@@ -305,7 +307,9 @@ jobs:
   test-e2e-mobile-smoke:
     name: E2E Mobile Smoke (Chromium)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Headroom for a degraded-apt-mirror day (#876): bounded install-deps
+    # attempts plus the specs still fit.
+    timeout-minutes: 25
     needs: changes
     if: needs.changes.outputs.code == 'true'
     services:
@@ -343,7 +347,7 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright Chromium
-        run: pnpm playwright install --with-deps chromium
+        uses: ./.github/actions/playwright-install
       - name: Run mobile device specs (Pixel 7)
         run: pnpm playwright test --project=mobile-chromium --grep @mobile --grep-invert @visual
         env:
@@ -359,7 +363,9 @@ jobs:
   test-e2e-landing:
     name: E2E Landing (Chromium)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Headroom for a degraded-apt-mirror day (#876): bounded install-deps
+    # attempts plus the specs still fit.
+    timeout-minutes: 25
     needs: changes
     if: needs.changes.outputs.landing == 'true'
     steps:
@@ -374,7 +380,7 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright Chromium
-        run: pnpm playwright install --with-deps chromium
+        uses: ./.github/actions/playwright-install
       - name: Run landing e2e suite
         # The landing is a static Astro site with no database, so this needs no
         # Postgres/Redis services. The suite's webServer starts `astro dev` on 4350.
@@ -396,8 +402,9 @@ jobs:
     name: E2E Docs (Chromium)
     runs-on: ubuntu-latest
     # vitepress build renders ~3,800 pages and then runs Pagefind over them,
-    # which the config allows up to 10 minutes for on a loaded machine.
-    timeout-minutes: 30
+    # which the config allows up to 10 minutes for on a loaded machine. The
+    # extra 10 is degraded-apt-mirror headroom (#876).
+    timeout-minutes: 40
     needs: changes
     if: needs.changes.outputs.docs == 'true'
     steps:
@@ -412,7 +419,7 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright Chromium
-        run: pnpm playwright install --with-deps chromium
+        uses: ./.github/actions/playwright-install
       - name: Run docs e2e suite
         # Static VitePress site with no database, so no Postgres/Redis services.
         # The suite's webServer builds the site and serves the preview itself.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,10 +52,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install system dependencies
-        run: |
-          read -r -a system_deps <<< "$SYSTEM_DEPS"
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends "${system_deps[@]}"
+        uses: ./.github/actions/apt-install
+        with:
+          packages: ${{ env.SYSTEM_DEPS }}
       - uses: ./.github/actions/setup
       - name: Get Playwright version
         id: pw-version
@@ -109,10 +108,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install system dependencies
-        run: |
-          read -r -a system_deps <<< "$SYSTEM_DEPS"
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends "${system_deps[@]}"
+        uses: ./.github/actions/apt-install
+        with:
+          packages: ${{ env.SYSTEM_DEPS }}
       - uses: ./.github/actions/setup
       - name: Get Playwright version
         id: pw-version
@@ -176,10 +174,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install system dependencies
-        run: |
-          read -r -a system_deps <<< "$SYSTEM_DEPS"
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends "${system_deps[@]}"
+        uses: ./.github/actions/apt-install
+        with:
+          packages: ${{ env.SYSTEM_DEPS }}
       - uses: ./.github/actions/setup
       - name: Get Playwright version
         id: pw-version
@@ -296,10 +293,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install system dependencies
-        run: |
-          read -r -a system_deps <<< "$SYSTEM_DEPS"
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends "${system_deps[@]}"
+        uses: ./.github/actions/apt-install
+        with:
+          packages: ${{ env.SYSTEM_DEPS }}
       - uses: ./.github/actions/setup
       - name: Get Playwright version
         id: pw-version
@@ -367,10 +363,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install system dependencies
-        run: |
-          read -r -a system_deps <<< "$SYSTEM_DEPS"
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends "${system_deps[@]}"
+        uses: ./.github/actions/apt-install
+        with:
+          packages: ${{ env.SYSTEM_DEPS }}
       - name: Allow ImageMagick to read EPS/PS via Ghostscript delegate
         run: |
           POLICY_FILE=$(find /etc/ImageMagick* -name policy.xml 2>/dev/null | head -1)
@@ -437,10 +432,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install system dependencies
-        run: |
-          read -r -a system_deps <<< "$SYSTEM_DEPS"
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends "${system_deps[@]}"
+        uses: ./.github/actions/apt-install
+        with:
+          packages: ${{ env.SYSTEM_DEPS }}
       - uses: ./.github/actions/setup
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -503,10 +497,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install system dependencies
-        run: |
-          read -r -a system_deps <<< "$SYSTEM_DEPS"
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends "${system_deps[@]}"
+        uses: ./.github/actions/apt-install
+        with:
+          packages: ${{ env.SYSTEM_DEPS }}
       - name: Allow ImageMagick to read EPS/PS via Ghostscript delegate
         run: |
           POLICY_FILE=$(find /etc/ImageMagick* -name policy.xml 2>/dev/null | head -1)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,7 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright Chromium
-        run: pnpm playwright install --with-deps chromium
+        uses: ./.github/actions/playwright-install
       - name: Run full e2e suite (shard)
         run: pnpm playwright test --project=chromium --shard=${{ matrix.shard }}/4
         env:
@@ -121,7 +121,7 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright Chromium
-        run: pnpm playwright install --with-deps chromium
+        uses: ./.github/actions/playwright-install
       - name: Run serial bucket (global-state specs)
         run: pnpm playwright test --project=chromium-serial --workers=1
       # chromium-widths owns the exact CSS boundary and wide-screen assertions.
@@ -187,7 +187,7 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright Chromium
-        run: pnpm playwright install --with-deps chromium
+        uses: ./.github/actions/playwright-install
       - name: Run editor suite
         run: pnpm playwright test --config playwright.editor.config.ts
         env:
@@ -250,7 +250,9 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-all-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright browsers
-        run: pnpm playwright install --with-deps chromium firefox webkit
+        uses: ./.github/actions/playwright-install
+        with:
+          browsers: chromium firefox webkit
       - name: Run cross-browser spec
         run: pnpm playwright test --project=firefox --project=webkit
         env:
@@ -306,7 +308,9 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-all-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright browsers (chromium + webkit)
-        run: pnpm playwright install --with-deps chromium webkit
+        uses: ./.github/actions/playwright-install
+        with:
+          browsers: chromium webkit
       - name: Run all device projects
         run: pnpm playwright test --project=mobile-chromium --project=mobile-webkit --project=tablet-webkit --project=tablet-chromium --grep-invert "@visual"
         env:

--- a/tests/unit/features/ocr-runtime-build-contract.test.ts
+++ b/tests/unit/features/ocr-runtime-build-contract.test.ts
@@ -128,10 +128,13 @@ describe("OCR v3 runtime artifact contract", () => {
       /^ {2}test-integration:\n[\s\S]*?(?=^ {2}test-e2e-smoke:)/m,
     )?.[0];
     expect(integrationJob).toBeDefined();
-    const systemDependencyRunBlock = integrationJob?.match(
-      /^ {6}- name: Install system dependencies[^\n]*\n {8}run: \|\n(?<run>[\s\S]*?)(?=^ {6}- )/m,
-    )?.groups?.run;
-    expect(systemDependencyRunBlock).toBeDefined();
+
+    // The install goes through .github/actions/apt-install (#876), so the
+    // payload lives in the step's folded `packages:` scalar.
+    const packagesBlock = integrationJob?.match(
+      /^ {6}- name: Install system dependencies[^\n]*\n {8}uses: \.\/\.github\/actions\/apt-install\n {8}with:\n {10}packages: >-\n(?<packages>(?: {12}[^\n]+\n)+)/m,
+    )?.groups?.packages;
+    expect(packagesBlock).toBeDefined();
 
     const expectedPackages = [
       "tesseract-ocr",
@@ -142,20 +145,17 @@ describe("OCR v3 runtime artifact contract", () => {
       "tesseract-ocr-chi-sim",
       "tesseract-ocr-jpn",
     ];
-    const systemDependencyLines = systemDependencyRunBlock?.split("\n") ?? [];
-    const installStart = systemDependencyLines.findIndex((line) =>
-      line.includes("sudo apt-get install -y --no-install-recommends"),
-    );
-    expect(installStart).toBeGreaterThanOrEqual(0);
-    const installCommand: string[] = [];
-    for (let index = installStart; index < systemDependencyLines.length; index++) {
-      const line = systemDependencyLines[index];
-      installCommand.push(line);
-      if (!line.trimEnd().endsWith("\\")) break;
-    }
-    const installedPackages =
-      installCommand.join("\n").match(/\btesseract-ocr(?:-[a-z0-9-]+)?\b/g) ?? [];
+    const installedPackages = packagesBlock?.match(/\btesseract-ocr(?:-[a-z0-9-]+)?\b/g) ?? [];
     expect([...new Set(installedPackages)].sort()).toEqual([...expectedPackages].sort());
+
+    // The post-install checks moved to the follow-up verification step.
+    const systemDependencyLines =
+      integrationJob
+        ?.match(
+          /^ {6}- name: Install the ImageMagick EXR coder and verify the format toolchain\n {8}run: \|\n(?<run>[\s\S]*?)(?=^ {6}- )/m,
+        )
+        ?.groups?.run?.split("\n") ?? [];
+    expect(systemDependencyLines.length).toBeGreaterThan(0);
 
     const osdPath = "/usr/share/tesseract-ocr/5/tessdata/osd.traineddata";
     const orderedCommands: Array<[string, (line: string) => boolean]> = [
@@ -174,10 +174,10 @@ describe("OCR v3 runtime artifact contract", () => {
           /\[\[ "\$\{actual\[\*\]\}" == "\$\{expected\[\*\]\}" \]\] \|\| \{/.test(line.trim()),
       ],
     ];
-    let previousCommand = installStart + installCommand.length - 1;
+    let previousCommand = -1;
     for (const [label, matches] of orderedCommands) {
       const command = systemDependencyLines.findIndex(matches);
-      expect(command, `${label} must follow the integration apt install command`).toBeGreaterThan(
+      expect(command, `${label} must appear in order in the verification step`).toBeGreaterThan(
         previousCommand,
       );
       previousCommand = command;


### PR DESCRIPTION
Fixes the CI redness that re-runs could not clear. Since this morning the runners' apt mirrors have been degraded (kB/s transfers, hung fetches), and the unbounded install steps ate entire job budgets before any test started: Integration shards died at exactly the 30-minute cap across five runs, and E2E Mobile Smoke died at its 15-minute cap inside playwright's internal apt-get (13 minutes hung on one InRelease fetch). The one real test failure in that window is separate and already fixed in PR #875.

What this does:

- New composite action .github/actions/apt-install: every apt network step runs under timeout(1), because apt's own Acquire timeouts only catch dead connections, not a mirror that keeps trickling bytes. On a stall or failure it recovers dpkg state, swaps the Azure mirror for the canonical archive.ubuntu.com in the apt sources, and retries once. Used by the ci.yml unit and integration jobs and all seven nightly install sites. Package lists pass through env, never interpolated into the script.
- New composite action .github/actions/playwright-install: splits the CDN browser download from install-deps, bounds each install-deps attempt, kills any orphaned apt-get holding the dpkg lock, and retries once. Used by the four ci.yml e2e jobs and the five nightly playwright sites.
- Job timeouts get worst-case-fallback headroom: unit 8 to 15, integration 30 to 40, e2e 15 to 25, docs e2e 30 to 40. A healthy day is unaffected; jobs end when done.
- The OCR payload contract test now parses the new install-step shape with the same payload and ordering assertions.

Verified:

- Live, on this PR's first run: Integration shards 1 and 2 landed on the sick mirror, printed the fallback warning, re-fetched 154 MB at 3.7 MB/s from the canonical archive, and passed. Shards 3 and 4 got a healthy mirror and never entered the fallback. These same shard slots had died at the cap in every run since morning.
- In an amd64 ubuntu:24.04 container with the Azure host blackholed: install.sh bounds the stall, rewrites the sources, and installs via the canonical archive, 77s end to end. Healthy-mirror control run never enters the fallback.
- actionlint clean (the one SC2129 style nit at ci.yml:50 predates this change); all six workflow-parsing guardrail test files pass locally (73 tests).

Known residual, noted in #876: mirror sickness can hit archive.ubuntu.com too; in that case the bounded attempts fail the job fast instead of hanging it to the cap, which is the intended worst case.

Fixes #876