### PR TITLE
fix(api): settle the SSE alias when a queued run is canceled by its server id

### DIFF
--- a/apps/api/src/jobs/cancel.ts
+++ b/apps/api/src/jobs/cancel.ts
@@ -21,7 +21,7 @@
  *   registered AbortControllers.
  */
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type Redis from "ioredis";
 import { db, schema } from "../db/index.js";
 import { cancelSingleJobGuarded } from "../routes/progress.js";
@@ -267,7 +267,44 @@ export async function requestCancel(jobId: string): Promise<boolean> {
     }
   }
 
-  return (await cancelQueueJob(jobId)) !== false;
+  const outcome = await cancelQueueJob(jobId);
+
+  // Reverse alias settle (#885): removing a queued job by its server id
+  // leaves any SSE alias pointing at it nonterminal, and nothing else will
+  // ever settle it (no worker runs a removed job; active cancels
+  // dual-write through the worker instead). Tool artifact rows carry no
+  // reverse pointer (their settings are the tool's own, possibly
+  // redacted), so resolve by the pointer itself, scoped to type "single"
+  // so a pipeline flow row's clientJobId shape can never match. Cancels
+  // are rare enough that the jsonb scan needs no index. The settle's own
+  // pointer condition keeps a channel a newer run re-pointed untouched,
+  // and the alias owner is the artifact owner by construction (the upsert
+  // claims only ownerless or same-owner rows), so the route's
+  // authorization already covered this row.
+  if (outcome === "removed") {
+    // Best-effort as a whole, lookup included: the cancel itself already
+    // committed (job removed, server row canceled), so a fault anywhere
+    // here must not 500 it. A later alias-side cancel converges the row
+    // through the heal branch, which reads the canceled artifact this
+    // cancel wrote.
+    try {
+      const aliases = await db
+        .select({ id: schema.jobs.id })
+        .from(schema.jobs)
+        .where(
+          and(
+            eq(schema.jobs.type, "single"),
+            sql`${schema.jobs.settings}->>'artifactJobId' = ${jobId}`,
+          ),
+        );
+      for (const alias of aliases) {
+        await cancelSingleJobGuarded({ jobId: alias.id, expectedArtifactJobId: jobId });
+      }
+    } catch (err) {
+      console.error("reverse alias settle failed", jobId, err);
+    }
+  }
+  return outcome !== false;
 }
 
 /**

--- a/tests/integration/platform/single-tool-cancel.test.ts
+++ b/tests/integration/platform/single-tool-cancel.test.ts
@@ -749,6 +749,77 @@ describe("requestCancel through a single-tool alias (#808)", () => {
     expect(invoked).not.toContain("direct-cancel");
   });
 
+  it("settles the alias when a queued run is canceled by its server id (#885)", async () => {
+    // The reverse direction of the alias resolution: an API caller who
+    // cancels with the server id from the 200/202 payload must not strand
+    // the SSE channel replaying a live run forever. Only the queued
+    // removal needs this; active cancels dual-write through the worker.
+    const clientJobId = randomUUID();
+    const unrelatedAlias = randomUUID();
+    const owner = await createOwner();
+    await db.insert(schema.jobs).values({
+      id: unrelatedAlias,
+      userId: owner,
+      type: "single",
+      status: "queued",
+      inputRefs: [],
+      settings: { artifactJobId: randomUUID() },
+    });
+
+    const queue = getQueue("image");
+    await queue.pause();
+    let jobId: string;
+    try {
+      ({ jobId } = await enqueueSingleRun({
+        mode: "fast",
+        tag: "direct-alias",
+        clientJobId,
+        userId: owner,
+      }));
+      expect(await requestCancel(jobId)).toBe(true);
+    } finally {
+      await queue.resume();
+    }
+
+    expect((await jobRow(jobId))?.status).toBe("canceled");
+    const alias = await jobRow(clientJobId);
+    expect(alias?.status).toBe("canceled");
+    // The settle stayed inside the route's authorization: the alias owner
+    // is the artifact owner by construction.
+    expect(alias?.userId).toBe(owner);
+    const frame = await terminalFrame(clientJobId);
+    expect(frame.phase).toBe("failed");
+    expect(frame.error).toBe("Canceled");
+
+    // Resolution is by pointer: a channel pointing at some other run is
+    // not touched.
+    expect((await jobRow(unrelatedAlias))?.status).toBe("queued");
+  });
+
+  it("keeps a committed direct-id cancel when the reverse settle faults (#885)", async () => {
+    // The job removal and the server-row write already committed; a
+    // faulted settle must not turn that into a 500. The alias stays
+    // stranded until an alias-side cancel heals it off the canceled
+    // artifact, which is the convergence this test walks end to end.
+    const clientJobId = randomUUID();
+    const queue = getQueue("image");
+    await queue.pause();
+    let jobId: string;
+    guardedWriteFault.target = clientJobId;
+    try {
+      ({ jobId } = await enqueueSingleRun({ mode: "fast", tag: "reverse-fault", clientJobId }));
+      expect(await requestCancel(jobId)).toBe(true);
+      expect((await jobRow(jobId))?.status).toBe("canceled");
+      expect((await jobRow(clientJobId))?.status).toBe("queued");
+    } finally {
+      guardedWriteFault.target = null;
+      await queue.resume();
+    }
+
+    expect(await requestCancel(clientJobId)).toBe(true);
+    expect((await jobRow(clientJobId))?.status).toBe("canceled");
+  });
+
   it("keeps the ephemeral terminal frame on a direct-id active cancel", async () => {
     // API callers with no clientJobId ride the worker's publishEphemeral
     // branch; the alias dual write must not have stripped it.


### PR DESCRIPTION
Closes #885, the last open issue from the #808 cancel work.

Cancel a queued run with the server id from the 200/202 payload and the job died correctly, but the SSE alias pointing at it stayed nonterminal forever: no worker ever runs a removed job, so nothing else settles the channel, and a reconnecting consumer replays a live run indefinitely. Active direct-id cancels never had the problem (the worker's abort path dual-writes through `data.clientJobId`), so only the queued-removal branch needed the reverse direction.

A `"removed"` outcome now looks up `type = 'single'` rows whose `artifactJobId` points at the removed job and settles each through `cancelSingleJobGuarded` with the pointer condition, so a channel a newer run re-pointed stays untouched. Tool artifact rows carry no reverse pointer (their settings are the tool's own, sometimes redacted), which is why resolution goes by the pointer itself; the type scope keeps pipeline rows and open-schema tool settings out of reach, and the unindexed jsonb scan is deliberate since cancels are rare. The whole block is best-effort: the cancel already committed, so a fault there must not 500 it, and a dropped settle converges through the alias-side heal branch off the canceled artifact this cancel wrote. Review moved the failure boundary to include the lookup itself (a select fault sits at the same post-commit point) and confirmed the heal convergence, the same-owner-by-construction authz, and the query's reach against every pointer writer.

Two new harness tests: the queued direct-id cancel settling the alias (terminal frame, owner intact, unrelated channels untouched), and the fault-injected settle keeping the cancel committed and then converging through an alias-side cancel end to end. Full sweep: 2440 platform/security, 8551 unit, typecheck, lint.

That closes out the follow-up set from #808: #885, #886, #887, #888, #889, and #892 are all fixed. #895 (persist writes through a refused channel claim) remains the one open cancel issue, filed with its fix sketch during the #896 review.
