### PR TITLE
fix(api): return 404 when a library download's local blob is missing

### DIFF
--- a/apps/api/src/lib/file-storage.ts
+++ b/apps/api/src/lib/file-storage.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createReadStream } from "node:fs";
-import { mkdir, readFile, statfs, unlink, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, statfs, unlink, writeFile } from "node:fs/promises";
 import { basename, extname, isAbsolute, join } from "node:path";
 import type { Readable } from "node:stream";
 import type { S3StorageModule } from "@snapotter/enterprise";
@@ -189,7 +189,12 @@ export async function streamStoredFile(storedName: string): Promise<Readable> {
     const s3 = await getS3();
     return s3.getObjectStream(storedName);
   }
-  return createReadStream(join(env.FILES_STORAGE_PATH, storedName));
+  const filePath = join(env.FILES_STORAGE_PATH, storedName);
+  // createReadStream defers the open, so a missing file would only surface as
+  // an async "error" event after the caller's try/catch has exited. Probe
+  // first so a missing blob rejects here, like the S3 branch does.
+  await access(filePath);
+  return createReadStream(filePath);
 }
 
 export async function deleteStoredFile(storedName: string): Promise<void> {

--- a/apps/api/src/lib/file-storage.ts
+++ b/apps/api/src/lib/file-storage.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { createReadStream } from "node:fs";
-import { access, mkdir, readFile, statfs, unlink, writeFile } from "node:fs/promises";
+import { mkdir, open, readFile, statfs, unlink, writeFile } from "node:fs/promises";
 import { basename, extname, isAbsolute, join } from "node:path";
 import type { Readable } from "node:stream";
 import type { S3StorageModule } from "@snapotter/enterprise";
@@ -190,11 +189,12 @@ export async function streamStoredFile(storedName: string): Promise<Readable> {
     return s3.getObjectStream(storedName);
   }
   const filePath = join(env.FILES_STORAGE_PATH, storedName);
-  // createReadStream defers the open, so a missing file would only surface as
-  // an async "error" event after the caller's try/catch has exited. Probe
-  // first so a missing blob rejects here, like the S3 branch does.
-  await access(filePath);
-  return createReadStream(filePath);
+  // A path-based createReadStream defers the open, so any open-time failure
+  // (missing blob, EACCES) would only surface as an async "error" event after
+  // the caller's try/catch has exited. Open eagerly so those reject here,
+  // like the S3 branch does.
+  const handle = await open(filePath, "r");
+  return handle.createReadStream();
 }
 
 export async function deleteStoredFile(storedName: string): Promise<void> {

--- a/apps/api/src/routes/user-files.ts
+++ b/apps/api/src/routes/user-files.ts
@@ -482,7 +482,18 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
       let stream: Awaited<ReturnType<typeof streamStoredFile>>;
       try {
         stream = await streamStoredFile(file.storedName);
-      } catch {
+      } catch (e) {
+        // streamStoredFile rejects for every open-time fault, not only a
+        // missing blob. A syscall failure other than ENOENT (EACCES, ENOTDIR)
+        // is a storage fault that must keep reaching the global handler and
+        // Sentry. Errors without a syscall (S3 NoSuchKey, a poisoned
+        // stored_name) keep their long-standing 404 mapping.
+        const { code, syscall } = e as NodeJS.ErrnoException;
+        if (syscall && code !== "ENOENT") throw e;
+        request.log.warn(
+          { fileId: id, storedName: file.storedName },
+          "library download: stored blob missing",
+        );
         return reply.status(404).send({ error: "File not found in storage" });
       }
 

--- a/tests/integration/platform/user-files.test.ts
+++ b/tests/integration/platform/user-files.test.ts
@@ -5,8 +5,12 @@
  * bulk delete, save-result versioning, search, and pagination.
  */
 
+import { unlink } from "node:fs/promises";
+import { eq } from "drizzle-orm";
 import sharp from "sharp";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../../apps/api/src/db/index.js";
+import { getStoredFilePath } from "../../../apps/api/src/lib/file-storage.js";
 import { fixtures, readFixture } from "../../fixtures/index.js";
 import {
   buildTestApp,
@@ -285,6 +289,40 @@ describe("File download", () => {
     });
 
     expect(res.statusCode).toBe(404);
+  });
+
+  // #899: a userFiles row whose backing blob vanished (volume reset, manual
+  // prune) must 404 like any other missing file, not 500. createReadStream
+  // used to defer the ENOENT past the route's try/catch.
+  it("returns 404 when the backing blob is missing from storage", async () => {
+    const { body: uploadBody, contentType: uploadCt } = createMultipartPayload([
+      { name: "file", filename: "gone-blob.png", contentType: "image/png", content: PNG },
+    ]);
+
+    const uploadRes = await app.inject({
+      method: "POST",
+      url: "/api/v1/files/upload",
+      headers: { "content-type": uploadCt, authorization: `Bearer ${adminToken}` },
+      body: uploadBody,
+    });
+
+    const fileId = JSON.parse(uploadRes.body).files[0].id;
+
+    // Remove the blob out from under the row, like a pruned data volume would
+    const [row] = await db
+      .select({ storedName: schema.userFiles.storedName })
+      .from(schema.userFiles)
+      .where(eq(schema.userFiles.id, fileId));
+    await unlink(getStoredFilePath(row.storedName));
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/files/${fileId}/download`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body).error).toMatch(/not found/i);
   });
 });
 

--- a/tests/integration/platform/user-files.test.ts
+++ b/tests/integration/platform/user-files.test.ts
@@ -5,7 +5,7 @@
  * bulk delete, save-result versioning, search, and pagination.
  */
 
-import { unlink } from "node:fs/promises";
+import { chmod, unlink } from "node:fs/promises";
 import { eq } from "drizzle-orm";
 import sharp from "sharp";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -322,7 +322,45 @@ describe("File download", () => {
     });
 
     expect(res.statusCode).toBe(404);
-    expect(JSON.parse(res.body).error).toMatch(/not found/i);
+    expect(JSON.parse(res.body).error).toMatch(/not found in storage/i);
+  });
+
+  // An unreadable blob is a storage fault (volume UID drift, botched restore),
+  // not a deleted file. It must stay a 500 that reaches the error handler and
+  // Sentry, never fold into the missing-blob 404.
+  const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+  it.skipIf(isRoot)("returns 500, not a silent 404, when the blob is unreadable", async () => {
+    const { body: uploadBody, contentType: uploadCt } = createMultipartPayload([
+      { name: "file", filename: "locked-blob.png", contentType: "image/png", content: PNG },
+    ]);
+
+    const uploadRes = await app.inject({
+      method: "POST",
+      url: "/api/v1/files/upload",
+      headers: { "content-type": uploadCt, authorization: `Bearer ${adminToken}` },
+      body: uploadBody,
+    });
+
+    const fileId = JSON.parse(uploadRes.body).files[0].id;
+
+    const [row] = await db
+      .select({ storedName: schema.userFiles.storedName })
+      .from(schema.userFiles)
+      .where(eq(schema.userFiles.id, fileId));
+    const blobPath = getStoredFilePath(row.storedName);
+    await chmod(blobPath, 0o000);
+
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/files/${fileId}/download`,
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+
+      expect(res.statusCode).toBe(500);
+    } finally {
+      await chmod(blobPath, 0o644);
+    }
   });
 });
 

