### PR TITLE
fix(api): keep a canceled run canceled after the cancel flag TTL expires

### DIFF
--- a/apps/api/src/jobs/batch-progress.ts
+++ b/apps/api/src/jobs/batch-progress.ts
@@ -82,8 +82,10 @@ export async function markBatchCanceled(parentId: string): Promise<void> {
 /** Whether a cooperative batch cancel was requested. A Redis read fault
  * reports false: keep-working is the safe direction, and a Redis outage has
  * already stopped the queues themselves. The swallowed error is still
- * logged, because at the finalize this read labels the terminal outcome and
- * a silent false can commit "completed" for a canceled batch. */
+ * logged. Only the queued-work skips read this flag (#809 moved the
+ * finalize's terminal label onto durable canceled rows), so a false here
+ * means the child or step processes normally and the run settles as a
+ * too-late cancel. */
 export async function isBatchCanceled(parentId: string): Promise<boolean> {
   try {
     return (await sharedRedis().exists(canceledKey(parentId))) === 1;

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -611,6 +611,10 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
         jobsTotal.inc({ pool: data.pool, status: isCanceled ? "canceled" : "failed" });
         jobDuration.observe({ pool: data.pool }, durationMs / 1000);
 
+        // Swallowed so the rethrow below stays authoritative, but logged:
+        // for a canceled child or step this row is the only evidence the
+        // finalize reads when it labels the run (#809), so a dropped write
+        // here must be visible somewhere.
         await db
           .update(schema.jobs)
           .set({
@@ -620,7 +624,12 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
             error: { message: friendlyError(finalError) },
           })
           .where(eq(schema.jobs.id, jobId))
-          .catch(() => {});
+          .catch((writeErr) => {
+            logger.error(
+              { err: writeErr, jobId, toolId: data.toolId },
+              "terminal status write failed",
+            );
+          });
 
         if (isCanceled) {
           if (progressJobId !== jobId) {
@@ -955,19 +964,18 @@ async function processPipelineFinalize(job: Job<ToolJobData>): Promise<ToolJobRe
   const progressJobId = data.clientJobId ?? data.jobId;
 
   // ── Cancel path (#771) ──────────────────────────────────────
-  // Cancel requires both halves (#770's too-late rule): the flag proves a
-  // cancel was requested, a canceled step proves it landed before the work
-  // finished. A flag with zero canceled steps means every step completed
-  // first; that pipeline completes normally, matching a too-late cancel on
-  // a single run. The flag's 1h TTL means a cancel on a pipeline that runs
-  // longer than that settles as a failure whose message still reads
-  // "Canceled": the same accepted tradeoff batch finalize inherited from
-  // #770. Intermediate step outputs are internal artifacts (a
-  // half-processed frame is not a deliverable), so a canceled pipeline
-  // returns nothing.
-  const cancelScope = data.parentId ?? data.clientJobId ?? data.jobId;
-  const canceled =
-    failedAtStep !== null && failedStepCanceled && (await isBatchCanceled(cancelScope));
+  // A canceled step row is durable proof a user cancel landed (#809):
+  // every writer of that status (the flag skip, requestCancel's queued-job
+  // removal, the cancel-channel abort) traces back to a user cancel
+  // somewhere in the run, including one scoped to a single step id. The
+  // Redis flag is deliberately not read here: its 1h TTL can expire under
+  // a tail longer than that, and a canceled run must settle as canceled
+  // regardless of how long the tail took. #770's too-late rule holds
+  // without the flag: zero canceled steps means every step completed
+  // first, and that pipeline completes normally below. Intermediate step
+  // outputs are internal artifacts (a half-processed frame is not a
+  // deliverable), so a canceled pipeline returns nothing.
+  const canceled = failedAtStep !== null && failedStepCanceled;
 
   if (canceled) {
     // Guarded dual write (#766): the SSE channel (clientJobId) and the
@@ -1374,11 +1382,14 @@ async function processBatchFinalize(job: Job<ToolJobData>): Promise<ToolJobResul
   const counters = await readBatchCounters(data.jobId);
   const failedFiles = Math.max(0, totalFiles - successEntries.length);
 
-  // Cancel requires both halves: the flag proves a cancel was requested, a
-  // canceled child proves it landed before the work finished. A flag with
-  // zero canceled children means every file completed first; that batch
-  // completes normally, matching a too-late cancel on a single run.
-  const canceled = canceledChildren > 0 && (await isBatchCanceled(data.jobId));
+  // A canceled child row is durable proof a user cancel landed (#809):
+  // every writer of that status traces back to a user cancel somewhere in
+  // the run, including one scoped to a single child id. The Redis flag is
+  // deliberately not read here: its 1h TTL can expire under a tail longer
+  // than that, and a canceled run must settle as canceled anyway. #770's
+  // too-late rule holds without it: zero canceled children means every
+  // file completed first, and that batch completes normally.
+  const canceled = canceledChildren > 0;
 
   if (canceled && successEntries.length === 0) {
     await cancelBatchJob({

--- a/tests/integration/platform/batch-cancel.test.ts
+++ b/tests/integration/platform/batch-cancel.test.ts
@@ -469,6 +469,41 @@ describe("cooperative child skip and canceled finalize", () => {
     expect((returned.resultPayload as { canceled?: boolean }).canceled).toBe(true);
   });
 
+  it("a direct cancel of one queued child settles the run canceled and the flow still finalizes (#809)", async () => {
+    // The child-scoped shape #809's behavior change is about: no run-level
+    // flag, just requestCancel on a single child id. slow f0 holds the
+    // pool's one slot, so fast f1 is deterministically waiting when the
+    // cancel removes it from the queue. BullMQ drops the parent's
+    // dependency on a removed child, so the finalize must still run once
+    // f0 completes, and the canceled f1 row alone labels the run.
+    const { parentId } = await enqueueBatchFlow(["slow-1.png", "fast.png"]);
+
+    await waitFor(async () => {
+      const active = await jobRow(`${parentId}-f0`);
+      return active?.status === "processing" ? true : undefined;
+    });
+
+    expect(await requestCancel(`${parentId}-f1`)).toBe(true);
+    const canceledChild = await terminalRow(`${parentId}-f1`);
+    expect(canceledChild.status).toBe("canceled");
+
+    // No wedge: the finalize runs after f0's 20s hold resolves.
+    const parent = await terminalRow(parentId, 35_000);
+    expect(parent.status).toBe("canceled");
+    expect(parent.outputRefs?.length).toBe(1);
+
+    const zip = new AdmZip(await getObjectBuffer((parent.outputRefs ?? [])[0]));
+    const names = zip.getEntries().map((e) => e.entryName);
+    expect(names).toHaveLength(1);
+    expect(names[0]).toMatch(/^slow-1/);
+
+    const returned = await finalizeReturnValue(parentId);
+    expect((returned.resultPayload as { canceled?: boolean }).canceled).toBe(true);
+
+    const completedChild = await jobRow(`${parentId}-f0`);
+    expect(completedChild?.status).toBe("completed");
+  }, 45_000);
+
   it("a cancel that lands after every child finished completes normally", async () => {
     const { parentId } = await enqueueBatchFlow(["fast-a.png", "fast-b.png"]);
 

--- a/tests/integration/platform/worker-branches.test.ts
+++ b/tests/integration/platform/worker-branches.test.ts
@@ -627,7 +627,9 @@ describe("pipeline finalize", () => {
       inputRefs: [],
       error: { message: "Canceled" },
     });
-    // Both halves of #770's too-late rule: the flag plus the canceled step.
+    // The realistic sub-1h shape: the flag is still live alongside the
+    // canceled step. The label no longer depends on the flag (#809); the
+    // expired-flag twin below pins that.
     await markBatchCanceled(jobId);
 
     await enqueueToolJob(
@@ -653,6 +655,43 @@ describe("pipeline finalize", () => {
     expect(props.status).toBe("canceled");
     expect(props.is_batch).toBe(false);
     expect(props.file_count).toBe(1);
+  });
+
+  it("commits a canceled run when the cancel flag expired before the finalize (#809)", async () => {
+    const jobId = `pf-${randomUUID()}`;
+    await db.insert(schema.jobs).values({
+      id: `${jobId}-s0`,
+      type: "pipeline-step",
+      status: "canceled",
+      toolId: "resize",
+      pool: "image",
+      inputRefs: [],
+      error: { message: "Canceled" },
+    });
+    // No markBatchCanceled: a tail longer than the flag's 1h TTL reaches the
+    // finalize after the flag expired. The durable canceled row alone must
+    // prove the cancel (#809).
+
+    await enqueueToolJob(
+      toolJob({
+        jobId,
+        toolId: "pipeline",
+        kind: "pipeline-finalize",
+        totalSteps: 1,
+        filename: "chain.png",
+      }),
+    );
+
+    const row = await terminalRow(jobId);
+    expect(row.status).toBe("canceled");
+    expect(row.error?.message).toBe("Canceled");
+
+    const frame = await terminalFrame(jobId);
+    expect(frame.phase).toBe("failed");
+    expect(frame.error).toBe("Canceled");
+
+    const events = await emittedEvents(ANALYTICS_EVENTS.PIPELINE_EXECUTED, jobId);
+    expect(events[0].status).toBe("canceled");
   });
 
   it("propagates a failed step, records the batch outcome, and emits failed analytics", async () => {
@@ -1077,6 +1116,108 @@ describe("batch children and finalize", () => {
       { index: 1, filename: "orig.png", error: "child died" },
       { index: 2, filename: "file-2", error: "Child job row not found" },
     ]);
+  });
+
+  it("settles an all-canceled batch as canceled when the cancel flag expired (#809)", async () => {
+    const jobId = `bf-${randomUUID()}`;
+    for (const i of [0, 1]) {
+      await db.insert(schema.jobs).values({
+        id: `${jobId}-f${i}`,
+        type: "batch-child",
+        status: "canceled",
+        toolId: "wt-echo",
+        pool: "image",
+        inputRefs: [`uploads/seed-809/in${i}.png`],
+        error: { message: "Canceled" },
+      });
+    }
+    // No cancel flag: it expired before the finalize ran. The durable
+    // canceled rows alone must prove the cancel (#809).
+
+    await enqueueToolJob(
+      toolJob({
+        jobId,
+        toolId: "batch",
+        kind: "batch-finalize",
+        pool: "system",
+        totalFiles: 2,
+        settings: { flowChildCount: 2 },
+        filename: "",
+      }),
+    );
+
+    const row = await terminalRow(jobId);
+    expect(row.status).toBe("canceled");
+    expect(row.outputRefs ?? []).toEqual([]);
+
+    const frame = await terminalFrame(jobId);
+    expect(frame.status).toBe("failed");
+    const errors = (frame.errors ?? []) as Array<{ filename: string; error: string }>;
+    expect(errors[0]).toEqual({ filename: "", error: "Canceled" });
+
+    const result = await waitFor(async () => {
+      const job = await getQueue("system").getJob(jobId);
+      return job?.returnvalue ?? undefined;
+    });
+    const payload = result.resultPayload as { canceled?: boolean; allFailed?: boolean };
+    expect(payload.canceled).toBe(true);
+    expect(payload.allFailed).toBe(true);
+  });
+
+  it("keeps the partial ZIP and settles canceled when the flag expired mid-batch (#809)", async () => {
+    const jobId = `bf-${randomUUID()}`;
+    await putObject("outputs/seed-809/ok.png", Buffer.from("ok-bytes"));
+    await db.insert(schema.jobs).values({
+      id: `${jobId}-f0`,
+      type: "batch-child",
+      status: "completed",
+      toolId: "wt-echo",
+      pool: "image",
+      inputRefs: ["uploads/seed-809/in0.png"],
+      outputRefs: ["outputs/seed-809/ok.png"],
+    });
+    await db.insert(schema.jobs).values({
+      id: `${jobId}-f1`,
+      type: "batch-child",
+      status: "canceled",
+      toolId: "wt-echo",
+      pool: "image",
+      inputRefs: ["uploads/seed-809/in1.png"],
+      error: { message: "Canceled" },
+    });
+
+    await enqueueToolJob(
+      toolJob({
+        jobId,
+        toolId: "batch",
+        kind: "batch-finalize",
+        pool: "system",
+        totalFiles: 2,
+        settings: { flowChildCount: 2 },
+        filename: "",
+      }),
+    );
+
+    // The parent row is canceled (the authoritative outcome), while the
+    // announced frame keeps the completed-with-result shape so the client
+    // settles on the partial ZIP.
+    const row = await terminalRow(jobId);
+    expect(row.status).toBe("canceled");
+    expect(row.outputRefs?.length).toBe(1);
+
+    const zip = new AdmZip(await getObjectBuffer((row.outputRefs ?? [])[0]));
+    expect(zip.getEntries().map((e) => e.entryName)).toEqual(["ok.png"]);
+
+    const frame = await terminalFrame(jobId);
+    expect(frame.status).toBe("completed");
+    const frameResult = (frame.result ?? {}) as { downloadUrl?: string };
+    expect(frameResult.downloadUrl).toContain(`/api/v1/download/${jobId}/`);
+
+    const result = await waitFor(async () => {
+      const job = await getQueue("system").getJob(jobId);
+      return job?.returnvalue ?? undefined;
+    });
+    expect((result.resultPayload as { canceled?: boolean }).canceled).toBe(true);
   });
 
   it("rejects unknown jobs on the system pool and terminally fails them", async () => {


### PR DESCRIPTION
Fixes #809.

Cancel a batch or pipeline with more than an hour of queued work behind the cancel point and the run settled as failed. The cooperative-cancel flag in Redis carries a 1h TTL, and both finalizers required it to still exist before labeling the outcome: `canceledChildren > 0 && isBatchCanceled(id)` in `processBatchFinalize`, the equivalent conjunction in `processPipelineFinalize`. Outlive the flag and the second half goes false.

The fix drops the flag read. A canceled child or step row is durable proof a cancel landed: every writer of that status (the flag skip, requestCancel's queued-job removal, the cancel-channel abort) traces back to a user cancel. The too-late rule from #770 survives untouched, because zero canceled rows already means "complete normally" with or without a flag. The flag itself stays; the queued-work skips still read it.

Two smaller things ride along:

- The abort path's terminal status write swallowed DB faults with a bare catch. That row is now the only evidence the finalize reads, so the catch logs at error level (same treatment as the alias write below it, still swallowed so the UnrecoverableError rethrow stays authoritative).
- Stale comments in `worker.ts`, `batch-progress.ts`, and the flag-live test updated to the new semantics.

**Behavior change**, the one #809 asked to be stated here: an owner who cancels a single step or child id directly (ids are derivable from the flow id) now settles the whole run as canceled rather than failed. A user cancel did land inside that run, so canceled is the honest label; it is observable in job status for API callers. The frontend only issues run-level cancels and is unaffected.

Verification: three new integration tests in `worker-branches.test.ts` seed canceled rows with no Redis flag (the expiry shape) and pin the terminal outcome: pipeline finalize, batch all-canceled, batch partial ZIP. All three failed on the old mislabel before the fix. A fourth test in `batch-cancel.test.ts` pins the behavior change end to end: it cancels one queued child directly by id and asserts BullMQ drops the parent's dependency, the flow still finalizes, and the run settles canceled with the partial ZIP intact. Full cancel surface run locally: worker-branches, batch-cancel, pipeline-cancel, pipeline-cancel-http, single-tool-cancel, single-tool-cancel-http, 77 tests passing, plus typecheck and Biome.
