### PR TITLE
fix(api): resolve single-tool cancels through the SSE alias id

### DIFF
--- a/apps/api/src/jobs/cancel.ts
+++ b/apps/api/src/jobs/cancel.ts
@@ -2,7 +2,7 @@
  * Cooperative job cancellation via Redis pub/sub.
  *
  * - Workers call registerCancelable(jobId) on start and unregister on finish.
- * - requestCancel(jobId) handles six states:
+ * - requestCancel(jobId) handles seven states:
  *   1. Batch parent (plain or pipeline-batch): flag the batch canceled and
  *      publish every runnable child id on the cancel channel; batch-finalize
  *      commits terminal state (#767, #771).
@@ -10,10 +10,13 @@
  *      publish the step ids; pipeline-finalize commits terminal state (#771).
  *   3. Pipeline SSE alias: resolve the settings.pipelineFlowId pointer the
  *      route stamped, then cancel the flow the same way (#771).
- *   4. Waiting/delayed: remove from queue, mark DB row canceled.
- *   5. Active (in a worker): publish the jobId on the cancel channel;
+ *   4. Single-tool SSE alias: resolve the settings.artifactJobId pointer
+ *      enqueueToolJob stamped, then run the queue scan under the server id;
+ *      a removed queued job also settles the alias row terminally (#808).
+ *   5. Waiting/delayed: remove from queue, mark DB row canceled.
+ *   6. Active (in a worker): publish the jobId on the cancel channel;
  *      the worker's AbortSignal fires and it cleans up.
- *   6. Terminal or absent: no-op, returns false.
+ *   7. Terminal or absent: no-op, returns false.
  * - startCancelListener() subscribes to the cancel channel and fires
  *   registered AbortControllers.
  */
@@ -21,6 +24,7 @@
 import { eq } from "drizzle-orm";
 import type Redis from "ioredis";
 import { db, schema } from "../db/index.js";
+import { cancelSingleJobGuarded } from "../routes/progress.js";
 import { markBatchCanceled } from "./batch-progress.js";
 import { createRedisSubscriberConnection, sharedRedis } from "./connection.js";
 import { getQueue } from "./queues.js";
@@ -77,6 +81,7 @@ interface CancelRowSettings {
   stepCount?: number;
   clientJobId?: string;
   pipelineFlowId?: string;
+  artifactJobId?: string;
 }
 
 function isTerminal(status: string): boolean {
@@ -183,8 +188,54 @@ export async function requestCancel(jobId: string): Promise<boolean> {
       }
       return true;
     }
+
+    // Single-tool SSE alias (#808): the client-facing id a tool route
+    // enqueued under a server-generated uuid. Follow the pointer into the
+    // queue scan without consulting the alias row's own status: on a
+    // reused id it is stale (terminal from the previous run, since
+    // nonterminal frames cannot resurrect it), and the artifact side of
+    // the scan already refuses terminal runs. A removed queued job never
+    // reaches a worker, so nothing else would ever emit a frame for it:
+    // the alias row gets the same terminal write and announcement (#766's
+    // lesson: a reconnecting client replays from this row, and a
+    // nonterminal alias replays a live run that will never finish). An
+    // active job's worker settles both rows itself.
+    if (settings.artifactJobId) {
+      const outcome = await cancelQueueJob(settings.artifactJobId);
+      if (outcome === "removed") {
+        await cancelSingleJobGuarded({ jobId });
+        return true;
+      }
+      if (outcome === "signaled") return true;
+
+      // Nothing in any queue. Either the run is genuinely over, or a
+      // prior cancel removed the job but died before the alias settled (a
+      // crash or thrown write between the two). The artifact row is
+      // authoritative: heal a nonterminal alias over a canceled artifact
+      // so retries converge instead of answering false forever.
+      if (!isTerminal(row.status)) {
+        const [artifact] = await db
+          .select({ status: schema.jobs.status })
+          .from(schema.jobs)
+          .where(eq(schema.jobs.id, settings.artifactJobId));
+        if (artifact?.status === "canceled") {
+          await cancelSingleJobGuarded({ jobId });
+          return true;
+        }
+      }
+      return false;
+    }
   }
 
+  return (await cancelQueueJob(jobId)) !== false;
+}
+
+/**
+ * Scan the pools for a queue job under `jobId` and cancel it: remove it
+ * when waiting/delayed (marking its DB row canceled), signal the worker
+ * when active. Returns false when the job is terminal or in no queue.
+ */
+async function cancelQueueJob(jobId: string): Promise<"removed" | "signaled" | false> {
   for (const pool of POOLS) {
     const queue = getQueue(pool);
     const job = await queue.getJob(jobId);
@@ -199,13 +250,13 @@ export async function requestCancel(jobId: string): Promise<boolean> {
         .update(schema.jobs)
         .set({ status: "canceled", completedAt: new Date() })
         .where(eq(schema.jobs.id, jobId));
-      return true;
+      return "removed";
     }
 
     // Active: publish cancel signal for the worker
     if (state === "active") {
       await sharedRedis().publish(CANCEL_CHANNEL(), jobId);
-      return true;
+      return "signaled";
     }
 
     // Terminal (completed, failed): no-op

--- a/apps/api/src/jobs/enqueue.ts
+++ b/apps/api/src/jobs/enqueue.ts
@@ -7,7 +7,7 @@
  */
 import { context, propagation } from "@opentelemetry/api";
 import { FlowProducer, type Job, QueueEvents } from "bullmq";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull, or } from "drizzle-orm";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { assertAiJobQuota } from "../lib/ai-quota.js";
@@ -176,6 +176,53 @@ export async function enqueueToolJob(data: ToolJobData): Promise<Job<ToolJobData
     inputRefs: data.inputRefs,
     settings: stripNulBytes((data.dbSettings ?? data.settings) as Record<string, unknown>),
   });
+
+  // Client-facing SSE alias row (#808). The web client cancels by the id it
+  // generated (clientJobId); the queue job lives under the server jobId.
+  // The pointer stamped here lets requestCancel resolve one to the other,
+  // and the owner lets the cancel route authorize the run's own starter.
+  // Awaited and committed before the queue add, so from the first moment
+  // cancelable work exists the pointer is durable. Unlike the pipeline
+  // route's pre-insert (which runs before any progress write), enqueue
+  // happens after validation has already published progress frames, so the
+  // lazy persist layer may have created this row first: ownerless rows are
+  // claimed (this run's own lazy insert, or an abandoned channel), while a
+  // row another user owns is left alone so a reused id cannot transfer it
+  // or strip their cancel authorization.
+  if (data.clientJobId && data.clientJobId !== data.jobId) {
+    const aliasSettings = { artifactJobId: data.jobId };
+    const claimableOwner = data.userId
+      ? or(isNull(schema.jobs.userId), eq(schema.jobs.userId, data.userId))
+      : isNull(schema.jobs.userId);
+    const res = await db
+      .insert(schema.jobs)
+      .values({
+        id: data.clientJobId,
+        userId: data.userId,
+        pool: data.pool,
+        type: "single",
+        status: "queued",
+        inputRefs: [],
+        settings: aliasSettings,
+      })
+      .onConflictDoUpdate({
+        target: schema.jobs.id,
+        // Only alias rows are claimable: a colliding batch parent or
+        // pipeline row the same user owns must keep its own cancel
+        // metadata (batch parent ids ARE client-supplied, so that
+        // collision is reachable).
+        set: { settings: aliasSettings, userId: data.userId },
+        setWhere: and(eq(schema.jobs.type, "single"), claimableOwner),
+      });
+    if (((res as { rowCount?: number | null })?.rowCount ?? 0) === 0) {
+      // The claim was skipped (foreign owner or non-alias collision). The
+      // run proceeds, but its starter cannot cancel through this id; make
+      // that debuggable instead of a silent 404 months later.
+      console.warn(
+        `alias claim skipped for clientJobId ${data.clientJobId} (job ${data.jobId}); cancel by this id will not resolve`,
+      );
+    }
+  }
 
   // Fire-and-forget: compute deleteAfter from team retention override
   if (data.userId) {

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -623,9 +623,33 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
           .catch(() => {});
 
         if (isCanceled) {
-          // Ephemeral terminal event for live SSE clients. Uses
-          // publishEphemeral so the replay key is set without
-          // overwriting the DB row (which stays "canceled").
+          if (progressJobId !== jobId) {
+            // Alias dual write (#808), the finalize's #766 pattern: a
+            // reconnecting client replays from the alias row, so it needs
+            // the same terminal state, not just an ephemeral frame that
+            // expires with the Redis key. Guarded, so a cancel racing a
+            // committed completion cannot downgrade it. A failed write
+            // must not replace the UnrecoverableError thrown below
+            // (anything else would let BullMQ retry a canceled job), so it
+            // logs at error level (a dropped terminal write is the one
+            // failure a client may never recover from) and falls through
+            // to the ephemeral publish, which requestCancel's repair path
+            // backs up on the next cancel.
+            try {
+              await cancelSingleJobGuarded({ jobId: progressJobId });
+            } catch (aliasErr) {
+              logger.error(
+                { err: aliasErr, jobId, progressJobId },
+                "canceled alias terminal write failed",
+              );
+            }
+          }
+          // Ephemeral terminal event for live SSE clients, published
+          // unconditionally: liveness must not depend on the durable write
+          // (which the guard also skips when a reused alias id is still
+          // terminal from an earlier run). publishEphemeral sets the
+          // replay key without overwriting the DB row (which stays
+          // "canceled").
           publishEphemeral({
             jobId: progressJobId,
             type: "single",

--- a/apps/api/src/routes/tool-factory.ts
+++ b/apps/api/src/routes/tool-factory.ts
@@ -10,7 +10,7 @@ import {
   TOOL_BUNDLE_MAP,
   TOOLS,
 } from "@snapotter/shared";
-import { and, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, ne, sql } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import type { z } from "zod";
 import { env } from "../config.js";
@@ -520,7 +520,10 @@ export function createToolRoute<T>(app: FastifyInstance, config: ToolRouteConfig
           });
         }
 
-        // Check per-user concurrent job limit before enqueuing
+        // Check per-user concurrent job limit before enqueuing. Type
+        // "single" rows are SSE alias bookkeeping, not work (#808: they now
+        // carry the owner so cancels can be authorized); counting them
+        // would double-charge every tool-route run against the limit.
         const userId = authUser.id;
         const maxConcurrent = await getSettingNumber("maxConcurrentJobsPerUser", 0);
         if (maxConcurrent > 0 && userId) {
@@ -531,6 +534,7 @@ export function createToolRoute<T>(app: FastifyInstance, config: ToolRouteConfig
               and(
                 sql`${schema.jobs.userId} = ${userId}`,
                 inArray(schema.jobs.status, ["queued", "processing"]),
+                ne(schema.jobs.type, "single"),
               ),
             );
 
@@ -607,6 +611,24 @@ export function createToolRoute<T>(app: FastifyInstance, config: ToolRouteConfig
           }
           return reply.status(202).send(buildAsyncAcceptedPayload(jobId, clientJobId));
         } catch (err) {
+          // A cancel that lands inside the sync window surfaces here as the
+          // worker's UnrecoverableError("Canceled") (#808). Answer the
+          // structural canceled shape the web client maps to its localized
+          // canceled state, mirroring pipeline and batch. The message alone
+          // is forgeable (a tool can fail with exactly this string), so the
+          // row the worker committed before throwing is the authority; a
+          // mismatch falls through to the logged generic path.
+          if (err instanceof Error && err.message === "Canceled") {
+            const wasCanceled = await db
+              .select({ status: schema.jobs.status })
+              .from(schema.jobs)
+              .where(eq(schema.jobs.id, jobId))
+              .then((rows) => rows[0]?.status === "canceled")
+              .catch(() => false);
+            if (wasCanceled) {
+              return reply.status(422).send({ error: "Canceled", canceled: true });
+            }
+          }
           // Keep the full error (incl. raw ffmpeg/tool stderr) in server logs,
           // but return only a user-safe detail to the client.
           request.log.error({ err, toolId: config.toolId }, "tool processing failed");

--- a/tests/integration/platform/single-tool-cancel-http.test.ts
+++ b/tests/integration/platform/single-tool-cancel-http.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Single-tool cancel over the real HTTP surface (#808).
+ *
+ * The worker-harness suite (single-tool-cancel.test.ts) drives requestCancel
+ * against jobs it enqueues itself; this file pins what the routes stamp and
+ * answer: the alias row carries the artifact pointer and the owner (so plain
+ * users can cancel their own runs instead of hitting the 404 path that
+ * mislabels a live run as locally canceled), reused ids keep their owner,
+ * and a sync request whose worker was canceled answers the structural
+ * canceled 422 the web client settles on.
+ *
+ * Mid-run timing is deliberately absent here, mirroring the #771 http suite:
+ * a tiny resize completes in milliseconds, so requestCancel's live behavior
+ * stays in the worker-harness suite.
+ */
+
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+// Canned sync-wait failures, keyed by pool: lets the route's catch branch
+// (the structural canceled 422) run deterministically. `markCanceled`
+// mirrors the real worker sequence, which commits the canceled row before
+// the failed event ever reaches waitUntilFinished; the negative test turns
+// it off to model a tool that merely failed with that message. The chain
+// this mock stands in for is pinned by the worker-harness suite
+// ("surfaces an active cancel to the sync window as the Canceled
+// rejection"). Absent entries keep the real waitForJob.
+const enqueueMock = vi.hoisted(() => ({
+  throwByPool: new Map<string, string>(),
+  markCanceled: false,
+}));
+
+vi.mock("../../../apps/api/src/jobs/enqueue.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../apps/api/src/jobs/enqueue.js")>();
+  return {
+    ...actual,
+    waitForJob: async (...args: Parameters<typeof actual.waitForJob>) => {
+      const message = enqueueMock.throwByPool.get(args[0]);
+      if (message) {
+        if (enqueueMock.markCanceled) {
+          const { db, schema } = await import("../../../apps/api/src/db/index.js");
+          const { eq } = await import("drizzle-orm");
+          await db
+            .update(schema.jobs)
+            .set({ status: "canceled", completedAt: new Date() })
+            .where(eq(schema.jobs.id, args[1]));
+        }
+        throw new Error(message);
+      }
+      return actual.waitForJob(...args);
+    },
+  };
+});
+
+const { eq } = await import("drizzle-orm");
+const { db, schema } = await import("../../../apps/api/src/db/index.js");
+const { sharedRedis } = await import("../../../apps/api/src/jobs/connection.js");
+const { getQueue } = await import("../../../apps/api/src/jobs/queues.js");
+const { bullPrefix } = await import("../../../apps/api/src/jobs/types.js");
+const { fixtures, readFixture } = await import("../../fixtures/index.js");
+const { buildTestApp, createMultipartPayload, createUserAndLogin, loginAsAdmin } = await import(
+  "../test-server.js"
+);
+
+const PNG = readFixture(fixtures.image.base.png200);
+
+let testApp: Awaited<ReturnType<typeof buildTestApp>>;
+let app: (typeof testApp)["app"];
+let adminToken: string;
+
+type JobRow = typeof schema.jobs.$inferSelect;
+
+async function jobRow(jobId: string): Promise<JobRow | undefined> {
+  const [row] = await db.select().from(schema.jobs).where(eq(schema.jobs.id, jobId));
+  return row;
+}
+
+/** Poll the Redis terminal replay key until the terminal frame appears. */
+async function waitForTerminalFrame(
+  jobId: string,
+  timeoutMs = 30_000,
+): Promise<Record<string, unknown>> {
+  const key = `${bullPrefix()}:terminal:${jobId}`;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const raw = await sharedRedis().get(key);
+    if (raw) return JSON.parse(raw) as Record<string, unknown>;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`No terminal frame for ${jobId} within ${timeoutMs}ms`);
+}
+
+/** Run a resize to completion under a fresh clientJobId. */
+async function runResize(clientJobId: string, token: string): Promise<void> {
+  const { body, contentType } = createMultipartPayload([
+    { name: "file", filename: "photo.png", contentType: "image/png", content: PNG },
+    { name: "settings", content: JSON.stringify({ width: 50 }) },
+    { name: "clientJobId", content: clientJobId },
+  ]);
+  const res = await app.inject({
+    method: "POST",
+    url: "/api/v1/tools/image/resize",
+    headers: { "content-type": contentType, authorization: `Bearer ${token}` },
+    body,
+  });
+  expect([200, 202]).toContain(res.statusCode);
+  await waitForTerminalFrame(clientJobId);
+}
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  app = testApp.app;
+  adminToken = await loginAsAdmin(app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+describe("route-stamped alias metadata (#808)", () => {
+  it("stamps the alias pointer and owner on a factory tool route", async () => {
+    const clientJobId = randomUUID();
+    await runResize(clientJobId, adminToken);
+
+    const alias = await jobRow(clientJobId);
+    expect(alias?.type).toBe("single");
+    // The owner lands on the alias so the cancel route's ownership check
+    // passes for the user who started the run.
+    expect(alias?.userId).not.toBeNull();
+    const aliasSettings = (alias?.settings ?? {}) as { artifactJobId?: string };
+    expect(typeof aliasSettings.artifactJobId).toBe("string");
+
+    const artifact = await jobRow(aliasSettings.artifactJobId as string);
+    expect(artifact?.type).toBe("tool");
+    expect(artifact?.toolId).toBe("resize");
+    expect(artifact?.userId).toBe(alias?.userId);
+  });
+
+  it("re-points the alias at the newest artifact when a clientJobId is reused", async () => {
+    const clientJobId = randomUUID();
+    await runResize(clientJobId, adminToken);
+    const first = await jobRow(clientJobId);
+    const firstArtifact = ((first?.settings ?? {}) as { artifactJobId?: string }).artifactJobId;
+    expect(typeof firstArtifact).toBe("string");
+
+    // Clear run 1's terminal frame so runResize waits on run 2's own.
+    await sharedRedis().del(`${bullPrefix()}:terminal:${clientJobId}`);
+    await runResize(clientJobId, adminToken);
+
+    const reused = await jobRow(clientJobId);
+    const secondArtifact = ((reused?.settings ?? {}) as { artifactJobId?: string }).artifactJobId;
+    expect(typeof secondArtifact).toBe("string");
+    expect(secondArtifact).not.toBe(firstArtifact);
+  });
+
+  it("does not let a second user take over an alias row by reusing its id", async () => {
+    const owner = await createUserAndLogin(app, `single-cancel-owner-${Date.now()}`);
+    const clientJobId = randomUUID();
+    await runResize(clientJobId, owner.token);
+    const before = await jobRow(clientJobId);
+    const pointerBefore = ((before?.settings ?? {}) as { artifactJobId?: string }).artifactJobId;
+    expect(before?.userId).toBe(owner.userId);
+
+    // A second user submits their own run under the first user's id. The
+    // run may proceed (colliding channels were always latest-run-wins), but
+    // the alias row's owner and pointer must survive: transferring them
+    // would strip the first user's cancel authorization.
+    const attacker = await createUserAndLogin(app, `single-cancel-reuse-${Date.now()}`);
+    await sharedRedis().del(`${bullPrefix()}:terminal:${clientJobId}`);
+    await runResize(clientJobId, attacker.token);
+
+    const after = await jobRow(clientJobId);
+    expect(after?.userId).toBe(owner.userId);
+    expect(((after?.settings ?? {}) as { artifactJobId?: string }).artifactJobId).toBe(
+      pointerBefore,
+    );
+  });
+});
+
+describe("HTTP cancel on route-created single-tool rows", () => {
+  it("answers 200 for the run's own plain user instead of the 404 mislabel path", async () => {
+    const owner = await createUserAndLogin(app, `single-cancel-plain-${Date.now()}`);
+    const clientJobId = randomUUID();
+    await runResize(clientJobId, owner.token);
+
+    // Pre-#808 the alias row had no owner, so this answered 404 and the
+    // client settled a live run locally as "Canceled". A finished run
+    // refuses the cancel, but through a 200.
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/jobs/${clientJobId}/cancel`,
+      headers: { authorization: `Bearer ${owner.token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ canceled: false });
+  });
+
+  it("blocks a non-owner from canceling through the alias (404)", async () => {
+    const owner = await createUserAndLogin(app, `single-cancel-victim-${Date.now()}`);
+    const clientJobId = randomUUID();
+    await runResize(clientJobId, owner.token);
+    const attacker = await createUserAndLogin(app, `single-cancel-attacker-${Date.now()}`);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/jobs/${clientJobId}/cancel`,
+      headers: { authorization: `Bearer ${attacker.token}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("concurrent-job limit with alias rows (#808)", () => {
+  it("does not count alias rows against maxConcurrentJobsPerUser", async () => {
+    const user = await createUserAndLogin(app, `single-cancel-limit-${Date.now()}`);
+    // One real in-flight job plus one SSE alias row for it. Only the real
+    // job may count: alias rows are bookkeeping, and counting them would
+    // silently halve the effective limit for every tool-route run.
+    await db.insert(schema.jobs).values([
+      {
+        id: randomUUID(),
+        userId: user.userId,
+        type: "tool",
+        status: "processing",
+        inputRefs: [],
+      },
+      {
+        id: randomUUID(),
+        userId: user.userId,
+        type: "single",
+        status: "processing",
+        inputRefs: [],
+        settings: { artifactJobId: randomUUID() },
+      },
+    ]);
+    await db
+      .insert(schema.settings)
+      .values({ key: "maxConcurrentJobsPerUser", value: "2" })
+      .onConflictDoUpdate({ target: schema.settings.key, set: { value: "2" } });
+
+    try {
+      const clientJobId = randomUUID();
+      const { body, contentType } = createMultipartPayload([
+        { name: "file", filename: "photo.png", contentType: "image/png", content: PNG },
+        { name: "settings", content: JSON.stringify({ width: 50 }) },
+        { name: "clientJobId", content: clientJobId },
+      ]);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/tools/image/resize",
+        headers: { "content-type": contentType, authorization: `Bearer ${user.token}` },
+        body,
+      });
+      expect([200, 202]).toContain(res.statusCode);
+      await waitForTerminalFrame(clientJobId);
+    } finally {
+      await db
+        .update(schema.settings)
+        .set({ value: "0" })
+        .where(eq(schema.settings.key, "maxConcurrentJobsPerUser"));
+    }
+  });
+
+  it("still rejects real over-limit runs with 429", async () => {
+    // The counter-direction pin: without it, a broader type filter could
+    // turn the per-user limit into a no-op with every test green.
+    const user = await createUserAndLogin(app, `single-cancel-429-${Date.now()}`);
+    await db.insert(schema.jobs).values({
+      id: randomUUID(),
+      userId: user.userId,
+      type: "tool",
+      status: "queued",
+      inputRefs: [],
+    });
+    await db
+      .insert(schema.settings)
+      .values({ key: "maxConcurrentJobsPerUser", value: "1" })
+      .onConflictDoUpdate({ target: schema.settings.key, set: { value: "1" } });
+
+    try {
+      const { body, contentType } = createMultipartPayload([
+        { name: "file", filename: "photo.png", contentType: "image/png", content: PNG },
+        { name: "settings", content: JSON.stringify({ width: 50 }) },
+        { name: "clientJobId", content: randomUUID() },
+      ]);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/tools/image/resize",
+        headers: { "content-type": contentType, authorization: `Bearer ${user.token}` },
+        body,
+      });
+      expect(res.statusCode).toBe(429);
+      const parsed = JSON.parse(res.body) as { activeJobs?: number; limit?: number };
+      expect(parsed.activeJobs).toBe(1);
+      expect(parsed.limit).toBe(1);
+    } finally {
+      await db
+        .update(schema.settings)
+        .set({ value: "0" })
+        .where(eq(schema.settings.key, "maxConcurrentJobsPerUser"));
+    }
+  });
+});
+
+describe("sync response for a canceled run", () => {
+  async function postResizeSync(): Promise<{ statusCode: number; body: string }> {
+    const { body, contentType } = createMultipartPayload([
+      { name: "file", filename: "photo.png", contentType: "image/png", content: PNG },
+      { name: "settings", content: JSON.stringify({ width: 50 }) },
+      { name: "clientJobId", content: randomUUID() },
+    ]);
+    return app.inject({
+      method: "POST",
+      url: "/api/v1/tools/image/resize",
+      headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+      body,
+    });
+  }
+
+  it("answers the structural canceled 422 when the worker was canceled", async () => {
+    // A cancel that lands while the route blocks in the sync window
+    // surfaces as the worker's UnrecoverableError("Canceled") after the
+    // worker committed the canceled row; the route must answer the shape
+    // the web client maps to its localized canceled state. The queue is
+    // paused so the real worker cannot race the canned row state.
+    const queue = getQueue("image");
+    await queue.pause();
+    enqueueMock.throwByPool.set("image", "Canceled");
+    enqueueMock.markCanceled = true;
+    try {
+      const res = await postResizeSync();
+      expect(res.statusCode).toBe(422);
+      const parsed = JSON.parse(res.body) as { error: string; canceled?: boolean };
+      expect(parsed.error).toBe("Canceled");
+      expect(parsed.canceled).toBe(true);
+    } finally {
+      enqueueMock.throwByPool.delete("image");
+      enqueueMock.markCanceled = false;
+      await queue.resume();
+    }
+  });
+
+  it("does not mislabel a genuine failure whose message is Canceled", async () => {
+    // A tool process function can fail with exactly this string without
+    // any cancel happening. The row is authoritative: no canceled status,
+    // no canceled response, and the failure keeps its generic logged path.
+    const queue = getQueue("image");
+    await queue.pause();
+    enqueueMock.throwByPool.set("image", "Canceled");
+    try {
+      const res = await postResizeSync();
+      expect(res.statusCode).toBe(422);
+      const parsed = JSON.parse(res.body) as { error: string; canceled?: boolean };
+      expect(parsed.error).toBe("Processing failed");
+      expect(parsed.canceled).toBeUndefined();
+    } finally {
+      enqueueMock.throwByPool.delete("image");
+      await queue.resume();
+    }
+  });
+});

--- a/tests/integration/platform/single-tool-cancel.test.ts
+++ b/tests/integration/platform/single-tool-cancel.test.ts
@@ -1,0 +1,521 @@
+/**
+ * Single-tool cancel (#808): requestCancel's alias resolution for plain
+ * tool runs, the enqueue-time alias stamping, and the worker's dual
+ * terminal write when an active run is canceled through its alias.
+ *
+ * Follows the batch-cancel.test.ts harness: no HTTP app is built. The test
+ * tool is registered directly in the process registry, jobs are enqueued
+ * through the real enqueueToolJob (the seam every single-tool route shares,
+ * factory and custom AI routes alike), and the real workers drain them
+ * against this fork's Postgres + Redis. Queue pauses stand in for "the job
+ * is still waiting" so removal is deterministic instead of a race.
+ */
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+// Injects a bounded fault into the worker's durable alias write so the
+// liveness fallback (the ephemeral terminal frame must reach live SSE
+// clients even when the DB write fails) is testable. Scoped by target id so
+// every other test runs against the real implementation.
+const guardedWriteFault = vi.hoisted(() => ({ target: null as string | null }));
+
+vi.mock("../../../apps/api/src/routes/progress.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../apps/api/src/routes/progress.js")>();
+  return {
+    ...actual,
+    cancelSingleJobGuarded: async (args: { jobId: string }) => {
+      if (args.jobId === guardedWriteFault.target) {
+        throw new Error("injected alias-write outage");
+      }
+      return actual.cancelSingleJobGuarded(args);
+    },
+  };
+});
+
+import { db, schema } from "../../../apps/api/src/db/index.js";
+import { runMigrations } from "../../../apps/api/src/db/migrate.js";
+import {
+  requestCancel,
+  startCancelListener,
+  stopCancelListener,
+} from "../../../apps/api/src/jobs/cancel.js";
+import {
+  createRedisSubscriberConnection,
+  sharedRedis,
+} from "../../../apps/api/src/jobs/connection.js";
+import {
+  closeQueueEvents,
+  enqueueToolJob,
+  waitForJob,
+} from "../../../apps/api/src/jobs/enqueue.js";
+import { closeQueues, getQueue } from "../../../apps/api/src/jobs/queues.js";
+import { bullPrefix } from "../../../apps/api/src/jobs/types.js";
+import { closeWorkers, startWorkers } from "../../../apps/api/src/jobs/worker.js";
+import { putObject } from "../../../apps/api/src/lib/object-storage.js";
+import type { ToolProcessCtx } from "../../../apps/api/src/routes/tool-factory.js";
+import { registerToolProcessFn } from "../../../apps/api/src/routes/tool-factory.js";
+
+const passthroughSchema = { parse: (v: unknown) => v } as never;
+
+interface RunSettings {
+  mode: "fast" | "slow";
+  tag: string;
+}
+
+// Behavior keyed on settings: fast returns instantly, slow waits on the
+// worker's abort signal, so a cancel has a real running target. Every
+// invocation records its tag, so "this run never started" is a positive
+// assertion instead of a timing guess.
+const invoked: string[] = [];
+registerToolProcessFn({
+  toolId: "wt-single-cancel",
+  settingsSchema: passthroughSchema,
+  process: async (
+    inputBuffer: Buffer,
+    settings: unknown,
+    filename: string,
+    ctx?: ToolProcessCtx,
+  ) => {
+    const { mode, tag } = settings as RunSettings;
+    invoked.push(tag);
+    if (mode === "slow") {
+      await new Promise<void>((resolve, reject) => {
+        const signal = ctx?.signal;
+        if (!signal) {
+          reject(new Error("wt-single-cancel requires an abort signal"));
+          return;
+        }
+        if (signal.aborted) {
+          reject(new Error("aborted before start"));
+          return;
+        }
+        const timer = setTimeout(resolve, 20_000);
+        signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            reject(new Error("aborted by signal"));
+          },
+          { once: true },
+        );
+      });
+    }
+    return { buffer: inputBuffer, filename, contentType: "image/png" };
+  },
+});
+
+mkdirSync(process.env.WORKSPACE_PATH ?? "", { recursive: true });
+await runMigrations();
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+type JobRow = typeof schema.jobs.$inferSelect;
+
+async function waitFor<T>(probe: () => Promise<T | undefined>, timeoutMs = 20_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await probe();
+    if (value !== undefined) return value;
+    if (Date.now() > deadline) throw new Error(`condition not met within ${timeoutMs}ms`);
+    await delay(150);
+  }
+}
+
+async function jobRow(jobId: string): Promise<JobRow | undefined> {
+  const [row] = await db.select().from(schema.jobs).where(eq(schema.jobs.id, jobId));
+  return row;
+}
+
+async function terminalRow(jobId: string, timeoutMs = 25_000): Promise<JobRow> {
+  return waitFor(async () => {
+    const row = await jobRow(jobId);
+    return row && row.status !== "queued" && row.status !== "processing" ? row : undefined;
+  }, timeoutMs);
+}
+
+async function terminalFrame(jobId: string): Promise<Record<string, unknown>> {
+  const raw = await waitFor(async () => {
+    const value = await sharedRedis().get(`${bullPrefix()}:terminal:${jobId}`);
+    return value ?? undefined;
+  }, 25_000);
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+/** Collect ids published on the cancel channel for the duration of `fn`. */
+async function collectCancelPublishes(fn: () => Promise<void>): Promise<string[]> {
+  const received: string[] = [];
+  const sub = createRedisSubscriberConnection();
+  await sub.subscribe(`${bullPrefix()}:cancel`);
+  sub.on("message", (_ch: string, msg: string) => received.push(msg));
+  try {
+    await fn();
+    // Publishes are awaited inside requestCancel, but delivery to this
+    // subscriber is async; give the frames a beat to arrive.
+    await delay(300);
+    return received;
+  } finally {
+    await sub.quit();
+  }
+}
+
+/** Insert a users row so jobs.userId's FK holds; returns the id. */
+async function createOwner(): Promise<string> {
+  const id = randomUUID();
+  await db.insert(schema.users).values({
+    id,
+    username: `wt-single-cancel-${id.slice(0, 8)}`,
+  });
+  return id;
+}
+
+interface EnqueueOpts {
+  mode: "fast" | "slow";
+  tag: string;
+  clientJobId?: string;
+  userId?: string | null;
+}
+
+/** Enqueue a single-tool run the way every tool route does. */
+async function enqueueSingleRun(
+  opts: EnqueueOpts,
+): Promise<{ jobId: string; userId: string | null }> {
+  const jobId = randomUUID();
+  const userId = opts.userId === undefined ? await createOwner() : opts.userId;
+  const uploadKey = `uploads/${jobId}/input.png`;
+  await putObject(uploadKey, Buffer.from("payload"));
+  await enqueueToolJob({
+    kind: "tool",
+    jobId,
+    toolId: "wt-single-cancel",
+    userId,
+    pool: "image",
+    inputRefs: [uploadKey],
+    filename: "input.png",
+    settings: { mode: opts.mode, tag: opts.tag },
+    clientJobId: opts.clientJobId,
+  });
+  return { jobId, userId };
+}
+
+beforeAll(async () => {
+  await startCancelListener();
+  startWorkers();
+}, 30_000);
+
+afterAll(async () => {
+  await closeWorkers();
+  await stopCancelListener();
+  await closeQueueEvents();
+  await closeQueues();
+  await sharedRedis().quit();
+}, 20_000);
+
+// ── Tests ───────────────────────────────────────────────────────
+
+describe("enqueueToolJob alias stamping (#808)", () => {
+  it("pre-inserts the alias row with owner, pool, and artifact pointer", async () => {
+    const clientJobId = randomUUID();
+    const queue = getQueue("image");
+    await queue.pause();
+    try {
+      const { jobId, userId } = await enqueueSingleRun({
+        mode: "fast",
+        tag: "stamp-a",
+        clientJobId,
+      });
+
+      const alias = await jobRow(clientJobId);
+      expect(alias?.type).toBe("single");
+      expect(alias?.userId).toBe(userId);
+      expect(alias?.pool).toBe("image");
+      expect((alias?.settings ?? {}) as { artifactJobId?: string }).toMatchObject({
+        artifactJobId: jobId,
+      });
+    } finally {
+      await queue.resume();
+    }
+  });
+
+  it("claims the lazily created ownerless SSE row instead of leaving it pointerless", async () => {
+    // A progress frame that beats the enqueue creates the alias row the way
+    // persistSingleFileProgress does: type single, no owner, no settings.
+    const clientJobId = randomUUID();
+    await db.insert(schema.jobs).values({
+      id: clientJobId,
+      type: "single",
+      status: "processing",
+      inputRefs: [],
+    });
+
+    const { jobId, userId } = await enqueueSingleRun({
+      mode: "fast",
+      tag: "stamp-lazy",
+      clientJobId,
+    });
+    await terminalRow(jobId);
+
+    const alias = await jobRow(clientJobId);
+    expect(alias?.userId).toBe(userId);
+    expect(((alias?.settings ?? {}) as { artifactJobId?: string }).artifactJobId).toBe(jobId);
+  });
+
+  it("does not clobber a same-owner batch parent row that collides with the alias id", async () => {
+    // Batch parent ids ARE the client-supplied id, so a collision with a
+    // later single-tool run is reachable for the same user. The upsert must
+    // not replace the parent's cancel metadata with an alias pointer.
+    const owner = await createOwner();
+    const clientJobId = randomUUID();
+    await db.insert(schema.jobs).values({
+      id: clientJobId,
+      userId: owner,
+      type: "batch",
+      status: "processing",
+      inputRefs: [],
+      settings: { flowChildCount: 2, stepCount: 1 },
+    });
+
+    const { jobId } = await enqueueSingleRun({
+      mode: "fast",
+      tag: "batch-collide",
+      clientJobId,
+      userId: owner,
+    });
+    await terminalRow(jobId);
+
+    const parent = await jobRow(clientJobId);
+    expect(parent?.type).toBe("batch");
+    expect(parent?.settings).toMatchObject({ flowChildCount: 2, stepCount: 1 });
+  });
+
+  it("leaves a foreign user's row untouched when its id is reused", async () => {
+    const foreignOwner = await createOwner();
+    const clientJobId = randomUUID();
+    await db.insert(schema.jobs).values({
+      id: clientJobId,
+      userId: foreignOwner,
+      type: "single",
+      status: "queued",
+      inputRefs: [],
+      settings: { artifactJobId: "foreign-artifact" },
+    });
+
+    const { jobId } = await enqueueSingleRun({ mode: "fast", tag: "stamp-foreign", clientJobId });
+    await terminalRow(jobId);
+
+    const alias = await jobRow(clientJobId);
+    expect(alias?.userId).toBe(foreignOwner);
+    expect(((alias?.settings ?? {}) as { artifactJobId?: string }).artifactJobId).toBe(
+      "foreign-artifact",
+    );
+  });
+});
+
+describe("requestCancel through a single-tool alias (#808)", () => {
+  it("resolves a waiting job: removes it and settles both rows terminally", async () => {
+    const clientJobId = randomUUID();
+    const queue = getQueue("image");
+    await queue.pause();
+    let jobId: string;
+    try {
+      ({ jobId } = await enqueueSingleRun({ mode: "fast", tag: "wait-cancel", clientJobId }));
+      expect(await requestCancel(clientJobId)).toBe(true);
+    } finally {
+      await queue.resume();
+    }
+
+    // The queue job is gone, both rows are canceled, and the client-facing
+    // channel got its terminal frame (a reconnecting client must not replay
+    // a live run that will never finish, the #766 lesson).
+    expect(await getQueue("image").getJob(jobId)).toBeUndefined();
+    expect((await jobRow(jobId))?.status).toBe("canceled");
+    expect((await jobRow(clientJobId))?.status).toBe("canceled");
+    const frame = await terminalFrame(clientJobId);
+    expect(frame.phase).toBe("failed");
+    expect(frame.error).toBe("Canceled");
+    expect(invoked).not.toContain("wait-cancel");
+  });
+
+  it("resolves an active job: publishes the server id and the worker settles both rows", async () => {
+    const clientJobId = randomUUID();
+    const { jobId } = await enqueueSingleRun({ mode: "slow", tag: "active-cancel", clientJobId });
+    await waitFor(async () => (invoked.includes("active-cancel") ? true : undefined));
+
+    const received = await collectCancelPublishes(async () => {
+      expect(await requestCancel(clientJobId)).toBe(true);
+    });
+    expect(received).toContain(jobId);
+
+    expect((await terminalRow(jobId)).status).toBe("canceled");
+    expect((await terminalRow(clientJobId)).status).toBe("canceled");
+    const frame = await terminalFrame(clientJobId);
+    expect(frame.phase).toBe("failed");
+    expect(frame.error).toBe("Canceled");
+  });
+
+  it("surfaces an active cancel to the sync window as the Canceled rejection", async () => {
+    // The route's structural 422 keys on this exact chain: worker
+    // UnrecoverableError("Canceled") -> BullMQ failedReason ->
+    // waitUntilFinished rejection. Pin it here so the HTTP suite's canned
+    // waitForJob stays an honest stand-in.
+    const clientJobId = randomUUID();
+    const { jobId } = await enqueueSingleRun({ mode: "slow", tag: "sync-window", clientJobId });
+    await waitFor(async () => (invoked.includes("sync-window") ? true : undefined));
+
+    const settled = waitForJob("image", jobId).then(
+      () => "resolved",
+      (err) => (err instanceof Error ? err.message : String(err)),
+    );
+    expect(await requestCancel(clientJobId)).toBe(true);
+    expect(await settled).toBe("Canceled");
+    expect((await terminalRow(jobId)).status).toBe("canceled");
+  });
+
+  it("cancels a live run whose reused alias id is terminal from an earlier run", async () => {
+    const owner = await createOwner();
+    const clientJobId = randomUUID();
+    const first = await enqueueSingleRun({
+      mode: "fast",
+      tag: "reuse-1",
+      clientJobId,
+      userId: owner,
+    });
+    await terminalRow(first.jobId);
+    await terminalRow(clientJobId);
+
+    const second = await enqueueSingleRun({
+      mode: "slow",
+      tag: "reuse-2",
+      clientJobId,
+      userId: owner,
+    });
+    await waitFor(async () => (invoked.includes("reuse-2") ? true : undefined));
+    await sharedRedis().del(`${bullPrefix()}:terminal:${clientJobId}`);
+
+    // The alias row is still terminal from run 1 (nonterminal frames
+    // cannot resurrect it), but the pointer follows run 2. The cancel must
+    // reach run 2's live job, not answer false off the stale alias status.
+    expect(await requestCancel(clientJobId)).toBe(true);
+    expect((await terminalRow(second.jobId)).status).toBe("canceled");
+
+    // The alias row keeps run 1's terminal state (the guarded write cannot
+    // downgrade it); the live channel still settles through the ephemeral
+    // frame.
+    const frame = await terminalFrame(clientJobId);
+    expect(frame.phase).toBe("failed");
+    expect(frame.error).toBe("Canceled");
+    expect((await jobRow(clientJobId))?.status).toBe("completed");
+  });
+
+  it("heals a half-canceled run instead of answering false forever", async () => {
+    // A prior cancel removed the queue job and marked the artifact row,
+    // but died before the alias settled (a crash or 500 between the
+    // writes). The retry must converge: settle the alias, answer true.
+    const owner = await createOwner();
+    const clientJobId = randomUUID();
+    const artifactId = randomUUID();
+    await db.insert(schema.jobs).values([
+      {
+        id: artifactId,
+        userId: owner,
+        type: "tool",
+        status: "canceled",
+        completedAt: new Date(),
+        inputRefs: [],
+      },
+      {
+        id: clientJobId,
+        userId: owner,
+        type: "single",
+        status: "processing",
+        inputRefs: [],
+        settings: { artifactJobId: artifactId },
+      },
+    ]);
+
+    expect(await requestCancel(clientJobId)).toBe(true);
+    expect((await jobRow(clientJobId))?.status).toBe("canceled");
+    const frame = await terminalFrame(clientJobId);
+    expect(frame.error).toBe("Canceled");
+  });
+
+  it("still delivers the terminal frame when the durable alias write fails", async () => {
+    // Liveness must not depend on DB health: the pre-#808 worker always
+    // published the ephemeral frame, and the dual write keeps that
+    // guarantee. The row stays unsettled (the write failed), which the
+    // repair path above covers on the next cancel.
+    const clientJobId = randomUUID();
+    const { jobId } = await enqueueSingleRun({ mode: "slow", tag: "fault-cancel", clientJobId });
+    await waitFor(async () => (invoked.includes("fault-cancel") ? true : undefined));
+
+    guardedWriteFault.target = clientJobId;
+    try {
+      expect(await requestCancel(clientJobId)).toBe(true);
+      expect((await terminalRow(jobId)).status).toBe("canceled");
+      const frame = await terminalFrame(clientJobId);
+      expect(frame.phase).toBe("failed");
+      expect(frame.error).toBe("Canceled");
+    } finally {
+      guardedWriteFault.target = null;
+    }
+    expect((await jobRow(clientJobId))?.status).not.toBe("canceled");
+  });
+
+  it("returns false for a terminal alias row and does not flag anything", async () => {
+    const clientJobId = randomUUID();
+    const { jobId } = await enqueueSingleRun({ mode: "fast", tag: "done-cancel", clientJobId });
+    await terminalRow(jobId);
+    await terminalRow(clientJobId);
+
+    expect(await requestCancel(clientJobId)).toBe(false);
+    expect((await jobRow(jobId))?.status).toBe("completed");
+  });
+
+  it("returns false when the pointer resolves to no queue job", async () => {
+    // The enqueue window: the alias row is durable but the queue add has
+    // not happened yet. The cancel answers an honest false (button stays
+    // armed) instead of pretending the run stopped.
+    const owner = await createOwner();
+    const clientJobId = randomUUID();
+    await db.insert(schema.jobs).values({
+      id: clientJobId,
+      userId: owner,
+      type: "single",
+      status: "queued",
+      inputRefs: [],
+      settings: { artifactJobId: randomUUID() },
+    });
+
+    expect(await requestCancel(clientJobId)).toBe(false);
+    expect((await jobRow(clientJobId))?.status).toBe("queued");
+  });
+
+  it("keeps the direct server-id cancel path working with no clientJobId", async () => {
+    const queue = getQueue("image");
+    await queue.pause();
+    let jobId: string;
+    try {
+      ({ jobId } = await enqueueSingleRun({ mode: "fast", tag: "direct-cancel" }));
+      expect(await requestCancel(jobId)).toBe(true);
+    } finally {
+      await queue.resume();
+    }
+    expect((await jobRow(jobId))?.status).toBe("canceled");
+    expect(invoked).not.toContain("direct-cancel");
+  });
+
+  it("keeps the ephemeral terminal frame on a direct-id active cancel", async () => {
+    // API callers with no clientJobId ride the worker's publishEphemeral
+    // branch; the alias dual write must not have stripped it.
+    const { jobId } = await enqueueSingleRun({ mode: "slow", tag: "direct-active" });
+    await waitFor(async () => (invoked.includes("direct-active") ? true : undefined));
+
+    expect(await requestCancel(jobId)).toBe(true);
+    expect((await terminalRow(jobId)).status).toBe("canceled");
+    const frame = await terminalFrame(jobId);
+    expect(frame.phase).toBe("failed");
+    expect(frame.error).toBe("Canceled");
+  });
+});


### PR DESCRIPTION
Closes #808.

Cancel on a plain single-tool run did nothing. The client cancels by the id it generated for the SSE channel; the queue job lives under a server uuid, and nothing connected the two. Admins got `{canceled: false}` back. Plain users had it worse: the lazily created alias row carried no owner, the ownership check 404ed, and the client settles a 404 by painting a still-running job as "Canceled".

Everything here is server-side. The 202 payload keeps returning the client id, so the web client needs no change.

## Where the fix lives

- `enqueueToolJob` pre-inserts the alias row (owner, pool, `settings.artifactJobId` pointer) before the queue add. #808 sketched this in tool-factory, but the custom AI routes (upscale, remove-background, transcribe-audio, and the rest) enqueue through the same function with the same broken cancel, and "an AI tool" is the issue's own repro. One seam covers every tool route. Unlike the pipeline pre-insert it cribs from, this runs after validation has already published progress frames, so the lazy persist layer may have created the row first, ownerless; those get claimed. A row another user owns, or any non-alias row (batch parent ids are client-supplied, so a same-owner collision is reachable), stays untouched, and a skipped claim logs a warning instead of failing silently.
- `requestCancel` follows the pointer into the existing queue scan, deliberately ignoring the alias row's own status: on a reused id that status is stale (terminal from the previous run, which nonterminal frames cannot resurrect), and the artifact side of the scan already refuses finished runs. Removing a waiting job also settles the alias row and announces the terminal frame, answering the issue's semantics question the way it recommended: nothing else will ever emit a frame for a job no worker runs, and a reconnecting client replays from that row (#766). And when nothing is in any queue but the artifact row says canceled, a nonterminal alias gets healed and the cancel answers true, so a cancel that died between its two writes converges on retry instead of answering false forever.
- The worker's cancel path dual-writes the alias row (guarded, like the pipeline finalize) and now publishes the ephemeral terminal frame unconditionally. Liveness never depends on the durable write. A failed alias write logs at error level and cannot displace the `UnrecoverableError("Canceled")`, since anything else would let BullMQ retry a canceled job.
- The factory's sync catch answers `{error: "Canceled", canceled: true}` when the worker was canceled inside the sync window. The message alone is forgeable (a tool can fail with exactly that string), so the row the worker committed before throwing is the authority; a mismatch keeps the generic logged path.
- The concurrent-job count excludes type "single" rows. Alias rows carry the owner now; counting them would have halved the effective `maxConcurrentJobsPerUser` for every run.

## Verification

Two new suites, split the way PR #807 split pipeline coverage: mid-run timing in the worker harness, stamping and authz over HTTP. 23 tests, written failing-first, including the chain pin for the sync-window rejection (so the HTTP suite's canned `waitForJob` stays an honest stand-in), the 429 counter-direction (the limit cannot silently become a no-op), a fault-injected alias write proving the frame still arrives, the reused-id live cancel, the half-canceled heal, and the plain-user 200 vs attacker 404 pair that pins the original mislabel bug. Full platform, security, and drift sweep (2427 tests), unit suite (8545), typecheck, and lint all pass locally.

One HTTP-level gap is deliberate: `{canceled: true}` on a live run is never asserted over HTTP, because the cancel route is a short composition of an ownership check and `requestCancel`, both pinned separately, and a live-job HTTP test collides with the 30s SYNC_WAIT floor.

## Filed as follow-ups

- #885: canceling by the server jobId strands the alias row (the reverse direction of this fix; the repair path here softens it).
- #886: a cancel during pre-enqueue validation still answers an honest `{canceled: false}`; closing it needs the #771 flag-consult pattern.
- #887: the pipeline alias pre-insert is missing the type guard this PR added on the tool side.
- #888: the pipeline finalize's cancel frame still couples liveness to the durable write, the same shape this PR fixed for tools.
- #889: `job.remove()` can 500 a cancel that races the worker taking the lock; pre-existing, crossed by both cancel paths.
