### PR TITLE
fix(i18n): stop i18n:check from rewriting English docs sources

### DIFF
--- a/scripts/i18n/adapters/docs-md.mjs
+++ b/scripts/i18n/adapters/docs-md.mjs
@@ -126,6 +126,22 @@ function injectAnchors(body) {
 }
 
 /**
+ * Read a root doc and compute its anchored form without writing. Returns the
+ * original bytes (so callers can detect a no-op), the split frontmatter, the
+ * anchored body, and the rebuilt full document. Shared by the read-only
+ * extract() and the write-side persistSourceAnchors() (#870).
+ * @param {string} abs
+ * @returns {Promise<{ original: string, fm: string|null, anchored: string, rebuilt: string }>}
+ */
+async function anchorDoc(abs) {
+  const original = await readFile(abs, "utf8");
+  const { fm, body } = splitFrontmatter(original);
+  const anchored = injectAnchors(body);
+  const rebuilt = fm != null ? `---\n${fm}\n---\n${anchored}` : anchored;
+  return { original, fm, anchored, rebuilt };
+}
+
+/**
  * Docs-dialect pre-mask over non-code segments: hide `:::` container markers
  * (keep the title label), `[[toc]]`, and explicit `{#anchor}` slugs so the model
  * never rewrites them. Returns masked text plus the token table.
@@ -279,24 +295,37 @@ export function createDocsAdapter({ root = DEFAULT_ROOT } = {}) {
   return {
     name: "docs",
 
+    // Read-only: builds the anchored, masked units in memory without touching
+    // the English sources. A parity check must never mutate the tree (#870); the
+    // on-disk anchor normalization lives in persistSourceAnchors() on the write
+    // path. extract() still anchors in memory so a unit's sourceText (and its
+    // hash) matches what persistSourceAnchors() commits.
     async extract() {
       const files = await listRootMarkdown(root);
       const units = [];
       for (const id of files) {
-        const abs = join(root, id);
-        const original = await readFile(abs, "utf8");
-        const { fm, body } = splitFrontmatter(original);
-        const anchored = injectAnchors(body);
-        const rebuilt = fm != null ? `---\n${fm}\n---\n${anchored}` : anchored;
-        // Persist anchored English source in place (idempotent) so the running
-        // site and every locale share the same stable slugs.
-        if (rebuilt !== original) await writeFile(abs, rebuilt, "utf8");
+        const { fm, anchored } = await anchorDoc(join(root, id));
         const { masked, tokens } = maskDocs(anchored);
         tokenTables.set(id, tokens);
         const sourceText = fm != null ? `---\n${fm}\n---\n${masked}` : masked;
         units.push({ id, sourceText, kind: "markdown" });
       }
       return units;
+    },
+
+    // Adapter extra (not part of the 3-method contract): normalize English
+    // headings to explicit {#slug} anchors in place, so the running site and
+    // every locale share stable slugs. This is the write half extract() used to
+    // do as a side effect; it belongs on the translate write path, never the
+    // read-only parity check (#870). Idempotent: already-anchored files are a
+    // no-op, so a clean tree stays clean.
+    async persistSourceAnchors() {
+      const files = await listRootMarkdown(root);
+      for (const id of files) {
+        const abs = join(root, id);
+        const { original, rebuilt } = await anchorDoc(abs);
+        if (rebuilt !== original) await writeFile(abs, rebuilt, "utf8");
+      }
     },
 
     async load(locale) {

--- a/scripts/i18n/translate.mjs
+++ b/scripts/i18n/translate.mjs
@@ -68,6 +68,14 @@ async function main() {
     const mod = await ADAPTERS[surface]();
     const adapter = mod.adapter;
 
+    // Normalize the English source anchors here, on the write path where
+    // mutating the tree is expected. The read-only parity check (i18n:check)
+    // never does this, which is the whole point of moving it off extract()
+    // (snapotter-hq/SnapOtter#870). Optional: only the docs adapter defines it.
+    if (typeof adapter.persistSourceAnchors === "function") {
+      await adapter.persistSourceAnchors();
+    }
+
     if (args.mode === "export") {
       const units = await adapter.extract();
       for (const locale of locales) {

--- a/tests/unit/scripts/i18n/docs-md.test.ts
+++ b/tests/unit/scripts/i18n/docs-md.test.ts
@@ -32,16 +32,39 @@ describe("docs-md adapter", () => {
     expect(units[0].kind).toBe("markdown");
   });
 
-  it("injects stable explicit anchors into English headings, idempotently", async () => {
-    await seed("guide/x.md", "# Getting Started\n\n## Quick Start\n\n## Already {#pinned}\n");
+  it("extract does not modify English source files on disk (read-only, #870)", async () => {
+    const before = "# Getting Started\n\n## Quick Start\n\nBody.\n"; // no explicit anchors
+    await seed("guide/ro.md", before);
     const adapter = createDocsAdapter({ root });
     await adapter.extract();
+    const after = await readFile(join(root, "guide/ro.md"), "utf8");
+    // A parity check must never mutate sources; extract() is read-only. The
+    // anchor normalization moved to persistSourceAnchors() on the write path.
+    expect(after).toBe(before);
+  });
+
+  it("extract anchors the returned sourceText in memory without writing to disk", async () => {
+    await seed("guide/mem.md", "# Getting Started\n\nBody.\n");
+    const adapter = createDocsAdapter({ root });
+    const units = await adapter.extract();
+    // Anchors are masked out of sourceText, but the slug survives inside a mask
+    // token, so the translated unit still carries the stable anchor. The point
+    // here: extraction produced anchored units while leaving the file untouched.
+    expect(units[0].sourceText).toContain("Getting Started");
+    const onDisk = await readFile(join(root, "guide/mem.md"), "utf8");
+    expect(onDisk).toBe("# Getting Started\n\nBody.\n");
+  });
+
+  it("persistSourceAnchors injects stable explicit anchors into English headings, idempotently", async () => {
+    await seed("guide/x.md", "# Getting Started\n\n## Quick Start\n\n## Already {#pinned}\n");
+    const adapter = createDocsAdapter({ root });
+    await adapter.persistSourceAnchors();
     const onDisk = await readFile(join(root, "guide/x.md"), "utf8");
     expect(onDisk).toContain("# Getting Started {#getting-started}");
     expect(onDisk).toContain("## Quick Start {#quick-start}");
     expect(onDisk).toContain("## Already {#pinned}"); // untouched
-    // Running extract again does not double-anchor.
-    await adapter.extract();
+    // Running it again does not double-anchor.
+    await adapter.persistSourceAnchors();
     const again = await readFile(join(root, "guide/x.md"), "utf8");
     expect(again).toBe(onDisk);
   });
@@ -52,7 +75,7 @@ describe("docs-md adapter", () => {
       "## Example Request\n\ntext\n\n## Example Request\n\nmore\n\n## Example Request\n",
     );
     const adapter = createDocsAdapter({ root });
-    await adapter.extract();
+    await adapter.persistSourceAnchors();
     const onDisk = await readFile(join(root, "guide/z.md"), "utf8");
     expect(onDisk).toContain("## Example Request {#example-request}");
     expect(onDisk).toContain("## Example Request {#example-request-1}");
@@ -62,7 +85,7 @@ describe("docs-md adapter", () => {
   it("does not treat fenced # lines as headings", async () => {
     await seed("guide/y.md", "# Real Heading\n\n```bash\n# not a heading\n```\n");
     const adapter = createDocsAdapter({ root });
-    await adapter.extract();
+    await adapter.persistSourceAnchors();
     const onDisk = await readFile(join(root, "guide/y.md"), "utf8");
     expect(onDisk).toContain("# Real Heading {#real-heading}");
     expect(onDisk).toContain("# not a heading\n"); // still inside the fence, no anchor


### PR DESCRIPTION
`pnpm i18n:check` is a read-only parity gate, but it mutated the working tree. The docs adapter's `extract()` injected `{#slug}` heading anchors into the English source files and wrote them back in place, as a side effect. Every caller of `extract()` triggered it, including `check-parity.mjs`, so a plain check rewrote `apps/docs/guide/account-recovery.md` (which has no anchors) on every run and left it staged into whatever commit came next. It slipped into staging twice while landing #865 and #869.

## Fix (the issue's durable option)

Split the read from the write:

- `extract()` is now read-only. It still injects anchors in memory to build each unit's `sourceText`, so the hash parity compares against is identical to before; it just no longer touches disk.
- A new adapter method `persistSourceAnchors()` does the on-disk normalization. `translate.mjs` calls it once per surface on the write path, where mutating the tree is expected. `i18n:check` never calls it.
- A shared `anchorDoc()` helper keeps `extract()` and `persistSourceAnchors()` computing the same anchored form, so they cannot drift.

Anchoring the English source still happens, just on `pnpm i18n:translate` instead of `pnpm i18n:check`. `account-recovery.md` stays unanchored on disk until the next translate run picks it up (verified: `i18n:translate --export` anchors it through the new method). Its slugs already match VitePress's auto-generated ones, so the rendered site is unaffected in the meantime.

## Verification

New tests: `extract()` leaves the source byte-identical (the bug, written RED first) and returns anchored `sourceText` without writing. The three existing anchor-injection tests (idempotent, slug dedup, fence-aware) now exercise `persistSourceAnchors()`, the method that actually writes. All 16 docs-md tests and 74 i18n script tests pass; typecheck and biome are clean.

Confirmed end to end: on a clean tree, `pnpm i18n:check` now leaves `git status` clean, where before it showed `M apps/docs/guide/account-recovery.md`. The parity failures the check reports (stale and missing translations across locales) are unrelated to this change and are also present on main.

Fixes #870