--- a/tests/unit/api/file-storage.test.ts
+++ b/tests/unit/api/file-storage.test.ts
@@ -168,6 +168,22 @@ describe("streamStoredFile", () => {
     for await (const chunk of stream) chunks.push(chunk as Buffer);
     expect(Buffer.concat(chunks).toString()).toBe("stream me");
   });
+
+  // A blob that exists but can't be opened must also reject up front, so the
+  // download route can tell a storage fault (rethrow, 500) from a missing
+  // blob (404) instead of the EACCES escaping as an async stream error.
+  const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+  it.skipIf(isRoot)("rejects with EACCES when the stored file is unreadable", async () => {
+    const { saveFile, streamStoredFile } = await importModule();
+    const name = await saveFile(Buffer.from("locked"), "photo.png");
+    await chmod(join(testDir, name), 0o000);
+    const err = (await streamStoredFile(name).then(
+      () => null,
+      (e: unknown) => e,
+    )) as NodeJS.ErrnoException | null;
+    expect(err).toBeInstanceOf(Error);
+    expect(err?.code).toBe("EACCES");
+  });
 });
 
 // Regression guard for the path-traversal report: stored names are generated

--- a/tests/unit/api/file-storage.test.ts
+++ b/tests/unit/api/file-storage.test.ts
@@ -145,6 +145,31 @@ describe("getStoredFilePath", () => {
   });
 });
 
