### PR TITLE
fix(api): return 409 instead of 500 on duplicate-username register race

### DIFF
--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -955,14 +955,26 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
     const id = randomUUID();
     const passwordHash = await hashPassword(body.password);
 
-    await db.insert(schema.users).values({
-      id,
-      username: body.username,
-      passwordHash,
-      role,
-      team: teamId,
-      mustChangePassword: true,
-    });
+    // The duplicate pre-check above can't close the race: two concurrent
+    // registers both pass the SELECT before either insert commits (issue #900).
+    const inserted = await db
+      .insert(schema.users)
+      .values({
+        id,
+        username: body.username,
+        passwordHash,
+        role,
+        team: teamId,
+        mustChangePassword: true,
+      })
+      .onConflictDoNothing({ target: schema.users.username });
+
+    if (!inserted.rowCount) {
+      return reply.status(409).send({
+        error: "Username already exists",
+        code: "CONFLICT",
+      });
+    }
 
     await auditFromRequest(request)("USER_CREATED", {
       adminId: admin.id,

--- a/tests/integration/platform/auth-edge-cases.test.ts
+++ b/tests/integration/platform/auth-edge-cases.test.ts
@@ -462,6 +462,48 @@ describe("Register validation", () => {
     expect(body.role).toBe("user");
   });
 
+  it("duplicate username returns 409", async () => {
+    const { username } = await createUser();
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { username, password: "ValidPass1" },
+    });
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      error: "Username already exists",
+      code: "CONFLICT",
+    });
+  });
+
+  it("concurrent duplicate registers return one 201 and one 409, never 500", async () => {
+    // Issue #900: both requests pass the duplicate pre-check before either
+    // insert commits (scrypt hashing sits between the two), so the loser
+    // used to surface the 23505 unique violation as a 500.
+    const username = uid();
+    const register = () =>
+      testApp.app.inject({
+        method: "POST",
+        url: "/api/auth/register",
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { username, password: "ValidPass1" },
+      });
+
+    const [first, second] = await Promise.all([register(), register()]);
+    const statuses = [first.statusCode, second.statusCode].sort();
+    expect(statuses).toEqual([201, 409]);
+
+    const conflict = first.statusCode === 409 ? first : second;
+    expect(JSON.parse(conflict.body)).toEqual({
+      error: "Username already exists",
+      code: "CONFLICT",
+    });
+
+    const rows = await db.select().from(schema.users).where(eq(schema.users.username, username));
+    expect(rows).toHaveLength(1);
+  });
+
   it("delete non-existent user returns 404", async () => {
     const res = await testApp.app.inject({
       method: "DELETE",


### PR DESCRIPTION
Closes #900

Two concurrent POST /api/auth/register calls with the same username both pass the duplicate pre-check before either insert commits. Async scrypt hashing sits between the SELECT and the INSERT, so the window is wide enough to hit in production (Sentry NODE-62: a 23505 from `_bt_check_unique` surfacing as a 500 with error_class=bug).

The insert now carries `.onConflictDoNothing({ target: schema.users.username })`, and a zero rowCount maps to the same 409 CONFLICT body the pre-check returns. The pre-check stays: it keeps the common case fast and lets 409 win over the user-limit check. Same idiom as `ensureDefaultAdmin` in the same file. Pinning the conflict target to the username column means any future non-username unique violation still surfaces as an error instead of a mislabeled 409.

Verification:
- New integration test fires two concurrent registers with the same username and asserts one 201, one 409, and exactly one row in `users` afterward. It failed with `[201, 500]` before the fix.
- Added the plain sequential duplicate-409 test alongside it, pinning the exact response body so the two hand-written 409 literals can't drift apart.
- `pnpm vitest run tests/integration/platform/auth-edge-cases.test.ts`: 51 passed.
- `pnpm lint` and `pnpm typecheck` clean.

The sibling pre-check races #900 lists (teams, roles, OIDC auto-create, SCIM) are tracked in #927. The MAX_USERS count race found during review is #928.