### PR TITLE
fix(auth): flag an unrecognized stored mfaPolicy value in snapotter-admin status

### DIFF
--- a/apps/api/src/plugins/mfa.ts
+++ b/apps/api/src/plugins/mfa.ts
@@ -109,19 +109,46 @@ async function decryptSecret(stored: string): Promise<string | null> {
 
 export type MfaPolicy = "optional" | "admins_only" | "required";
 
-export async function getMfaPolicy(): Promise<MfaPolicy> {
-  // Deliberately not getSettingString: that helper swallows DB errors into
-  // its default, which would silently disarm a required policy whenever the
-  // settings read fails (#815). A missing row legitimately means "optional";
-  // a failed read must throw so login paths can fail closed.
+/**
+ * Read the stored `mfaPolicy` row and classify it. `policy` is what login
+ * enforces; `recognized` is false only when the stored value is none of the
+ * three known policies, which means the row was written out of band (a hand-run
+ * UPDATE, a restored or tampered row, wrong casing like "REQUIRED"), since every
+ * in-app write goes through a Zod-validated route.
+ *
+ * Deliberately not getSettingString: that helper swallows DB errors into its
+ * default, which would silently disarm a required policy whenever the settings
+ * read fails (#815). A missing row legitimately means "optional"; a failed read
+ * must throw so login paths can fail closed.
+ *
+ * `getMfaPolicy` is the normalizing wrapper most callers want. The recovery CLI
+ * uses `raw`/`recognized` to surface a garbage value instead of printing an
+ * authoritative-looking "optional" over it (snapotter-hq/SnapOtter#873).
+ */
+export async function readMfaPolicySetting(): Promise<{
+  policy: MfaPolicy;
+  raw: string | undefined;
+  recognized: boolean;
+}> {
   const result = await db
     .select({ value: schema.settings.value })
     .from(schema.settings)
     .where(eq(schema.settings.key, "mfaPolicy"))
     .limit(1);
   const raw = result[0]?.value;
-  if (raw === "required" || raw === "admins_only") return raw;
-  if (raw !== undefined && raw !== "optional") {
+  if (raw === "required" || raw === "admins_only") {
+    return { policy: raw, raw, recognized: true };
+  }
+  // A missing row (undefined) legitimately means "optional", and so does a
+  // stored "optional". Anything else is an out-of-band value: enforced as
+  // optional, but flagged so it does not pass as a genuine one.
+  const recognized = raw === undefined || raw === "optional";
+  return { policy: "optional", raw, recognized };
+}
+
+export async function getMfaPolicy(): Promise<MfaPolicy> {
+  const { policy, raw, recognized } = await readMfaPolicySetting();
+  if (!recognized) {
     // Writes are Zod-validated, so an unrecognized stored value means the DB
     // was modified out of band. Treating it as "optional" disarms the policy,
     // which must at least be loud (it is indistinguishable from tampering).
@@ -130,7 +157,7 @@ export async function getMfaPolicy(): Promise<MfaPolicy> {
       "mfaPolicy setting holds an unrecognized value; treating as optional",
     );
   }
-  return "optional";
+  return policy;
 }
 
 export function isMfaRequiredForUser(policy: MfaPolicy, userRole: string): boolean {

--- a/apps/api/src/scripts/mfa-recover.ts
+++ b/apps/api/src/scripts/mfa-recover.ts
@@ -5,7 +5,7 @@ import { closeDb, db, schema } from "../db/index.js";
 import { auditLog } from "../lib/audit.js";
 import { upsertSetting } from "../lib/settings-helpers.js";
 import { clearUserMfa } from "../lib/user-mfa.js";
-import { getMfaPolicy, type MfaPolicy } from "../plugins/mfa.js";
+import { type MfaPolicy, readMfaPolicySetting } from "../plugins/mfa.js";
 
 // auditLog's first parameter is a FastifyBaseLogger, but a CLI has no request.
 // It only calls .info(obj, msg) and .warn(obj, msg), so a console-backed shim
@@ -49,6 +49,7 @@ export async function disableUserMfa(username: string): Promise<DisableMfaResult
 /** Read-only snapshot for diagnosing which login gate is blocking someone. */
 export async function mfaStatus(): Promise<{
   policy: MfaPolicy | null;
+  unrecognizedPolicyValue?: string;
   policyError?: string;
   enrolled: string[];
   enrolledError?: string;
@@ -56,16 +57,24 @@ export async function mfaStatus(): Promise<{
   // The two login gates (the policy, and whether the user is enrolled) are read
   // independently, and each read is reported on its own. This command runs
   // mid-incident against a possibly-degraded DB, so a failed read must surface
-  // as a failed read, never be swallowed. That is the #867 fix: getMfaPolicy
+  // as a failed read, never be swallowed. That is the #867 fix: readMfaPolicySetting
   // reads the settings row directly and throws on a DB fault, where the old
   // getSettingString path returned "optional". Reporting "optional" over a
   // stored "required" sends the operator to the wrong wall. A read that fails
   // leaves its value empty and records the cause; the other gate is still read
   // and reported, so a partial fault still tells the operator something useful.
+  //
+  // A successful read of an unrecognized value (an out-of-band DB edit, wrong
+  // casing like "REQUIRED") is reported distinctly too (#873): login enforces it
+  // as "optional", but a bare "optional" would hide that the stored row is
+  // garbage worth cleaning up. `unrecognizedPolicyValue` carries the raw string.
   let policy: MfaPolicy | null = null;
+  let unrecognizedPolicyValue: string | undefined;
   let policyError: string | undefined;
   try {
-    policy = await getMfaPolicy();
+    const { policy: enforced, raw, recognized } = await readMfaPolicySetting();
+    policy = enforced;
+    if (!recognized) unrecognizedPolicyValue = raw;
   } catch (err) {
     policyError = err instanceof Error ? err.message : String(err);
   }
@@ -82,7 +91,7 @@ export async function mfaStatus(): Promise<{
     enrolledError = err instanceof Error ? err.message : String(err);
   }
 
-  return { policy, policyError, enrolled, enrolledError };
+  return { policy, unrecognizedPolicyValue, policyError, enrolled, enrolledError };
 }
 
 const USAGE = `snapotter-admin: offline MFA recovery
@@ -97,11 +106,22 @@ export async function runRecoveryCli(argv: string[]): Promise<number> {
   const [command, ...rest] = argv;
   switch (command) {
     case "status": {
-      const { policy, policyError, enrolled, enrolledError } = await mfaStatus();
+      const { policy, unrecognizedPolicyValue, policyError, enrolled, enrolledError } =
+        await mfaStatus();
       // A failed read goes loud on stderr with a non-zero exit below, so it can
-      // never read as "this gate is fine, look elsewhere" (#867).
+      // never read as "this gate is fine, look elsewhere" (#867). An unrecognized
+      // stored value is surfaced the same way (#873): login enforces it as
+      // "optional", but it is a data-integrity problem worth flagging, and a
+      // non-zero exit keeps a scripted `status` from passing over it. The line
+      // still names the effective policy so the operator knows login isn't the
+      // blocker. JSON.stringify quotes the raw value so an empty or whitespace
+      // string stays visible.
       if (policyError) {
         console.error(`MFA policy: could not read (${policyError})`);
+      } else if (unrecognizedPolicyValue !== undefined) {
+        console.error(
+          `MFA policy: ${policy} (stored value ${JSON.stringify(unrecognizedPolicyValue)} is not a recognized policy; treated as ${policy})`,
+        );
       } else {
         console.log(`MFA policy: ${policy}`);
       }
@@ -114,7 +134,7 @@ export async function runRecoveryCli(argv: string[]): Promise<number> {
             : "Enrolled users: none",
         );
       }
-      return policyError || enrolledError ? 1 : 0;
+      return policyError || enrolledError || unrecognizedPolicyValue !== undefined ? 1 : 0;
     }
     case "reset-mfa-policy": {
       await resetMfaPolicy();

--- a/tests/integration/platform/mfa-recovery.test.ts
+++ b/tests/integration/platform/mfa-recovery.test.ts
@@ -275,3 +275,76 @@ describe("mfaStatus when the policy read fails (#867)", () => {
     }
   });
 });
+
+// #873: a *successful* read of an unrecognized stored mfaPolicy value (an
+// out-of-band DB edit, wrong casing like "REQUIRED", a restored/tampered row)
+// must be reported distinctly, not flattened to a bare "optional". Login treats
+// such a value as optional too, so this is not a lockout mislead, but the
+// operator must learn the stored row holds a garbage value worth cleaning up.
+describe("mfaStatus with an unrecognized stored policy (#873)", () => {
+  async function setRawPolicy(value: string): Promise<void> {
+    await db
+      .insert(schema.settings)
+      .values({ key: "mfaPolicy", value })
+      .onConflictDoUpdate({ target: schema.settings.key, set: { value } });
+  }
+
+  it("reports the raw value alongside the enforced optional, without an error", async () => {
+    await setRawPolicy("REQUIRED"); // wrong casing: not one of the three known policies
+
+    const status = await mfaStatus();
+
+    expect(status.policy).toBe("optional"); // what login actually enforces
+    expect(status.unrecognizedPolicyValue).toBe("REQUIRED");
+    expect(status.policyError).toBeUndefined();
+  });
+
+  it("does not flag a legitimately missing policy row as unrecognized", async () => {
+    // A fresh install has no mfaPolicy row; that is a genuine "optional", not a
+    // tampered value, and must never trip the unrecognized-value path.
+    await db.delete(schema.settings).where(eq(schema.settings.key, "mfaPolicy"));
+
+    const status = await mfaStatus();
+
+    expect(status.policy).toBe("optional");
+    expect(status.unrecognizedPolicyValue).toBeUndefined();
+    expect(status.policyError).toBeUndefined();
+  });
+
+  it("runRecoveryCli status exits 1 and surfaces the raw value on stderr", async () => {
+    await setRawPolicy("REQUIRED");
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const code = await runRecoveryCli(["status"]);
+      expect(code).toBe(1);
+      // The line names the raw stored value and the effective policy, so the
+      // operator sees both the anomaly and that login is not the blocker.
+      expect(errSpy).toHaveBeenCalledWith(
+        expect.stringContaining('stored value "REQUIRED" is not a recognized policy'),
+      );
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("MFA policy: optional"));
+      // It must NOT also print a bare, authoritative-looking "optional" line.
+      expect(logSpy).not.toHaveBeenCalledWith("MFA policy: optional");
+    } finally {
+      errSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+
+  it("runRecoveryCli status stays clean (exit 0, stdout) for a legitimately missing row", async () => {
+    await db.delete(schema.settings).where(eq(schema.settings.key, "mfaPolicy"));
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      expect(await runRecoveryCli(["status"])).toBe(0);
+      expect(logSpy).toHaveBeenCalledWith("MFA policy: optional");
+      expect(errSpy).not.toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
`snapotter-admin status` read the MFA policy through `getMfaPolicy()`, which normalizes any value that isn't one of the three known policies (`optional`, `admins_only`, `required`) down to `optional`. A value that got into the row out of band (a hand-run `UPDATE`, a restored or tampered row, wrong casing like `REQUIRED`) collapsed to `optional` before the CLI ever saw it, so `status` printed an authoritative `MFA policy: optional` and exited 0 over a garbage row. The one `logger.warn` that fires goes to the API's pino logger, not the CLI's stderr, so the operator never learns the row needs cleaning up.

## Fix

- `readMfaPolicySetting()` is a new export in `mfa.ts` that does the raw settings read and returns `{policy, raw, recognized}`. `getMfaPolicy()` is now a thin wrapper over it, so the three login paths (`auth`, `oidc`, `saml`) keep identical behavior. Unknown still collapses to `optional`, the warn still logs, a failed read still throws for the fail-closed `unavailable` sentinel (#815). The classification lives in one place instead of being duplicated CLI-side.
- `mfaStatus()` returns `unrecognizedPolicyValue` when the stored value isn't recognized.
- `snapotter-admin status` prints a distinct stderr line and exits 1 for an unrecognized value:

  ```
  MFA policy: optional (stored value "REQUIRED" is not a recognized policy; treated as optional)
  ```

  It names the effective policy so the operator knows login isn't the blocker, and the non-zero exit stops a scripted `status` from passing over a dirty row. A legitimately missing row (a fresh install) still reads as a clean `optional` at exit 0.

This stays in the CLI rather than the shared helper on purpose. Login deliberately treats an unknown value as a loud `optional`, so making `getMfaPolicy()` reject or expose unknowns would ripple into all three login paths and change login semantics. Keeping the raw read in a sibling helper leaves `getMfaPolicy()`'s signature and behavior untouched.

## Exit code

An unrecognized value exits 1, on stderr, alongside the read-failure lines. It's a data-integrity signal a scripted `status` shouldn't pass over silently, and it's consistent with how a failed read already exits 1. The message states the effective policy, so it can't misdirect an operator toward a lockout that isn't there.

## Verification

Four new cases in `mfa-recovery.test.ts`: an unrecognized value reports the raw string with the enforced `optional`; a missing row is not flagged; the CLI exits 1 and surfaces the value on stderr; a missing row stays clean at exit 0. TDD, watched the two behavior cases fail first.

mfa-recovery 22/22, oidc + saml + e2e login paths 25/25, mfa unit 39/39, monorepo typecheck 9/9, Biome clean.

Fixes #873