+// Regression guard for #899: createReadStream defers the open, so a missing
+// blob used to surface as an async "error" event after the caller's try/catch
+// had already exited (the download route then 500ed instead of 404ing). The
+// local branch must reject the promise itself so callers can catch it.
+describe("streamStoredFile", () => {
+  it("rejects with ENOENT when the stored file is missing", async () => {
+    const { streamStoredFile } = await importModule();
+    const err = (await streamStoredFile("00000000-dead-beef-0000-000000000000.png").then(
+      () => null,
+      (e: unknown) => e,
+    )) as NodeJS.ErrnoException | null;
+    expect(err).toBeInstanceOf(Error);
+    expect(err?.code).toBe("ENOENT");
+  });
+
+  it("streams back a saved file", async () => {
+    const { saveFile, streamStoredFile } = await importModule();
+    const name = await saveFile(Buffer.from("stream me"), "photo.png");
+    const stream = await streamStoredFile(name);
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) chunks.push(chunk as Buffer);
+    expect(Buffer.concat(chunks).toString()).toBe("stream me");
+  });
+});
+
 // Regression guard for the path-traversal report: stored names are generated
 // basenames, so any separator/parent-reference/absolute name must be rejected
 // before it is joined onto FILES_STORAGE_PATH. Without the guard a poisoned


### PR DESCRIPTION
Downloading a library file whose backing blob is gone from local storage returned a 500 and reported to Sentry as a code bug (NODE-66/NODE-67 on 2.2.0). The route already catches a failed `streamStoredFile` and returns 404, but the local branch handed back a lazy `createReadStream`: the ENOENT only fired as an async error event inside `reply.send()`, after the catch had exited, so it fell through to the global error handler. S3 was never affected because `getObjectStream` awaits the GET and rejects before send.

Two changes:

- `streamStoredFile` now opens the file eagerly (`open()` + `handle.createReadStream()`) instead of a path-based `createReadStream`, so every open-time fault rejects where callers can catch it. No probe/open race, and an unreadable blob rejects too instead of crashing async.
- The download route's catch is no longer a bare swallow. ENOENT maps to 404 with a warn log carrying fileId and storedName; any other syscall failure (EACCES from a volume UID drift, ENOTDIR) rethrows so it still reaches the global handler and Sentry. Errors without a syscall (S3 NoSuchKey, poisoned stored_name rows) keep their existing 404 mapping.

Tests, each watched fail before the code that makes it pass:

- unit: `streamStoredFile` rejects with ENOENT for a missing blob and EACCES for an unreadable one (both used to escape as uncaught async exceptions), plus a happy-path stream read
- integration: delete the blob from disk, download returns 404 "not found in storage"; chmod it to 0o000, download returns 500, not a silent 404

`pnpm vitest run` on both files: 90 passed. `pnpm lint` exit 0, `pnpm typecheck` 9/9 workspaces. The S3 suite skips without minio and the S3 branch didn't change.

Closes #899