### PR TITLE
fix(web): report result-preview load errors and keep the input overlay alive

### DIFF
--- a/apps/web/src/components/common/image-viewer.tsx
+++ b/apps/web/src/components/common/image-viewer.tsx
@@ -1,9 +1,12 @@
+import { SafeError } from "@snapotter/shared";
 import { useGesture } from "@use-gesture/react";
 import { FileImage, Maximize, Minimize2, ZoomIn, ZoomOut } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type Point, resolvePanStart } from "@/components/common/image-viewer-drag";
 import { useTranslation } from "@/contexts/i18n-context";
+import { captureHandledError } from "@/lib/analytics";
 import { formatFileSize } from "@/lib/download";
+import { format } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 export interface BgPreviewState {
@@ -22,7 +25,14 @@ export interface BgPreviewState {
 interface ImageViewerProps {
   src: string;
   filename: string;
-  fileSize: number;
+  /** null = unknown; the size line is omitted rather than shown as zero */
+  fileSize: number | null;
+  /**
+   * Set when src is a completed job's result. A load failure then reports to
+   * Sentry and shows recovery copy (the download often still works) instead
+   * of the generic "no preview" fallback.
+   */
+  resultContext?: { toolId?: string };
   originalWidth?: number | null;
   originalHeight?: number | null;
   cssRotate?: number;
@@ -50,6 +60,7 @@ export function ImageViewer({
   bgPreview,
   imageWrapperStyle,
   imageWrapperChildren,
+  resultContext,
 }: ImageViewerProps) {
   const { t } = useTranslation();
   const [zoom, setZoom] = useState(DEFAULT_ZOOM);
@@ -57,7 +68,9 @@ export function ImageViewer({
   const [naturalHeight, setNaturalHeight] = useState<number | null>(null);
   const [fitMode, setFitMode] = useState<"fit" | "actual">("fit");
   const [loadError, setLoadError] = useState(false);
+  const [errorEventId, setErrorEventId] = useState<string | null>(null);
   const [panOffset, setPanOffset] = useState({ x: 0, y: 0 });
+  const reportedSrcRef = useRef<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
   const zoomRef = useRef(zoom);
@@ -81,9 +94,27 @@ export function ImageViewer({
     }
   }, []);
 
+  const isResult = resultContext != null;
+  const resultToolId = resultContext?.toolId;
+
   const handleImageError = useCallback(() => {
     setLoadError(true);
-  }, []);
+    // A completed result that stops loading (output-retention 404, lapsed
+    // session, revoked blob) is otherwise invisible; report it and surface the
+    // event id. Once per src: a re-render must not spam Sentry.
+    if (!isResult || reportedSrcRef.current === src) return;
+    reportedSrcRef.current = src;
+    void captureHandledError(
+      new SafeError("Result image failed to load", {
+        kind: "operational",
+        code: src.startsWith("blob:") ? "blob-url" : "download-url",
+      }),
+      { error_class: "operational", ...(resultToolId ? { tool_id: resultToolId } : {}) },
+    ).then((id) => {
+      // Drop the id if src changed while the report was in flight
+      if (id && reportedSrcRef.current === src) setErrorEventId(id);
+    });
+  }, [isResult, resultToolId, src]);
 
   const zoomIn = useCallback(() => {
     setZoom((prev) => {
@@ -120,6 +151,8 @@ export function ImageViewer({
     setNaturalWidth(null);
     setNaturalHeight(null);
     setLoadError(false);
+    setErrorEventId(null);
+    reportedSrcRef.current = null;
     setPanOffset({ x: 0, y: 0 });
   }, [src]);
 
@@ -193,6 +226,29 @@ export function ImageViewer({
           ...(cssFilter && { filter: cssFilter, transition: "filter 0.15s ease" }),
         };
 
+  const errorCard = (
+    <div className="flex flex-col items-center justify-center gap-3 text-center p-4">
+      <FileImage className="h-8 w-8 text-muted-foreground" />
+      {isResult ? (
+        <>
+          <p className="text-sm font-medium text-foreground">{t.toolPage.resultPreviewFailed}</p>
+          <p className="text-xs text-muted-foreground">{t.toolPage.resultPreviewFailedHint}</p>
+          <p className="text-xs text-muted-foreground">{filename}</p>
+          {errorEventId && (
+            <p className="text-[10px] font-mono text-muted-foreground">
+              {format(t.toolPage.resultPreviewErrorId, { id: errorEventId })}
+            </p>
+          )}
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-muted-foreground">{t.toolPage.previewNotAvailable}</p>
+          <p className="text-xs text-muted-foreground">{filename}</p>
+        </>
+      )}
+    </div>
+  );
+
   return (
     <div className="flex flex-col w-full h-full max-w-3xl mx-auto min-h-0">
       {/* Toolbar */}
@@ -251,12 +307,8 @@ export function ImageViewer({
         )}
         style={{ backgroundColor: "hsl(var(--muted) / 0.2)" }}
       >
-        {loadError ? (
-          <div className="flex flex-col items-center justify-center gap-3 text-center">
-            <FileImage className="h-8 w-8 text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">Preview not available</p>
-            <p className="text-xs text-muted-foreground">{filename}</p>
-          </div>
+        {loadError && !imageWrapperStyle ? (
+          errorCard
         ) : bgPreview?.backgroundSrc || bgPreview?.containerBackground ? (
           /* Layered bg-removal preview: background layer + subject layer */
           <div
@@ -337,22 +389,30 @@ export function ImageViewer({
             }}
           >
             {imageWrapperChildren}
-            <img
-              ref={imgRef}
-              src={src}
-              alt={filename}
-              onLoad={handleImageLoad}
-              onError={handleImageError}
-              className="select-none"
-              style={{
-                display: "block",
-                flex: "0 1 auto",
-                minHeight: 0,
-                maxWidth: "100%",
-                objectFit: "contain" as const,
-              }}
-              draggable={false}
-            />
+            {loadError ? (
+              /* Keep the wrapper and its overlay children mounted: for
+                 input-overlay tools (pixelate) the overlay is the control for
+                 the next run, so the error card renders in the image's place
+                 instead of replacing the whole branch (#797). */
+              errorCard
+            ) : (
+              <img
+                ref={imgRef}
+                src={src}
+                alt={filename}
+                onLoad={handleImageLoad}
+                onError={handleImageError}
+                className="select-none"
+                style={{
+                  display: "block",
+                  flex: "0 1 auto",
+                  minHeight: 0,
+                  maxWidth: "100%",
+                  objectFit: "contain" as const,
+                }}
+                draggable={false}
+              />
+            )}
           </div>
         ) : (
           <img
@@ -377,7 +437,7 @@ export function ImageViewer({
               {originalWidth || naturalWidth} x {originalHeight || naturalHeight}
             </span>
           )}
-          <span>{formatFileSize(fileSize)}</span>
+          {fileSize != null && <span>{formatFileSize(fileSize)}</span>}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/common/non-native-preview.tsx
+++ b/apps/web/src/components/common/non-native-preview.tsx
@@ -22,7 +22,8 @@ export interface NonNativePreviewProps {
   file?: File;
   src?: string;
   filename: string;
-  fileSize: number;
+  /** null = unknown; the size is omitted rather than shown as zero */
+  fileSize: number | null;
   modality: "video" | "audio";
 }
 
@@ -124,7 +125,8 @@ export function NonNativePreview({
           </div>
           <p className="font-medium text-foreground mb-1">{filename}</p>
           <p className="text-sm text-muted-foreground mb-3">
-            {ext} &middot; {formatFileSize(fileSize)}
+            {ext}
+            {fileSize != null && <> &middot; {formatFileSize(fileSize)}</>}
           </p>
           <button
             type="button"
@@ -149,7 +151,8 @@ export function NonNativePreview({
           </div>
           <p className="font-medium text-foreground mb-1">{filename}</p>
           <p className="text-sm text-muted-foreground mb-4">
-            {ext} &middot; {formatFileSize(fileSize)}
+            {ext}
+            {fileSize != null && <> &middot; {formatFileSize(fileSize)}</>}
           </p>
           <div className="w-full h-1.5 bg-muted rounded-full overflow-hidden mb-3">
             <div
@@ -175,7 +178,8 @@ export function NonNativePreview({
           </div>
           <p className="font-medium text-foreground mb-1">{t.toolPage.previewFailed}</p>
           <p className="text-sm text-muted-foreground mb-3">
-            {filename} &middot; {formatFileSize(fileSize)}
+            {filename}
+            {fileSize != null && <> &middot; {formatFileSize(fileSize)}</>}
           </p>
           <button
             type="button"

--- a/apps/web/src/components/tools/pixelate-settings.tsx
+++ b/apps/web/src/components/tools/pixelate-settings.tsx
@@ -24,17 +24,35 @@ export function PixelateSettings({
   const [blockSize, setBlockSize] = useState(12);
   const [mode, setMode] = useState<PixelateMode>("whole");
 
-  // Natural image dimensions (for converting normalized box to pixel region)
+  // Natural image dimensions (for converting normalized box to pixel region).
+  // Selection mode is blocked until these are known: without them the drawn box
+  // would be silently dropped and the whole image pixelated (#797).
   const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+  const [dimsFailed, setDimsFailed] = useState(false);
   useEffect(() => {
-    if (!blobUrl) {
-      setDims(null);
-      return;
-    }
+    setDims(null);
+    setDimsFailed(false);
+    if (!blobUrl) return;
     const img = new Image();
     img.onload = () => setDims({ w: img.naturalWidth, h: img.naturalHeight });
+    img.onerror = () => setDimsFailed(true);
     img.src = blobUrl;
+    return () => {
+      // Neutralize stale callbacks if the file changes mid-probe
+      img.onload = null;
+      img.onerror = null;
+    };
   }, [blobUrl]);
+
+  // Server-preview formats (TIFF, RAW, HEIC) swap blobUrl for a preview capped
+  // at 1200px, but the server pixelates the ORIGINAL file, so the region must
+  // be placed in the true pixel space carried by the entry (X-Original-Width/
+  // Height from the decode). The probe covers plain formats, where blobUrl is
+  // the original file itself.
+  const effectiveDims =
+    entry?.originalWidth != null && entry?.originalHeight != null
+      ? { w: entry.originalWidth, h: entry.originalHeight }
+      : dims;
 
   // Normalized selection box in 0..1 (default centered 40x40%)
   const [boxX, setBoxX] = useState(0.3);
@@ -167,9 +185,9 @@ export function PixelateSettings({
 
   const handleProcess = () => {
     const settings: Record<string, unknown> = { blockSize };
-    if (mode === "selection" && dims) {
-      const W = dims.w;
-      const H = dims.h;
+    if (mode === "selection" && effectiveDims) {
+      const W = effectiveDims.w;
+      const H = effectiveDims.h;
       const left = Math.round(boxX * W);
       const top = Math.round(boxY * H);
       const width = Math.max(1, Math.min(Math.round(boxW * W), W - left));
@@ -184,7 +202,7 @@ export function PixelateSettings({
   };
 
   const hasFile = files.length > 0;
-  const canProcess = hasFile && !processing;
+  const canProcess = hasFile && !processing && (mode !== "selection" || effectiveDims != null);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -290,6 +308,11 @@ export function PixelateSettings({
           {hasFile && (
             <p className="text-[10px] text-muted-foreground">
               Drag the selection box on the image to reposition
+            </p>
+          )}
+          {dimsFailed && effectiveDims == null && (
+            <p className="text-xs text-destructive-ink">
+              {t.toolSettings.pixelate.dimensionsFailed}
             </p>
           )}
         </div>

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -171,6 +171,31 @@ export function setSentryTag(key: string, value: string): void {
     .catch(() => {});
 }
 
+/**
+ * Capture a handled (non-crash) error and return its Sentry event id so UI
+ * copy can reference it, or null when telemetry is off (analytics disabled,
+ * no web DSN baked, or opted out). Only allowlisted tags survive the scrubber
+ * (see sentry-scrub.ts TAG_ALLOWLIST), and the error must carry an authored
+ * SafeError message or beforeSend reduces it to its type. Lazy import so this
+ * module keeps no static @sentry/react dependency.
+ */
+export async function captureHandledError(
+  error: Error,
+  tags?: Record<string, string>,
+): Promise<string | null> {
+  if (!enabled) return null;
+  try {
+    const Sentry = await import("@sentry/react");
+    if (!Sentry.getClient()) return null;
+    return Sentry.withScope((scope) => {
+      if (tags) scope.setTags(tags);
+      return Sentry.captureException(error);
+    });
+  } catch {
+    return null;
+  }
+}
+
 export function track(event: string, properties?: Record<string, unknown>): void {
   if (!enabled || !posthog) return;
   try {

--- a/apps/web/src/pages/tool-page.tsx
+++ b/apps/web/src/pages/tool-page.tsx
@@ -733,7 +733,8 @@ export function ToolPage() {
             <ImageViewer
               src={processedUrl}
               filename={outName}
-              fileSize={currentEntry?.processedSize ?? 0}
+              fileSize={currentEntry?.processedSize ?? null}
+              resultContext={{ toolId }}
             />
           );
         }
@@ -750,7 +751,7 @@ export function ToolPage() {
         const previewFile = hasProcessed ? undefined : currentEntry?.file;
         const previewSrc = hasProcessed ? (processedUrl ?? originalBlobUrl) : undefined;
         const previewSize = hasProcessed
-          ? (currentEntry?.processedSize ?? 0)
+          ? (currentEntry?.processedSize ?? null)
           : (currentEntry?.file?.size ?? 0);
         return (
           <Suspense fallback={<div className="text-sm text-muted-foreground">Loading...</div>}>
@@ -964,7 +965,12 @@ export function ToolPage() {
 
     if (hasProcessed && originalBlobUrl && displayMode === "no-comparison") {
       return (
-        <ImageViewer src={displayUrl} filename={processedFileName} fileSize={processedSize ?? 0} />
+        <ImageViewer
+          src={displayUrl}
+          filename={processedFileName}
+          fileSize={processedSize}
+          resultContext={{ toolId }}
+        />
       );
     }
 
@@ -988,7 +994,8 @@ export function ToolPage() {
           <ImageViewer
             src={resultSrc}
             filename={processedFileName}
-            fileSize={processedSize ?? 0}
+            fileSize={processedSize}
+            resultContext={{ toolId }}
             imageWrapperStyle={imageWrapperStyle}
             imageWrapperChildren={imageWrapperChildren}
           />
@@ -1007,7 +1014,12 @@ export function ToolPage() {
 
     if (hasProcessed && originalBlobUrl && displayMode === "live-preview") {
       return (
-        <ImageViewer src={displayUrl} filename={processedFileName} fileSize={processedSize ?? 0} />
+        <ImageViewer
+          src={displayUrl}
+          filename={processedFileName}
+          fileSize={processedSize}
+          resultContext={{ toolId }}
+        />
       );
     }
 

--- a/packages/shared/src/i18n/ar.ts
+++ b/packages/shared/src/i18n/ar.ts
@@ -2175,6 +2175,8 @@ export const ar: TranslationKeys = {
       submit: "بكسلة",
       submitBatch: "بكسلة ({count} ملفات)",
       progressLabel: "جارٍ البكسلة",
+      dimensionsFailed:
+        "تعذرت قراءة أبعاد الصورة، لذا لا يمكن تطبيق التحديد. أضف الملف مرة أخرى أو طبّق البكسلة على الصورة كاملة.",
     },
     vignette: {
       strength: "الشدة",
@@ -3025,6 +3027,10 @@ export const ar: TranslationKeys = {
     previewUnavailable: "ستتوفر المعاينة بعد المعالجة",
     generatePreview: "إنشاء معاينة",
     previewFailed: "فشل إنشاء المعاينة",
+    previewNotAvailable: "المعاينة غير متوفرة",
+    resultPreviewFailed: "تعذر تحميل معاينة النتيجة",
+    resultPreviewFailedHint: "اكتملت المعالجة. استخدم زر التحميل لحفظ ملفك.",
+    resultPreviewErrorId: "معرّف الخطأ: {id}",
     backToTools: "العودة إلى الأدوات",
     original: "الأصلي",
     processed: "المعالَج",

--- a/packages/shared/src/i18n/de.ts
+++ b/packages/shared/src/i18n/de.ts
@@ -2199,6 +2199,8 @@ export const de: TranslationKeys = {
       submit: "Verpixeln",
       submitBatch: "Verpixeln ({count} Dateien)",
       progressLabel: "Wird verpixelt",
+      dimensionsFailed:
+        "Die Bildabmessungen konnten nicht gelesen werden, daher kann die Auswahl nicht angewendet werden. Fügen Sie die Datei erneut hinzu oder verpixeln Sie das ganze Bild.",
     },
     vignette: {
       strength: "Stärke",
@@ -3053,6 +3055,11 @@ export const de: TranslationKeys = {
     previewUnavailable: "Vorschau ist nach der Verarbeitung verfügbar",
     generatePreview: "Vorschau erzeugen",
     previewFailed: "Vorschauerzeugung fehlgeschlagen",
+    previewNotAvailable: "Vorschau nicht verfügbar",
+    resultPreviewFailed: "Ergebnisvorschau konnte nicht geladen werden",
+    resultPreviewFailedHint:
+      "Die Verarbeitung ist abgeschlossen. Verwenden Sie die Download-Schaltfläche, um Ihre Datei zu speichern.",
+    resultPreviewErrorId: "Fehler-ID: {id}",
     backToTools: "Zurück zu Werkzeugen",
     original: "Original",
     processed: "Verarbeitet",

--- a/packages/shared/src/i18n/en.ts
+++ b/packages/shared/src/i18n/en.ts
@@ -2139,6 +2139,8 @@ export const en = {
       submit: "Pixelate",
       submitBatch: "Pixelate ({count} files)",
       progressLabel: "Pixelating",
+      dimensionsFailed:
+        "Couldn't read the image dimensions, so the selection can't be applied. Add the file again or pixelate the whole image.",
     },
     vignette: {
       strength: "Strength",
@@ -2991,6 +2993,10 @@ export const en = {
     previewUnavailable: "Preview will be available after processing",
     generatePreview: "Generate Preview",
     previewFailed: "Preview generation failed",
+    previewNotAvailable: "Preview not available",
+    resultPreviewFailed: "Result preview failed to load",
+    resultPreviewFailedHint: "Processing finished. Use the download button to save your file.",
+    resultPreviewErrorId: "Error ID: {id}",
     backToTools: "Back to Tools",
     original: "Original",
     processed: "Processed",

--- a/packages/shared/src/i18n/es.ts
+++ b/packages/shared/src/i18n/es.ts
@@ -2181,6 +2181,8 @@ export const es: TranslationKeys = {
       submit: "Pixelar",
       submitBatch: "Pixelar ({count} archivos)",
       progressLabel: "Pixelando",
+      dimensionsFailed:
+        "No se pudieron leer las dimensiones de la imagen, así que la selección no se puede aplicar. Añade el archivo de nuevo o pixela la imagen completa.",
     },
     vignette: {
       strength: "Intensidad",
@@ -3034,6 +3036,11 @@ export const es: TranslationKeys = {
     previewUnavailable: "La vista previa estará disponible después del procesamiento",
     generatePreview: "Generar vista previa",
     previewFailed: "Error al generar la vista previa",
+    previewNotAvailable: "Vista previa no disponible",
+    resultPreviewFailed: "No se pudo cargar la vista previa del resultado",
+    resultPreviewFailedHint:
+      "El procesamiento ha finalizado. Usa el botón de descarga para guardar tu archivo.",
+    resultPreviewErrorId: "ID de error: {id}",
     backToTools: "Volver a herramientas",
     original: "Original",
     processed: "Procesado",

--- a/packages/shared/src/i18n/fr.ts
+++ b/packages/shared/src/i18n/fr.ts
@@ -2206,6 +2206,8 @@ export const fr: TranslationKeys = {
       submit: "Pixéliser",
       submitBatch: "Pixéliser ({count} fichiers)",
       progressLabel: "Pixélisation",
+      dimensionsFailed:
+        "Impossible de lire les dimensions de l'image, la sélection ne peut donc pas être appliquée. Ajoutez à nouveau le fichier ou pixélisez l'image entière.",
     },
     vignette: {
       strength: "Intensité",
@@ -3059,6 +3061,11 @@ export const fr: TranslationKeys = {
     previewUnavailable: "L'aperçu sera disponible après le traitement",
     generatePreview: "Générer l'aperçu",
     previewFailed: "Échec de la génération de l'aperçu",
+    previewNotAvailable: "Aperçu non disponible",
+    resultPreviewFailed: "Échec du chargement de l'aperçu du résultat",
+    resultPreviewFailedHint:
+      "Le traitement est terminé. Utilisez le bouton de téléchargement pour enregistrer votre fichier.",
+    resultPreviewErrorId: "ID d'erreur : {id}",
     backToTools: "Retour aux outils",
     original: "Original",
     processed: "Traité",

--- a/packages/shared/src/i18n/hi.ts
+++ b/packages/shared/src/i18n/hi.ts
@@ -2004,6 +2004,8 @@ export const hi: TranslationKeys = {
       submit: "पिक्सेलेट करें",
       submitBatch: "पिक्सेलेट करें ({count} फ़ाइलें)",
       progressLabel: "पिक्सेलेट हो रहा है",
+      dimensionsFailed:
+        "छवि के आयाम पढ़े नहीं जा सके, इसलिए चयन लागू नहीं किया जा सकता। फाइल फिर से जोड़ें या पूरी छवि को पिक्सेलेट करें।",
     },
     vignette: {
       strength: "तीव्रता",
@@ -2855,6 +2857,10 @@ export const hi: TranslationKeys = {
     previewUnavailable: "प्रीव्यू प्रोसेसिंग के बाद उपलब्ध होगा",
     generatePreview: "प्रीव्यू बनाएं",
     previewFailed: "प्रीव्यू बनाना विफल रहा",
+    previewNotAvailable: "प्रीव्यू उपलब्ध नहीं है",
+    resultPreviewFailed: "परिणाम का प्रीव्यू लोड नहीं हो सका",
+    resultPreviewFailedHint: "प्रोसेसिंग पूरी हो गई। फाइल सहेजने के लिए डाउनलोड बटन का उपयोग करें।",
+    resultPreviewErrorId: "त्रुटि ID: {id}",
     backToTools: "टूल्स पर वापस जाएं",
     original: "मूल",
     processed: "प्रोसेस्ड",

--- a/packages/shared/src/i18n/id.ts
+++ b/packages/shared/src/i18n/id.ts
@@ -2189,6 +2189,8 @@ export const id: TranslationKeys = {
       submit: "Pikselasi",
       submitBatch: "Pikselasi ({count} file)",
       progressLabel: "Mempikselasi",
+      dimensionsFailed:
+        "Dimensi gambar tidak dapat dibaca, jadi seleksi tidak dapat diterapkan. Tambahkan file lagi atau pikselasi seluruh gambar.",
     },
     vignette: {
       strength: "Kekuatan",
@@ -3042,6 +3044,10 @@ export const id: TranslationKeys = {
     previewUnavailable: "Pratinjau akan tersedia setelah pemrosesan",
     generatePreview: "Buat Pratinjau",
     previewFailed: "Pembuatan pratinjau gagal",
+    previewNotAvailable: "Pratinjau tidak tersedia",
+    resultPreviewFailed: "Pratinjau hasil gagal dimuat",
+    resultPreviewFailedHint: "Pemrosesan selesai. Gunakan tombol unduh untuk menyimpan file Anda.",
+    resultPreviewErrorId: "ID kesalahan: {id}",
     backToTools: "Kembali ke Alat",
     original: "Asli",
     processed: "Diproses",

--- a/packages/shared/src/i18n/it.ts
+++ b/packages/shared/src/i18n/it.ts
@@ -2196,6 +2196,8 @@ export const it: TranslationKeys = {
       submit: "Pixelatura",
       submitBatch: "Pixelatura ({count} file)",
       progressLabel: "Applicazione pixelatura",
+      dimensionsFailed:
+        "Impossibile leggere le dimensioni dell'immagine, quindi la selezione non può essere applicata. Aggiungi di nuovo il file o applica la pixelatura all'intera immagine.",
     },
     vignette: {
       strength: "Intensità",
@@ -3049,6 +3051,11 @@ export const it: TranslationKeys = {
     previewUnavailable: "L'anteprima sarà disponibile dopo l'elaborazione",
     generatePreview: "Genera anteprima",
     previewFailed: "Generazione dell'anteprima non riuscita",
+    previewNotAvailable: "Anteprima non disponibile",
+    resultPreviewFailed: "Impossibile caricare l'anteprima del risultato",
+    resultPreviewFailedHint:
+      "L'elaborazione è completata. Usa il pulsante di download per salvare il file.",
+    resultPreviewErrorId: "ID errore: {id}",
     backToTools: "Torna agli strumenti",
     original: "Originale",
     processed: "Elaborato",

--- a/packages/shared/src/i18n/ja.ts
+++ b/packages/shared/src/i18n/ja.ts
@@ -2148,6 +2148,8 @@ export const ja: TranslationKeys = {
       submit: "モザイク化",
       submitBatch: "モザイク化 ({count} ファイル)",
       progressLabel: "モザイク化中",
+      dimensionsFailed:
+        "画像の寸法を読み取れなかったため、選択範囲を適用できません。ファイルを追加し直すか、画像全体をモザイク化してください。",
     },
     vignette: {
       strength: "強度",
@@ -2999,6 +3001,11 @@ export const ja: TranslationKeys = {
     previewUnavailable: "プレビューは処理後に表示されます",
     generatePreview: "プレビューを生成",
     previewFailed: "プレビューの生成に失敗しました",
+    previewNotAvailable: "プレビューを利用できません",
+    resultPreviewFailed: "結果のプレビューを読み込めませんでした",
+    resultPreviewFailedHint:
+      "処理は完了しています。ダウンロードボタンでファイルを保存してください。",
+    resultPreviewErrorId: "エラーID: {id}",
     backToTools: "ツール一覧に戻る",
     original: "元画像",
     processed: "処理済み",

--- a/packages/shared/src/i18n/ko.ts
+++ b/packages/shared/src/i18n/ko.ts
@@ -2128,6 +2128,8 @@ export const ko: TranslationKeys = {
       submit: "픽셀화",
       submitBatch: "픽셀화 ({count}개 파일)",
       progressLabel: "픽셀화 중",
+      dimensionsFailed:
+        "이미지 크기를 읽을 수 없어 선택 영역을 적용할 수 없습니다. 파일을 다시 추가하거나 전체 이미지를 픽셀화하세요.",
     },
     vignette: {
       strength: "강도",
@@ -2979,6 +2981,10 @@ export const ko: TranslationKeys = {
     previewUnavailable: "처리 후 미리보기를 사용할 수 있습니다",
     generatePreview: "미리보기 생성",
     previewFailed: "미리보기 생성 실패",
+    previewNotAvailable: "미리보기를 사용할 수 없습니다",
+    resultPreviewFailed: "결과 미리보기를 불러오지 못했습니다",
+    resultPreviewFailedHint: "처리는 완료되었습니다. 다운로드 버튼으로 파일을 저장하세요.",
+    resultPreviewErrorId: "오류 ID: {id}",
     backToTools: "도구로 돌아가기",
     original: "원본",
     processed: "처리됨",

--- a/packages/shared/src/i18n/nl.ts
+++ b/packages/shared/src/i18n/nl.ts
@@ -2196,6 +2196,8 @@ export const nl: TranslationKeys = {
       submit: "Pixeleren",
       submitBatch: "Pixeleren ({count} bestanden)",
       progressLabel: "Pixeleren",
+      dimensionsFailed:
+        "De afmetingen van de afbeelding konden niet worden gelezen, dus de selectie kan niet worden toegepast. Voeg het bestand opnieuw toe of pixeleer de hele afbeelding.",
     },
     vignette: {
       strength: "Sterkte",
@@ -3049,6 +3051,11 @@ export const nl: TranslationKeys = {
     previewUnavailable: "Voorbeeld beschikbaar na verwerking",
     generatePreview: "Voorbeeld genereren",
     previewFailed: "Voorbeeld genereren mislukt",
+    previewNotAvailable: "Voorbeeld niet beschikbaar",
+    resultPreviewFailed: "Resultaatvoorbeeld kon niet worden geladen",
+    resultPreviewFailedHint:
+      "De verwerking is voltooid. Gebruik de downloadknop om je bestand op te slaan.",
+    resultPreviewErrorId: "Fout-ID: {id}",
     backToTools: "Terug naar Tools",
     original: "Origineel",
     processed: "Verwerkt",

--- a/packages/shared/src/i18n/pl.ts
+++ b/packages/shared/src/i18n/pl.ts
@@ -2192,6 +2192,8 @@ export const pl: TranslationKeys = {
       submit: "Pikselizuj",
       submitBatch: "Pikselizuj ({count} plików)",
       progressLabel: "Pikselizacja",
+      dimensionsFailed:
+        "Nie udało się odczytać wymiarów obrazu, więc zaznaczenie nie może zostać zastosowane. Dodaj plik ponownie lub pikselizuj cały obraz.",
     },
     vignette: {
       strength: "Siła",
@@ -3045,6 +3047,11 @@ export const pl: TranslationKeys = {
     previewUnavailable: "Podgląd będzie dostępny po przetworzeniu",
     generatePreview: "Generuj podgląd",
     previewFailed: "Generowanie podglądu nie powiodło się",
+    previewNotAvailable: "Podgląd niedostępny",
+    resultPreviewFailed: "Nie udało się wczytać podglądu wyniku",
+    resultPreviewFailedHint:
+      "Przetwarzanie zakończone. Użyj przycisku pobierania, aby zapisać plik.",
+    resultPreviewErrorId: "ID błędu: {id}",
     backToTools: "Powrót do narzędzi",
     original: "Oryginał",
     processed: "Przetworzony",

--- a/packages/shared/src/i18n/pt-BR.ts
+++ b/packages/shared/src/i18n/pt-BR.ts
@@ -2192,6 +2192,8 @@ export const ptBR: TranslationKeys = {
       submit: "Pixelar",
       submitBatch: "Pixelar ({count} arquivos)",
       progressLabel: "Pixelando",
+      dimensionsFailed:
+        "Não foi possível ler as dimensões da imagem, então a seleção não pode ser aplicada. Adicione o arquivo novamente ou pixele a imagem inteira.",
     },
     vignette: {
       strength: "Intensidade",
@@ -3044,6 +3046,11 @@ export const ptBR: TranslationKeys = {
     previewUnavailable: "A pré-visualização estará disponível após o processamento",
     generatePreview: "Gerar pré-visualização",
     previewFailed: "Falha ao gerar pré-visualização",
+    previewNotAvailable: "Pré-visualização indisponível",
+    resultPreviewFailed: "Falha ao carregar a pré-visualização do resultado",
+    resultPreviewFailedHint:
+      "O processamento foi concluído. Use o botão de download para salvar seu arquivo.",
+    resultPreviewErrorId: "ID do erro: {id}",
     backToTools: "Voltar para Ferramentas",
     original: "Original",
     processed: "Processado",

--- a/packages/shared/src/i18n/ru.ts
+++ b/packages/shared/src/i18n/ru.ts
@@ -2191,6 +2191,8 @@ export const ru: TranslationKeys = {
       submit: "Пикселизировать",
       submitBatch: "Пикселизировать ({count} файлов)",
       progressLabel: "Пикселизация",
+      dimensionsFailed:
+        "Не удалось прочитать размеры изображения, поэтому выделение нельзя применить. Добавьте файл заново или пикселизируйте всё изображение.",
     },
     vignette: {
       strength: "Интенсивность",
@@ -3044,6 +3046,11 @@ export const ru: TranslationKeys = {
     previewUnavailable: "Предпросмотр будет доступен после обработки",
     generatePreview: "Сгенерировать предпросмотр",
     previewFailed: "Не удалось сгенерировать предпросмотр",
+    previewNotAvailable: "Предпросмотр недоступен",
+    resultPreviewFailed: "Не удалось загрузить предпросмотр результата",
+    resultPreviewFailedHint:
+      "Обработка завершена. Используйте кнопку скачивания для сохранения файла.",
+    resultPreviewErrorId: "ID ошибки: {id}",
     backToTools: "Назад к инструментам",
     original: "Оригинал",
     processed: "Обработано",

--- a/packages/shared/src/i18n/sv.ts
+++ b/packages/shared/src/i18n/sv.ts
@@ -2187,6 +2187,8 @@ export const sv: TranslationKeys = {
       submit: "Pixelera",
       submitBatch: "Pixelera ({count} filer)",
       progressLabel: "Pixelerar",
+      dimensionsFailed:
+        "Bildens dimensioner kunde inte läsas, så markeringen kan inte tillämpas. Lägg till filen igen eller pixelera hela bilden.",
     },
     vignette: {
       strength: "Styrka",
@@ -3040,6 +3042,11 @@ export const sv: TranslationKeys = {
     previewUnavailable: "Förhandsgranskning tillgänglig efter bearbetning",
     generatePreview: "Generera förhandsgranskning",
     previewFailed: "Förhandsgranskning misslyckades",
+    previewNotAvailable: "Förhandsvisning är inte tillgänglig",
+    resultPreviewFailed: "Resultatets förhandsvisning kunde inte läsas in",
+    resultPreviewFailedHint:
+      "Bearbetningen är klar. Använd nedladdningsknappen för att spara din fil.",
+    resultPreviewErrorId: "Fel-ID: {id}",
     backToTools: "Tillbaka till verktyg",
     original: "Original",
     processed: "Bearbetad",

--- a/packages/shared/src/i18n/th.ts
+++ b/packages/shared/src/i18n/th.ts
@@ -2158,6 +2158,7 @@ export const th: TranslationKeys = {
       submit: "ทำพิกเซล",
       submitBatch: "ทำพิกเซล ({count} ไฟล์)",
       progressLabel: "กำลังทำพิกเซล",
+      dimensionsFailed: "ไม่สามารถอ่านขนาดของภาพได้ จึงไม่สามารถใช้พื้นที่ที่เลือกได้ เพิ่มไฟล์อีกครั้งหรือทำพิกเซลทั้งภาพ",
     },
     vignette: {
       strength: "ความเข้ม",
@@ -3008,6 +3009,10 @@ export const th: TranslationKeys = {
     previewUnavailable: "ตัวอย่างจะพร้อมใช้งานหลังประมวลผลเสร็จ",
     generatePreview: "สร้างตัวอย่าง",
     previewFailed: "สร้างตัวอย่างไม่สำเร็จ",
+    previewNotAvailable: "ไม่มีตัวอย่างให้แสดง",
+    resultPreviewFailed: "โหลดตัวอย่างผลลัพธ์ไม่สำเร็จ",
+    resultPreviewFailedHint: "การประมวลผลเสร็จสิ้นแล้ว ใช้ปุ่มดาวน์โหลดเพื่อบันทึกไฟล์",
+    resultPreviewErrorId: "รหัสข้อผิดพลาด: {id}",
     backToTools: "กลับไปยังเครื่องมือ",
     original: "ต้นฉบับ",
     processed: "ประมวลผลแล้ว",

--- a/packages/shared/src/i18n/tr.ts
+++ b/packages/shared/src/i18n/tr.ts
@@ -2194,6 +2194,8 @@ export const tr: TranslationKeys = {
       submit: "Pikselle",
       submitBatch: "Pikselle ({count} dosya)",
       progressLabel: "Pikselleştiriliyor",
+      dimensionsFailed:
+        "Görselin boyutları okunamadığı için seçim uygulanamıyor. Dosyayı yeniden ekleyin veya tüm görseli pikselleyin.",
     },
     vignette: {
       strength: "Yoğunluk",
@@ -3046,6 +3048,11 @@ export const tr: TranslationKeys = {
     previewUnavailable: "Önizleme işlemden sonra kullanılabilir olacak",
     generatePreview: "Önizleme Oluştur",
     previewFailed: "Önizleme oluşturulamadı",
+    previewNotAvailable: "Önizleme kullanılamıyor",
+    resultPreviewFailed: "Sonuç önizlemesi yüklenemedi",
+    resultPreviewFailedHint:
+      "İşlem tamamlandı. Dosyanızı kaydetmek için indirme düğmesini kullanın.",
+    resultPreviewErrorId: "Hata kimliği: {id}",
     backToTools: "Araçlara Dön",
     original: "Orijinal",
     processed: "İşlenmiş",

--- a/packages/shared/src/i18n/uk.ts
+++ b/packages/shared/src/i18n/uk.ts
@@ -2191,6 +2191,8 @@ export const uk: TranslationKeys = {
       submit: "Пікселізувати",
       submitBatch: "Пікселізувати ({count} файлів)",
       progressLabel: "Пікселізація",
+      dimensionsFailed:
+        "Не вдалося прочитати розміри зображення, тому виділення не можна застосувати. Додайте файл ще раз або пікселізуйте все зображення.",
     },
     vignette: {
       strength: "Інтенсивність",
@@ -3043,6 +3045,11 @@ export const uk: TranslationKeys = {
     previewUnavailable: "Попередній перегляд буде доступний після обробки",
     generatePreview: "Створити попередній перегляд",
     previewFailed: "Не вдалося створити попередній перегляд",
+    previewNotAvailable: "Попередній перегляд недоступний",
+    resultPreviewFailed: "Не вдалося завантажити попередній перегляд результату",
+    resultPreviewFailedHint:
+      "Обробку завершено. Скористайтеся кнопкою завантаження для збереження файлу.",
+    resultPreviewErrorId: "ID помилки: {id}",
     backToTools: "Назад до інструментів",
     original: "Оригінал",
     processed: "Оброблено",

--- a/packages/shared/src/i18n/vi.ts
+++ b/packages/shared/src/i18n/vi.ts
@@ -2189,6 +2189,8 @@ export const vi: TranslationKeys = {
       submit: "Làm khảm",
       submitBatch: "Làm khảm ({count} tệp)",
       progressLabel: "Đang làm khảm",
+      dimensionsFailed:
+        "Không thể đọc kích thước ảnh nên không áp dụng được vùng chọn. Thêm lại tệp hoặc làm khảm toàn bộ ảnh.",
     },
     vignette: {
       strength: "Cường độ",
@@ -3041,6 +3043,10 @@ export const vi: TranslationKeys = {
     previewUnavailable: "Xem trước sẽ có sau khi xử lý",
     generatePreview: "Tạo xem trước",
     previewFailed: "Tạo xem trước thất bại",
+    previewNotAvailable: "Không có bản xem trước",
+    resultPreviewFailed: "Không tải được bản xem trước kết quả",
+    resultPreviewFailedHint: "Đã xử lý xong. Sử dụng nút tải xuống để lưu tệp.",
+    resultPreviewErrorId: "ID lỗi: {id}",
     backToTools: "Quay lại Công cụ",
     original: "Gốc",
     processed: "Đã xử lý",

--- a/packages/shared/src/i18n/zh-CN.ts
+++ b/packages/shared/src/i18n/zh-CN.ts
@@ -1946,6 +1946,8 @@ export const zhCN: TranslationKeys = {
       submit: "像素化",
       submitBatch: "像素化（{count} 个文件）",
       progressLabel: "正在像素化",
+      dimensionsFailed:
+        "无法读取图像尺寸，因此无法应用选区。请重新添加文件或对整张图像进行像素化。",
     },
     vignette: {
       strength: "强度",
@@ -2795,6 +2797,10 @@ export const zhCN: TranslationKeys = {
     previewUnavailable: "处理完成后可预览",
     generatePreview: "生成预览",
     previewFailed: "预览生成失败",
+    previewNotAvailable: "预览不可用",
+    resultPreviewFailed: "结果预览加载失败",
+    resultPreviewFailedHint: "处理已完成。请使用下载按钮保存文件。",
+    resultPreviewErrorId: "错误 ID：{id}",
     backToTools: "返回工具",
     original: "原始",
     processed: "已处理",

--- a/packages/shared/src/i18n/zh-TW.ts
+++ b/packages/shared/src/i18n/zh-TW.ts
@@ -1946,6 +1946,8 @@ export const zhTW: TranslationKeys = {
       submit: "像素化",
       submitBatch: "像素化（{count} 個檔案）",
       progressLabel: "正在像素化",
+      dimensionsFailed:
+        "無法讀取影像尺寸，因此無法套用選取範圍。請重新加入檔案或將整張影像像素化。",
     },
     vignette: {
       strength: "強度",
@@ -2795,6 +2797,10 @@ export const zhTW: TranslationKeys = {
     previewUnavailable: "處理完成後即可預覽",
     generatePreview: "產生預覽",
     previewFailed: "預覽產生失敗",
+    previewNotAvailable: "預覽無法使用",
+    resultPreviewFailed: "結果預覽載入失敗",
+    resultPreviewFailedHint: "處理已完成。請使用下載按鈕儲存檔案。",
+    resultPreviewErrorId: "錯誤 ID：{id}",
     backToTools: "返回工具列表",
     original: "原始",
     processed: "已處理",

--- a/tests/unit/web/analytics-capture-handled-error.test.ts
+++ b/tests/unit/web/analytics-capture-handled-error.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import type { AnalyticsConfig } from "@snapotter/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sentry = vi.hoisted(() => ({
+  init: vi.fn(),
+  getClient: vi.fn(),
+  withScope: vi.fn(),
+  captureException: vi.fn(),
+  setTag: vi.fn(),
+}));
+vi.mock("@sentry/react", () => sentry);
+vi.mock("@/lib/early-errors", () => ({ flushEarlyErrors: vi.fn() }));
+
+type Analytics = typeof import("@/lib/analytics");
+
+// analytics.ts keeps module-level enabled/initialized state; a fresh module per
+// test isolates the "before init" case from the "after init" ones.
+async function freshAnalytics(): Promise<Analytics> {
+  vi.resetModules();
+  return await import("@/lib/analytics");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sentry.withScope.mockImplementation((cb: (scope: unknown) => unknown) =>
+    cb({ setTags: vi.fn(), setTag: vi.fn() }),
+  );
+});
+
+describe("captureHandledError", () => {
+  it("returns null and sends nothing before analytics is initialized", async () => {
+    const a = await freshAnalytics();
+    expect(await a.captureHandledError(new Error("x"))).toBeNull();
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no Sentry client exists (DSN absent or opt-out)", async () => {
+    const a = await freshAnalytics();
+    await a.initAnalytics({ enabled: true } as AnalyticsConfig);
+    sentry.getClient.mockReturnValue(undefined);
+    expect(await a.captureHandledError(new Error("x"))).toBeNull();
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("captures with the given tags and returns the Sentry event id", async () => {
+    const a = await freshAnalytics();
+    await a.initAnalytics({ enabled: true } as AnalyticsConfig);
+    sentry.getClient.mockReturnValue({});
+    sentry.captureException.mockReturnValue("evt-1");
+    const scope = { setTags: vi.fn(), setTag: vi.fn() };
+    sentry.withScope.mockImplementation((cb: (s: unknown) => unknown) => cb(scope));
+
+    const err = new Error("boom");
+    const id = await a.captureHandledError(err, {
+      tool_id: "pixelate",
+      error_class: "operational",
+    });
+
+    expect(id).toBe("evt-1");
+    expect(sentry.captureException).toHaveBeenCalledWith(err);
+    expect(scope.setTags).toHaveBeenCalledWith({
+      tool_id: "pixelate",
+      error_class: "operational",
+    });
+  });
+});

--- a/tests/unit/web/image-viewer-result-load-error.test.tsx
+++ b/tests/unit/web/image-viewer-result-load-error.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The load-error path must report through analytics (Sentry) and surface the
+// returned event id in the copy; the mock stands in for the lazy SDK import.
+const captureHandledError = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/analytics", () => ({ captureHandledError }));
+
+import { ImageViewer } from "@/components/common/image-viewer";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ImageViewer result load error (#797)", () => {
+  it("keeps the input overlay mounted and points at the download button", async () => {
+    captureHandledError.mockResolvedValue("abc123deadbeef");
+    render(
+      <ImageViewer
+        src="http://localhost/api/v1/jobs/j1/download"
+        filename="photo-pixelated.png"
+        fileSize={1234}
+        resultContext={{ toolId: "pixelate" }}
+        imageWrapperStyle={{}}
+        imageWrapperChildren={<div data-testid="selection-overlay" />}
+      />,
+    );
+
+    fireEvent.error(screen.getByAltText("photo-pixelated.png"));
+
+    // Result-specific copy with a next step, not the generic dead end
+    expect(await screen.findByText(/result preview failed to load/i)).toBeInTheDocument();
+    expect(screen.getByText(/download button/i)).toBeInTheDocument();
+    // The input overlay (pixelate's selection box) survives the error
+    expect(screen.getByTestId("selection-overlay")).toBeInTheDocument();
+    // The Sentry event id is shown so the failure is referenceable
+    expect(await screen.findByText(/abc123deadbeef/)).toBeInTheDocument();
+  });
+
+  it("reports the failure once with the tool id and an authored-safe message", async () => {
+    captureHandledError.mockResolvedValue("evt1");
+    render(
+      <ImageViewer
+        src="blob:result"
+        filename="out.png"
+        fileSize={5}
+        resultContext={{ toolId: "pixelate" }}
+      />,
+    );
+
+    fireEvent.error(screen.getByAltText("out.png"));
+
+    await waitFor(() => expect(captureHandledError).toHaveBeenCalledTimes(1));
+    const [err, tags] = captureHandledError.mock.calls[0];
+    expect(err).toBeInstanceOf(Error);
+    // Plain Error messages get type-only'd by the Sentry scrubber; the report
+    // must carry the SafeError marker so the message survives.
+    expect((err as { isSafeMessage?: unknown }).isSafeMessage).toBe(true);
+    expect(tags).toMatchObject({ tool_id: "pixelate", error_class: "operational" });
+  });
+
+  it("omits the error id line when telemetry is off", async () => {
+    captureHandledError.mockResolvedValue(null);
+    render(
+      <ImageViewer
+        src="blob:result"
+        filename="out.png"
+        fileSize={5}
+        resultContext={{ toolId: "pixelate" }}
+      />,
+    );
+
+    fireEvent.error(screen.getByAltText("out.png"));
+
+    expect(await screen.findByText(/result preview failed to load/i)).toBeInTheDocument();
+    expect(screen.queryByText(/error id/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps the generic copy and stays silent for a non-result preview", () => {
+    render(<ImageViewer src="blob:original" filename="in.png" fileSize={5} />);
+
+    fireEvent.error(screen.getByAltText("in.png"));
+
+    expect(screen.getByText("Preview not available")).toBeInTheDocument();
+    expect(captureHandledError).not.toHaveBeenCalled();
+  });
+
+  it("hides the size line for an unknown fileSize instead of showing a zero size", () => {
+    render(<ImageViewer src="blob:x" filename="out.png" fileSize={null} />);
+    expect(screen.queryByText(/^(?:0|null)\s*[KMG]?B$/)).not.toBeInTheDocument();
+  });
+
+  it("still shows a known fileSize", () => {
+    render(<ImageViewer src="blob:x" filename="out.png" fileSize={2048} />);
+    expect(screen.getByText("2 KB")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/web/pixelate-dims-probe.test.tsx
+++ b/tests/unit/web/pixelate-dims-probe.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const processFiles = vi.hoisted(() => vi.fn());
+const processAllFiles = vi.hoisted(() => vi.fn());
+vi.mock("@/hooks/use-tool-processor", () => ({
+  useToolProcessor: () => ({
+    processFiles,
+    processAllFiles,
+    processing: false,
+    error: null,
+    downloadUrl: null,
+    progress: { phase: "idle", percent: 0, stage: undefined, elapsed: 0 },
+  }),
+}));
+
+import { PixelateSettings } from "@/components/tools/pixelate-settings";
+import { useFileStore } from "@/stores/file-store";
+
+// jsdom never loads images, so the dimensions probe is driven by hand: the
+// component's `new Image()` lands here and the test fires onload/onerror.
+class FakeImage {
+  static instances: FakeImage[] = [];
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  naturalWidth = 0;
+  naturalHeight = 0;
+  set src(_value: string) {
+    FakeImage.instances.push(this);
+  }
+}
+
+function seedFile(
+  overrides: { originalWidth?: number | null; originalHeight?: number | null } = {},
+) {
+  const file = new File(["png"], "photo.png", { type: "image/png" });
+  useFileStore.setState({
+    files: [file],
+    selectedIndex: 0,
+    entries: [
+      {
+        id: "e1",
+        file,
+        blobUrl: "blob:photo",
+        previewLoading: false,
+        processedUrl: null,
+        processedPreviewUrl: null,
+        processedFilename: null,
+        processedSize: null,
+        originalSize: file.size,
+        originalWidth: overrides.originalWidth ?? null,
+        originalHeight: overrides.originalHeight ?? null,
+        status: "pending",
+        error: null,
+        modality: "image",
+        previewKind: "image",
+      },
+    ],
+  });
+}
+
+beforeEach(() => {
+  FakeImage.instances = [];
+  vi.stubGlobal("Image", FakeImage);
+  seedFile();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  useFileStore.setState({ files: [], entries: [], selectedIndex: 0 });
+});
+
+describe("PixelateSettings dimension probe (#797)", () => {
+  it("blocks selection-mode processing and says why when the probe fails", async () => {
+    render(<PixelateSettings />);
+    fireEvent.click(screen.getByTestId("pixelate-mode-selection"));
+
+    const probe = FakeImage.instances.at(-1);
+    expect(probe).toBeDefined();
+    act(() => probe?.onerror?.());
+
+    expect(await screen.findByText(/couldn't read the image dimensions/i)).toBeInTheDocument();
+    expect(screen.getByTestId("pixelate-submit")).toBeDisabled();
+
+    // Submitting the form anyway must not silently pixelate the whole image
+    fireEvent.submit(screen.getByTestId("pixelate-submit").closest("form") as HTMLFormElement);
+    expect(processFiles).not.toHaveBeenCalled();
+    expect(processAllFiles).not.toHaveBeenCalled();
+  });
+
+  it("blocks selection-mode processing while the probe is still pending", () => {
+    render(<PixelateSettings />);
+    fireEvent.click(screen.getByTestId("pixelate-mode-selection"));
+
+    // Probe neither loaded nor failed yet: no dimensions, no region possible
+    expect(screen.getByTestId("pixelate-submit")).toBeDisabled();
+    fireEvent.submit(screen.getByTestId("pixelate-submit").closest("form") as HTMLFormElement);
+    expect(processFiles).not.toHaveBeenCalled();
+  });
+
+  it("still allows whole-image mode when the probe fails", () => {
+    render(<PixelateSettings />);
+    const probe = FakeImage.instances.at(-1);
+    act(() => probe?.onerror?.());
+
+    const submit = screen.getByTestId("pixelate-submit");
+    expect(submit).toBeEnabled();
+    fireEvent.click(submit);
+    expect(processFiles).toHaveBeenCalledTimes(1);
+    expect(processFiles.mock.calls[0][1]).not.toHaveProperty("region");
+  });
+
+  it("computes the region from the entry's true dimensions, not the downscaled preview", () => {
+    // Server-preview formats (TIFF, RAW, HEIC) swap blobUrl for a preview
+    // capped at 1200px, but the server pixelates the ORIGINAL file. The store
+    // carries the true dimensions from X-Original-Width/Height; the region
+    // must use those or the redaction lands in the wrong place.
+    seedFile({ originalWidth: 4000, originalHeight: 3000 });
+    render(<PixelateSettings />);
+    fireEvent.click(screen.getByTestId("pixelate-mode-selection"));
+
+    const probe = FakeImage.instances.at(-1);
+    act(() => {
+      if (!probe) return;
+      probe.naturalWidth = 1200; // downscaled preview
+      probe.naturalHeight = 900;
+      probe.onload?.();
+    });
+
+    fireEvent.click(screen.getByTestId("pixelate-submit"));
+    expect(processFiles).toHaveBeenCalledTimes(1);
+    expect(processFiles.mock.calls[0][1]).toMatchObject({
+      region: { left: 1200, top: 900, width: 1600, height: 1200 },
+    });
+  });
+
+  it("allows selection mode via entry dimensions even when the probe fails", () => {
+    // A raw TIFF blobUrl never decodes in the browser, but the true
+    // dimensions from the server decode are enough to place the region.
+    seedFile({ originalWidth: 4000, originalHeight: 3000 });
+    render(<PixelateSettings />);
+    fireEvent.click(screen.getByTestId("pixelate-mode-selection"));
+
+    const probe = FakeImage.instances.at(-1);
+    act(() => probe?.onerror?.());
+
+    const submit = screen.getByTestId("pixelate-submit");
+    expect(submit).toBeEnabled();
+    expect(screen.queryByText(/couldn't read the image dimensions/i)).not.toBeInTheDocument();
+    fireEvent.click(submit);
+    expect(processFiles).toHaveBeenCalledTimes(1);
+    expect(processFiles.mock.calls[0][1]).toMatchObject({
+      region: { left: 1200, top: 900, width: 1600, height: 1200 },
+    });
+  });
+
+  it("sends the drawn region once the probe succeeds", () => {
+    render(<PixelateSettings />);
+    fireEvent.click(screen.getByTestId("pixelate-mode-selection"));
+
+    const probe = FakeImage.instances.at(-1);
+    expect(probe).toBeDefined();
+    act(() => {
+      if (!probe) return;
+      probe.naturalWidth = 800;
+      probe.naturalHeight = 600;
+      probe.onload?.();
+    });
+
+    const submit = screen.getByTestId("pixelate-submit");
+    expect(submit).toBeEnabled();
+    fireEvent.click(submit);
+    expect(processFiles).toHaveBeenCalledTimes(1);
+    // Default box is 40x40% centered at 30/30: exact pixel region from 800x600
+    expect(processFiles.mock.calls[0][1]).toMatchObject({
+      region: { left: 240, top: 180, width: 320, height: 240 },
+    });
+  });
+});


### PR DESCRIPTION
Fixes #797. Part 3 of the #746 follow-ups.

When a completed job's result image failed to load in the browser (output-retention 404, lapsed session, revoked blob), `ImageViewer` dropped to a dead-end "Preview not available" card. No Sentry event, no next step, and the error branch replaced the wrapper, so pixelate lost its selection box.

What changed:

- `ImageViewer` takes a `resultContext` prop at the four result call sites in tool-page. A load error now reports a `SafeError("Result image failed to load")` through the new `captureHandledError()` in analytics.ts and shows the returned event id in the copy. When telemetry is off (no DSN, opt-out), nothing is sent and no id is shown. Tags are `tool_id` and `error_class: operational`; the blob-vs-download distinction goes in `code` so Sentry grouping stays stable, per the constant-message rule on `SafeError`.
- The result error card says processing finished and points at the download button, which usually still works. Original-preview failures keep the old generic copy, now through i18n instead of a hardcoded string.
- In the wrapper branch the error card renders in the image's place inside the wrapper, so an input-overlay tool keeps its overlay mounted and usable for the next run.
- Unknown result sizes no longer render as "0 KB". `ImageViewer` and `NonNativePreview` accept `fileSize: number | null` and omit the size line when it is unknown; the `processedSize ?? 0` call sites pass the real nullable value.
- Pixelate's dimension probe gets an `onerror` and a fail-closed gate: in selection mode the submit stays disabled, with a message, until dimensions are known. Before, a failed probe silently dropped the drawn region and pixelated the whole image.
- Found while fixing that: for server-preview formats (TIFF, RAW, HEIC) the probe was reading the preview blob, which `/api/v1/preview` caps at 1200px, so the region was computed in preview space and the server applied it to the full-size original. On a 4000x3000 TIFF the redaction landed in the wrong place. The region now prefers the entry's true dimensions (from `X-Original-Width/Height`) and falls back to the probe for plain formats.

Five new i18n keys in all 21 locales. The hint copy reuses each locale's existing "use the download button to save your file" sentence from `cannotPreviewDownload`, and `dimensionsFailed` uses each locale's own pixelate verb.

Verification: 15 new unit tests in `tests/unit/web` (written first and watched fail), full unit suite green (487 files, 8566 passed), typecheck, biome, and the `pixelate-display` e2e spec against the real stack (5 passed, including TIFF selection mode). `i18n:check` reports the same 280 pre-existing stale units as main (#882) and nothing new.
