### PR TITLE
fix(api): harden the cancel paths against races, faults, and id collisions

### DIFF
--- a/apps/api/src/jobs/cancel.ts
+++ b/apps/api/src/jobs/cancel.ts
@@ -177,11 +177,26 @@ export async function requestCancel(jobId: string): Promise<boolean> {
     const settings = (row.settings ?? {}) as CancelRowSettings;
     if (settings.pipelineFlowId) {
       if (isTerminal(row.status)) return false;
-      await markBatchCanceled(jobId);
       const [flowRow] = await db
-        .select({ settings: schema.jobs.settings })
+        .select({ status: schema.jobs.status, settings: schema.jobs.settings })
         .from(schema.jobs)
         .where(eq(schema.jobs.id, settings.pipelineFlowId));
+
+      // The run is over but the alias never settled: the finalize's dual
+      // write can fault (#888), and flag-and-publish would answer true
+      // every time while converging nothing. The flow row is
+      // authoritative: heal the alias over a canceled flow so replay
+      // stops showing a live run; a completed or failed flow refuses,
+      // since healing it as canceled would lie about a finished run.
+      if (flowRow && isTerminal(flowRow.status)) {
+        if (flowRow.status === "canceled") {
+          await cancelSingleJobGuarded({ jobId });
+          return true;
+        }
+        return false;
+      }
+
+      await markBatchCanceled(jobId);
       const stepCount = ((flowRow?.settings ?? {}) as CancelRowSettings).stepCount ?? 0;
       for (let j = 0; j < stepCount; j++) {
         await publishCancel(`${settings.pipelineFlowId}-s${j}`);
@@ -270,7 +285,21 @@ async function cancelQueueJob(jobId: string): Promise<"removed" | "signaled" | f
 
     // Waiting or delayed: remove from queue and mark DB row
     if (state === "waiting" || state === "delayed") {
-      await job.remove();
+      try {
+        await job.remove();
+      } catch (err) {
+        // Lost the race (#889): a worker took the lock between getState
+        // and remove, so the job is active now; signal its worker instead
+        // of letting the throw 500 the cancel. BullMQ has no typed error
+        // here, so match its message (bullmq 5.80.9, Job.remove; a unit
+        // tripwire pins the wording against upgrades) and let anything
+        // else (Redis down) propagate loudly. The worker's abort path
+        // owns the terminal write for active jobs, so no row update here.
+        const message = err instanceof Error ? err.message : String(err);
+        if (!/locked by another worker/.test(message)) throw err;
+        await sharedRedis().publish(CANCEL_CHANNEL(), jobId);
+        return "signaled";
+      }
       await db
         .update(schema.jobs)
         .set({ status: "canceled", completedAt: new Date() })

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -687,6 +687,13 @@ async function processToolJob(job: Job<ToolJobData>): Promise<ToolJobResult> {
                 { err: aliasErr, jobId, progressJobId },
                 "canceled alias terminal write failed",
               );
+              // Same class as the finalize's settle fault (#888): pino has
+              // no Sentry transport, so the catch reports its own fault.
+              void reportError(aliasErr, {
+                source: "worker",
+                pool: data.pool,
+                jobId: progressJobId,
+              });
             }
           }
           // Ephemeral terminal event for live SSE clients, published
@@ -1016,10 +1023,42 @@ async function processPipelineFinalize(job: Job<ToolJobData>): Promise<ToolJobRe
   if (canceled) {
     // Guarded dual write (#766): the SSE channel (clientJobId) and the
     // authoritative flow row can differ; both must settle canceled or a
-    // reconnecting client replays a live row forever.
-    await cancelSingleJobGuarded({ jobId: data.jobId });
+    // reconnecting client replays a live row forever. Each write catches
+    // its own fault (#888): a thrown write used to fail the whole
+    // finalize, turning the user's cancel into a generic pipeline failure
+    // and dropping the terminal frame with it. The fault is logged AND
+    // reported (pino has no Sentry transport, and a dropped terminal
+    // write is the one failure a client may never recover from);
+    // requestCancel's pipeline-alias heal converges the row on a later
+    // cancel, off the canceled flow row this finalize still commits.
+    const settleGuarded = async (rowId: string) => {
+      try {
+        await cancelSingleJobGuarded({ jobId: rowId });
+      } catch (err) {
+        logger.error(
+          { err, jobId: data.jobId, target: rowId },
+          "canceled pipeline terminal write failed",
+        );
+        void reportError(err, { source: "worker", pool: data.pool, jobId: rowId });
+      }
+    };
+    await settleGuarded(data.jobId);
     if (progressJobId !== data.jobId) {
-      await cancelSingleJobGuarded({ jobId: progressJobId });
+      await settleGuarded(progressJobId);
+    }
+    // Ephemeral terminal event for live SSE clients, published
+    // unconditionally for single-run pipelines: liveness must not depend
+    // on the durable write (which the guard also skips when a reused
+    // alias id is still terminal from an earlier run). Pipeline-batch
+    // per-file finalizes report through the parent batch channel instead.
+    if (!data.parentId) {
+      publishEphemeral({
+        jobId: progressJobId,
+        type: "single",
+        phase: "failed",
+        percent: 0,
+        error: "Canceled",
+      });
     }
 
     // Batch progress (pipeline-batch only): the canceled file counts like a
@@ -1634,9 +1673,9 @@ export function startWorkers(): void {
       // SSE channel (clientJobId) and the authoritative flow row can differ,
       // so both get the guarded write; a committed completion is never
       // downgraded, and the frame is announced only for a transition this
-      // call owned. A finalize that dies inside its own cancel dual-write
-      // (#771) lands here too and gets labeled a failure; once that write
-      // threw, the net cannot know the run was canceled.
+      // call owned. Since #888 the cancel dual-write catches its own faults
+      // and the finalize survives them, so canceled runs no longer land
+      // here; this net covers crashes and stall evictions only.
       if (data?.kind === "pipeline-finalize") {
         const netFail = (jobId: string) =>
           failSingleJobGuarded({ jobId, message: "Pipeline processing failed" }).catch((netErr) => {

--- a/apps/api/src/routes/pipeline.ts
+++ b/apps/api/src/routes/pipeline.ts
@@ -11,7 +11,7 @@ import { randomUUID } from "node:crypto";
 import { readFile, rm } from "node:fs/promises";
 import { FEATURE_BUNDLES, MODALITY_POOL, TOOLS } from "@snapotter/shared";
 import type { FlowJob } from "bullmq";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { env } from "../config.js";
@@ -635,7 +635,7 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
             // authorization. A foreign or pre-#771 ownerless row is left
             // alone, the old lazy-create semantics, with no 409 so the
             // response cannot become an id-existence oracle.
-            await db
+            const aliasRes = await db
               .insert(schema.jobs)
               .values({
                 id: clientJobId,
@@ -648,9 +648,23 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
               })
               .onConflictDoUpdate({
                 target: schema.jobs.id,
+                // Only alias rows are re-pointable (#887): a colliding
+                // batch parent or tool artifact the same user owns must
+                // keep its own cancel metadata (batch parent ids ARE
+                // client-supplied, so that collision is reachable).
                 set: { settings: { pipelineFlowId: jobId } },
-                setWhere: eq(schema.jobs.userId, userId),
+                setWhere: and(eq(schema.jobs.type, "single"), eq(schema.jobs.userId, userId)),
               });
+            if (((aliasRes as { rowCount?: number | null })?.rowCount ?? 0) === 0) {
+              // The claim was skipped (foreign owner or non-alias
+              // collision). The run proceeds, but its starter cannot
+              // cancel through this id; make that debuggable instead of a
+              // silent 404 months later.
+              request.log.warn(
+                { clientJobId, pipelineFlowId: jobId },
+                "pipeline alias claim skipped; cancel by this id will not resolve",
+              );
+            }
 
             // Report initial progress. Awaited: this write settles the
             // client-facing row the SSE replays, which is the evidence a

--- a/tests/integration/platform/pipeline-cancel-http.test.ts
+++ b/tests/integration/platform/pipeline-cancel-http.test.ts
@@ -148,6 +148,44 @@ describe("route-stamped cancel metadata (#771)", () => {
     expect(flow?.type).toBe("pipeline");
   });
 
+  it("does not clobber a same-owner batch parent row that collides with the alias id (#887)", async () => {
+    // Batch parent ids ARE the client-supplied id, so this collision is
+    // reachable by an API caller reusing an id across the two endpoints.
+    // The alias upsert must not replace the parent's cancel metadata, or a
+    // later cancel of that batch publishes zero child aborts.
+    const owner = await createUserAndLogin(app, `pipe-alias-collide-${Date.now()}`);
+    const clientJobId = randomUUID();
+    await db.insert(schema.jobs).values({
+      id: clientJobId,
+      userId: owner.userId,
+      type: "batch",
+      status: "processing",
+      inputRefs: [],
+      settings: { flowChildCount: 2, stepCount: 1 },
+    });
+
+    const { body, contentType } = createMultipartPayload([
+      { name: "file", filename: "photo.png", contentType: "image/png", content: PNG },
+      {
+        name: "pipeline",
+        content: JSON.stringify({ steps: [{ toolId: "resize", settings: { width: 50 } }] }),
+      },
+      { name: "clientJobId", content: clientJobId },
+    ]);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/pipeline/execute",
+      headers: { "content-type": contentType, authorization: `Bearer ${owner.token}` },
+      body,
+    });
+    expect([200, 202]).toContain(res.statusCode);
+    await waitForTerminalFrame(clientJobId);
+
+    const parent = await jobRow(clientJobId);
+    expect(parent?.type).toBe("batch");
+    expect(parent?.settings).toMatchObject({ flowChildCount: 2, stepCount: 1 });
+  });
+
   it("stamps stepCount on the pipeline-batch parent", async () => {
     const clientJobId = randomUUID();
     const { body, contentType } = createMultipartPayload([

--- a/tests/integration/platform/pipeline-cancel.test.ts
+++ b/tests/integration/platform/pipeline-cancel.test.ts
@@ -40,6 +40,43 @@ vi.mock("../../../apps/api/src/jobs/batch-progress.js", async (importOriginal) =
   };
 });
 
+// Injects a bounded fault into the finalize's durable terminal write so the
+// liveness fallback (#888: the client's terminal frame must not depend on
+// DB health) is testable. Scoped by target id so every other test runs
+// against the real implementation.
+const guardedWriteFault = vi.hoisted(() => ({ target: null as string | null }));
+
+vi.mock("../../../apps/api/src/routes/progress.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../apps/api/src/routes/progress.js")>();
+  return {
+    ...actual,
+    cancelSingleJobGuarded: async (args: { jobId: string }) => {
+      if (args.jobId === guardedWriteFault.target) {
+        throw new Error("injected terminal-write outage");
+      }
+      return actual.cancelSingleJobGuarded(args);
+    },
+  };
+});
+
+// Captures Sentry-bound reports: a swallowed terminal-write fault must
+// still phone home (#888), and pino has no Sentry transport.
+const reported = vi.hoisted(() => ({ errors: [] as unknown[] }));
+
+vi.mock("../../../apps/api/src/lib/error-report.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../apps/api/src/lib/error-report.js")>();
+  return {
+    ...actual,
+    reportError: async (
+      err: unknown,
+      ctx: Parameters<typeof actual.reportError>[1],
+    ): Promise<void> => {
+      reported.errors.push(err);
+      return actual.reportError(err, ctx);
+    },
+  };
+});
+
 const { eq } = await import("drizzle-orm");
 const { db, schema } = await import("../../../apps/api/src/db/index.js");
 const { runMigrations } = await import("../../../apps/api/src/db/migrate.js");
@@ -617,6 +654,119 @@ describe("cooperative step skip and canceled finalize", () => {
     const payload = returned.resultPayload as { canceled?: boolean; error?: string };
     expect(payload.canceled).toBe(true);
     expect(payload.error).toBe("Canceled");
+  });
+
+  it("still delivers the terminal frame when the finalize's alias write fails (#888)", async () => {
+    // The finalize's guarded write is the durable half; the client's
+    // terminal frame is the liveness half and must not die with it. A
+    // thrown alias write also must not fail the finalize itself: its
+    // canceled resultPayload is what the sync route's structural 422
+    // branches on.
+    const clientJobId = randomUUID();
+    const tag = `fault-fin-${clientJobId.slice(0, 8)}`;
+    const { flowId, stepIds } = await enqueuePipelineFlow({
+      steps: [{ mode: "slow", tag }],
+      clientJobId,
+    });
+    await waitFor(async () => {
+      const row = await jobRow(stepIds[0]);
+      return row?.status === "processing" ? true : undefined;
+    });
+
+    guardedWriteFault.target = clientJobId;
+    reported.errors.length = 0;
+    try {
+      expect(await requestCancel(clientJobId)).toBe(true);
+
+      const frame = await terminalFrame(clientJobId);
+      expect(frame.phase).toBe("failed");
+      expect(frame.error).toBe("Canceled");
+
+      // The flow row's own (unfaulted) write still settles, and the
+      // finalize still returns the canceled payload.
+      expect((await terminalRow(flowId)).status).toBe("canceled");
+      const returned = await finalizeReturnValue(flowId);
+      const payload = returned.resultPayload as { canceled?: boolean };
+      expect(payload.canceled).toBe(true);
+
+      // The swallowed fault still phones home: pino has no Sentry
+      // transport, so the catch must call reportError itself.
+      expect(
+        reported.errors.some(
+          (e) => e instanceof Error && e.message === "injected terminal-write outage",
+        ),
+      ).toBe(true);
+
+      // The alias row itself is unsettled (the write failed) until a
+      // retry cancel heals it off the canceled flow row.
+      expect((await jobRow(clientJobId))?.status).not.toBe("canceled");
+    } finally {
+      guardedWriteFault.target = null;
+    }
+
+    expect(await requestCancel(clientJobId)).toBe(true);
+    expect((await jobRow(clientJobId))?.status).toBe("canceled");
+  });
+
+  it("heals a nonterminal alias over a canceled flow instead of flagging forever (#888)", async () => {
+    // The faulted-dual-write residue: flow row canceled, alias never
+    // settled. Flag-and-publish would answer true every time and converge
+    // nothing; the heal settles the row so replay stops showing a live
+    // run. A completed flow stays refusable: healing it as canceled would
+    // lie about a finished run.
+    const clientJobId = randomUUID();
+    const flowId = randomUUID();
+    await db.insert(schema.jobs).values([
+      {
+        id: flowId,
+        toolId: "pipeline",
+        pool: "image",
+        type: "pipeline",
+        status: "canceled",
+        completedAt: new Date(),
+        inputRefs: [],
+        settings: { stepCount: 1, clientJobId },
+      },
+      {
+        id: clientJobId,
+        type: "single",
+        status: "processing",
+        inputRefs: [],
+        settings: { pipelineFlowId: flowId },
+      },
+    ]);
+
+    expect(await requestCancel(clientJobId)).toBe(true);
+    expect((await jobRow(clientJobId))?.status).toBe("canceled");
+    const frame = await terminalFrame(clientJobId);
+    expect(frame.error).toBe("Canceled");
+  });
+
+  it("refuses to heal a nonterminal alias over a completed flow", async () => {
+    const clientJobId = randomUUID();
+    const flowId = randomUUID();
+    await db.insert(schema.jobs).values([
+      {
+        id: flowId,
+        toolId: "pipeline",
+        pool: "image",
+        type: "pipeline",
+        status: "completed",
+        completedAt: new Date(),
+        inputRefs: [],
+        settings: { stepCount: 1, clientJobId },
+      },
+      {
+        id: clientJobId,
+        type: "single",
+        status: "processing",
+        inputRefs: [],
+        settings: { pipelineFlowId: flowId },
+      },
+    ]);
+
+    expect(await requestCancel(clientJobId)).toBe(false);
+    expect((await jobRow(clientJobId))?.status).toBe("processing");
   });
 
   it("a cancel that lands after every step finished completes normally", async () => {

--- a/tests/integration/platform/single-tool-cancel.test.ts
+++ b/tests/integration/platform/single-tool-cancel.test.ts
@@ -51,6 +51,7 @@ import {
   enqueueToolJob,
   insertToolJobAlias,
   waitForJob,
+  warmQueueEvents,
 } from "../../../apps/api/src/jobs/enqueue.js";
 import { closeQueues, getQueue } from "../../../apps/api/src/jobs/queues.js";
 import { bullPrefix } from "../../../apps/api/src/jobs/types.js";
@@ -206,6 +207,12 @@ async function enqueueSingleRun(
 beforeAll(async () => {
   await startCancelListener();
   startWorkers();
+  // The sync-window test arms waitForJob and cancels concurrently; a
+  // lazily created QueueEvents consumer can position at the stream tail
+  // AFTER the failed event publishes on a loaded CI shard, hanging both
+  // promises. Warm the consumers up front, the way the production spine
+  // does for exactly this reason.
+  await warmQueueEvents();
 }, 30_000);
 
 afterAll(async () => {

--- a/tests/unit/api/jobs/cancel-remove-race.test.ts
+++ b/tests/unit/api/jobs/cancel-remove-race.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The remove() lock race (#889): a worker can take a queued job's lock
+ * between requestCancel's getState and its remove. BullMQ then throws a
+ * locked-removal error, which used to escape and 500 a cancel that should
+ * have resolved as "the job is active now, signal its worker". The window
+ * is one queue round-trip wide, so this is pinned with a stubbed queue
+ * instead of a real race.
+ */
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { describe, expect, it, vi } from "vitest";
+
+const stubs = vi.hoisted(() => ({
+  publishes: [] as string[],
+  removeError: null as Error | null,
+  rowUpdates: 0,
+}));
+
+vi.mock("../../../../apps/api/src/db/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../apps/api/src/db/index.js")>();
+  return {
+    ...actual,
+    db: {
+      select: () => ({ from: () => ({ where: async () => [] }) }),
+      update: () => ({
+        set: () => ({
+          where: async () => {
+            stubs.rowUpdates++;
+            return { rowCount: 1 };
+          },
+        }),
+      }),
+    },
+  };
+});
+
+vi.mock("../../../../apps/api/src/routes/progress.js", () => ({
+  cancelSingleJobGuarded: vi.fn(),
+}));
+
+vi.mock("../../../../apps/api/src/jobs/batch-progress.js", () => ({
+  markBatchCanceled: vi.fn(),
+}));
+
+vi.mock("../../../../apps/api/src/jobs/connection.js", () => ({
+  createRedisSubscriberConnection: vi.fn(),
+  sharedRedis: () => ({
+    publish: async (_channel: string, id: string) => {
+      stubs.publishes.push(id);
+      return 1;
+    },
+  }),
+}));
+
+vi.mock("../../../../apps/api/src/jobs/queues.js", () => ({
+  getQueue: (pool: string) =>
+    pool === "image"
+      ? {
+          getJob: async () => ({
+            getState: async () => "waiting",
+            remove: async () => {
+              if (stubs.removeError) throw stubs.removeError;
+            },
+          }),
+        }
+      : { getJob: async () => undefined },
+}));
+
+const { requestCancel } = await import("../../../../apps/api/src/jobs/cancel.js");
+
+describe("requestCancel when remove() races the worker lock (#889)", () => {
+  it("falls through to the active signal when the job is locked", async () => {
+    stubs.publishes.length = 0;
+    stubs.rowUpdates = 0;
+    stubs.removeError = new Error(
+      "Job j1 could not be removed because it is locked by another worker",
+    );
+
+    await expect(requestCancel("j1")).resolves.toBe(true);
+    expect(stubs.publishes).toContain("j1");
+    // The worker's abort path owns the terminal write for active jobs; a
+    // row write here would recreate the row-vs-worker disagreement the
+    // repair machinery exists for.
+    expect(stubs.rowUpdates).toBe(0);
+  });
+
+  it("pins the BullMQ wording the lock-race match relies on", () => {
+    // The fallthrough matches BullMQ's message because it throws no typed
+    // error. A BullMQ upgrade that rewords it silently turns the fix back
+    // into 500s; this fails the upgrade PR instead. The regex lives in
+    // apps/api/src/jobs/cancel.ts (cancelQueueJob).
+    const require = createRequire(import.meta.url);
+    const source = readFileSync(require.resolve("bullmq/dist/cjs/classes/job.js"), "utf8");
+    expect(source).toContain("could not be removed because it is locked by another worker");
+  });
+
+  it("still propagates removal failures that are not the lock race", async () => {
+    stubs.publishes.length = 0;
+    stubs.removeError = new Error("Connection is closed.");
+
+    await expect(requestCancel("j2")).rejects.toThrow("Connection is closed.");
+    expect(stubs.publishes).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #887, #888, #889: the three cancel-machinery issues filed during the #808/#886 work, batched because they live in the same code and share test patterns.

**#887**: the pipeline alias upsert's conflict update filtered on ownership only, so a same-owner batch parent colliding on the client-supplied id got its `flowChildCount` wiped, after which canceling that batch published zero child aborts. The `setWhere` now also requires `type = 'single'`, mirroring the guard `upsertToolJobAlias` got in #890, and a skipped claim logs a warning with both ids so "my cancel 404s" is debuggable later.

**#888**: the finalize's cancel dual write was the only place a canceled pipeline's terminal frame came from, and a thrown write failed the whole finalize: the user's cancel came back as a generic "Pipeline processing failed" frame (the RED run showed exactly that), the rows never converged, and since the failed-handler net reported it as a failure, even the label was wrong. Now each guarded write catches its own fault, reports it through `reportError` (review caught that pino alone never reaches Sentry; the sibling nets pair both, and the same-class catch in the single-tool path from #890 got the same fix), and the client's terminal frame publishes unconditionally for single-run pipelines. `requestCancel` gained the matching heal so retries converge: a nonterminal alias over a specifically canceled flow settles, while completed and failed flows refuse (healing those as canceled would lie about a finished run). Review also caught that my first draft's comment credited the #886 repair machinery, which only covers the single-tool branch; the heal makes the claim true instead of fixing the comment.

**#889**: `getState` then `remove()` is a TOCTOU; a worker taking the lock in between made BullMQ throw and the cancel route 500. The locked-removal throw now falls through to the active-signal publish, anything else still propagates loudly, and no row is written in the fallthrough (the worker's abort path owns terminal writes for active jobs, pinned by a zero-write assertion). The BullMQ wording the match relies on is pinned by a tripwire test against the installed package source, so a dependabot bump that rewords it fails the upgrade PR instead of silently regressing to 500s.

**Verification**: six new or extended tests, each watched failing first where behavior changed: the batch-parent collision over real HTTP, the fault-injected finalize frame (plus Sentry-report capture and the heal-on-retry convergence), the standalone heal and its refuse-over-completed sibling, and the mocked-queue lock-race pair with its propagate-other-errors negative. Full sweep: 76 cancel-suite tests, 2439 platform/security, 8551 unit, typecheck, lint.

**Filed as #895** (surfaced by review, out of scope here): the persist layer still writes through an id collision whose alias claim was refused; the durable fix is claim-aware channel fallback, which touches the flow-building contract and deserves its own change. The #887 guard protects the cancel metadata; #895 covers the colliding row's status and progress.
