### PR TITLE
fix(api): stamp the SSE cancel alias pre-enqueue in custom AI tool routes

### DIFF
--- a/apps/api/src/routes/tools/ai-canvas-expand.ts
+++ b/apps/api/src/routes/tools/ai-canvas-expand.ts
@@ -8,7 +8,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import sharp from "sharp";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
@@ -184,6 +184,13 @@ export function registerAiCanvasExpand(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/auto-subtitles.ts
+++ b/apps/api/src/routes/tools/auto-subtitles.ts
@@ -7,7 +7,7 @@ import { getBundleForTool, TOOL_BUNDLE_MAP } from "@snapotter/shared";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
 import { isToolInstalled } from "../../lib/feature-status.js";
@@ -141,6 +141,13 @@ export function registerAutoSubtitles(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/background-replace.ts
+++ b/apps/api/src/routes/tools/background-replace.ts
@@ -5,7 +5,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import sharp from "sharp";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { compositeOnColor, createGradientBackground } from "../../lib/bg-effects.js";
@@ -166,6 +166,13 @@ export function registerBackgroundReplace(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/blur-background.ts
+++ b/apps/api/src/routes/tools/blur-background.ts
@@ -5,7 +5,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import sharp from "sharp";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { blurBackground } from "../../lib/bg-effects.js";
@@ -136,6 +136,13 @@ export function registerBlurBackground(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/blur-faces.ts
+++ b/apps/api/src/routes/tools/blur-faces.ts
@@ -8,7 +8,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import sharp from "sharp";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
@@ -117,6 +117,13 @@ export function registerBlurFaces(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/colorize.ts
+++ b/apps/api/src/routes/tools/colorize.ts
@@ -8,7 +8,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import sharp from "sharp";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
@@ -116,6 +116,13 @@ export function registerColorize(app: FastifyInstance) {
         error: "Failed to parse multipart request",
         details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
       });
+    }
+
+    // Stamp the client-facing alias before any pre-enqueue work (#892): a
+    // cancel landing between parse and enqueueToolJob needs a durable pointer
+    // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+    if (clientJobId && clientJobId !== jobId) {
+      await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
     }
 
     const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/enhance-faces.ts
+++ b/apps/api/src/routes/tools/enhance-faces.ts
@@ -7,7 +7,7 @@ import { FEATURE_BUNDLES, TOOL_BUNDLE_MAP } from "@snapotter/shared";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
@@ -111,6 +111,13 @@ export function registerEnhanceFaces(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/erase-object.ts
+++ b/apps/api/src/routes/tools/erase-object.ts
@@ -4,7 +4,7 @@ import { FEATURE_BUNDLES, getBundleForTool, TOOL_BUNDLE_MAP } from "@snapotter/s
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import sharp from "sharp";
 import { z } from "zod";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { stripInternalPaths } from "../../lib/errors.js";
@@ -103,6 +103,13 @@ export function registerEraseObject(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/noise-removal.ts
+++ b/apps/api/src/routes/tools/noise-removal.ts
@@ -7,7 +7,7 @@ import { getBundleForTool, TOOL_BUNDLE_MAP } from "@snapotter/shared";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
@@ -121,6 +121,13 @@ export function registerNoiseRemoval(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/ocr-pdf.ts
+++ b/apps/api/src/routes/tools/ocr-pdf.ts
@@ -6,7 +6,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { env } from "../../config.js";
 import { registerAiPathJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
 import { copyObjectToFile, deleteObject } from "../../lib/object-storage.js";
@@ -163,6 +163,13 @@ export function registerOcrPdf(app: FastifyInstance) {
           error: ocrUploadErrorMessage(statusCode),
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/ocr.ts
+++ b/apps/api/src/routes/tools/ocr.ts
@@ -10,7 +10,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { env } from "../../config.js";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
 import { deleteObject } from "../../lib/object-storage.js";
@@ -168,6 +168,13 @@ export function registerOcr(app: FastifyInstance) {
         error: ocrUploadErrorMessage(statusCode),
         details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
       });
+    }
+
+    // Stamp the client-facing alias before any pre-enqueue work (#892): a
+    // cancel landing between parse and enqueueToolJob needs a durable pointer
+    // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+    if (clientJobId && clientJobId !== jobId) {
+      await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
     }
 
     const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/red-eye-removal.ts
+++ b/apps/api/src/routes/tools/red-eye-removal.ts
@@ -7,7 +7,7 @@ import { getBundleForTool, TOOL_BUNDLE_MAP } from "@snapotter/shared";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
@@ -109,6 +109,13 @@ export function registerRedEyeRemoval(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/remove-background.ts
+++ b/apps/api/src/routes/tools/remove-background.ts
@@ -7,7 +7,7 @@ import { getBundleForTool, TOOL_BUNDLE_MAP } from "@snapotter/shared";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { autoSaveToLibrary } from "../../jobs/postprocess.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
@@ -145,6 +145,13 @@ export function registerRemoveBackground(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/remove-gif-background.ts
+++ b/apps/api/src/routes/tools/remove-gif-background.ts
@@ -9,7 +9,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { env } from "../../config.js";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { detectAnimation } from "../../lib/animation-detect.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
@@ -168,6 +168,13 @@ export function registerRemoveGifBackground(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/restore-photo.ts
+++ b/apps/api/src/routes/tools/restore-photo.ts
@@ -8,7 +8,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import sharp from "sharp";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
@@ -134,6 +134,13 @@ export function registerRestorePhoto(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/sign-pdf.ts
+++ b/apps/api/src/routes/tools/sign-pdf.ts
@@ -7,7 +7,7 @@ import type { SignPlacement } from "@snapotter/shared";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob, waitForJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias, waitForJob } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { stripInternalPaths } from "../../lib/errors.js";
 import { validateImageBuffer } from "../../lib/file-validation.js";
@@ -92,6 +92,13 @@ export function registerSignPdf(app: FastifyInstance) {
         error: "Failed to parse multipart request",
         details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
       });
+    }
+
+    // Stamp the client-facing alias before any pre-enqueue work (#892): a
+    // cancel landing between parse and enqueueToolJob needs a durable pointer
+    // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+    if (clientJobId && clientJobId !== jobId) {
+      await insertToolJobAlias({ jobId, clientJobId, userId, pool: "docs" });
     }
 
     const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/transcribe-audio.ts
+++ b/apps/api/src/routes/tools/transcribe-audio.ts
@@ -6,7 +6,7 @@ import { getBundleForTool, TOOL_BUNDLE_MAP } from "@snapotter/shared";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
 import { isToolInstalled } from "../../lib/feature-status.js";
@@ -129,6 +129,13 @@ export function registerTranscribeAudio(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/transparency-fixer.ts
+++ b/apps/api/src/routes/tools/transparency-fixer.ts
@@ -8,7 +8,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import sharp from "sharp";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
@@ -202,6 +202,13 @@ export function registerTransparencyFixer(app: FastifyInstance) {
           error: "Failed to parse multipart request",
           details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
         });
+      }
+
+      // Stamp the client-facing alias before any pre-enqueue work (#892): a
+      // cancel landing between parse and enqueueToolJob needs a durable pointer
+      // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+      if (clientJobId && clientJobId !== jobId) {
+        await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
       }
 
       const saveMode = parseSaveModeField(saveModeRaw);

--- a/apps/api/src/routes/tools/upscale.ts
+++ b/apps/api/src/routes/tools/upscale.ts
@@ -8,7 +8,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import sharp from "sharp";
 import { z } from "zod";
 import { registerAiJobHandler } from "../../jobs/ai-handlers.js";
-import { enqueueToolJob } from "../../jobs/enqueue.js";
+import { enqueueToolJob, insertToolJobAlias } from "../../jobs/enqueue.js";
 import { INVALID_SAVE_MODE_ERROR, parseSaveModeField } from "../../jobs/types.js";
 import { autoOrient } from "../../lib/auto-orient.js";
 import { formatZodErrors, stripInternalPaths } from "../../lib/errors.js";
@@ -174,6 +174,13 @@ export function registerUpscale(app: FastifyInstance) {
         error: "Failed to parse multipart request",
         details: stripInternalPaths(err instanceof Error ? err.message : String(err)),
       });
+    }
+
+    // Stamp the client-facing alias before any pre-enqueue work (#892): a
+    // cancel landing between parse and enqueueToolJob needs a durable pointer
+    // to resolve. Insert-only; enqueueToolJob re-points it at enqueue (#886).
+    if (clientJobId && clientJobId !== jobId) {
+      await insertToolJobAlias({ jobId, clientJobId, userId, pool: "ai" });
     }
 
     const saveMode = parseSaveModeField(saveModeRaw);

