### PR TITLE
fix(enterprise): stop swallowing license-check failures in feature gates

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -21,6 +21,7 @@ import { closeWorkers, startWorkers } from "./jobs/worker.js";
 import { initAnalytics, shutdownAnalytics, trackEvent } from "./lib/analytics.js";
 import { shouldRunStartupCleanup } from "./lib/cleanup.js";
 import { buildCsp } from "./lib/csp.js";
+import { isEnterpriseFeatureEnabled } from "./lib/enterprise-feature.js";
 import { reportError, setSentryInstanceTag } from "./lib/error-report.js";
 import { stripInternalPaths } from "./lib/errors.js";
 import {
@@ -261,13 +262,7 @@ try {
 // Enforce the gate at boot so an unlicensed deploy fails fast rather than silently
 // writing data to S3 it isn't entitled to use.
 if (env.STORAGE_MODE === "s3") {
-  let s3Licensed = false;
-  try {
-    const { isFeatureEnabled } = await import("@snapotter/enterprise");
-    s3Licensed = isFeatureEnabled("s3_storage");
-  } catch {
-    s3Licensed = false;
-  }
+  const s3Licensed = await isEnterpriseFeatureEnabled("s3_storage", "boot");
   if (!s3Licensed) {
     console.error(
       "[FATAL] STORAGE_MODE=s3 requires a license that includes the s3_storage feature. " +
@@ -658,15 +653,9 @@ app.get("/api/v1/config/auth", async () => {
   }
 
   // SAML SSO requires both env flag and enterprise license
-  let samlLicensed = false;
-  if (env.SAML_ENABLED) {
-    try {
-      const { isFeatureEnabled } = await import("@snapotter/enterprise");
-      samlLicensed = isFeatureEnabled("saml_sso");
-    } catch {
-      // Enterprise package not available
-    }
-  }
+  const samlLicensed = env.SAML_ENABLED
+    ? await isEnterpriseFeatureEnabled("saml_sso", "boot")
+    : false;
   if (env.SAML_ENABLED && samlLicensed) {
     config.samlEnabled = true;
     config.samlProviderName = env.SAML_PROVIDER_NAME || "SSO";

--- a/apps/api/src/jobs/alert-evaluator.ts
+++ b/apps/api/src/jobs/alert-evaluator.ts
@@ -14,6 +14,7 @@ import { statfs } from "node:fs/promises";
 import { and, eq, gte, sql } from "drizzle-orm";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
+import { isEnterpriseFeatureEnabled } from "../lib/enterprise-feature.js";
 import { getSettingString } from "../lib/settings-helpers.js";
 
 /**
@@ -24,12 +25,7 @@ import { getSettingString } from "../lib/settings-helpers.js";
  * stormed Sentry, not this one).
  */
 async function alertsLicensed(): Promise<boolean> {
-  try {
-    const { isFeatureEnabled } = await import("@snapotter/enterprise");
-    return isFeatureEnabled("admin_alerts");
-  } catch {
-    return false;
-  }
+  return isEnterpriseFeatureEnabled("admin_alerts", "worker");
 }
 
 export async function evaluateAlerts(): Promise<void> {

--- a/apps/api/src/jobs/audit-archive.ts
+++ b/apps/api/src/jobs/audit-archive.ts
@@ -27,6 +27,7 @@ import { eq, lt } from "drizzle-orm";
 import type { FastifyBaseLogger } from "fastify";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
+import { isEnterpriseFeatureEnabled } from "../lib/enterprise-feature.js";
 import { upsertSetting } from "../lib/settings-helpers.js";
 
 type ArchivalState = "PENDING" | "EXPORTING" | "EXPORTED" | "PURGING" | "COMPLETE";
@@ -68,13 +69,7 @@ function getArchiveDir(): string {
 
 export async function runAuditArchive(log?: FastifyBaseLogger): Promise<void> {
   // 1. Check enterprise feature gate
-  let featureEnabled = false;
-  try {
-    const { isFeatureEnabled } = await import("@snapotter/enterprise");
-    featureEnabled = isFeatureEnabled("tamper_resistant_audit");
-  } catch {
-    // Enterprise package not available
-  }
+  const featureEnabled = await isEnterpriseFeatureEnabled("tamper_resistant_audit", "worker");
   if (!featureEnabled) {
     return;
   }

--- a/apps/api/src/jobs/enqueue.ts
+++ b/apps/api/src/jobs/enqueue.ts
@@ -11,6 +11,7 @@ import { eq } from "drizzle-orm";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { assertAiJobQuota } from "../lib/ai-quota.js";
+import { isEnterpriseFeatureEnabled } from "../lib/enterprise-feature.js";
 import { createBullMQConnection } from "./connection.js";
 import { getQueue } from "./queues.js";
 import { POOLS, type Pool, queueName, type ToolJobData, type ToolJobResult } from "./types.js";
@@ -225,11 +226,10 @@ export async function waitForJob(
  * never block job creation.
  */
 async function computeDeleteAfter(jobId: string, userId: string): Promise<void> {
-  let isTeamRetentionEnabled = false;
-  try {
-    const { isFeatureEnabled } = await import("@snapotter/enterprise");
-    isTeamRetentionEnabled = isFeatureEnabled("team_retention_overrides");
-  } catch {}
+  const isTeamRetentionEnabled = await isEnterpriseFeatureEnabled(
+    "team_retention_overrides",
+    "worker",
+  );
 
   if (!isTeamRetentionEnabled) return;
 

--- a/apps/api/src/jobs/siem-forward.ts
+++ b/apps/api/src/jobs/siem-forward.ts
@@ -18,6 +18,7 @@ import { asc, eq, gte } from "drizzle-orm";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { decrypt, isEncrypted } from "../lib/encryption.js";
+import { isEnterpriseFeatureEnabled } from "../lib/enterprise-feature.js";
 import { upsertSetting } from "../lib/settings-helpers.js";
 import { deliverWebhook } from "../lib/webhook-delivery.js";
 import { readSiemConfig } from "../routes/enterprise/siem.js";
@@ -42,12 +43,7 @@ async function readSettingValue(key: string): Promise<string | null> {
  * event storm (NODE-1E, July 2026).
  */
 async function siemLicensed(): Promise<boolean> {
-  try {
-    const { isFeatureEnabled } = await import("@snapotter/enterprise");
-    return isFeatureEnabled("siem_forwarding");
-  } catch {
-    return false;
-  }
+  return isEnterpriseFeatureEnabled("siem_forwarding", "worker");
 }
 
 export async function runSiemForward(): Promise<{ forwarded: number } | undefined> {

--- a/apps/api/src/lib/audit.ts
+++ b/apps/api/src/lib/audit.ts
@@ -5,6 +5,7 @@ import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { computeHmac } from "./audit-integrity.js";
 import { deriveAuditHmacKey } from "./encryption.js";
+import { isEnterpriseFeatureEnabled } from "./enterprise-feature.js";
 
 const MAX_AUDIT_INPUT_LENGTH = 200;
 
@@ -29,12 +30,7 @@ export async function isToolAuditEnabled(): Promise<boolean> {
     // fall through to enterprise check
   }
 
-  try {
-    const enterprise = await import("@snapotter/enterprise");
-    return enterprise.isFeatureEnabled("audit_export");
-  } catch {
-    return false;
-  }
+  return isEnterpriseFeatureEnabled("audit_export");
 }
 
 const AUDIT_STRIP_RE = /[<>&"'\r\n\0\x85\u2028\u2029]/g;

--- a/apps/api/src/lib/enterprise-feature.ts
+++ b/apps/api/src/lib/enterprise-feature.ts
@@ -1,0 +1,87 @@
+import type { EnterpriseFeature } from "@snapotter/enterprise";
+import { type ReportContext, reportError } from "./error-report.js";
+
+/**
+ * Node raises one of these codes when a dynamically imported module genuinely is
+ * not installed. Any other import failure means the module is present but failed
+ * to load, which is a real fault, not the expected OSS "no enterprise" state.
+ * Exported for direct unit testing: vitest wraps a throwing module mock in its
+ * own error and strips the original code, so this branch cannot be driven with a
+ * real ERR_MODULE_NOT_FOUND through the module mock.
+ */
+export function isModuleNotFound(err: unknown): boolean {
+  const code = (err as { code?: string } | null)?.code;
+  return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
+}
+
+/**
+ * Log and report a genuine enterprise-check failure. Two guards, because the
+ * whole point of this helper is to degrade gracefully: reporting the degradation
+ * must never itself throw.
+ *
+ * `reportError` runs first and is internally guarded. `logger` is imported lazily
+ * (a static import would pull the file-transport logger, which builds pino
+ * targets from env at load, into every gate consumer's module graph) and its use
+ * is wrapped, so a logging fault can never turn a disabled feature into a throw.
+ */
+async function reportFeatureFailure(
+  err: unknown,
+  feature: EnterpriseFeature,
+  source: ReportContext["source"],
+  message: string,
+): Promise<void> {
+  void reportError(err, { source, subsystem: "enterprise-feature" });
+  try {
+    const { logger } = await import("./logger.js");
+    logger.error({ err, feature }, message);
+  } catch {
+    // Best-effort local log; telemetry must never throw.
+  }
+}
+
+/**
+ * Whether an enterprise feature is licensed, resolved through the sanctioned
+ * `@snapotter/enterprise` boundary (the same dynamic import every gate uses).
+ *
+ * Returns false when the enterprise package is absent (the OSS build) and stays
+ * silent, because that is the expected state. Every other failure degrades to
+ * false too, but is logged and reported first: a present-but-broken enterprise
+ * module, or `isFeatureEnabled` throwing (it cannot today, but a future refactor
+ * that adds IO could). Without that split, a licensed instance whose license
+ * machinery faulted is indistinguishable from an unlicensed one and the gate
+ * denies with no trace (snapotter-hq/SnapOtter#868).
+ *
+ * `source` only tags the Sentry report with where the check ran (a request is
+ * "http", boot-time registration is "boot", a job is "worker"); it never changes
+ * the result.
+ */
+export async function isEnterpriseFeatureEnabled(
+  feature: EnterpriseFeature,
+  source: ReportContext["source"] = "http",
+): Promise<boolean> {
+  let mod: typeof import("@snapotter/enterprise");
+  try {
+    mod = await import("@snapotter/enterprise");
+  } catch (err) {
+    if (!isModuleNotFound(err)) {
+      await reportFeatureFailure(
+        err,
+        feature,
+        source,
+        "enterprise module failed to load; treating feature as disabled",
+      );
+    }
+    return false;
+  }
+  try {
+    return mod.isFeatureEnabled(feature);
+  } catch (err) {
+    await reportFeatureFailure(
+      err,
+      feature,
+      source,
+      "isFeatureEnabled threw; treating feature as disabled",
+    );
+    return false;
+  }
+}

--- a/apps/api/src/lib/settings-policy.ts
+++ b/apps/api/src/lib/settings-policy.ts
@@ -1,6 +1,7 @@
 import { type Permission, SUPPORTED_LOCALES } from "@snapotter/shared";
 import { type ZodIssue, z } from "zod";
 import { env } from "../config.js";
+import { isEnterpriseFeatureEnabled } from "./enterprise-feature.js";
 
 export type SettingAuthority = Permission | "full-admin" | "none";
 
@@ -205,13 +206,7 @@ export async function validateSettingsRuntimeConstraints(
     ({ key, value }) => key === "mfaPolicy" && (value === "admins_only" || value === "required"),
   );
   if (enforcesMfa) {
-    let mfaLicensed = false;
-    try {
-      const { isFeatureEnabled } = await import("@snapotter/enterprise");
-      mfaLicensed = isFeatureEnabled("mfa");
-    } catch {
-      // Enterprise package not available.
-    }
+    const mfaLicensed = await isEnterpriseFeatureEnabled("mfa");
 
     if (!mfaLicensed) {
       return {

--- a/apps/api/src/permissions.ts
+++ b/apps/api/src/permissions.ts
@@ -2,6 +2,7 @@ import type { Permission, Role } from "@snapotter/shared";
 import { eq } from "drizzle-orm";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { db, schema } from "./db/index.js";
+import { isEnterpriseFeatureEnabled } from "./lib/enterprise-feature.js";
 import { type AuthUser, getAuthUser } from "./plugins/auth.js";
 
 const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
@@ -158,12 +159,7 @@ function normalizeManagedRole(role: string): string {
 }
 
 async function isPerToolPermissionEnforced(): Promise<boolean> {
-  try {
-    const { isFeatureEnabled } = await import("@snapotter/enterprise");
-    return isFeatureEnabled("per_tool_permissions");
-  } catch {
-    return false;
-  }
+  return isEnterpriseFeatureEnabled("per_tool_permissions");
 }
 
 async function toolPermissionAllows(

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -9,6 +9,7 @@ import { db, schema } from "../db/index.js";
 import { sharedRedis } from "../jobs/connection.js";
 import { trackEvent } from "../lib/analytics.js";
 import { auditFromRequest, sanitizeAuditInput } from "../lib/audit.js";
+import { isEnterpriseFeatureEnabled } from "../lib/enterprise-feature.js";
 import { reportError } from "../lib/error-report.js";
 import {
   checkLoginThrottle,
@@ -361,11 +362,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       // SSO enforcement check
       const ssoEnforced = await getSettingString("ssoEnforcement", "false");
       if (ssoEnforced === "true") {
-        let isEnabled = false;
-        try {
-          const { isFeatureEnabled } = await import("@snapotter/enterprise");
-          isEnabled = isFeatureEnabled("sso_enforcement");
-        } catch {}
+        const isEnabled = await isEnterpriseFeatureEnabled("sso_enforcement");
 
         if (isEnabled) {
           const breakGlassUsername = await getSettingString("ssoBreakGlassUsername", "");

--- a/apps/api/src/plugins/ip-allowlist.ts
+++ b/apps/api/src/plugins/ip-allowlist.ts
@@ -10,6 +10,7 @@
  */
 import { BlockList } from "node:net";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { isEnterpriseFeatureEnabled } from "../lib/enterprise-feature.js";
 
 // Paths exempt from IP filtering -- infrastructure probes, IdP callbacks
 const EXEMPT_PATHS = [
@@ -97,13 +98,7 @@ const ALLOWLIST_CHANNEL = "ip:allowlist:refresh";
 
 export async function registerIpAllowlist(app: FastifyInstance): Promise<void> {
   // Only run if enterprise feature is enabled
-  let isEnabled = false;
-  try {
-    const { isFeatureEnabled } = await import("@snapotter/enterprise");
-    isEnabled = isFeatureEnabled("ip_allowlist");
-  } catch {
-    // Enterprise package not available
-  }
+  const isEnabled = await isEnterpriseFeatureEnabled("ip_allowlist", "boot");
   if (!isEnabled) return;
 
   // Load allowlist from settings table

--- a/apps/api/src/plugins/mfa.ts
+++ b/apps/api/src/plugins/mfa.ts
@@ -8,6 +8,7 @@ import { db, schema } from "../db/index.js";
 import { sharedRedis } from "../jobs/connection.js";
 import { auditFromRequest } from "../lib/audit.js";
 import { decrypt, encrypt } from "../lib/encryption.js";
+import { isEnterpriseFeatureEnabled } from "../lib/enterprise-feature.js";
 import { logger } from "../lib/logger.js";
 import { clearUserMfa } from "../lib/user-mfa.js";
 import {
@@ -178,13 +179,7 @@ export async function beginForcedEnrollment(user: {
   id: string;
   username: string;
 }): Promise<{ enrollmentToken: string; uri: string; recoveryCodes: string[] } | null> {
-  let mfaLicensed = false;
-  try {
-    const { isFeatureEnabled } = await import("@snapotter/enterprise");
-    mfaLicensed = isFeatureEnabled("mfa");
-  } catch {
-    // Enterprise package not available.
-  }
+  const mfaLicensed = await isEnterpriseFeatureEnabled("mfa");
   if (!mfaLicensed) return null;
 
   const totp = createTotp(user.username);
@@ -218,13 +213,7 @@ export async function registerMfa(app: FastifyInstance): Promise<void> {
       if (!user) return;
 
       // Check enterprise feature gate
-      let mfaLicensed = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        mfaLicensed = isFeatureEnabled("mfa");
-      } catch {
-        // Enterprise package not available
-      }
+      const mfaLicensed = await isEnterpriseFeatureEnabled("mfa");
 
       if (!mfaLicensed) {
         return reply.status(403).send({

--- a/apps/api/src/plugins/saml.ts
+++ b/apps/api/src/plugins/saml.ts
@@ -8,6 +8,7 @@ import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { sharedRedis } from "../jobs/connection.js";
 import { auditFromRequest } from "../lib/audit.js";
+import { isEnterpriseFeatureEnabled } from "../lib/enterprise-feature.js";
 import { reportError } from "../lib/error-report.js";
 import {
   findUniqueUsername,
@@ -57,13 +58,7 @@ function redirectToLogin(reply: FastifyReply, errorCode: string): void {
 export async function registerSaml(app: FastifyInstance): Promise<void> {
   if (!env.SAML_ENABLED) return;
 
-  let isEnabled = false;
-  try {
-    const { isFeatureEnabled } = await import("@snapotter/enterprise");
-    isEnabled = isFeatureEnabled("saml_sso");
-  } catch {
-    // Enterprise package not available
-  }
+  const isEnabled = await isEnterpriseFeatureEnabled("saml_sso", "boot");
 
   if (!isEnabled) {
     app.log.warn("SAML is enabled via env but saml_sso enterprise feature is not licensed");

--- a/apps/api/src/routes/enterprise/audit-export.ts
+++ b/apps/api/src/routes/enterprise/audit-export.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, gte, lte } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { db, schema } from "../../db/index.js";
+import { isEnterpriseFeatureEnabled } from "../../lib/enterprise-feature.js";
 import { requirePermission } from "../../permissions.js";
 
 const querySchema = z.object({
@@ -42,13 +43,7 @@ export async function registerAuditExport(app: FastifyInstance): Promise<void> {
       if (!user) return;
 
       // Check enterprise feature gate
-      let featureEnabled = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        featureEnabled = isFeatureEnabled("audit_export");
-      } catch {
-        // Enterprise package not available
-      }
+      const featureEnabled = await isEnterpriseFeatureEnabled("audit_export");
       if (!featureEnabled) {
         return reply.status(403).send({
           error: "Audit export requires an enterprise license with the audit_export feature",

--- a/apps/api/src/routes/enterprise/config.ts
+++ b/apps/api/src/routes/enterprise/config.ts
@@ -4,6 +4,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { db, schema } from "../../db/index.js";
 import { auditFromRequest } from "../../lib/audit.js";
+import { isEnterpriseFeatureEnabled } from "../../lib/enterprise-feature.js";
 import {
   getSettingPolicy,
   isConfigExportableSetting,
@@ -108,13 +109,7 @@ export async function registerConfigRoutes(app: FastifyInstance): Promise<void> 
       if (!user) return;
 
       // Enterprise feature gate
-      let featureEnabled = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        featureEnabled = isFeatureEnabled("config_export_import");
-      } catch {
-        // Enterprise package not available
-      }
+      const featureEnabled = await isEnterpriseFeatureEnabled("config_export_import");
       if (!featureEnabled) {
         return reply.status(403).send({
           error:
@@ -179,13 +174,7 @@ export async function registerConfigRoutes(app: FastifyInstance): Promise<void> 
       if (!user) return;
 
       // Enterprise feature gate
-      let featureEnabled = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        featureEnabled = isFeatureEnabled("config_export_import");
-      } catch {
-        // Enterprise package not available
-      }
+      const featureEnabled = await isEnterpriseFeatureEnabled("config_export_import");
       if (!featureEnabled) {
         return reply.status(403).send({
           error:

--- a/apps/api/src/routes/enterprise/gdpr.ts
+++ b/apps/api/src/routes/enterprise/gdpr.ts
@@ -7,6 +7,7 @@ import { requestCancel } from "../../jobs/cancel.js";
 import { getQueue } from "../../jobs/queues.js";
 import { SYSTEM_JOBS } from "../../jobs/system-jobs.js";
 import { auditFromRequest } from "../../lib/audit.js";
+import { isEnterpriseFeatureEnabled } from "../../lib/enterprise-feature.js";
 import { deleteStoredFile, deleteThumbnail } from "../../lib/file-storage.js";
 import { deletePrefix } from "../../lib/object-storage.js";
 import { canManageTargetRole, requirePermission } from "../../permissions.js";
@@ -104,13 +105,7 @@ export async function registerGdprRoutes(app: FastifyInstance): Promise<void> {
       if (!user) return;
 
       // Enterprise feature gate
-      let featureEnabled = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        featureEnabled = isFeatureEnabled("gdpr_lifecycle");
-      } catch {
-        // Enterprise package not available
-      }
+      const featureEnabled = await isEnterpriseFeatureEnabled("gdpr_lifecycle");
       if (!featureEnabled) {
         return reply.status(403).send({
           error: "GDPR data export requires an enterprise license with the gdpr_lifecycle feature",
@@ -175,13 +170,7 @@ export async function registerGdprRoutes(app: FastifyInstance): Promise<void> {
       if (!user) return;
 
       // Enterprise feature gate
-      let featureEnabled = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        featureEnabled = isFeatureEnabled("gdpr_lifecycle");
-      } catch {
-        // Enterprise package not available
-      }
+      const featureEnabled = await isEnterpriseFeatureEnabled("gdpr_lifecycle");
       if (!featureEnabled) {
         return reply.status(403).send({
           error: "GDPR data export requires an enterprise license with the gdpr_lifecycle feature",
@@ -241,13 +230,7 @@ export async function registerGdprRoutes(app: FastifyInstance): Promise<void> {
       if (!user) return;
 
       // Enterprise feature gate
-      let featureEnabled = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        featureEnabled = isFeatureEnabled("gdpr_lifecycle");
-      } catch {
-        // Enterprise package not available
-      }
+      const featureEnabled = await isEnterpriseFeatureEnabled("gdpr_lifecycle");
       if (!featureEnabled) {
         return reply.status(403).send({
           error: "GDPR data purge requires an enterprise license with the gdpr_lifecycle feature",
@@ -330,13 +313,7 @@ export async function registerGdprRoutes(app: FastifyInstance): Promise<void> {
       if (!user) return;
 
       // Enterprise feature gate
-      let featureEnabled = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        featureEnabled = isFeatureEnabled("gdpr_lifecycle");
-      } catch {
-        // Enterprise package not available
-      }
+      const featureEnabled = await isEnterpriseFeatureEnabled("gdpr_lifecycle");
       if (!featureEnabled) {
         return reply.status(403).send({
           error: "GDPR data purge requires an enterprise license with the gdpr_lifecycle feature",

--- a/apps/api/src/routes/enterprise/ip-allowlist.ts
+++ b/apps/api/src/routes/enterprise/ip-allowlist.ts
@@ -9,6 +9,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { db, schema } from "../../db/index.js";
 import { auditFromRequest } from "../../lib/audit.js";
+import { isEnterpriseFeatureEnabled } from "../../lib/enterprise-feature.js";
 import { requirePermission } from "../../permissions.js";
 import { isValidCidr, publishAllowlistRefresh } from "../../plugins/ip-allowlist.js";
 
@@ -27,13 +28,7 @@ export async function registerIpAllowlistRoutes(app: FastifyInstance): Promise<v
       if (!user) return;
 
       // Enterprise feature gate
-      let featureEnabled = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        featureEnabled = isFeatureEnabled("ip_allowlist");
-      } catch {
-        // Enterprise package not available
-      }
+      const featureEnabled = await isEnterpriseFeatureEnabled("ip_allowlist");
       if (!featureEnabled) {
         return reply.status(403).send({
           error: "IP allowlisting requires an enterprise license with the ip_allowlist feature",
@@ -58,13 +53,7 @@ export async function registerIpAllowlistRoutes(app: FastifyInstance): Promise<v
       if (!user) return;
 
       // Enterprise feature gate
-      let featureEnabled = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        featureEnabled = isFeatureEnabled("ip_allowlist");
-      } catch {
-        // Enterprise package not available
-      }
+      const featureEnabled = await isEnterpriseFeatureEnabled("ip_allowlist");
       if (!featureEnabled) {
         return reply.status(403).send({
           error: "IP allowlisting requires an enterprise license with the ip_allowlist feature",

--- a/apps/api/src/routes/enterprise/legal-hold.ts
+++ b/apps/api/src/routes/enterprise/legal-hold.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { db, schema } from "../../db/index.js";
 import { auditFromRequest } from "../../lib/audit.js";
+import { isEnterpriseFeatureEnabled } from "../../lib/enterprise-feature.js";
 import { requirePermission } from "../../permissions.js";
 
 const holdSchema = z.object({
@@ -20,13 +21,7 @@ export async function registerLegalHoldRoutes(app: FastifyInstance): Promise<voi
       if (!user) return;
 
       // Enterprise feature gate
-      let featureEnabled = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        featureEnabled = isFeatureEnabled("legal_hold");
-      } catch {
-        // Enterprise package not available
-      }
+      const featureEnabled = await isEnterpriseFeatureEnabled("legal_hold");
       if (!featureEnabled) {
         return reply
           .status(403)
@@ -82,13 +77,7 @@ export async function registerLegalHoldRoutes(app: FastifyInstance): Promise<voi
     if (!user) return;
 
     // Enterprise feature gate
-    let featureEnabled = false;
-    try {
-      const { isFeatureEnabled } = await import("@snapotter/enterprise");
-      featureEnabled = isFeatureEnabled("legal_hold");
-    } catch {
-      // Enterprise package not available
-    }
+    const featureEnabled = await isEnterpriseFeatureEnabled("legal_hold");
     if (!featureEnabled) {
       return reply
         .status(403)

--- a/apps/api/src/routes/enterprise/scim.ts
+++ b/apps/api/src/routes/enterprise/scim.ts
@@ -4,6 +4,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { db, schema } from "../../db/index.js";
 import { sharedRedis } from "../../jobs/connection.js";
 import { auditLog } from "../../lib/audit.js";
+import { isEnterpriseFeatureEnabled } from "../../lib/enterprise-feature.js";
 import { getSettingString, upsertSetting } from "../../lib/settings-helpers.js";
 import { isDisabledRole, requireFullAdmin } from "../../permissions.js";
 import { hashPassword, verifyPassword } from "../../plugins/auth.js";
@@ -109,13 +110,7 @@ async function scimAuth(request: FastifyRequest, reply: FastifyReply): Promise<b
 // ── Enterprise Feature Gate ──────────────────────────────────────
 
 async function requireScimFeature(reply: FastifyReply): Promise<boolean> {
-  let featureEnabled = false;
-  try {
-    const { isFeatureEnabled } = await import("@snapotter/enterprise");
-    featureEnabled = isFeatureEnabled("scim");
-  } catch {
-    // Enterprise package not available
-  }
+  const featureEnabled = await isEnterpriseFeatureEnabled("scim");
   if (!featureEnabled) {
     reply
       .status(403)

--- a/apps/api/src/routes/enterprise/siem.ts
+++ b/apps/api/src/routes/enterprise/siem.ts
@@ -5,6 +5,7 @@ import { env } from "../../config.js";
 import { db, schema } from "../../db/index.js";
 import { auditFromRequest } from "../../lib/audit.js";
 import { encrypt } from "../../lib/encryption.js";
+import { isEnterpriseFeatureEnabled } from "../../lib/enterprise-feature.js";
 import { requirePermission } from "../../permissions.js";
 
 const configSchema = z.object({
@@ -27,13 +28,7 @@ export async function registerSiemRoutes(app: FastifyInstance): Promise<void> {
       if (!user) return;
 
       // Enterprise feature gate
-      let featureEnabled = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        featureEnabled = isFeatureEnabled("siem_forwarding");
-      } catch {
-        // Enterprise package not available
-      }
+      const featureEnabled = await isEnterpriseFeatureEnabled("siem_forwarding");
       if (!featureEnabled) {
         return reply.status(403).send({
           error: "SIEM forwarding requires an enterprise license with the siem_forwarding feature",
@@ -70,13 +65,7 @@ export async function registerSiemRoutes(app: FastifyInstance): Promise<void> {
       if (!user) return;
 
       // Enterprise feature gate
-      let featureEnabled = false;
-      try {
-        const { isFeatureEnabled } = await import("@snapotter/enterprise");
-        featureEnabled = isFeatureEnabled("siem_forwarding");
-      } catch {
-        // Enterprise package not available
-      }
+      const featureEnabled = await isEnterpriseFeatureEnabled("siem_forwarding");
       if (!featureEnabled) {
         return reply.status(403).send({
           error: "SIEM forwarding requires an enterprise license with the siem_forwarding feature",

--- a/apps/api/src/routes/enterprise/upgrade.ts
+++ b/apps/api/src/routes/enterprise/upgrade.ts
@@ -7,16 +7,12 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { env } from "../../config.js";
 import { db, schema } from "../../db/index.js";
 import { pingRedis } from "../../jobs/connection.js";
+import { isEnterpriseFeatureEnabled } from "../../lib/enterprise-feature.js";
 import { requirePermission } from "../../permissions.js";
 
 function requireUpgradeFeature(reply: FastifyReply): Promise<boolean> {
   return (async () => {
-    try {
-      const { isFeatureEnabled } = await import("@snapotter/enterprise");
-      if (isFeatureEnabled("upgrade_management")) return true;
-    } catch {
-      // Enterprise package not available
-    }
+    if (await isEnterpriseFeatureEnabled("upgrade_management")) return true;
     reply.status(403).send({
       error: "Upgrade management requires a license with the upgrade_management feature",
     });

--- a/apps/api/src/routes/enterprise/webhooks.ts
+++ b/apps/api/src/routes/enterprise/webhooks.ts
@@ -14,6 +14,7 @@ import { env } from "../../config.js";
 import { db, schema } from "../../db/index.js";
 import { auditFromRequest } from "../../lib/audit.js";
 import { encrypt } from "../../lib/encryption.js";
+import { isEnterpriseFeatureEnabled } from "../../lib/enterprise-feature.js";
 import { validateFetchUrl } from "../../lib/ssrf.js";
 import { deliverWebhook } from "../../lib/webhook-delivery.js";
 import { requirePermission } from "../../permissions.js";
@@ -67,13 +68,7 @@ async function writeDestinations(destinations: WebhookDestination[]): Promise<vo
 }
 
 async function checkFeatureGate(reply: FastifyReply): Promise<boolean> {
-  let featureEnabled = false;
-  try {
-    const { isFeatureEnabled } = await import("@snapotter/enterprise");
-    featureEnabled = isFeatureEnabled("admin_alerts");
-  } catch {
-    // Enterprise package not available
-  }
+  const featureEnabled = await isEnterpriseFeatureEnabled("admin_alerts");
   if (!featureEnabled) {
     reply.status(403).send({
       error: "Webhook management requires a license with the admin_alerts feature",

--- a/tests/unit/api/compute-delete-after.test.ts
+++ b/tests/unit/api/compute-delete-after.test.ts
@@ -47,7 +47,9 @@ describe("computeDeleteAfter logic (source verification)", () => {
   });
 
   it("gates on team_retention_overrides enterprise feature", () => {
-    expect(source).toContain('isFeatureEnabled("team_retention_overrides")');
+    // The gate goes through the shared isEnterpriseFeatureEnabled helper (#868);
+    // the regex spans the line break biome inserts on the wrapped call.
+    expect(source).toMatch(/isEnterpriseFeatureEnabled\(\s*"team_retention_overrides"/);
   });
 
   it("returns early when feature is not enabled", () => {

--- a/tests/unit/api/enterprise-feature.test.ts
+++ b/tests/unit/api/enterprise-feature.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isModuleNotFound } from "../../../apps/api/src/lib/enterprise-feature.js";
+
+// The absent-package branch stays silent, but vitest wraps a throwing module
+// mock in its own error and drops the original `code`, so a real
+// ERR_MODULE_NOT_FOUND cannot be reproduced through the enterprise mock. The
+// classification that decides silent-vs-reported is a pure predicate, so it is
+// tested directly here; the helper tests below cover the reachable behaviors.
+describe("isModuleNotFound (#868)", () => {
+  it("treats a genuine module-not-found as absent", () => {
+    expect(isModuleNotFound({ code: "ERR_MODULE_NOT_FOUND" })).toBe(true);
+    expect(isModuleNotFound({ code: "MODULE_NOT_FOUND" })).toBe(true);
+  });
+
+  it("treats any other failure as present-but-broken", () => {
+    expect(isModuleNotFound({ code: "EACCES" })).toBe(false);
+    expect(isModuleNotFound(new Error("blew up at load"))).toBe(false);
+    expect(isModuleNotFound(null)).toBe(false);
+    expect(isModuleNotFound(undefined)).toBe(false);
+  });
+});
+
+// Each case loads a fresh copy of the helper with the enterprise module (and the
+// logger / error-report it reports through) mocked, so the feature-on,
+// feature-off, and check-throws branches can be driven independently. Mirrors
+// the vi.doMock + dynamic-import toggle used across the enterprise unit tests
+// (permissions-authority, tracing-bootstrap).
+async function loadHelper(enterprise: "broken" | ((f: string) => boolean)) {
+  vi.resetModules();
+  const logErrorMock = vi.fn();
+  const reportErrorMock = vi.fn();
+  vi.doMock("../../../apps/api/src/lib/logger.js", () => ({
+    logger: { error: logErrorMock, warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  }));
+  vi.doMock("../../../apps/api/src/lib/error-report.js", () => ({
+    reportError: reportErrorMock,
+  }));
+  if (enterprise === "broken") {
+    vi.doMock("@snapotter/enterprise", () => {
+      throw new Error("enterprise module threw during load");
+    });
+  } else {
+    vi.doMock("@snapotter/enterprise", () => ({ isFeatureEnabled: enterprise }));
+  }
+  const mod = await import("../../../apps/api/src/lib/enterprise-feature.js");
+  return { ...mod, logErrorMock, reportErrorMock };
+}
+
+afterEach(() => {
+  vi.doUnmock("@snapotter/enterprise");
+  vi.doUnmock("../../../apps/api/src/lib/logger.js");
+  vi.doUnmock("../../../apps/api/src/lib/error-report.js");
+  vi.resetModules();
+});
+
+describe("isEnterpriseFeatureEnabled (#868)", () => {
+  it("returns true when the licensed feature is enabled", async () => {
+    const { isEnterpriseFeatureEnabled } = await loadHelper((f) => f === "mfa");
+    expect(await isEnterpriseFeatureEnabled("mfa")).toBe(true);
+  });
+
+  it("returns false when the feature is not licensed", async () => {
+    const { isEnterpriseFeatureEnabled } = await loadHelper(() => false);
+    expect(await isEnterpriseFeatureEnabled("mfa")).toBe(false);
+  });
+
+  it("degrades to false but reports when the enterprise module fails to load", async () => {
+    const { isEnterpriseFeatureEnabled, logErrorMock, reportErrorMock } =
+      await loadHelper("broken");
+    expect(await isEnterpriseFeatureEnabled("mfa")).toBe(false);
+    // A load failure that is not a clean module-not-found is a real fault: a
+    // licensed instance whose enterprise build is broken must not read as
+    // unlicensed without a trace.
+    expect(logErrorMock).toHaveBeenCalled();
+    expect(reportErrorMock).toHaveBeenCalled();
+  });
+
+  it("degrades to false but reports when isFeatureEnabled itself throws", async () => {
+    const { isEnterpriseFeatureEnabled, logErrorMock, reportErrorMock } = await loadHelper(() => {
+      throw new Error("license check exploded");
+    });
+    expect(await isEnterpriseFeatureEnabled("mfa")).toBe(false);
+    expect(logErrorMock).toHaveBeenCalled();
+    expect(reportErrorMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Every enterprise feature gate in the API ran the same block: dynamically import `@snapotter/enterprise`, call `isFeatureEnabled(...)`, and `catch {}` anything into "feature off". The catch comment said "package not available", but it swallowed more than that: a present-but-broken enterprise module, and any future throw from the check itself. `isFeatureEnabled` is a pure function today so it can't throw, and the package ships in every image so the import basically never fails, which is why this has stayed quiet. When it does fail on a licensed instance, the instance reads as unlicensed with no log line.

This is #868. `beginForcedEnrollment` maps the swallowed failure to `null`, and the login route turns that into a hard `403 MFA_ENROLLMENT_REQUIRED`, pointing an operator at policy config instead of the license machinery that actually failed. The same shape repeated across every gate, and some fail open rather than closed: a swallowed check on the SSO-enforcement or IP-allowlist gate silently switches a security control off.

## The helper

`isEnterpriseFeatureEnabled(feature, source?)` in `apps/api/src/lib/enterprise-feature.ts` is now the one gate:

- Package genuinely absent (`ERR_MODULE_NOT_FOUND`) stays silent and returns false. That is the expected OSS state.
- A present-but-broken module load, or `isFeatureEnabled` throwing, is logged and reported to Sentry (`subsystem: "enterprise-feature"`) before returning false. A licensed-but-faulted instance no longer reads as a clean "unlicensed".
- Reporting the failure never throws. `reportError` runs first (it is internally guarded), and the lazily-imported `logger` is wrapped, so a logging fault can't turn a degraded gate into a crashing one.

`logger` is imported lazily on purpose: a static import would pull the file-transport logger (which builds pino targets from env at load) into every gate consumer's module graph.

## The sweep

Migrated every `isFeatureEnabled` gate to the helper, thirty call sites across twenty files: plugins (`mfa` enroll + forced-enrollment, `auth` SSO enforcement, `saml`, `ip-allowlist`), lib (`audit`, `settings-policy`, `permissions`), boot in `index.ts` (`s3_storage`, `saml_sso`), jobs (`siem-forward`, `alert-evaluator`, `audit-archive`, `enqueue` team-retention), and the enterprise routes (`gdpr`, `scim`, `config`, `legal-hold`, `upgrade`, `ip-allowlist`, `audit-export`, `siem`, `webhooks`). `source` tags the report with where the check ran (`http` / `worker` / `boot`); it never changes the result.

Left alone on purpose: `tracing.ts` calls `initEnterprise` on the same import to bootstrap the license, so it is a license bootstrap, not a plain gate. The `loadS3Storage` / `getActiveLicense` / `initEnterprise` imports load functionality, not a boolean gate, so they keep their own handling.

## Verification

New `enterprise-feature.test.ts`: feature on and off, a broken module load reported, `isFeatureEnabled` throwing reported, and the `isModuleNotFound` classification. The absent-vs-broken split is a pure predicate tested directly, because vitest wraps a throwing module mock and strips the original error code, so a real `ERR_MODULE_NOT_FOUND` can't be reproduced through the mock.

Full api typecheck, biome, and license-boundary all clean. Regression-checked the migrated modules and the login paths: the permissions / settings-policy / audit / jobs unit suites, the enterprise-route unit suites, and the oidc / saml / mfa integration suites all pass. A completeness grep confirms no `isFeatureEnabled(` gate remains outside the helper and `tracing.ts`.

Fixes #868
