### PR TITLE
fix(api): resolve cancels that land before the job reaches the queue

### DIFF
--- a/apps/api/src/jobs/cancel.ts
+++ b/apps/api/src/jobs/cancel.ts
@@ -21,7 +21,7 @@
  *   registered AbortControllers.
  */
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type Redis from "ioredis";
 import { db, schema } from "../db/index.js";
 import { cancelSingleJobGuarded } from "../routes/progress.js";
@@ -191,35 +191,60 @@ export async function requestCancel(jobId: string): Promise<boolean> {
 
     // Single-tool SSE alias (#808): the client-facing id a tool route
     // enqueued under a server-generated uuid. Follow the pointer into the
-    // queue scan without consulting the alias row's own status: on a
-    // reused id it is stale (terminal from the previous run, since
-    // nonterminal frames cannot resurrect it), and the artifact side of
-    // the scan already refuses terminal runs. A removed queued job never
-    // reaches a worker, so nothing else would ever emit a frame for it:
-    // the alias row gets the same terminal write and announcement (#766's
-    // lesson: a reconnecting client replays from this row, and a
+    // queue scan; the artifact side of the scan refuses terminal runs, so
+    // the alias row's own status never gates resolution. A removed queued
+    // job never reaches a worker, so nothing else would ever emit a frame
+    // for it: the alias row gets the same terminal write and announcement
+    // (#766's lesson: a reconnecting client replays from this row, and a
     // nonterminal alias replays a live run that will never finish). An
-    // active job's worker settles both rows itself.
+    // active job's worker settles both rows itself. Every settle carries
+    // the pointer it resolved, so one landing after a new run re-pointed
+    // the channel no-ops instead of killing that run (#886).
     if (settings.artifactJobId) {
-      const outcome = await cancelQueueJob(settings.artifactJobId);
+      const expectedArtifactJobId = settings.artifactJobId;
+      const outcome = await cancelQueueJob(expectedArtifactJobId);
       if (outcome === "removed") {
-        await cancelSingleJobGuarded({ jobId });
+        await cancelSingleJobGuarded({ jobId, expectedArtifactJobId });
         return true;
       }
       if (outcome === "signaled") return true;
 
-      // Nothing in any queue. Either the run is genuinely over, or a
-      // prior cancel removed the job but died before the alias settled (a
-      // crash or thrown write between the two). The artifact row is
-      // authoritative: heal a nonterminal alias over a canceled artifact
-      // so retries converge instead of answering false forever.
+      // Nothing in any queue. Three live cases, told apart by the
+      // artifact row, which is authoritative:
+      //   - canceled: a prior cancel removed the job but died before the
+      //     alias settled. Heal the alias so retries converge instead of
+      //     answering false forever.
+      //   - absent or still queued: the run has not reached the queue
+      //     (#886): the factory stamped the pointer before validation, or
+      //     the enqueue is between its row insert and the queue add.
+      //     Settle the alias durably; the worker's gate refuses the run
+      //     however it later materializes, with no TTL to outlive. The
+      //     publish is a belt for the sliver where a worker picked the
+      //     job up between the queue scan and the artifact read.
+      //   - anything else (completed, failed, processing): the run is
+      //     genuinely over or actively finishing; refuse.
       if (!isTerminal(row.status)) {
         const [artifact] = await db
           .select({ status: schema.jobs.status })
           .from(schema.jobs)
-          .where(eq(schema.jobs.id, settings.artifactJobId));
+          .where(eq(schema.jobs.id, expectedArtifactJobId));
         if (artifact?.status === "canceled") {
-          await cancelSingleJobGuarded({ jobId });
+          await cancelSingleJobGuarded({ jobId, expectedArtifactJobId });
+          return true;
+        }
+        if (!artifact || artifact.status === "queued") {
+          if (artifact) {
+            // Conditional, so a job that went active in this instant is
+            // not clobbered; the publish below reaches its worker instead.
+            await db
+              .update(schema.jobs)
+              .set({ status: "canceled", completedAt: new Date() })
+              .where(
+                and(eq(schema.jobs.id, expectedArtifactJobId), eq(schema.jobs.status, "queued")),
+              );
+          }
+          await cancelSingleJobGuarded({ jobId, expectedArtifactJobId });
+          await publishCancel(expectedArtifactJobId);
           return true;
         }
       }

--- a/apps/api/src/jobs/enqueue.ts
+++ b/apps/api/src/jobs/enqueue.ts
@@ -7,7 +7,7 @@
  */
 import { context, propagation } from "@opentelemetry/api";
 import { FlowProducer, type Job, QueueEvents } from "bullmq";
-import { and, eq, isNull, or } from "drizzle-orm";
+import { and, eq, isNull, or, sql } from "drizzle-orm";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { assertAiJobQuota } from "../lib/ai-quota.js";
@@ -150,6 +150,108 @@ export function injectTraceContext(data: ToolJobData): void {
 // ── Enqueue + wait ──────────────────────────────────────────────
 
 /**
+ * Insert the client-facing SSE alias row before validation starts (#886).
+ *
+ * The tool factory calls this right after multipart parse, ahead of the
+ * first progress write, so a cancel landing in the validation window has a
+ * durable pointer to resolve. Insert-only: at this point the lazy persist
+ * layer cannot have created the row yet, so a conflict can only be a
+ * reused id, and the previous run's state (its terminal result included)
+ * must survive until this run proves viable at enqueue, where
+ * upsertToolJobAlias claims and re-points it. Resetting here would leave
+ * the channel replaying a live run forever if this run then dies in
+ * validation.
+ */
+export async function insertToolJobAlias(args: {
+  jobId: string;
+  clientJobId: string;
+  userId: string | null;
+  pool: Pool;
+}): Promise<void> {
+  await db
+    .insert(schema.jobs)
+    .values({
+      id: args.clientJobId,
+      userId: args.userId,
+      pool: args.pool,
+      type: "single",
+      status: "queued",
+      inputRefs: [],
+      settings: { artifactJobId: args.jobId },
+    })
+    .onConflictDoNothing();
+}
+
+/**
+ * Upsert the client-facing SSE alias row for a single-tool run (#808).
+ *
+ * The web client cancels by the id it generated (clientJobId); the queue
+ * job lives under the server jobId. The pointer stamped here lets
+ * requestCancel resolve one to the other, and the owner lets the cancel
+ * route authorize the run's own starter. The tool factory calls this right
+ * after multipart parse (#886), before validation, so a cancel landing in
+ * the validation window already has a durable pointer; enqueueToolJob
+ * calls it again as the catch-all for custom routes.
+ *
+ * Conflict semantics: the lazy persist layer may have created this row
+ * first (ownerless), so ownerless rows are claimed; a row another user
+ * owns is left alone so a reused id cannot transfer it or strip their
+ * cancel authorization; and only type "single" rows are claimable, so a
+ * colliding batch parent or pipeline row keeps its own cancel metadata
+ * (batch parent ids ARE client-supplied, so that collision is reachable).
+ *
+ * When the stored pointer differs from this run's jobId (a new run reusing
+ * an old channel), the row's status resets to "queued" so a stale terminal
+ * state from the previous run neither replays as this run's outcome nor
+ * trips the worker's canceled-alias gate (#886). When the pointer is
+ * unchanged (this run's own second stamp), the status is preserved, so a
+ * cancel that already settled the alias survives the re-stamp.
+ */
+export async function upsertToolJobAlias(args: {
+  jobId: string;
+  clientJobId: string;
+  userId: string | null;
+  pool: Pool;
+}): Promise<void> {
+  const aliasSettings = { artifactJobId: args.jobId };
+  const claimableOwner = args.userId
+    ? or(isNull(schema.jobs.userId), eq(schema.jobs.userId, args.userId))
+    : isNull(schema.jobs.userId);
+  const isRepoint = sql`${schema.jobs.settings}->>'artifactJobId' is distinct from ${args.jobId}`;
+  const res = await db
+    .insert(schema.jobs)
+    .values({
+      id: args.clientJobId,
+      userId: args.userId,
+      pool: args.pool,
+      type: "single",
+      status: "queued",
+      inputRefs: [],
+      settings: aliasSettings,
+    })
+    .onConflictDoUpdate({
+      target: schema.jobs.id,
+      set: {
+        settings: aliasSettings,
+        userId: args.userId,
+        status: sql`CASE WHEN ${isRepoint} THEN 'queued' ELSE ${schema.jobs.status} END`,
+        completedAt: sql`CASE WHEN ${isRepoint} THEN NULL ELSE ${schema.jobs.completedAt} END`,
+        error: sql`CASE WHEN ${isRepoint} THEN NULL ELSE ${schema.jobs.error} END`,
+        progress: sql`CASE WHEN ${isRepoint} THEN NULL ELSE ${schema.jobs.progress} END`,
+      },
+      setWhere: and(eq(schema.jobs.type, "single"), claimableOwner),
+    });
+  if (((res as { rowCount?: number | null })?.rowCount ?? 0) === 0) {
+    // The claim was skipped (foreign owner or non-alias collision). The
+    // run proceeds, but its starter cannot cancel through this id; make
+    // that debuggable instead of a silent 404 months later.
+    console.warn(
+      `alias claim skipped for clientJobId ${args.clientJobId} (job ${args.jobId}); cancel by this id will not resolve`,
+    );
+  }
+}
+
+/**
  * Insert a durable job row and enqueue the job in BullMQ.
  * Returns the BullMQ Job instance.
  */
@@ -177,51 +279,18 @@ export async function enqueueToolJob(data: ToolJobData): Promise<Job<ToolJobData
     settings: stripNulBytes((data.dbSettings ?? data.settings) as Record<string, unknown>),
   });
 
-  // Client-facing SSE alias row (#808). The web client cancels by the id it
-  // generated (clientJobId); the queue job lives under the server jobId.
-  // The pointer stamped here lets requestCancel resolve one to the other,
-  // and the owner lets the cancel route authorize the run's own starter.
-  // Awaited and committed before the queue add, so from the first moment
-  // cancelable work exists the pointer is durable. Unlike the pipeline
-  // route's pre-insert (which runs before any progress write), enqueue
-  // happens after validation has already published progress frames, so the
-  // lazy persist layer may have created this row first: ownerless rows are
-  // claimed (this run's own lazy insert, or an abandoned channel), while a
-  // row another user owns is left alone so a reused id cannot transfer it
-  // or strip their cancel authorization.
+  // Client-facing SSE alias row (#808), re-stamped here as the catch-all
+  // for routes that never call upsertToolJobAlias themselves (the custom
+  // AI routes). The tool factory also stamps it right after multipart
+  // parse (#886), so for factory runs this second upsert is an idempotent
+  // re-point of the same values.
   if (data.clientJobId && data.clientJobId !== data.jobId) {
-    const aliasSettings = { artifactJobId: data.jobId };
-    const claimableOwner = data.userId
-      ? or(isNull(schema.jobs.userId), eq(schema.jobs.userId, data.userId))
-      : isNull(schema.jobs.userId);
-    const res = await db
-      .insert(schema.jobs)
-      .values({
-        id: data.clientJobId,
-        userId: data.userId,
-        pool: data.pool,
-        type: "single",
-        status: "queued",
-        inputRefs: [],
-        settings: aliasSettings,
-      })
-      .onConflictDoUpdate({
-        target: schema.jobs.id,
-        // Only alias rows are claimable: a colliding batch parent or
-        // pipeline row the same user owns must keep its own cancel
-        // metadata (batch parent ids ARE client-supplied, so that
-        // collision is reachable).
-        set: { settings: aliasSettings, userId: data.userId },
-        setWhere: and(eq(schema.jobs.type, "single"), claimableOwner),
-      });
-    if (((res as { rowCount?: number | null })?.rowCount ?? 0) === 0) {
-      // The claim was skipped (foreign owner or non-alias collision). The
-      // run proceeds, but its starter cannot cancel through this id; make
-      // that debuggable instead of a silent 404 months later.
-      console.warn(
-        `alias claim skipped for clientJobId ${data.clientJobId} (job ${data.jobId}); cancel by this id will not resolve`,
-      );
-    }
+    await upsertToolJobAlias({
+      jobId: data.jobId,
+      clientJobId: data.clientJobId,
+      userId: data.userId,
+      pool: data.pool,
+    });
   }
 
   // Fire-and-forget: compute deleteAfter from team retention override

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -295,6 +295,36 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
     try {
       await mkdir(scratchDir, { recursive: true });
 
+      // Cooperative window cancel (#886): a cancel that landed before this
+      // job reached the queue settled the alias row durably; honor it
+      // before any work or status write. The pointer match keeps a stale
+      // canceled alias from a previous run under a reused id from killing
+      // this one (upsertToolJobAlias resets the row on re-point, so both
+      // halves agree). Aborting the signal routes the throw through the
+      // catch's existing cancel bookkeeping (row, metrics, frame,
+      // UnrecoverableError). A fault in the read falls through to normal
+      // processing, mirroring the pipeline step's skip: a failed check
+      // must not wedge the job.
+      if (data.clientJobId && data.clientJobId !== jobId) {
+        try {
+          const [alias] = await db
+            .select({ status: schema.jobs.status, settings: schema.jobs.settings })
+            .from(schema.jobs)
+            .where(eq(schema.jobs.id, data.clientJobId));
+          const pointer = (alias?.settings as { artifactJobId?: string } | null)?.artifactJobId;
+          if (alias?.status === "canceled" && pointer === jobId) {
+            ac.abort();
+            throw new Error("Canceled");
+          }
+        } catch (gateErr) {
+          if (signal.aborted) throw gateErr;
+          logger.warn(
+            { err: gateErr, jobId, clientJobId: data.clientJobId },
+            "window-cancel gate read failed; processing the job normally",
+          );
+        }
+      }
+
       // Mark job as processing in the durable row
       await db
         .update(schema.jobs)
@@ -645,7 +675,13 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
             // to the ephemeral publish, which requestCancel's repair path
             // backs up on the next cancel.
             try {
-              await cancelSingleJobGuarded({ jobId: progressJobId });
+              // The pointer condition spares a channel a newer run has
+              // already re-pointed (#886): this job's cancel must not
+              // repaint that run's row.
+              await cancelSingleJobGuarded({
+                jobId: progressJobId,
+                expectedArtifactJobId: jobId,
+              });
             } catch (aliasErr) {
               logger.error(
                 { err: aliasErr, jobId, progressJobId },

--- a/apps/api/src/routes/progress.ts
+++ b/apps/api/src/routes/progress.ts
@@ -10,7 +10,7 @@
  * Terminal events are cached in a Redis key (10-min TTL) so that
  * SSE reconnects can replay the final frame without polling the DB.
  */
-import { and, eq, notInArray } from "drizzle-orm";
+import { and, eq, notInArray, sql } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { db, schema } from "../db/index.js";
 import { createRedisSubscriberConnection, sharedRedis } from "../jobs/connection.js";
@@ -636,6 +636,15 @@ export async function failSingleJobGuarded(args: FailSingleJobArgs): Promise<voi
 
 export interface CancelSingleJobArgs {
   jobId: string;
+  /**
+   * When set, the guarded write additionally requires the row's
+   * settings.artifactJobId to still equal this id. A single-tool cancel
+   * resolves the pointer before it settles; if a new run re-pointed the
+   * channel in between, the row belongs to a run the user never canceled
+   * and must be left alone (#886). Alias-less callers (pipeline finalize)
+   * omit it.
+   */
+  expectedArtifactJobId?: string;
 }
 
 /**
@@ -668,6 +677,9 @@ export async function cancelSingleJobGuarded(args: CancelSingleJobArgs): Promise
         and(
           eq(schema.jobs.id, args.jobId),
           notInArray(schema.jobs.status, ["completed", "failed", "canceled"]),
+          args.expectedArtifactJobId
+            ? sql`${schema.jobs.settings}->>'artifactJobId' = ${args.expectedArtifactJobId}`
+            : undefined,
         ),
       );
     applied = ((res as { rowCount?: number | null } | undefined)?.rowCount ?? 0) > 0;

--- a/apps/api/src/routes/tool-factory.ts
+++ b/apps/api/src/routes/tool-factory.ts
@@ -15,7 +15,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import type { z } from "zod";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
-import { enqueueToolJob, waitForJob } from "../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias, waitForJob } from "../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../jobs/types.js";
 import { formatZodErrors, friendlyError, stripInternalPaths } from "../lib/errors.js";
 import { getFirstMissingBundleForTool, isToolInstalled } from "../lib/feature-status.js";
@@ -342,6 +342,17 @@ export function createToolRoute<T>(app: FastifyInstance, config: ToolRouteConfig
         });
       }
 
+      // Stamp the client-facing alias before validation starts (#886):
+      // decode can take seconds on a big HEIC, and a cancel clicked in
+      // that window needs a durable pointer to resolve. Awaited, and ahead
+      // of the first progress write, so the lazy persist layer can never
+      // create the row first. Insert-only: a reused id keeps its previous
+      // run's state until enqueueToolJob claims and re-points it.
+      const pool = resolveToolPool(config.toolId);
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId: authUser.id, pool });
+      }
+
       const reportProgress = (percent: number, stage?: string) => {
         if (!clientJobId) return;
         void updateSingleFileProgress({
@@ -548,7 +559,6 @@ export function createToolRoute<T>(app: FastifyInstance, config: ToolRouteConfig
         }
 
         const startTime = Date.now();
-        const pool = resolveToolPool(config.toolId);
 
         // Enqueue for the BullMQ worker
         const dbSettings = config.redactSettingsForAudit

--- a/tests/integration/platform/single-tool-cancel-http.test.ts
+++ b/tests/integration/platform/single-tool-cancel-http.test.ts
@@ -136,6 +136,38 @@ describe("route-stamped alias metadata (#808)", () => {
     expect(artifact?.userId).toBe(alias?.userId);
   });
 
+  it("stamps the alias before validation, not just at enqueue (#886)", async () => {
+    // A run that dies in input validation never reaches enqueueToolJob.
+    // The factory must have stamped the pointer and owner by then, or a
+    // cancel clicked during a slow decode has nothing to resolve.
+    const clientJobId = randomUUID();
+    const { body, contentType } = createMultipartPayload([
+      {
+        name: "file",
+        filename: "photo.png",
+        contentType: "image/png",
+        content: Buffer.from("not a png at all"),
+      },
+      { name: "settings", content: JSON.stringify({ width: 50 }) },
+      { name: "clientJobId", content: clientJobId },
+    ]);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/tools/image/resize",
+      headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+      body,
+    });
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+    expect(res.statusCode).toBeLessThan(500);
+
+    const alias = await jobRow(clientJobId);
+    expect(alias?.type).toBe("single");
+    expect(alias?.userId).not.toBeNull();
+    expect(typeof ((alias?.settings ?? {}) as { artifactJobId?: string }).artifactJobId).toBe(
+      "string",
+    );
+  });
+
   it("re-points the alias at the newest artifact when a clientJobId is reused", async () => {
     const clientJobId = randomUUID();
     await runResize(clientJobId, adminToken);

--- a/tests/integration/platform/single-tool-cancel.test.ts
+++ b/tests/integration/platform/single-tool-cancel.test.ts
@@ -49,12 +49,14 @@ import {
 import {
   closeQueueEvents,
   enqueueToolJob,
+  insertToolJobAlias,
   waitForJob,
 } from "../../../apps/api/src/jobs/enqueue.js";
 import { closeQueues, getQueue } from "../../../apps/api/src/jobs/queues.js";
 import { bullPrefix } from "../../../apps/api/src/jobs/types.js";
 import { closeWorkers, startWorkers } from "../../../apps/api/src/jobs/worker.js";
 import { putObject } from "../../../apps/api/src/lib/object-storage.js";
+import { cancelSingleJobGuarded } from "../../../apps/api/src/routes/progress.js";
 import type { ToolProcessCtx } from "../../../apps/api/src/routes/tool-factory.js";
 import { registerToolProcessFn } from "../../../apps/api/src/routes/tool-factory.js";
 
@@ -176,13 +178,14 @@ interface EnqueueOpts {
   tag: string;
   clientJobId?: string;
   userId?: string | null;
+  jobId?: string;
 }
 
 /** Enqueue a single-tool run the way every tool route does. */
 async function enqueueSingleRun(
   opts: EnqueueOpts,
 ): Promise<{ jobId: string; userId: string | null }> {
-  const jobId = randomUUID();
+  const jobId = opts.jobId ?? randomUUID();
   const userId = opts.userId === undefined ? await createOwner() : opts.userId;
   const uploadKey = `uploads/${jobId}/input.png`;
   await putObject(uploadKey, Buffer.from("payload"));
@@ -394,19 +397,16 @@ describe("requestCancel through a single-tool alias (#808)", () => {
     await waitFor(async () => (invoked.includes("reuse-2") ? true : undefined));
     await sharedRedis().del(`${bullPrefix()}:terminal:${clientJobId}`);
 
-    // The alias row is still terminal from run 1 (nonterminal frames
-    // cannot resurrect it), but the pointer follows run 2. The cancel must
-    // reach run 2's live job, not answer false off the stale alias status.
+    // Run 2's enqueue re-pointed the alias and reset its stale terminal
+    // state (#886), so the cancel resolves the live job and this run's
+    // outcome lands on the row instead of run 1's leftover "completed".
     expect(await requestCancel(clientJobId)).toBe(true);
     expect((await terminalRow(second.jobId)).status).toBe("canceled");
 
-    // The alias row keeps run 1's terminal state (the guarded write cannot
-    // downgrade it); the live channel still settles through the ephemeral
-    // frame.
     const frame = await terminalFrame(clientJobId);
     expect(frame.phase).toBe("failed");
     expect(frame.error).toBe("Canceled");
-    expect((await jobRow(clientJobId))?.status).toBe("completed");
+    expect((await terminalRow(clientJobId)).status).toBe("canceled");
   });
 
   it("heals a half-canceled run instead of answering false forever", async () => {
@@ -473,23 +473,259 @@ describe("requestCancel through a single-tool alias (#808)", () => {
     expect((await jobRow(jobId))?.status).toBe("completed");
   });
 
-  it("returns false when the pointer resolves to no queue job", async () => {
-    // The enqueue window: the alias row is durable but the queue add has
-    // not happened yet. The cancel answers an honest false (button stays
-    // armed) instead of pretending the run stopped.
+  it("settles a cancel whose run has not reached the queue yet (#886)", async () => {
+    // The validation window: the factory stamped the pointer, but neither
+    // the artifact row nor the queue job exists yet. Pre-#886 this
+    // answered an honest false and the button stayed armed; now the alias
+    // settles durably and the worker gate refuses the run if it ever
+    // materializes.
     const owner = await createOwner();
     const clientJobId = randomUUID();
+    const artifactId = randomUUID();
     await db.insert(schema.jobs).values({
       id: clientJobId,
       userId: owner,
       type: "single",
       status: "queued",
       inputRefs: [],
-      settings: { artifactJobId: randomUUID() },
+      settings: { artifactJobId: artifactId },
     });
 
+    const received = await collectCancelPublishes(async () => {
+      expect(await requestCancel(clientJobId)).toBe(true);
+    });
+    // Belt for the sliver where a worker picked the job up between the
+    // queue scan and the artifact read.
+    expect(received).toContain(artifactId);
+    expect((await jobRow(clientJobId))?.status).toBe("canceled");
+    const frame = await terminalFrame(clientJobId);
+    expect(frame.phase).toBe("failed");
+    expect(frame.error).toBe("Canceled");
+
+    // A second click is a refusal, not a loop: the alias is terminal now.
     expect(await requestCancel(clientJobId)).toBe(false);
+  });
+
+  it("cancels the pre-add sliver: artifact row inserted, queue add not yet run (#886)", async () => {
+    const owner = await createOwner();
+    const clientJobId = randomUUID();
+    const artifactId = randomUUID();
+    await db.insert(schema.jobs).values([
+      {
+        id: artifactId,
+        userId: owner,
+        toolId: "wt-single-cancel",
+        pool: "image",
+        type: "tool",
+        status: "queued",
+        inputRefs: [],
+      },
+      {
+        id: clientJobId,
+        userId: owner,
+        type: "single",
+        status: "queued",
+        inputRefs: [],
+        settings: { artifactJobId: artifactId },
+      },
+    ]);
+
+    expect(await requestCancel(clientJobId)).toBe(true);
+    expect((await jobRow(artifactId))?.status).toBe("canceled");
+    expect((await jobRow(clientJobId))?.status).toBe("canceled");
+    const frame = await terminalFrame(clientJobId);
+    expect(frame.error).toBe("Canceled");
+  });
+
+  it("refuses a window-canceled run when it materializes (#886 round trip)", async () => {
+    // The full sequence the factory produces: early stamp, cancel during
+    // validation, then validation finishes and the run enqueues anyway.
+    // The worker gate must refuse it without running the tool.
+    const owner = await createOwner();
+    const clientJobId = randomUUID();
+    const jobId = randomUUID();
+    await insertToolJobAlias({ jobId, clientJobId, userId: owner, pool: "image" });
+
+    expect(await requestCancel(clientJobId)).toBe(true);
+    expect((await jobRow(clientJobId))?.status).toBe("canceled");
+
+    await enqueueSingleRun({
+      jobId,
+      mode: "fast",
+      tag: "window-cancel",
+      clientJobId,
+      userId: owner,
+    });
+    expect((await terminalRow(jobId)).status).toBe("canceled");
+    expect(invoked).not.toContain("window-cancel");
+  });
+
+  it("skips the guarded settle when the alias was re-pointed mid-cancel (#886)", async () => {
+    // A cancel resolves the pointer, then a new run re-points the channel
+    // before the settle lands. The settle carries the pointer it resolved;
+    // a mismatch means the row now belongs to a run the user never
+    // canceled, and it must be left alone.
+    const owner = await createOwner();
+    const clientJobId = randomUUID();
+    const livePointer = randomUUID();
+    await db.insert(schema.jobs).values({
+      id: clientJobId,
+      userId: owner,
+      type: "single",
+      status: "queued",
+      inputRefs: [],
+      settings: { artifactJobId: livePointer },
+    });
+
+    await cancelSingleJobGuarded({ jobId: clientJobId, expectedArtifactJobId: randomUUID() });
     expect((await jobRow(clientJobId))?.status).toBe("queued");
+
+    await cancelSingleJobGuarded({ jobId: clientJobId, expectedArtifactJobId: livePointer });
+    expect((await jobRow(clientJobId))?.status).toBe("canceled");
+  });
+
+  it("keeps a reused id's terminal state when the new run dies before enqueue (#886)", async () => {
+    // The early stamp is insert-only: a conflict can only be a reused id,
+    // and the previous run's terminal state (including the replayable
+    // result) must survive until the new run proves viable at enqueue.
+    // Resetting here would leave the channel replaying a live run forever
+    // if the new run then dies in validation.
+    const owner = await createOwner();
+    const clientJobId = randomUUID();
+    const first = await enqueueSingleRun({
+      mode: "fast",
+      tag: "reuse-dead-2",
+      clientJobId,
+      userId: owner,
+    });
+    await terminalRow(first.jobId);
+    await terminalRow(clientJobId);
+
+    // Run 2 stamps early, then dies in validation: nothing else happens.
+    await insertToolJobAlias({
+      jobId: randomUUID(),
+      clientJobId,
+      userId: owner,
+      pool: "image",
+    });
+
+    const alias = await jobRow(clientJobId);
+    expect(alias?.status).toBe("completed");
+    expect(((alias?.settings ?? {}) as { artifactJobId?: string }).artifactJobId).toBe(first.jobId);
+  });
+
+  it("refuses a window-style cancel when the artifact is actively finishing (#886)", async () => {
+    // The window arm's boundary: only absent-or-queued artifacts settle. A
+    // processing artifact with no queue job is a run mid-write (or a
+    // zombie); claiming canceled: true for it would be a lie, and the
+    // publish would abort a worker the user never asked to stop.
+    const owner = await createOwner();
+    const clientJobId = randomUUID();
+    const artifactId = randomUUID();
+    await db.insert(schema.jobs).values([
+      {
+        id: artifactId,
+        userId: owner,
+        type: "tool",
+        status: "processing",
+        inputRefs: [],
+      },
+      {
+        id: clientJobId,
+        userId: owner,
+        type: "single",
+        status: "queued",
+        inputRefs: [],
+        settings: { artifactJobId: artifactId },
+      },
+    ]);
+
+    const received = await collectCancelPublishes(async () => {
+      expect(await requestCancel(clientJobId)).toBe(false);
+    });
+    expect(received).not.toContain(artifactId);
+    expect((await jobRow(clientJobId))?.status).toBe("queued");
+    expect((await jobRow(artifactId))?.status).toBe("processing");
+  });
+
+  it("refuses a window-style cancel over a completed artifact", async () => {
+    // A crash between the worker's dual writes can leave the alias live
+    // over a completed artifact; a cancel then must not repaint the
+    // finished run as canceled.
+    const owner = await createOwner();
+    const clientJobId = randomUUID();
+    const artifactId = randomUUID();
+    await db.insert(schema.jobs).values([
+      {
+        id: artifactId,
+        userId: owner,
+        type: "tool",
+        status: "completed",
+        completedAt: new Date(),
+        inputRefs: [],
+      },
+      {
+        id: clientJobId,
+        userId: owner,
+        type: "single",
+        status: "processing",
+        inputRefs: [],
+        settings: { artifactJobId: artifactId },
+      },
+    ]);
+
+    expect(await requestCancel(clientJobId)).toBe(false);
+    expect((await jobRow(artifactId))?.status).toBe("completed");
+  });
+
+  it("does not let a foreign stale cancel kill another user's run (#886 gate)", async () => {
+    // Attacker-shaped reuse: user A's window-canceled alias still points at
+    // A's never-run artifact. User B starts a run under the same id; the
+    // upsert claim is skipped (foreign owner), so the alias stays A's,
+    // canceled. The gate's pointer match must spare B's run.
+    const ownerA = await createOwner();
+    const clientJobId = randomUUID();
+    await insertToolJobAlias({
+      jobId: randomUUID(),
+      clientJobId,
+      userId: ownerA,
+      pool: "image",
+    });
+    expect(await requestCancel(clientJobId)).toBe(true);
+
+    const ownerB = await createOwner();
+    const second = await enqueueSingleRun({
+      mode: "fast",
+      tag: "foreign-gate",
+      clientJobId,
+      userId: ownerB,
+    });
+    expect((await terminalRow(second.jobId)).status).toBe("completed");
+    expect(invoked).toContain("foreign-gate");
+  });
+
+  it("does not let a stale window cancel kill a rerun under the same id (#886)", async () => {
+    // Run 1 was canceled in its window; its alias row is canceled with
+    // run 1's pointer. A rerun reusing the channel re-points and resets
+    // the row, so the worker gate must let run 2 execute normally.
+    const owner = await createOwner();
+    const clientJobId = randomUUID();
+    const firstJobId = randomUUID();
+    await insertToolJobAlias({ jobId: firstJobId, clientJobId, userId: owner, pool: "image" });
+    expect(await requestCancel(clientJobId)).toBe(true);
+
+    const second = await enqueueSingleRun({
+      mode: "fast",
+      tag: "window-rerun",
+      clientJobId,
+      userId: owner,
+    });
+    expect((await terminalRow(second.jobId)).status).toBe("completed");
+    expect(invoked).toContain("window-rerun");
+
+    // The reset scrubbed run 1's stale error along with its status, so a
+    // reconnecting client cannot replay the old cancel over run 2.
+    expect((await jobRow(clientJobId))?.error).toBeNull();
   });
 
   it("keeps the direct server-id cancel path working with no clientJobId", async () => {

--- a/tests/unit/api/tool-factory-route.test.ts
+++ b/tests/unit/api/tool-factory-route.test.ts
@@ -34,6 +34,8 @@ vi.mock("../../../apps/api/src/config.js", () => ({
 
 vi.mock("../../../apps/api/src/jobs/enqueue.js", () => ({
   enqueueToolJob: vi.fn().mockResolvedValue({}),
+  insertToolJobAlias: vi.fn().mockResolvedValue(undefined),
+  upsertToolJobAlias: vi.fn().mockResolvedValue(undefined),
   waitForJob: vi.fn().mockResolvedValue({
     outputRefs: ["outputs/mock-job/result.png"],
     filename: "result.png",


### PR DESCRIPTION
Closes #886.

Click cancel in the first seconds of a big HEIC run and the button quietly did nothing: validation runs inside the HTTP handler before any queue job exists, so the cancel had nothing to resolve and answered `{canceled: false}`. That window was part of #808's original repro; PR #890 fixed everything after enqueue, this covers the stretch before it.

The design follows #891's principle: durable rows carry the correctness, no TTL'd flag involved. My original sketch in the issue used the #771 flag-consult; the durable-row version survives any late materialization of the job, including one hours later, which a 1h flag could not.

## How it works

- The factory stamps the client-facing alias (owner, pool, `artifactJobId` pointer) right after multipart parse, before validation and before the first progress write. Insert-only (`insertToolJobAlias`): at that point the lazy persist layer cannot have created the row, so a conflict can only be a reused id, and the previous run's terminal state (including its replayable result) survives until the new run proves viable at enqueue. Review caught that resetting here would destroy a finished run's state whenever a reused-id run then died in validation; the reset lives only in `upsertToolJobAlias`, which fires at enqueue and only when the stored pointer actually changes. A same-pointer re-stamp preserves a landed cancel, which is the half that makes the whole fix work.
- `requestCancel` gained a window arm: pointer resolved, nothing in any queue, and the artifact row absent or still queued means the run never started. The alias settles durably (terminal frame announced, so the client settles immediately), a queued artifact row gets stamped, and the abort publish covers the sliver where a worker grabbed the job mid-scan. Anything else (processing, completed, failed) refuses, and both refuse flavors are pinned so the boundary cannot silently widen into false "canceled" answers.
- The worker gates every aliased job before doing any work or status write: alias canceled AND its pointer equals this job means this run's own cancel landed first, so it aborts into the existing cancel bookkeeping. The pointer match is load-bearing twice over: a rerun under a reused channel is spared (the enqueue reset also clears the stale state), and a foreign user's run under someone else's stale canceled alias is spared (the upsert never claimed the row for them, so the pointer cannot match). A gate read fault logs and processes normally, mirroring the pipeline step skip's shipped tradeoff.
- Every alias settle (`cancelSingleJobGuarded`) now optionally carries the pointer it resolved. A settle that lands after a new run re-pointed the channel no-ops instead of repainting that run's row, closing a cross-run race review found in the window arm, the heal arm, and the worker's dual write alike.

## Verification

Ten new tests across the two #808 suites, written failing-first for every behavior change: the window settle (absent artifact), the pre-add sliver (queued artifact), the full round trip (stamp, cancel, run materializes anyway, worker refuses it, tool never invoked), rerun safety, foreign-rerun safety, the reused-id-then-dies-in-validation regression, the pointer-guarded settle both ways, both refuse-boundary negatives, and an HTTP pin that the stamp precedes validation (observable via a validation-failure run leaving an owned, pointered row). Two #890 tests deliberately flipped semantics with updated rationale: the dangling-pointer honest-false is now settle-and-true (the entire point of #886), and a reused id's alias now resets and carries the new run's outcome instead of replaying the old one. Both pr-review-toolkit agents ran on the diff; their two HIGH/MEDIUM findings (the reuse reset regression, the re-point race) are fixed above with their own failing-first tests. Full local sweep: 32 cancel-suite tests, 2440 platform/security/drift, 8545 unit, typecheck, lint.

## Known tradeoffs

- Upload time is uncoverable on any route: the `clientJobId` field can arrive anywhere in the multipart body, so no stamp can precede the parse loop. Client-side XHR abort already covers it.
- The AI custom routes keep their much smaller pre-enqueue window; filed as #892 with the wiring sketch (the helper is the whole mechanism, the work is one call per route).
- A fresh-id run that dies in validation leaves an owned queued alias row behind, strictly better than the ownerless lazy row the same path produced before, but still nonterminal until the reboot sweep. Same debt as before, now cancel-resolvable.
- The worker gate's fault-fallthrough (process normally on a read error) can discard an acknowledged cancel during a transient DB blip at exactly job pickup; it mirrors the pipeline and batch skip precedents and the repair path converges on the next cancel.