--- a/tests/integration/platform/single-tool-cancel-http.test.ts
+++ b/tests/integration/platform/single-tool-cancel-http.test.ts
@@ -168,6 +168,37 @@ describe("route-stamped alias metadata (#808)", () => {
     );
   });
 
+  it("stamps the alias on an AI custom route before its own validation (#892)", async () => {
+    // The custom AI routes bypass createToolRoute, so #886's factory stamp
+    // never runs for them. A run that dies in the route's own pre-enqueue
+    // work (here: the ocr settings parse) must still leave an owned,
+    // pointered alias row, or a cancel clicked in that window has nothing
+    // to resolve. Invalid settings JSON is used instead of the 501 bundle
+    // path because it dies before enqueueToolJob in every environment;
+    // with a bundle installed the 501 path would enqueue and stamp the
+    // row anyway, pinning nothing.
+    const clientJobId = randomUUID();
+    const { body, contentType } = createMultipartPayload([
+      { name: "file", filename: "scan.png", contentType: "image/png", content: PNG },
+      { name: "settings", content: "not json" },
+      { name: "clientJobId", content: clientJobId },
+    ]);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/tools/image/ocr",
+      headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+      body,
+    });
+    expect(res.statusCode).toBe(400);
+
+    const alias = await jobRow(clientJobId);
+    expect(alias?.type).toBe("single");
+    expect(alias?.userId).not.toBeNull();
+    expect(typeof ((alias?.settings ?? {}) as { artifactJobId?: string }).artifactJobId).toBe(
+      "string",
+    );
+  });
+
   it("re-points the alias at the newest artifact when a clientJobId is reused", async () => {
     const clientJobId = randomUUID();
     await runResize(clientJobId, adminToken);

--- a/tests/unit/api/tool-route-alias-stamp-drift.test.ts
+++ b/tests/unit/api/tool-route-alias-stamp-drift.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Drift guard for the pre-enqueue alias stamp (#892).
+ *
+ * Every hand-written tool route that accepts a clientJobId and enqueues via
+ * enqueueToolJob must stamp insertToolJobAlias after its multipart parse,
+ * or a cancel landing between parse and enqueue finds no pointer and
+ * answers {canceled: false} (the gap #886 closed for factory routes).
+ * The behavioral ordering is pinned on one route by the integration suite
+ * (single-tool-cancel-http.test.ts); this source scan keeps the next
+ * custom route from forgetting the stamp entirely.
+ *
+ * Routes that read clientJobId without calling enqueueToolJob are out of
+ * scope: they either use it as the job id itself (pdf-to-image,
+ * svg-to-raster) or only for progress frames (passport-photo), so there is
+ * no alias row to stamp.
+ *
+ * Detection boundary: a route that enqueues around enqueueToolJob (raw
+ * getQueue().add() or FlowProducer) evades this scan. No tool route does
+ * that today; if one appears, extend the predicate along with it.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const TOOLS_DIR = join(thisDir, "../../../apps/api/src/routes/tools");
+
+function toolRouteSources(): Array<{ file: string; source: string }> {
+  return readdirSync(TOOLS_DIR)
+    .filter((f) => f.endsWith(".ts") && f !== "index.ts")
+    .map((file) => ({ file, source: readFileSync(join(TOOLS_DIR, file), "utf8") }));
+}
+
+describe("custom tool routes stamp the SSE alias pre-enqueue (#892)", () => {
+  const routes = toolRouteSources();
+  const inScope = routes.filter(
+    ({ source }) => source.includes("clientJobId") && source.includes("enqueueToolJob("),
+  );
+
+  it("matches the known in-scope routes (guards the detection itself)", () => {
+    // If this detection ever stops matching, the main assertion below goes
+    // green on an empty set. These three are known members with distinct
+    // shapes (gated AI, ungated AI, docs-pool sync) and only leave the set
+    // if they move onto createToolRoute.
+    const files = inScope.map((r) => r.file);
+    expect(files).toContain("ocr.ts");
+    expect(files).toContain("upscale.ts");
+    expect(files).toContain("sign-pdf.ts");
+  });
+
+  it("every clientJobId-accepting route that enqueues also stamps the alias", () => {
+    const missing = inScope
+      .filter(({ source }) => !/await insertToolJobAlias\(/.test(source))
+      .map((r) => r.file);
+    expect(missing).toEqual([]);
+  });
+
+  it("stamps before the route's own pre-enqueue work, not just somewhere", () => {
+    // Presence alone would pass with the stamp moved back down next to
+    // enqueueToolJob, which is exactly the #892 window reopened. Every
+    // current in-scope route parses saveMode as its first post-parse step,
+    // so the stamp preceding that call is the sweep-wide ordering proxy;
+    // the behavioral version is pinned on ocr by the integration suite.
+    // The import line never contains "parseSaveModeField(", so indexOf
+    // finds the first real call.
+    const misplaced = inScope
+      .filter(({ source }) => source.includes("parseSaveModeField("))
+      .filter(({ source }) => {
+        const stamp = source.search(/await insertToolJobAlias\(/);
+        return stamp === -1 || stamp > source.indexOf("parseSaveModeField(");
+      })
+      .map((r) => r.file);
+    expect(misplaced).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #892.

The 19 hand-written routes that pass `clientJobId` to `enqueueToolJob` (the 18 `registerAiJobHandler` routes plus ocr-pdf) stamped their SSE alias only inside `enqueueToolJob`. A cancel landing between the multipart parse and that call found no pointer and answered `{canceled: false}`. Same window #886 closed for factory routes.

Each route now calls `insertToolJobAlias` right after its parse loop, exactly the factory's #886 stamp. Insert-only, safe on reused ids; the worker gate and `requestCancel`'s window arm already handle everything downstream.

Where this diverges from the issue sketch:

- The issue suggested pinning the 501 bundle-gate path. That gate runs before the multipart parse in every gated route, so `clientJobId` isn't known yet; moving the gate after the parse would make clients upload the whole file before hearing "not installed". The gates stay put. A pre-parse 501 leaves no row, and that's fine: nothing started, nothing to cancel.
- The behavioral pin uses ocr's invalid-settings 400 instead. It dies before `enqueueToolJob` in every environment. The 501 path only does that when no bundle is installed; with one present it would enqueue, stamp the row through the normal path, and pin nothing.
- Instead of the optional shared-parse-helper refactor, `tests/unit/api/tool-route-alias-stamp-drift.test.ts` scans the route sources: every routes/tools file that reads `clientJobId` and calls `enqueueToolJob` must `await insertToolJobAlias` before its first `parseSaveModeField` call. That pins both presence and position across the sweep without rewriting 19 parse loops that differ in file-count rules, field sets, and error mapping. Verified red on a deliberately misplaced stamp.
- passport-photo, pdf-to-image, and svg-to-raster read `clientJobId` but never hand it to `enqueueToolJob` (they use it as the job id itself, or only for progress frames), so there is no alias to stamp. Out of scope, documented in the drift test header.

Known tradeoff, pre-existing since #886 and widened marginally here: a run that dies in a cheap post-parse 400 (bad saveMode, no file) now leaves an orphaned alias row in `jobs` with status `queued`. Nothing purges jobs rows outside GDPR erasure; these rows are excluded from the AI quota and settle if a cancel ever hits them. Factory routes have left the same rows for validation deaths since #886.

Upload streaming stays uncovered on every route, as the issue documents: the `clientJobId` field can arrive anywhere in the multipart body.

Testing: new integration pin in `single-tool-cancel-http.test.ts` (ocr dies in settings validation with 400, alias row must exist with owner and pointer; watched it fail before the fix), the drift test above, both cancel platform suites, the per-route integration suites for all 19 touched routes (26 files, 320 tests passed), typecheck, Biome on the changed files.
