### PR TITLE
docs(guide): document Entra ID and Okta in the OIDC guide

### DIFF
--- a/apps/docs/ar/guide/oidc.md
+++ b/apps/docs/ar/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "أعدّ الدخول الموحّد باستخدام OpenID Connect. أدلة تفصيلية خطوة بخطوة لـ Keycloak وAuthentik وGoogle ومزودي OIDC الآخرين."
-i18n_source_hash: 4296343b3cc5
+description: "أعدّ الدخول الموحّد باستخدام OpenID Connect. أدلة تفصيلية خطوة بخطوة لـ Keycloak وAuthentik وGoogle وMicrosoft Entra ID (Azure AD) وOkta ومزودي OIDC الآخرين."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: 3bb7beb03713
 ---
 
 # OIDC / الدخول الموحّد {#oidc-single-sign-on}
 
-تدعم SnapOtter بروتوكول OpenID Connect (OIDC) للدخول الموحّد. يمكن للمستخدمين تسجيل الدخول بمزوّد هوية خارجي مثل Keycloak أو Authentik أو Google بدلاً من (أو إلى جانب) مصادقة اسم المستخدم/كلمة المرور المحلية.
+تدعم SnapOtter بروتوكول OpenID Connect (OIDC) للدخول الموحّد. يمكن للمستخدمين تسجيل الدخول بمزوّد هوية خارجي مثل Keycloak أو Authentik أو Google أو Microsoft Entra ID بدلاً من (أو إلى جانب) مصادقة اسم المستخدم/كلمة المرور المحلية.
 
 ::: tip انظر أيضًا
 [SAML SSO](/ar/guide/saml) | [توفير SCIM](/ar/guide/scim) | [المستخدمون والأدوار والأذونات](/ar/guide/users-roles)
@@ -89,6 +89,29 @@ ${EXTERNAL_URL}/api/auth/oidc/callback
 5. انسخ **Client ID** و**Client secret**.
 6. اضبط `OIDC_ISSUER_URL` على `https://accounts.google.com`.
 7. اضبط `OIDC_USERNAME_CLAIM` على `email` (لا توفّر Google `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. في بوابة Azure، انتقل إلى **Microsoft Entra ID > App registrations > New registration**.
+2. سمِّ التطبيق "SnapOtter". ضمن **Redirect URI**، اختر منصة **Web** وأدخل عنوان رد الاتصال الخاص بك (مثل `https://photos.example.com/api/auth/oidc/callback`). لا تختر **Single-page application**: تصادق SnapOtter باستخدام سر عميل، وهو ما يرفضه Entra ID في تسجيلات SPA.
+3. انسخ **Application (client) ID** و**Directory (tenant) ID** من صفحة **Overview**.
+4. انتقل إلى **Certificates & secrets > New client secret** وانسخ قيمة السر **Value** على الفور. تُعرض هذه القيمة مرة واحدة فقط، وSecret ID المجاور لها ليس هو السر.
+5. اضبط `OIDC_ISSUER_URL` على `https://login.microsoftonline.com/<tenant-id>/v2.0`، مستخدمًا Directory (tenant) ID من الخطوة 3.
+6. اترك `OIDC_USERNAME_CLAIM` على قيمته الافتراضية. يوفّر Entra ID المطالبة `preferred_username`، لذا لا حاجة هنا إلى تجاوز `email` المذكور في دليل Google.
+
+استخدم دائمًا معرّف المستأجر الخاص بك في عنوان URL للمُصدِّر، وليس `common` أو `organizations`. تعلن نقاط النهاية متعددة المستأجرين هذه القالب الحرفي `{tenantid}` كمُصدِّر لها، وهو ما يُفشل التحقق من صحة اكتشاف OIDC.
+
+::: warning
+تتبع مطالبة `preferred_username` في Entra ID اسم المستخدم الأساسي (user principal name)، وهو يتغيّر عند إعادة تسمية المستخدم أو نقله إلى مستأجر آخر. تقرأ SnapOtter المطالبة مرة واحدة عند أول تسجيل دخول، لذا يحتفظ الحساب باسم المستخدم الأصلي بعد ذلك. يستمر تسجيل الدخول في العمل في كلتا الحالتين: تجري مطابقة المستخدمين العائدين عبر الموضوع الثابت (subject) في الرمز، وليس عبر اسم المستخدم.
+:::
+
+لا يؤدي التحوّل إلى Entra ID إلى إيقاف تسجيل الدخول بكلمة المرور. راجع [تعطيل تسجيل الدخول المحلي](#disabling-local-login).
+
+### Okta والمزوّدون الآخرون {#okta-and-other-providers}
+
+يعمل أي مزوّد يدعم اكتشاف OIDC بالطريقة نفسها: أنشئ عميل ويب سريًا بعنوان رد الاتصال الخاص بك، ثم وجّه `OIDC_ISSUER_URL` إلى المُصدِّر. بالنسبة إلى Okta، أنشئ تطبيقًا بطريقة تسجيل الدخول **OIDC - OpenID Connect** ونوع **Web Application**، ثم استخدم نطاق Okta الخاص بك كمُصدِّر (مثل `https://your-company.okta.com`).
+
+لا تُطابق SnapOtter مجموعات مزوّد الهوية مع الأدوار. يحصل مستخدمو SSO الجدد على `OIDC_DEFAULT_ROLE`، ويغيّر المسؤولون الأدوار ضمن **Settings > Users**، وطلب مطالبات المجموعات عبر `OIDC_SCOPES` ليس له أي تأثير.
 
 ## توفير المستخدمين {#user-provisioning}
 

--- a/apps/docs/de/guide/oidc.md
+++ b/apps/docs/de/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "Richten Sie Single Sign-On mit OpenID Connect ein. Schritt-für-Schritt-Anleitungen für Keycloak, Authentik, Google und andere OIDC-Anbieter."
-i18n_source_hash: 4296343b3cc5
+description: "Richten Sie Single Sign-On mit OpenID Connect ein. Schritt-für-Schritt-Anleitungen für Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta und andere OIDC-Anbieter."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: 8f5a0caeda80
 ---
 
 # OIDC / Single Sign-On {#oidc-single-sign-on}
 
-SnapOtter unterstützt OpenID Connect (OIDC) für Single Sign-On. Benutzer können sich mit einem externen Identitätsanbieter wie Keycloak, Authentik oder Google anmelden, anstatt (oder zusätzlich zu) der lokalen Benutzername/Passwort-Authentifizierung.
+SnapOtter unterstützt OpenID Connect (OIDC) für Single Sign-On. Benutzer können sich mit einem externen Identitätsanbieter wie Keycloak, Authentik, Google oder Microsoft Entra ID anmelden, anstatt (oder zusätzlich zu) der lokalen Benutzername/Passwort-Authentifizierung.
 
 ::: tip Siehe auch
 [SAML SSO](/de/guide/saml) | [SCIM-Bereitstellung](/de/guide/scim) | [Benutzer, Rollen & Berechtigungen](/de/guide/users-roles)
@@ -89,6 +89,29 @@ Wenn `EXTERNAL_URL` beispielsweise `https://photos.example.com` ist, konfigurier
 5. Kopieren Sie die **Client ID** und das **Client secret**.
 6. Setzen Sie `OIDC_ISSUER_URL` auf `https://accounts.google.com`.
 7. Setzen Sie `OIDC_USERNAME_CLAIM` auf `email` (Google stellt `preferred_username` nicht bereit).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. Gehen Sie im Azure-Portal zu **Microsoft Entra ID > App registrations > New registration**.
+2. Nennen Sie die App "SnapOtter". Wählen Sie unter **Redirect URI** die Plattform **Web** und geben Sie Ihre Callback-URL ein (z. B. `https://photos.example.com/api/auth/oidc/callback`). Wählen Sie nicht **Single-page application**: SnapOtter authentifiziert sich mit einem Client-Secret, das Entra ID bei SPA-Registrierungen ablehnt.
+3. Kopieren Sie die **Application (client) ID** und die **Directory (tenant) ID** von der Seite **Overview**.
+4. Gehen Sie zu **Certificates & secrets > New client secret** und kopieren Sie den **Value** des Secrets sofort. Er wird nur einmal angezeigt, und die daneben stehende Secret ID ist nicht das Secret.
+5. Setzen Sie `OIDC_ISSUER_URL` auf `https://login.microsoftonline.com/<tenant-id>/v2.0` und verwenden Sie dabei die Directory (tenant) ID aus Schritt 3.
+6. Belassen Sie `OIDC_USERNAME_CLAIM` auf dem Standardwert. Entra ID stellt `preferred_username` bereit, daher ist das Überschreiben mit `email` aus der Google-Anleitung hier nicht nötig.
+
+Verwenden Sie in der Issuer-URL immer Ihre Tenant-ID, nicht `common` oder `organizations`. Diese Multi-Tenant-Endpunkte geben das wörtliche Template `{tenantid}` als Issuer an, wodurch die OIDC-Discovery-Validierung fehlschlägt.
+
+::: warning
+Der Claim `preferred_username` von Entra ID folgt dem Benutzerprinzipalnamen, der sich ändert, wenn ein Benutzer umbenannt oder in einen anderen Tenant verschoben wird. SnapOtter liest den Claim nur einmal bei der ersten Anmeldung, sodass das Konto danach seinen ursprünglichen Benutzernamen behält. Anmeldungen funktionieren in beiden Fällen weiter: Wiederkehrende Benutzer werden über das stabile Subject des Tokens zugeordnet, nicht über den Benutzernamen.
+:::
+
+Der Wechsel zu Entra ID deaktiviert die Passwort-Anmeldung nicht. Siehe [Lokale Anmeldung deaktivieren](#disabling-local-login).
+
+### Okta und andere Anbieter {#okta-and-other-providers}
+
+Jeder Anbieter, der OIDC Discovery unterstützt, funktioniert auf die gleiche Weise: Erstellen Sie einen vertraulichen Web-Client mit Ihrer Callback-URL und verweisen Sie `OIDC_ISSUER_URL` auf den Issuer. Für Okta erstellen Sie eine App mit der Anmeldemethode **OIDC - OpenID Connect** und dem Typ **Web Application** und verwenden dann Ihre Okta-Domain als Issuer (z. B. `https://your-company.okta.com`).
+
+SnapOtter ordnet Gruppen des Identitätsanbieters keinen Rollen zu. Neue SSO-Benutzer erhalten `OIDC_DEFAULT_ROLE`, Admins ändern Rollen unter **Einstellungen > Benutzer**, und das Anfordern von Gruppen-Claims über `OIDC_SCOPES` hat keine Wirkung.
 
 ## Benutzerbereitstellung {#user-provisioning}
 

--- a/apps/docs/es/guide/oidc.md
+++ b/apps/docs/es/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "Configura el inicio de sesión único con OpenID Connect. Guías paso a paso para Keycloak, Authentik, Google y otros proveedores OIDC."
-i18n_source_hash: 4296343b3cc5
+description: "Configura el inicio de sesión único con OpenID Connect. Guías paso a paso para Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta y otros proveedores OIDC."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: ed919192ab76
 ---
 
 # OIDC / Inicio de sesión único {#oidc-single-sign-on}
 
-SnapOtter admite OpenID Connect (OIDC) para el inicio de sesión único. Los usuarios pueden iniciar sesión con un proveedor de identidad externo como Keycloak, Authentik o Google en lugar de (o junto a) la autenticación local con usuario y contraseña.
+SnapOtter admite OpenID Connect (OIDC) para el inicio de sesión único. Los usuarios pueden iniciar sesión con un proveedor de identidad externo como Keycloak, Authentik, Google o Microsoft Entra ID en lugar de (o junto a) la autenticación local con usuario y contraseña.
 
 ::: tip Consulta también
 [SAML SSO](/es/guide/saml) | [Aprovisionamiento SCIM](/es/guide/scim) | [Usuarios, roles y permisos](/es/guide/users-roles)
@@ -89,6 +89,29 @@ Por ejemplo, si `EXTERNAL_URL` es `https://photos.example.com`, configura la URI
 5. Copia el **Client ID** y el **Client secret**.
 6. Define `OIDC_ISSUER_URL` como `https://accounts.google.com`.
 7. Define `OIDC_USERNAME_CLAIM` como `email` (Google no proporciona `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. En el portal de Azure, ve a **Microsoft Entra ID > App registrations > New registration**.
+2. Llama a la aplicación "SnapOtter". En **Redirect URI**, selecciona la plataforma **Web** e introduce tu URL de callback (p. ej. `https://photos.example.com/api/auth/oidc/callback`). No elijas **Single-page application**: SnapOtter se autentica con un secreto de cliente, que Entra ID rechaza en los registros de tipo SPA.
+3. Copia el **Application (client) ID** y el **Directory (tenant) ID** de la página **Overview**.
+4. Ve a **Certificates & secrets > New client secret** y copia enseguida el **Value** del secreto. Solo se muestra una vez, y el Secret ID adyacente no es el secreto.
+5. Define `OIDC_ISSUER_URL` como `https://login.microsoftonline.com/<tenant-id>/v2.0`, usando el Directory (tenant) ID del paso 3.
+6. Deja `OIDC_USERNAME_CLAIM` en su valor predeterminado. Entra ID proporciona `preferred_username`, así que aquí no hace falta la sustitución por `email` de la guía de Google.
+
+Usa siempre el ID de tu tenant en la URL del emisor, no `common` ni `organizations`. Esos endpoints multi-tenant anuncian la plantilla literal `{tenantid}` como su emisor, lo que hace fallar la validación de OIDC Discovery.
+
+::: warning
+El claim `preferred_username` de Entra ID sigue el nombre principal de usuario, que cambia cuando un usuario es renombrado o trasladado a otro tenant. SnapOtter lee el claim una sola vez, en el primer inicio de sesión, así que después la cuenta conserva su nombre de usuario original. El inicio de sesión sigue funcionando en cualquier caso: los usuarios que regresan se identifican por el subject estable del token, no por el nombre de usuario.
+:::
+
+Cambiar a Entra ID no desactiva el inicio de sesión con contraseña. Consulta [Desactivar el inicio de sesión local](#disabling-local-login).
+
+### Okta y otros proveedores {#okta-and-other-providers}
+
+Cualquier proveedor que admita OIDC Discovery funciona de la misma manera: crea un cliente web confidencial con tu URL de callback y apunta `OIDC_ISSUER_URL` al emisor. Para Okta, crea una aplicación con el método de inicio de sesión **OIDC - OpenID Connect** y el tipo **Web Application**, y usa tu dominio de Okta como emisor (p. ej. `https://your-company.okta.com`).
+
+SnapOtter no asigna los grupos del proveedor de identidad a roles. Los usuarios SSO nuevos reciben `OIDC_DEFAULT_ROLE`, los administradores cambian los roles en **Ajustes > Usuarios**, y solicitar claims de grupos mediante `OIDC_SCOPES` no tiene ningún efecto.
 
 ## Aprovisionamiento de usuarios {#user-provisioning}
 

--- a/apps/docs/fr/guide/oidc.md
+++ b/apps/docs/fr/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "Configurez l'authentification unique avec OpenID Connect. Guides étape par étape pour Keycloak, Authentik, Google et d'autres fournisseurs OIDC."
-i18n_source_hash: 4296343b3cc5
+description: "Configurez l'authentification unique avec OpenID Connect. Guides étape par étape pour Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta et d'autres fournisseurs OIDC."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: 6a7d713e4701
 ---
 
 # OIDC / Authentification unique {#oidc-single-sign-on}
 
-SnapOtter prend en charge OpenID Connect (OIDC) pour l'authentification unique. Les utilisateurs peuvent se connecter avec un fournisseur d'identité externe tel que Keycloak, Authentik ou Google au lieu de (ou en plus de) l'authentification locale par nom d'utilisateur/mot de passe.
+SnapOtter prend en charge OpenID Connect (OIDC) pour l'authentification unique. Les utilisateurs peuvent se connecter avec un fournisseur d'identité externe tel que Keycloak, Authentik, Google ou Microsoft Entra ID au lieu de (ou en plus de) l'authentification locale par nom d'utilisateur/mot de passe.
 
 ::: tip Voir aussi
 [SAML SSO](/fr/guide/saml) | [Provisionnement SCIM](/fr/guide/scim) | [Utilisateurs, rôles et permissions](/fr/guide/users-roles)
@@ -89,6 +89,29 @@ Par exemple, si `EXTERNAL_URL` est `https://photos.example.com`, configurez l'UR
 5. Copiez le **Client ID** et le **Client secret**.
 6. Définissez `OIDC_ISSUER_URL` sur `https://accounts.google.com`.
 7. Définissez `OIDC_USERNAME_CLAIM` sur `email` (Google ne fournit pas `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. Dans le portail Azure, allez dans **Microsoft Entra ID > App registrations > New registration**.
+2. Nommez l'application « SnapOtter ». Sous **Redirect URI**, sélectionnez la plateforme **Web** et saisissez votre URL de rappel (par ex. `https://photos.example.com/api/auth/oidc/callback`). Ne choisissez pas **Single-page application** : SnapOtter s'authentifie avec un secret client, ce qu'Entra ID refuse sur les enregistrements de type SPA.
+3. Copiez l'**Application (client) ID** et le **Directory (tenant) ID** depuis la page **Overview**.
+4. Allez dans **Certificates & secrets > New client secret** et copiez immédiatement la **Value** du secret. Elle n'est affichée qu'une seule fois, et le Secret ID adjacent n'est pas le secret.
+5. Définissez `OIDC_ISSUER_URL` sur `https://login.microsoftonline.com/<tenant-id>/v2.0`, en utilisant le Directory (tenant) ID de l'étape 3.
+6. Laissez `OIDC_USERNAME_CLAIM` à sa valeur par défaut. Entra ID fournit `preferred_username`, la substitution par `email` du guide Google n'est donc pas nécessaire ici.
+
+Utilisez toujours votre ID de tenant dans l'URL de l'émetteur, pas `common` ni `organizations`. Ces points de terminaison multi-tenant annoncent le modèle littéral `{tenantid}` comme émetteur, ce qui fait échouer la validation de la découverte OIDC.
+
+::: warning
+Le `preferred_username` d'Entra ID suit le nom d'utilisateur principal (user principal name), qui change lorsqu'un utilisateur est renommé ou déplacé vers un autre tenant. SnapOtter lit la revendication une seule fois, à la première connexion, le compte conserve donc ensuite son nom d'utilisateur d'origine. Les connexions continuent de fonctionner dans tous les cas : les utilisateurs qui reviennent sont identifiés par le sujet stable du jeton, pas par leur nom d'utilisateur.
+:::
+
+Passer à Entra ID ne désactive pas la connexion par mot de passe. Voir [Désactivation de la connexion locale](#disabling-local-login).
+
+### Okta et autres fournisseurs {#okta-and-other-providers}
+
+Tout fournisseur prenant en charge la découverte OIDC fonctionne de la même manière : créez un client web confidentiel avec votre URL de rappel, puis pointez `OIDC_ISSUER_URL` vers l'émetteur. Pour Okta, créez une application avec la méthode de connexion **OIDC - OpenID Connect** et le type **Web Application**, puis utilisez votre domaine Okta comme émetteur (par ex. `https://your-company.okta.com`).
+
+SnapOtter ne mappe pas les groupes du fournisseur d'identité vers des rôles. Les nouveaux utilisateurs SSO reçoivent `OIDC_DEFAULT_ROLE`, les administrateurs modifient les rôles sous **Settings > Users**, et demander des revendications de groupes via `OIDC_SCOPES` n'a aucun effet.
 
 ## Provisionnement des utilisateurs {#user-provisioning}
 

--- a/apps/docs/guide/oidc.md
+++ b/apps/docs/guide/oidc.md
@@ -1,10 +1,10 @@
 ---
-description: Set up Single Sign-On with OpenID Connect. Step-by-step guides for Keycloak, Authentik, Google, and other OIDC providers.
+description: Set up Single Sign-On with OpenID Connect. Step-by-step guides for Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta, and other OIDC providers.
 ---
 
 # OIDC / Single Sign-On {#oidc-single-sign-on}
 
-SnapOtter supports OpenID Connect (OIDC) for single sign-on. Users can log in with an external identity provider such as Keycloak, Authentik, or Google instead of (or alongside) local username/password authentication.
+SnapOtter supports OpenID Connect (OIDC) for single sign-on. Users can log in with an external identity provider such as Keycloak, Authentik, Google, or Microsoft Entra ID instead of (or alongside) local username/password authentication.
 
 ::: tip See also
 [SAML SSO](/guide/saml) | [SCIM Provisioning](/guide/scim) | [Users, Roles & Permissions](/guide/users-roles)
@@ -86,6 +86,29 @@ For example, if `EXTERNAL_URL` is `https://photos.example.com`, configure your p
 5. Copy the **Client ID** and **Client secret**.
 6. Set `OIDC_ISSUER_URL` to `https://accounts.google.com`.
 7. Set `OIDC_USERNAME_CLAIM` to `email` (Google does not provide `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. In the Azure portal, go to **Microsoft Entra ID > App registrations > New registration**.
+2. Name the app "SnapOtter". Under **Redirect URI**, select the **Web** platform and enter your callback URL (e.g. `https://photos.example.com/api/auth/oidc/callback`). Do not pick **Single-page application**: SnapOtter authenticates with a client secret, which Entra ID rejects on SPA registrations.
+3. Copy the **Application (client) ID** and **Directory (tenant) ID** from the **Overview** page.
+4. Go to **Certificates & secrets > New client secret** and copy the secret **Value** right away. It is shown only once, and the adjacent Secret ID is not the secret.
+5. Set `OIDC_ISSUER_URL` to `https://login.microsoftonline.com/<tenant-id>/v2.0`, using the Directory (tenant) ID from step 3.
+6. Leave `OIDC_USERNAME_CLAIM` at its default. Entra ID provides `preferred_username`, so the `email` override from the Google guide is not needed here.
+
+Always use your tenant ID in the issuer URL, not `common` or `organizations`. Those multi-tenant endpoints advertise the literal template `{tenantid}` as their issuer, which fails OIDC discovery validation.
+
+::: warning
+Entra ID's `preferred_username` tracks the user principal name, which changes when a user is renamed or moved to another tenant. SnapOtter reads the claim once, at first login, so the account keeps its original username afterwards. Logins keep working either way: returning users are matched by the token's stable subject, not by username.
+:::
+
+Switching to Entra ID does not turn off password login. See [Disabling local login](#disabling-local-login).
+
+### Okta and other providers {#okta-and-other-providers}
+
+Any provider that supports OIDC Discovery works the same way: create a confidential web client with your callback URL, then point `OIDC_ISSUER_URL` at the issuer. For Okta, create an app with the **OIDC - OpenID Connect** sign-in method and the **Web Application** type, then use your Okta domain as the issuer (e.g. `https://your-company.okta.com`).
+
+SnapOtter does not map identity provider groups to roles. New SSO users get `OIDC_DEFAULT_ROLE`, admins change roles under **Settings > Users**, and requesting group claims through `OIDC_SCOPES` has no effect.
 
 ## User provisioning {#user-provisioning}
 

--- a/apps/docs/hi/guide/oidc.md
+++ b/apps/docs/hi/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "OpenID Connect के साथ Single Sign-On सेटअप करें। Keycloak, Authentik, Google, और अन्य OIDC providers के लिए चरण-दर-चरण गाइड।"
-i18n_source_hash: 4296343b3cc5
+description: "OpenID Connect के साथ Single Sign-On सेटअप करें। Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta, और अन्य OIDC providers के लिए चरण-दर-चरण गाइड।"
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: 02d341718711
 ---
 
 # OIDC / Single Sign-On {#oidc-single-sign-on}
 
-SnapOtter single sign-on के लिए OpenID Connect (OIDC) का समर्थन करता है। Users स्थानीय username/password authentication के बजाय (या उसके साथ-साथ) Keycloak, Authentik, या Google जैसे किसी बाहरी identity provider से login कर सकते हैं।
+SnapOtter single sign-on के लिए OpenID Connect (OIDC) का समर्थन करता है। Users स्थानीय username/password authentication के बजाय (या उसके साथ-साथ) Keycloak, Authentik, Google, या Microsoft Entra ID जैसे किसी बाहरी identity provider से login कर सकते हैं।
 
 ::: tip यह भी देखें
 [SAML SSO](/hi/guide/saml) | [SCIM Provisioning](/hi/guide/scim) | [Users, Roles और Permissions](/hi/guide/users-roles)
@@ -89,6 +89,29 @@ ${EXTERNAL_URL}/api/auth/oidc/callback
 5. **Client ID** और **Client secret** कॉपी करें।
 6. `OIDC_ISSUER_URL` को `https://accounts.google.com` पर सेट करें।
 7. `OIDC_USERNAME_CLAIM` को `email` पर सेट करें (Google `preferred_username` प्रदान नहीं करता)।
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. Azure portal में, **Microsoft Entra ID > App registrations > New registration** पर जाएँ।
+2. app का नाम "SnapOtter" रखें। **Redirect URI** के अंतर्गत, **Web** platform चुनें और अपना callback URL दर्ज करें (उदा. `https://photos.example.com/api/auth/oidc/callback`)। **Single-page application** न चुनें: SnapOtter एक client secret से authenticate करता है, जिसे Entra ID SPA registrations पर अस्वीकार कर देता है।
+3. **Overview** पृष्ठ से **Application (client) ID** और **Directory (tenant) ID** कॉपी करें।
+4. **Certificates & secrets > New client secret** पर जाएँ और secret की **Value** तुरंत कॉपी करें। यह केवल एक बार दिखाई जाती है, और उसके बगल वाला Secret ID secret नहीं है।
+5. चरण 3 की Directory (tenant) ID का उपयोग करते हुए, `OIDC_ISSUER_URL` को `https://login.microsoftonline.com/<tenant-id>/v2.0` पर सेट करें।
+6. `OIDC_USERNAME_CLAIM` को उसके डिफ़ॉल्ट पर ही रहने दें। Entra ID `preferred_username` प्रदान करता है, इसलिए Google गाइड वाले `email` override की यहाँ आवश्यकता नहीं है।
+
+issuer URL में हमेशा अपनी tenant ID का उपयोग करें, `common` या `organizations` का नहीं। वे multi-tenant endpoints अपने issuer के रूप में शाब्दिक template `{tenantid}` घोषित करते हैं, जो OIDC discovery validation में विफल हो जाता है।
+
+::: warning
+Entra ID का `preferred_username` user principal name को दर्शाता है, जो user का नाम बदलने या उसे किसी दूसरे tenant में ले जाने पर बदल जाता है। SnapOtter इस claim को केवल एक बार, पहली login पर पढ़ता है, इसलिए उसके बाद account का मूल username बना रहता है। दोनों ही स्थितियों में logins काम करते रहते हैं: लौटने वाले users का मिलान username से नहीं, बल्कि token के स्थिर subject से किया जाता है।
+:::
+
+Entra ID पर switch करने से password login बंद नहीं होता। [स्थानीय login को अक्षम करना](#disabling-local-login) देखें।
+
+### Okta और अन्य providers {#okta-and-other-providers}
+
+OIDC Discovery का समर्थन करने वाला कोई भी provider इसी तरह काम करता है: अपने callback URL के साथ एक confidential web client बनाएँ, फिर `OIDC_ISSUER_URL` को issuer पर इंगित करें। Okta के लिए, **OIDC - OpenID Connect** sign-in method और **Web Application** type के साथ एक app बनाएँ, फिर अपने Okta domain को issuer के रूप में उपयोग करें (उदा. `https://your-company.okta.com`)।
+
+SnapOtter identity provider groups को roles से map नहीं करता। नए SSO users को `OIDC_DEFAULT_ROLE` मिलती है, admins **Settings > Users** के अंतर्गत roles बदलते हैं, और `OIDC_SCOPES` के माध्यम से group claims का अनुरोध करने का कोई प्रभाव नहीं होता।
 
 ## User provisioning {#user-provisioning}
 

--- a/apps/docs/id/guide/oidc.md
+++ b/apps/docs/id/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "Siapkan Single Sign-On dengan OpenID Connect. Panduan langkah demi langkah untuk Keycloak, Authentik, Google, dan penyedia OIDC lainnya."
-i18n_source_hash: 4296343b3cc5
+description: "Siapkan Single Sign-On dengan OpenID Connect. Panduan langkah demi langkah untuk Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta, dan penyedia OIDC lainnya."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: 5e6d2a00ca73
 ---
 
 # OIDC / Single Sign-On {#oidc-single-sign-on}
 
-SnapOtter mendukung OpenID Connect (OIDC) untuk single sign-on. Pengguna dapat login dengan penyedia identitas eksternal seperti Keycloak, Authentik, atau Google alih-alih (atau bersama) autentikasi username/kata sandi lokal.
+SnapOtter mendukung OpenID Connect (OIDC) untuk single sign-on. Pengguna dapat login dengan penyedia identitas eksternal seperti Keycloak, Authentik, Google, atau Microsoft Entra ID alih-alih (atau bersama) autentikasi username/kata sandi lokal.
 
 ::: tip Lihat juga
 [SAML SSO](/id/guide/saml) | [Provisioning SCIM](/id/guide/scim) | [Pengguna, Peran & Izin](/id/guide/users-roles)
@@ -89,6 +89,29 @@ Misalnya, jika `EXTERNAL_URL` adalah `https://photos.example.com`, konfigurasika
 5. Salin **Client ID** dan **Client secret**.
 6. Setel `OIDC_ISSUER_URL` ke `https://accounts.google.com`.
 7. Setel `OIDC_USERNAME_CLAIM` ke `email` (Google tidak menyediakan `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. Di portal Azure, buka **Microsoft Entra ID > App registrations > New registration**.
+2. Beri nama aplikasi "SnapOtter". Di bawah **Redirect URI**, pilih platform **Web** dan masukkan URL callback Anda (mis. `https://photos.example.com/api/auth/oidc/callback`). Jangan pilih **Single-page application**: SnapOtter melakukan autentikasi dengan client secret, yang ditolak Entra ID pada registrasi SPA.
+3. Salin **Application (client) ID** dan **Directory (tenant) ID** dari halaman **Overview**.
+4. Buka **Certificates & secrets > New client secret** dan segera salin **Value** dari secret tersebut. Nilai ini hanya ditampilkan sekali, dan Secret ID di sebelahnya bukanlah secret-nya.
+5. Setel `OIDC_ISSUER_URL` ke `https://login.microsoftonline.com/<tenant-id>/v2.0`, menggunakan Directory (tenant) ID dari langkah 3.
+6. Biarkan `OIDC_USERNAME_CLAIM` pada nilai default-nya. Entra ID menyediakan `preferred_username`, jadi override `email` dari panduan Google tidak diperlukan di sini.
+
+Selalu gunakan tenant ID Anda di URL issuer, bukan `common` atau `organizations`. Endpoint multi-tenant tersebut mengiklankan templat literal `{tenantid}` sebagai issuer-nya, yang gagal dalam validasi OIDC discovery.
+
+::: warning
+`preferred_username` di Entra ID mengikuti user principal name, yang berubah saat pengguna diganti namanya atau dipindahkan ke tenant lain. SnapOtter membaca klaim ini sekali, saat login pertama, sehingga akun tetap memakai username aslinya setelah itu. Apa pun kondisinya, login tetap berfungsi: pengguna yang kembali dicocokkan berdasarkan subject stabil dari token, bukan berdasarkan username.
+:::
+
+Beralih ke Entra ID tidak mematikan login kata sandi. Lihat [Menonaktifkan login lokal](#disabling-local-login).
+
+### Okta dan penyedia lainnya {#okta-and-other-providers}
+
+Penyedia mana pun yang mendukung OIDC Discovery bekerja dengan cara yang sama: buat confidential web client dengan URL callback Anda, lalu arahkan `OIDC_ISSUER_URL` ke issuer. Untuk Okta, buat aplikasi dengan metode sign-in **OIDC - OpenID Connect** dan tipe **Web Application**, lalu gunakan domain Okta Anda sebagai issuer (mis. `https://your-company.okta.com`).
+
+SnapOtter tidak memetakan grup penyedia identitas ke peran. Pengguna SSO baru mendapatkan `OIDC_DEFAULT_ROLE`, admin mengubah peran di **Settings > Users**, dan meminta klaim grup melalui `OIDC_SCOPES` tidak berpengaruh.
 
 ## Provisioning pengguna {#user-provisioning}
 

--- a/apps/docs/it/guide/oidc.md
+++ b/apps/docs/it/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "Configura il Single Sign-On con OpenID Connect. Guide passo passo per Keycloak, Authentik, Google e altri provider OIDC."
-i18n_source_hash: 4296343b3cc5
+description: "Configura il Single Sign-On con OpenID Connect. Guide passo passo per Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta e altri provider OIDC."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: 7784e9aeafd3
 ---
 
 # OIDC / Single Sign-On {#oidc-single-sign-on}
 
-SnapOtter supporta OpenID Connect (OIDC) per il single sign-on. Gli utenti possono accedere con un provider di identità esterno come Keycloak, Authentik o Google invece dell'autenticazione locale con username/password (o in aggiunta a essa).
+SnapOtter supporta OpenID Connect (OIDC) per il single sign-on. Gli utenti possono accedere con un provider di identità esterno come Keycloak, Authentik, Google o Microsoft Entra ID invece dell'autenticazione locale con username/password (o in aggiunta a essa).
 
 ::: tip Vedi anche
 [SAML SSO](/it/guide/saml) | [Provisioning SCIM](/it/guide/scim) | [Utenti, ruoli e permessi](/it/guide/users-roles)
@@ -89,6 +89,29 @@ Ad esempio, se `EXTERNAL_URL` è `https://photos.example.com`, configura l'URI d
 5. Copia il **Client ID** e il **Client secret**.
 6. Imposta `OIDC_ISSUER_URL` su `https://accounts.google.com`.
 7. Imposta `OIDC_USERNAME_CLAIM` su `email` (Google non fornisce `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. Nel portale di Azure, vai su **Microsoft Entra ID > App registrations > New registration**.
+2. Assegna all'app il nome "SnapOtter". In **Redirect URI**, seleziona la piattaforma **Web** e inserisci il tuo URL di callback (es. `https://photos.example.com/api/auth/oidc/callback`). Non scegliere **Single-page application**: SnapOtter si autentica con un client secret, che Entra ID rifiuta sulle registrazioni SPA.
+3. Copia l'**Application (client) ID** e il **Directory (tenant) ID** dalla pagina **Overview**.
+4. Vai su **Certificates & secrets > New client secret** e copia subito il **Value** del segreto. Viene mostrato una sola volta, e il Secret ID lì accanto non è il segreto.
+5. Imposta `OIDC_ISSUER_URL` su `https://login.microsoftonline.com/<tenant-id>/v2.0`, usando il Directory (tenant) ID del passaggio 3.
+6. Lascia `OIDC_USERNAME_CLAIM` al valore predefinito. Entra ID fornisce `preferred_username`, quindi l'override con `email` della guida per Google qui non serve.
+
+Usa sempre il tuo tenant ID nell'URL dell'issuer, non `common` o `organizations`. Questi endpoint multi-tenant dichiarano come issuer il template letterale `{tenantid}`, che non supera la validazione di OIDC Discovery.
+
+::: warning
+Il claim `preferred_username` di Entra ID segue lo user principal name, che cambia quando un utente viene rinominato o spostato in un altro tenant. SnapOtter legge il claim una sola volta, al primo login, quindi in seguito l'account mantiene lo username originale. I login continuano comunque a funzionare: gli utenti che ritornano vengono riconosciuti tramite il subject stabile del token, non tramite lo username.
+:::
+
+Passare a Entra ID non disattiva il login con password. Vedi [Disattivazione del login locale](#disabling-local-login).
+
+### Okta e altri provider {#okta-and-other-providers}
+
+Qualsiasi provider che supporti OIDC Discovery funziona allo stesso modo: crea un client web confidenziale con il tuo URL di callback, poi fai puntare `OIDC_ISSUER_URL` all'issuer. Per Okta, crea un'app con il metodo di accesso **OIDC - OpenID Connect** e il tipo **Web Application**, poi usa il tuo dominio Okta come issuer (es. `https://your-company.okta.com`).
+
+SnapOtter non mappa i gruppi del provider di identità sui ruoli. I nuovi utenti SSO ricevono `OIDC_DEFAULT_ROLE`, gli amministratori cambiano i ruoli in **Settings > Users**, e richiedere i claim dei gruppi tramite `OIDC_SCOPES` non ha alcun effetto.
 
 ## Provisioning degli utenti {#user-provisioning}
 

--- a/apps/docs/ja/guide/oidc.md
+++ b/apps/docs/ja/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "OpenID Connect でシングルサインオンをセットアップします。Keycloak、Authentik、Google、その他の OIDC プロバイダー向けのステップバイステップガイド。"
-i18n_source_hash: 4296343b3cc5
+description: "OpenID Connect でシングルサインオンをセットアップします。Keycloak、Authentik、Google、Microsoft Entra ID (Azure AD)、Okta、その他の OIDC プロバイダー向けのステップバイステップガイド。"
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: dc7b9859ab34
 ---
 
 # OIDC / シングルサインオン {#oidc-single-sign-on}
 
-SnapOtter はシングルサインオンのために OpenID Connect (OIDC) をサポートしています。ユーザーは、ローカルのユーザー名/パスワード認証の代わりに（または併用して）、Keycloak、Authentik、Google などの外部 ID プロバイダーでログインできます。
+SnapOtter はシングルサインオンのために OpenID Connect (OIDC) をサポートしています。ユーザーは、ローカルのユーザー名/パスワード認証の代わりに（または併用して）、Keycloak、Authentik、Google、Microsoft Entra ID などの外部 ID プロバイダーでログインできます。
 
 ::: tip 関連項目
 [SAML SSO](/ja/guide/saml) | [SCIM プロビジョニング](/ja/guide/scim) | [ユーザー、ロール、権限](/ja/guide/users-roles)
@@ -89,6 +89,29 @@ ${EXTERNAL_URL}/api/auth/oidc/callback
 5. **Client ID** と **Client secret** をコピーします。
 6. `OIDC_ISSUER_URL` を `https://accounts.google.com` に設定します。
 7. `OIDC_USERNAME_CLAIM` を `email` に設定します（Google は `preferred_username` を提供しません）。
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. Azure ポータルで **Microsoft Entra ID > App registrations > New registration** に移動します。
+2. アプリに「SnapOtter」という名前を付けます。**Redirect URI** で **Web** プラットフォームを選択し、コールバック URL（例: `https://photos.example.com/api/auth/oidc/callback`）を入力します。**Single-page application** は選択しないでください。SnapOtter はクライアントシークレットで認証しますが、SPA として登録すると Entra ID がクライアントシークレットを拒否します。
+3. **Overview** ページから **Application (client) ID** と **Directory (tenant) ID** をコピーします。
+4. **Certificates & secrets > New client secret** に移動し、シークレットの **Value** をすぐにコピーします。この値は一度しか表示されず、隣にある Secret ID はシークレットではありません。
+5. ステップ 3 の Directory (tenant) ID を使用して、`OIDC_ISSUER_URL` を `https://login.microsoftonline.com/<tenant-id>/v2.0` に設定します。
+6. `OIDC_USERNAME_CLAIM` はデフォルトのままにします。Entra ID は `preferred_username` を提供するため、Google のガイドにある `email` への上書きはここでは不要です。
+
+発行者 URL には `common` や `organizations` ではなく、必ず自分のテナント ID を使用してください。これらのマルチテナントエンドポイントは、発行者としてリテラルのテンプレート `{tenantid}` を通知するため、OIDC ディスカバリーの検証に失敗します。
+
+::: warning
+Entra ID の `preferred_username` はユーザープリンシパル名に追従するため、ユーザーの名前が変更されたり別のテナントに移動されたりすると変わります。SnapOtter はこのクレームを初回ログイン時に一度だけ読み取るため、その後もアカウントは元のユーザー名を保持します。どちらの場合でもログインは引き続き機能します。再ログインするユーザーは、ユーザー名ではなくトークンの安定したサブジェクトによって照合されます。
+:::
+
+Entra ID に切り替えてもパスワードログインは無効になりません。[ローカルログインの無効化](#disabling-local-login) を参照してください。
+
+### Okta とその他のプロバイダー {#okta-and-other-providers}
+
+OIDC ディスカバリーをサポートするプロバイダーはどれも同じ方法で動作します。コールバック URL を設定した機密 Web クライアントを作成し、`OIDC_ISSUER_URL` を発行者に向けます。Okta の場合は、サインイン方法に **OIDC - OpenID Connect**、タイプに **Web Application** を指定してアプリを作成し、Okta ドメイン（例: `https://your-company.okta.com`）を発行者として使用します。
+
+SnapOtter は ID プロバイダーのグループをロールにマッピングしません。新規 SSO ユーザーには `OIDC_DEFAULT_ROLE` が割り当てられ、管理者は **Settings > Users** でロールを変更できます。`OIDC_SCOPES` でグループクレームを要求しても効果はありません。
 
 ## ユーザープロビジョニング {#user-provisioning}
 

--- a/apps/docs/ko/guide/oidc.md
+++ b/apps/docs/ko/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "OpenID Connect로 싱글 사인온을 설정하세요. Keycloak, Authentik, Google 및 기타 OIDC 공급자에 대한 단계별 가이드입니다."
-i18n_source_hash: 4296343b3cc5
+description: "OpenID Connect로 싱글 사인온을 설정하세요. Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta 및 기타 OIDC 공급자에 대한 단계별 가이드입니다."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: cb2481dcd32f
 ---
 
 # OIDC / Single Sign-On {#oidc-single-sign-on}
 
-SnapOtter는 싱글 사인온을 위해 OpenID Connect(OIDC)를 지원합니다. 사용자는 로컬 사용자 이름/비밀번호 인증 대신(또는 이와 함께) Keycloak, Authentik, Google과 같은 외부 ID 공급자로 로그인할 수 있습니다.
+SnapOtter는 싱글 사인온을 위해 OpenID Connect(OIDC)를 지원합니다. 사용자는 로컬 사용자 이름/비밀번호 인증 대신(또는 이와 함께) Keycloak, Authentik, Google, Microsoft Entra ID와 같은 외부 ID 공급자로 로그인할 수 있습니다.
 
 ::: tip 함께 참고하기
 [SAML SSO](/ko/guide/saml) | [SCIM Provisioning](/ko/guide/scim) | [Users, Roles & Permissions](/ko/guide/users-roles)
@@ -89,6 +89,29 @@ ${EXTERNAL_URL}/api/auth/oidc/callback
 5. **Client ID**와 **Client secret**을 복사합니다.
 6. `OIDC_ISSUER_URL`을 `https://accounts.google.com`로 설정합니다.
 7. `OIDC_USERNAME_CLAIM`을 `email`으로 설정합니다(Google은 `preferred_username`을 제공하지 않습니다).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. Azure 포털에서 **Microsoft Entra ID > App registrations > New registration**으로 이동합니다.
+2. 앱 이름을 "SnapOtter"로 지정합니다. **Redirect URI**에서 **Web** 플랫폼을 선택하고 콜백 URL을 입력합니다(예: `https://photos.example.com/api/auth/oidc/callback`). **Single-page application**을 선택하지 마세요. SnapOtter는 클라이언트 시크릿으로 인증하는데, Entra ID는 SPA 등록에서 이를 거부합니다.
+3. **Overview** 페이지에서 **Application (client) ID**와 **Directory (tenant) ID**를 복사합니다.
+4. **Certificates & secrets > New client secret**으로 이동하여 시크릿 **Value**를 바로 복사합니다. 이 값은 한 번만 표시되며, 옆에 있는 Secret ID는 시크릿이 아닙니다.
+5. 3단계에서 복사한 Directory (tenant) ID를 사용하여 `OIDC_ISSUER_URL`을 `https://login.microsoftonline.com/<tenant-id>/v2.0`으로 설정합니다.
+6. `OIDC_USERNAME_CLAIM`은 기본값 그대로 둡니다. Entra ID는 `preferred_username`을 제공하므로, Google 가이드의 `email` 재정의는 여기서 필요하지 않습니다.
+
+issuer URL에는 `common`이나 `organizations`가 아니라 항상 사용자의 테넌트 ID를 사용하세요. 이러한 멀티 테넌트 엔드포인트는 리터럴 템플릿 `{tenantid}`를 issuer로 제시하므로 OIDC discovery 검증에 실패합니다.
+
+::: warning
+Entra ID의 `preferred_username`은 사용자 프린시펄 이름(user principal name)을 따르며, 이 값은 사용자 이름이 변경되거나 사용자가 다른 테넌트로 이동할 때 바뀝니다. SnapOtter는 첫 로그인 시 이 클레임을 한 번만 읽으므로, 그 후에도 계정은 원래 사용자 이름을 유지합니다. 어느 쪽이든 로그인은 계속 동작합니다. 재방문 사용자는 사용자 이름이 아니라 토큰의 안정적인 subject로 매칭되기 때문입니다.
+:::
+
+Entra ID로 전환해도 비밀번호 로그인이 꺼지지 않습니다. [Disabling local login](#disabling-local-login)을 참고하세요.
+
+### Okta 및 기타 공급자 {#okta-and-other-providers}
+
+OIDC Discovery를 지원하는 공급자라면 어떤 것이든 같은 방식으로 동작합니다. 콜백 URL로 confidential 웹 클라이언트를 생성한 다음, `OIDC_ISSUER_URL`이 issuer를 가리키도록 하세요. Okta의 경우 **OIDC - OpenID Connect** 로그인 방식과 **Web Application** 유형으로 앱을 생성한 다음, Okta 도메인을 issuer로 사용하세요(예: `https://your-company.okta.com`).
+
+SnapOtter는 ID 공급자의 그룹을 역할에 매핑하지 않습니다. 새 SSO 사용자는 `OIDC_DEFAULT_ROLE`을 받고, 관리자는 **Settings > Users**에서 역할을 변경하며, `OIDC_SCOPES`를 통해 그룹 클레임을 요청해도 아무 효과가 없습니다.
 
 ## User provisioning {#user-provisioning}
 

--- a/apps/docs/nl/guide/oidc.md
+++ b/apps/docs/nl/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "Stel Single Sign-On in met OpenID Connect. Stapsgewijze handleidingen voor Keycloak, Authentik, Google en andere OIDC-providers."
-i18n_source_hash: 4296343b3cc5
+description: "Stel Single Sign-On in met OpenID Connect. Stapsgewijze handleidingen voor Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta en andere OIDC-providers."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: 82d34f4b3c9e
 ---
 
 # OIDC / Single Sign-On {#oidc-single-sign-on}
 
-SnapOtter ondersteunt OpenID Connect (OIDC) voor single sign-on. Gebruikers kunnen inloggen met een externe identiteitsprovider zoals Keycloak, Authentik of Google in plaats van (of naast) lokale authenticatie met gebruikersnaam/wachtwoord.
+SnapOtter ondersteunt OpenID Connect (OIDC) voor single sign-on. Gebruikers kunnen inloggen met een externe identiteitsprovider zoals Keycloak, Authentik, Google of Microsoft Entra ID in plaats van (of naast) lokale authenticatie met gebruikersnaam/wachtwoord.
 
 ::: tip Zie ook
 [SAML SSO](/nl/guide/saml) | [SCIM-provisioning](/nl/guide/scim) | [Gebruikers, rollen & rechten](/nl/guide/users-roles)
@@ -89,6 +89,29 @@ Als `EXTERNAL_URL` bijvoorbeeld `https://photos.example.com` is, configureer dan
 5. Kopieer de **Client ID** en het **Client secret**.
 6. Stel `OIDC_ISSUER_URL` in op `https://accounts.google.com`.
 7. Stel `OIDC_USERNAME_CLAIM` in op `email` (Google levert geen `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. Ga in de Azure-portal naar **Microsoft Entra ID > App registrations > New registration**.
+2. Geef de app de naam "SnapOtter". Selecteer onder **Redirect URI** het platform **Web** en voer je callback-URL in (bijv. `https://photos.example.com/api/auth/oidc/callback`). Kies niet voor **Single-page application**: SnapOtter authenticeert met een clientgeheim, en dat accepteert Entra ID niet bij SPA-registraties.
+3. Kopieer de **Application (client) ID** en de **Directory (tenant) ID** van de pagina **Overview**.
+4. Ga naar **Certificates & secrets > New client secret** en kopieer meteen de **Value** van het geheim. Deze wordt maar één keer getoond, en de Secret ID ernaast is niet het geheim.
+5. Stel `OIDC_ISSUER_URL` in op `https://login.microsoftonline.com/<tenant-id>/v2.0`, met de Directory (tenant) ID uit stap 3.
+6. Laat `OIDC_USERNAME_CLAIM` op de standaardwaarde staan. Entra ID levert `preferred_username`, dus de `email`-override uit de Google-handleiding is hier niet nodig.
+
+Gebruik in de issuer-URL altijd je tenant-ID, niet `common` of `organizations`. Die multi-tenant-endpoints geven de letterlijke template `{tenantid}` op als issuer, waardoor de OIDC-discovery-validatie mislukt.
+
+::: warning
+De `preferred_username` van Entra ID volgt de user principal name, die verandert wanneer een gebruiker wordt hernoemd of naar een andere tenant wordt verplaatst. SnapOtter leest de claim één keer uit, bij de eerste login, dus daarna behoudt het account zijn oorspronkelijke gebruikersnaam. Inloggen blijft hoe dan ook werken: terugkerende gebruikers worden gematcht op het stabiele subject van het token, niet op de gebruikersnaam.
+:::
+
+Overstappen op Entra ID schakelt wachtwoordlogin niet uit. Zie [Lokale login uitschakelen](#disabling-local-login).
+
+### Okta en andere providers {#okta-and-other-providers}
+
+Elke provider die OIDC Discovery ondersteunt werkt op dezelfde manier: maak een vertrouwelijke webclient aan met je callback-URL en verwijs `OIDC_ISSUER_URL` naar de issuer. Maak voor Okta een app aan met de aanmeldmethode **OIDC - OpenID Connect** en het type **Web Application**, en gebruik daarna je Okta-domein als issuer (bijv. `https://your-company.okta.com`).
+
+SnapOtter koppelt groepen van de identiteitsprovider niet aan rollen. Nieuwe SSO-gebruikers krijgen `OIDC_DEFAULT_ROLE`, beheerders wijzigen rollen onder **Settings > Users**, en het aanvragen van groepsclaims via `OIDC_SCOPES` heeft geen effect.
 
 ## Gebruikersprovisioning {#user-provisioning}
 

--- a/apps/docs/pl/guide/oidc.md
+++ b/apps/docs/pl/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "Skonfiguruj logowanie jednokrotne z OpenID Connect. Przewodniki krok po kroku dla Keycloak, Authentik, Google i innych dostawców OIDC."
-i18n_source_hash: 4296343b3cc5
+description: "Skonfiguruj logowanie jednokrotne z OpenID Connect. Przewodniki krok po kroku dla Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta i innych dostawców OIDC."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: 0a980a795fc3
 ---
 
 # OIDC / Logowanie jednokrotne {#oidc-single-sign-on}
 
-SnapOtter obsługuje OpenID Connect (OIDC) do logowania jednokrotnego. Użytkownicy mogą logować się za pomocą zewnętrznego dostawcy tożsamości, takiego jak Keycloak, Authentik czy Google, zamiast (lub obok) lokalnego uwierzytelniania nazwą użytkownika i hasłem.
+SnapOtter obsługuje OpenID Connect (OIDC) do logowania jednokrotnego. Użytkownicy mogą logować się za pomocą zewnętrznego dostawcy tożsamości, takiego jak Keycloak, Authentik, Google czy Microsoft Entra ID, zamiast (lub obok) lokalnego uwierzytelniania nazwą użytkownika i hasłem.
 
 ::: tip Zobacz też
 [SAML SSO](/pl/guide/saml) | [Provisioning SCIM](/pl/guide/scim) | [Użytkownicy, role i uprawnienia](/pl/guide/users-roles)
@@ -89,6 +89,29 @@ Na przykład, jeśli `EXTERNAL_URL` to `https://photos.example.com`, skonfiguruj
 5. Skopiuj **Client ID** oraz **Client secret**.
 6. Ustaw `OIDC_ISSUER_URL` na `https://accounts.google.com`.
 7. Ustaw `OIDC_USERNAME_CLAIM` na `email` (Google nie udostępnia `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. W portalu Azure przejdź do **Microsoft Entra ID > App registrations > New registration**.
+2. Nazwij aplikację „SnapOtter”. W sekcji **Redirect URI** wybierz platformę **Web** i wpisz swój adres URL wywołania zwrotnego (np. `https://photos.example.com/api/auth/oidc/callback`). Nie wybieraj opcji **Single-page application**: SnapOtter uwierzytelnia się za pomocą sekretu klienta, który Entra ID odrzuca przy rejestracjach SPA.
+3. Skopiuj **Application (client) ID** oraz **Directory (tenant) ID** ze strony **Overview**.
+4. Przejdź do **Certificates & secrets > New client secret** i od razu skopiuj **Value** sekretu. Wartość jest wyświetlana tylko raz, a widoczny obok Secret ID nie jest sekretem.
+5. Ustaw `OIDC_ISSUER_URL` na `https://login.microsoftonline.com/<tenant-id>/v2.0`, używając Directory (tenant) ID z kroku 3.
+6. Pozostaw `OIDC_USERNAME_CLAIM` z wartością domyślną. Entra ID udostępnia `preferred_username`, więc nadpisanie wartością `email` z przewodnika Google nie jest tu potrzebne.
+
+W URL-u wydawcy zawsze używaj identyfikatora swojego tenanta, a nie `common` ani `organizations`. Te wielodostępne (multi-tenant) punkty końcowe ogłaszają jako wydawcę dosłowny szablon `{tenantid}`, co powoduje niepowodzenie walidacji OIDC Discovery.
+
+::: warning
+Oświadczenie `preferred_username` w Entra ID odzwierciedla główną nazwę użytkownika (user principal name), która zmienia się, gdy użytkownik zostanie przemianowany lub przeniesiony do innego tenanta. SnapOtter odczytuje to oświadczenie tylko raz, przy pierwszym logowaniu, więc konto zachowuje potem swoją pierwotną nazwę użytkownika. Logowanie działa jednak nadal: powracający użytkownicy są dopasowywani po stabilnym identyfikatorze podmiotu (subject) z tokenu, a nie po nazwie użytkownika.
+:::
+
+Przejście na Entra ID nie wyłącza logowania hasłem. Zobacz [Wyłączanie logowania lokalnego](#disabling-local-login).
+
+### Okta i inni dostawcy {#okta-and-other-providers}
+
+Każdy dostawca obsługujący OIDC Discovery działa w ten sam sposób: utwórz poufnego klienta typu web ze swoim adresem URL wywołania zwrotnego, a następnie wskaż w `OIDC_ISSUER_URL` wydawcę. W przypadku Okta utwórz aplikację z metodą logowania **OIDC - OpenID Connect** i typem **Web Application**, a następnie użyj swojej domeny Okta jako wydawcy (np. `https://your-company.okta.com`).
+
+SnapOtter nie mapuje grup dostawcy tożsamości na role. Nowi użytkownicy SSO otrzymują rolę `OIDC_DEFAULT_ROLE`, administratorzy zmieniają role w **Settings > Users**, a żądanie oświadczeń o grupach przez `OIDC_SCOPES` nie ma żadnego efektu.
 
 ## Provisioning użytkowników {#user-provisioning}
 

--- a/apps/docs/pt-BR/guide/oidc.md
+++ b/apps/docs/pt-BR/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "Configure o Single Sign-On com OpenID Connect. Guias passo a passo para Keycloak, Authentik, Google e outros provedores OIDC."
-i18n_source_hash: 4296343b3cc5
+description: "Configure o Single Sign-On com OpenID Connect. Guias passo a passo para Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta e outros provedores OIDC."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: d91e31e0728d
 ---
 
 # OIDC / Single Sign-On {#oidc-single-sign-on}
 
-O SnapOtter oferece suporte a OpenID Connect (OIDC) para single sign-on. Os usuários podem fazer login com um provedor de identidade externo, como Keycloak, Authentik ou Google, em vez de (ou junto com) a autenticação local por usuário/senha.
+O SnapOtter oferece suporte a OpenID Connect (OIDC) para single sign-on. Os usuários podem fazer login com um provedor de identidade externo, como Keycloak, Authentik, Google ou Microsoft Entra ID, em vez de (ou junto com) a autenticação local por usuário/senha.
 
 ::: tip Veja também
 [SAML SSO](/pt-BR/guide/saml) | [Provisionamento SCIM](/pt-BR/guide/scim) | [Usuários, Papéis e Permissões](/pt-BR/guide/users-roles)
@@ -89,6 +89,29 @@ Por exemplo, se `EXTERNAL_URL` for `https://photos.example.com`, configure a URI
 5. Copie o **Client ID** e o **Client secret**.
 6. Defina `OIDC_ISSUER_URL` como `https://accounts.google.com`.
 7. Defina `OIDC_USERNAME_CLAIM` como `email` (o Google não fornece `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. No portal do Azure, vá para **Microsoft Entra ID > App registrations > New registration**.
+2. Nomeie o aplicativo como "SnapOtter". Em **Redirect URI**, selecione a plataforma **Web** e informe sua URL de callback (por exemplo, `https://photos.example.com/api/auth/oidc/callback`). Não escolha **Single-page application**: o SnapOtter se autentica com um segredo de cliente, que o Entra ID rejeita em registros SPA.
+3. Copie o **Application (client) ID** e o **Directory (tenant) ID** da página **Overview**.
+4. Vá para **Certificates & secrets > New client secret** e copie imediatamente o **Value** do segredo. Ele é exibido apenas uma vez, e o Secret ID ao lado não é o segredo.
+5. Defina `OIDC_ISSUER_URL` como `https://login.microsoftonline.com/<tenant-id>/v2.0`, usando o Directory (tenant) ID da etapa 3.
+6. Deixe `OIDC_USERNAME_CLAIM` no valor padrão. O Entra ID fornece `preferred_username`, então a substituição por `email` do guia do Google não é necessária aqui.
+
+Sempre use o ID do seu tenant na URL do issuer, não `common` nem `organizations`. Esses endpoints multi-tenant anunciam o template literal `{tenantid}` como issuer, o que falha na validação do OIDC Discovery.
+
+::: warning
+O `preferred_username` do Entra ID acompanha o user principal name, que muda quando um usuário é renomeado ou movido para outro tenant. O SnapOtter lê a claim uma única vez, no primeiro login, então a conta mantém seu nome de usuário original depois disso. Os logins continuam funcionando de qualquer maneira: usuários recorrentes são identificados pelo subject estável do token, não pelo nome de usuário.
+:::
+
+Mudar para o Entra ID não desativa o login por senha. Veja [Desabilitando o login local](#disabling-local-login).
+
+### Okta e outros provedores {#okta-and-other-providers}
+
+Qualquer provedor que ofereça suporte a OIDC Discovery funciona da mesma maneira: crie um cliente web confidencial com sua URL de callback e aponte `OIDC_ISSUER_URL` para o issuer. No Okta, crie um aplicativo com o método de login **OIDC - OpenID Connect** e o tipo **Web Application** e, em seguida, use seu domínio Okta como issuer (por exemplo, `https://your-company.okta.com`).
+
+O SnapOtter não mapeia grupos do provedor de identidade para papéis. Novos usuários SSO recebem `OIDC_DEFAULT_ROLE`, os administradores alteram os papéis em **Settings > Users**, e solicitar claims de grupo via `OIDC_SCOPES` não tem efeito.
 
 ## Provisionamento de usuários {#user-provisioning}
 

--- a/apps/docs/ru/guide/oidc.md
+++ b/apps/docs/ru/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "Настройте единый вход через OpenID Connect. Пошаговые руководства для Keycloak, Authentik, Google и других провайдеров OIDC."
-i18n_source_hash: 4296343b3cc5
+description: "Настройте единый вход через OpenID Connect. Пошаговые руководства для Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta и других провайдеров OIDC."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: 30c887791088
 ---
 
 # OIDC / Единый вход {#oidc-single-sign-on}
 
-SnapOtter поддерживает OpenID Connect (OIDC) для единого входа. Пользователи могут входить с помощью внешнего поставщика удостоверений, такого как Keycloak, Authentik или Google, вместо (или наряду с) локальной аутентификации по имени пользователя и паролю.
+SnapOtter поддерживает OpenID Connect (OIDC) для единого входа. Пользователи могут входить с помощью внешнего поставщика удостоверений, такого как Keycloak, Authentik, Google или Microsoft Entra ID, вместо (или наряду с) локальной аутентификации по имени пользователя и паролю.
 
 ::: tip См. также
 [SAML SSO](/ru/guide/saml) | [Провижининг SCIM](/ru/guide/scim) | [Пользователи, роли и права доступа](/ru/guide/users-roles)
@@ -89,6 +89,29 @@ ${EXTERNAL_URL}/api/auth/oidc/callback
 5. Скопируйте **Client ID** и **Client secret**.
 6. Задайте `OIDC_ISSUER_URL` равным `https://accounts.google.com`.
 7. Задайте `OIDC_USERNAME_CLAIM` равным `email` (Google не предоставляет `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. На портале Azure перейдите в **Microsoft Entra ID > App registrations > New registration**.
+2. Назовите приложение «SnapOtter». В разделе **Redirect URI** выберите платформу **Web** и введите ваш callback URL (например, `https://photos.example.com/api/auth/oidc/callback`). Не выбирайте **Single-page application**: SnapOtter аутентифицируется с помощью секрета клиента, который Entra ID отклоняет для SPA-регистраций.
+3. Скопируйте **Application (client) ID** и **Directory (tenant) ID** со страницы **Overview**.
+4. Перейдите в **Certificates & secrets > New client secret** и сразу скопируйте **Value** секрета. Оно показывается только один раз, а соседний Secret ID не является секретом.
+5. Задайте `OIDC_ISSUER_URL` равным `https://login.microsoftonline.com/<tenant-id>/v2.0`, используя Directory (tenant) ID из шага 3.
+6. Оставьте `OIDC_USERNAME_CLAIM` со значением по умолчанию. Entra ID предоставляет `preferred_username`, поэтому переопределение на `email` из руководства по Google здесь не требуется.
+
+Всегда используйте в URL издателя идентификатор вашего тенанта, а не `common` или `organizations`. Эти мультитенантные конечные точки объявляют своим издателем буквальный шаблон `{tenantid}`, который не проходит проверку OIDC Discovery.
+
+::: warning
+Клейм `preferred_username` в Entra ID отражает имя участника-пользователя (user principal name), которое меняется при переименовании пользователя или его переносе в другой тенант. SnapOtter читает этот клейм один раз, при первом входе, поэтому учётная запись затем сохраняет исходное имя пользователя. Вход при этом продолжает работать: возвращающиеся пользователи сопоставляются по стабильному субъекту токена, а не по имени пользователя.
+:::
+
+Переход на Entra ID не отключает вход по паролю. См. [Отключение локального входа](#disabling-local-login).
+
+### Okta и другие провайдеры {#okta-and-other-providers}
+
+Любой провайдер с поддержкой OIDC Discovery работает так же: создайте конфиденциальный веб-клиент с вашим callback URL, затем укажите в `OIDC_ISSUER_URL` издателя. Для Okta создайте приложение с методом входа **OIDC - OpenID Connect** и типом **Web Application**, затем используйте ваш домен Okta в качестве издателя (например, `https://your-company.okta.com`).
+
+SnapOtter не сопоставляет группы поставщика удостоверений с ролями. Новые пользователи SSO получают `OIDC_DEFAULT_ROLE`, администраторы меняют роли в разделе **Settings > Users**, а запрос клеймов групп через `OIDC_SCOPES` не имеет эффекта.
 
 ## Провижининг пользователей {#user-provisioning}
 

--- a/apps/docs/sv/guide/oidc.md
+++ b/apps/docs/sv/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "Konfigurera Single Sign-On med OpenID Connect. Steg-för-steg-guider för Keycloak, Authentik, Google och andra OIDC-leverantörer."
-i18n_source_hash: 4296343b3cc5
+description: "Konfigurera Single Sign-On med OpenID Connect. Steg-för-steg-guider för Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta och andra OIDC-leverantörer."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: b3ed5df413a2
 ---
 
 # OIDC / Single Sign-On {#oidc-single-sign-on}
 
-SnapOtter stöder OpenID Connect (OIDC) för single sign-on. Användare kan logga in med en extern identitetsleverantör som Keycloak, Authentik eller Google i stället för (eller vid sidan av) lokal autentisering med användarnamn/lösenord.
+SnapOtter stöder OpenID Connect (OIDC) för single sign-on. Användare kan logga in med en extern identitetsleverantör som Keycloak, Authentik, Google eller Microsoft Entra ID i stället för (eller vid sidan av) lokal autentisering med användarnamn/lösenord.
 
 ::: tip Se även
 [SAML SSO](/sv/guide/saml) | [SCIM-provisionering](/sv/guide/scim) | [Användare, roller och behörigheter](/sv/guide/users-roles)
@@ -89,6 +89,29 @@ Om till exempel `EXTERNAL_URL` är `https://photos.example.com`, konfigurerar du
 5. Kopiera **Client ID** och **Client secret**.
 6. Sätt `OIDC_ISSUER_URL` till `https://accounts.google.com`.
 7. Sätt `OIDC_USERNAME_CLAIM` till `email` (Google tillhandahåller inte `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. I Azure-portalen, gå till **Microsoft Entra ID > App registrations > New registration**.
+2. Ge appen namnet "SnapOtter". Under **Redirect URI**, välj plattformen **Web** och ange din callback-URL (t.ex. `https://photos.example.com/api/auth/oidc/callback`). Välj inte **Single-page application**: SnapOtter autentiserar med en klienthemlighet, vilket Entra ID avvisar för SPA-registreringar.
+3. Kopiera **Application (client) ID** och **Directory (tenant) ID** från sidan **Overview**.
+4. Gå till **Certificates & secrets > New client secret** och kopiera hemlighetens **Value** direkt. Den visas bara en gång, och det intilliggande Secret ID är inte hemligheten.
+5. Sätt `OIDC_ISSUER_URL` till `https://login.microsoftonline.com/<tenant-id>/v2.0` med Directory (tenant) ID från steg 3.
+6. Låt `OIDC_USERNAME_CLAIM` behålla sitt standardvärde. Entra ID tillhandahåller `preferred_username`, så `email`-överstyrningen från Google-guiden behövs inte här.
+
+Använd alltid ditt tenant-ID i issuer-URL:en, inte `common` eller `organizations`. Dessa multi-tenant-endpoints annonserar den bokstavliga mallen `{tenantid}` som sin issuer, vilket får OIDC Discovery-valideringen att misslyckas.
+
+::: warning
+Entra ID:s `preferred_username` följer användarens user principal name, som ändras när en användare byter namn eller flyttas till en annan tenant. SnapOtter läser claimen en gång, vid första inloggningen, så kontot behåller sitt ursprungliga användarnamn efteråt. Inloggningar fortsätter att fungera oavsett: återkommande användare matchas via tokenens stabila subject, inte via användarnamnet.
+:::
+
+Att byta till Entra ID inaktiverar inte lösenordsinloggning. Se [Inaktivera lokal inloggning](#disabling-local-login).
+
+### Okta och andra leverantörer {#okta-and-other-providers}
+
+Alla leverantörer som stöder OIDC Discovery fungerar på samma sätt: skapa en konfidentiell webbklient med din callback-URL och peka sedan `OIDC_ISSUER_URL` mot issuern. För Okta skapar du en app med inloggningsmetoden **OIDC - OpenID Connect** och typen **Web Application**, och använder sedan din Okta-domän som issuer (t.ex. `https://your-company.okta.com`).
+
+SnapOtter mappar inte identitetsleverantörens grupper till roller. Nya SSO-användare får `OIDC_DEFAULT_ROLE`, administratörer ändrar roller under **Settings > Users**, och att begära grupp-claims via `OIDC_SCOPES` har ingen effekt.
 
 ## Användarprovisionering {#user-provisioning}
 

--- a/apps/docs/th/guide/oidc.md
+++ b/apps/docs/th/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "ตั้งค่า Single Sign-On ด้วย OpenID Connect คู่มือทีละขั้นตอนสำหรับ Keycloak, Authentik, Google และผู้ให้บริการ OIDC อื่น ๆ"
-i18n_source_hash: 4296343b3cc5
+description: "ตั้งค่า Single Sign-On ด้วย OpenID Connect คู่มือทีละขั้นตอนสำหรับ Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta และผู้ให้บริการ OIDC อื่น ๆ"
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: cf303e97a8f0
 ---
 
 # OIDC / Single Sign-On {#oidc-single-sign-on}
 
-SnapOtter รองรับ OpenID Connect (OIDC) สำหรับ single sign-on ผู้ใช้สามารถเข้าสู่ระบบด้วยผู้ให้บริการข้อมูลประจำตัวภายนอกอย่าง Keycloak, Authentik หรือ Google แทน (หรือควบคู่ไปกับ) การยืนยันตัวตนด้วยชื่อผู้ใช้/รหัสผ่านในเครื่อง
+SnapOtter รองรับ OpenID Connect (OIDC) สำหรับ single sign-on ผู้ใช้สามารถเข้าสู่ระบบด้วยผู้ให้บริการข้อมูลประจำตัวภายนอกอย่าง Keycloak, Authentik, Google หรือ Microsoft Entra ID แทน (หรือควบคู่ไปกับ) การยืนยันตัวตนด้วยชื่อผู้ใช้/รหัสผ่านในเครื่อง
 
 ::: tip ดูเพิ่มเติม
 [SAML SSO](/th/guide/saml) | [SCIM Provisioning](/th/guide/scim) | [ผู้ใช้ บทบาท และสิทธิ์](/th/guide/users-roles)
@@ -89,6 +89,29 @@ ${EXTERNAL_URL}/api/auth/oidc/callback
 5. คัดลอก **Client ID** และ **Client secret**
 6. ตั้งค่า `OIDC_ISSUER_URL` เป็น `https://accounts.google.com`
 7. ตั้งค่า `OIDC_USERNAME_CLAIM` เป็น `email` (Google ไม่ให้ `preferred_username`)
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. ในพอร์ทัล Azure ไปที่ **Microsoft Entra ID > App registrations > New registration**
+2. ตั้งชื่อแอปว่า "SnapOtter" ใต้ **Redirect URI** ให้เลือกแพลตฟอร์ม **Web** และป้อน callback URL ของคุณ (เช่น `https://photos.example.com/api/auth/oidc/callback`) อย่าเลือก **Single-page application** เพราะ SnapOtter ยืนยันตัวตนด้วย client secret ซึ่ง Entra ID ไม่ยอมรับสำหรับการลงทะเบียนแบบ SPA
+3. คัดลอก **Application (client) ID** และ **Directory (tenant) ID** จากหน้า **Overview**
+4. ไปที่ **Certificates & secrets > New client secret** และคัดลอก **Value** ของ secret ทันที ค่านี้แสดงเพียงครั้งเดียว และ Secret ID ที่อยู่ข้าง ๆ ไม่ใช่ตัว secret
+5. ตั้งค่า `OIDC_ISSUER_URL` เป็น `https://login.microsoftonline.com/<tenant-id>/v2.0` โดยใช้ Directory (tenant) ID จากขั้นตอนที่ 3
+6. ปล่อย `OIDC_USERNAME_CLAIM` ไว้ที่ค่าเริ่มต้น Entra ID ให้ `preferred_username` มาอยู่แล้ว จึงไม่ต้องตั้งค่าทับเป็น `email` แบบในคู่มือ Google
+
+ใช้ tenant ID ของคุณใน issuer URL เสมอ ไม่ใช่ `common` หรือ `organizations` เพราะ endpoint แบบ multi-tenant เหล่านั้นประกาศเทมเพลตตามตัวอักษร `{tenantid}` เป็น issuer ซึ่งทำให้การตรวจสอบ OIDC discovery ล้มเหลว
+
+::: warning
+`preferred_username` ของ Entra ID อิงตาม user principal name ซึ่งจะเปลี่ยนเมื่อผู้ใช้ถูกเปลี่ยนชื่อหรือถูกย้ายไปยัง tenant อื่น SnapOtter อ่าน claim นี้เพียงครั้งเดียวตอนเข้าสู่ระบบครั้งแรก บัญชีจึงคงชื่อผู้ใช้เดิมไว้หลังจากนั้น การเข้าสู่ระบบยังใช้งานได้ในทุกกรณี เพราะผู้ใช้ที่กลับมาจะถูกจับคู่ด้วย subject ที่คงที่ของ token ไม่ใช่ด้วยชื่อผู้ใช้
+:::
+
+การเปลี่ยนไปใช้ Entra ID ไม่ปิดการเข้าสู่ระบบด้วยรหัสผ่าน ดู [การปิดการเข้าสู่ระบบในเครื่อง](#disabling-local-login)
+
+### Okta และผู้ให้บริการอื่น ๆ {#okta-and-other-providers}
+
+ผู้ให้บริการรายใดก็ตามที่รองรับ OIDC Discovery ใช้งานได้ในแบบเดียวกัน: สร้าง web client แบบ confidential พร้อม callback URL ของคุณ แล้วชี้ `OIDC_ISSUER_URL` ไปที่ issuer สำหรับ Okta ให้สร้างแอปด้วยวิธีเข้าสู่ระบบ **OIDC - OpenID Connect** และประเภท **Web Application** จากนั้นใช้โดเมน Okta ของคุณเป็น issuer (เช่น `https://your-company.okta.com`)
+
+SnapOtter ไม่จับคู่กลุ่มจากผู้ให้บริการข้อมูลประจำตัวเข้ากับบทบาท ผู้ใช้ SSO ใหม่จะได้รับ `OIDC_DEFAULT_ROLE` ผู้ดูแลระบบเปลี่ยนบทบาทได้ที่ **Settings > Users** และการร้องขอ claim ของกลุ่มผ่าน `OIDC_SCOPES` ไม่มีผล
 
 ## การจัดสรรผู้ใช้ {#user-provisioning}
 

--- a/apps/docs/tr/guide/oidc.md
+++ b/apps/docs/tr/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "OpenID Connect ile Çoklu Oturum Açma kurulumu yapın. Keycloak, Authentik, Google ve diğer OIDC sağlayıcıları için adım adım kılavuzlar."
-i18n_source_hash: 4296343b3cc5
+description: "OpenID Connect ile Çoklu Oturum Açma kurulumu yapın. Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta ve diğer OIDC sağlayıcıları için adım adım kılavuzlar."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: d14739acc1c3
 ---
 
 # OIDC / Çoklu Oturum Açma {#oidc-single-sign-on}
 
-SnapOtter, çoklu oturum açma için OpenID Connect (OIDC) desteği sunar. Kullanıcılar, yerel kullanıcı adı/parola kimlik doğrulaması yerine (veya bununla birlikte) Keycloak, Authentik veya Google gibi harici bir kimlik sağlayıcıyla oturum açabilir.
+SnapOtter, çoklu oturum açma için OpenID Connect (OIDC) desteği sunar. Kullanıcılar, yerel kullanıcı adı/parola kimlik doğrulaması yerine (veya bununla birlikte) Keycloak, Authentik, Google veya Microsoft Entra ID gibi harici bir kimlik sağlayıcıyla oturum açabilir.
 
 ::: tip Ayrıca bkz.
 [SAML SSO](/tr/guide/saml) | [SCIM Sağlama](/tr/guide/scim) | [Kullanıcılar, Roller ve İzinler](/tr/guide/users-roles)
@@ -89,6 +89,29 @@ ${EXTERNAL_URL}/api/auth/oidc/callback
 5. **Client ID** ve **Client secret** öğelerini kopyalayın.
 6. `OIDC_ISSUER_URL` değerini `https://accounts.google.com` olarak ayarlayın.
 7. `OIDC_USERNAME_CLAIM` değerini `email` olarak ayarlayın (Google `preferred_username` sağlamaz).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. Azure portalında, **Microsoft Entra ID > App registrations > New registration** bölümüne gidin.
+2. Uygulamaya "SnapOtter" adını verin. **Redirect URI** altında **Web** platformunu seçin ve geri çağırma URL'nizi girin (örn. `https://photos.example.com/api/auth/oidc/callback`). **Single-page application** seçeneğini seçmeyin: SnapOtter, bir istemci gizli anahtarıyla kimlik doğrulaması yapar ve Entra ID bunu SPA kayıtlarında reddeder.
+3. **Overview** sayfasından **Application (client) ID** ve **Directory (tenant) ID** değerlerini kopyalayın.
+4. **Certificates & secrets > New client secret** bölümüne gidin ve gizli anahtarın **Value** değerini hemen kopyalayın. Yalnızca bir kez gösterilir ve hemen yanındaki Secret ID gizli anahtar değildir.
+5. `OIDC_ISSUER_URL` değerini, 3. adımdaki Directory (tenant) ID değerini kullanarak `https://login.microsoftonline.com/<tenant-id>/v2.0` olarak ayarlayın.
+6. `OIDC_USERNAME_CLAIM` değerini varsayılanında bırakın. Entra ID `preferred_username` sağladığından, Google kılavuzundaki `email` geçersiz kılması burada gerekli değildir.
+
+Veren URL'sinde her zaman kiracı kimliğinizi kullanın, `common` veya `organizations` kullanmayın. Bu çok kiracılı uç noktalar, veren olarak birebir `{tenantid}` şablonunu bildirir ve bu da OIDC keşif doğrulamasının başarısız olmasına neden olur.
+
+::: warning
+Entra ID'nin `preferred_username` istemi, kullanıcı yeniden adlandırıldığında veya başka bir kiracıya taşındığında değişen kullanıcı asıl adını (user principal name) izler. SnapOtter bu istemi yalnızca bir kez, ilk oturum açmada okur; bu nedenle hesap daha sonra özgün kullanıcı adını korur. Oturum açma her iki durumda da çalışmaya devam eder: geri dönen kullanıcılar, kullanıcı adına göre değil, token'daki sabit konu (subject) değerine göre eşleştirilir.
+:::
+
+Entra ID'ye geçmek parolayla oturum açmayı kapatmaz. [Yerel oturum açmayı devre dışı bırakma](#disabling-local-login) bölümüne bakın.
+
+### Okta ve diğer sağlayıcılar {#okta-and-other-providers}
+
+OIDC Discovery destekleyen her sağlayıcı aynı şekilde çalışır: geri çağırma URL'nizle gizli (confidential) bir web istemcisi oluşturun, ardından `OIDC_ISSUER_URL` değerini verene (issuer) yönlendirin. Okta için, **OIDC - OpenID Connect** oturum açma yöntemini ve **Web Application** türünü kullanan bir uygulama oluşturun, ardından veren olarak Okta alan adınızı kullanın (örn. `https://your-company.okta.com`).
+
+SnapOtter, kimlik sağlayıcı gruplarını rollere eşlemez. Yeni SSO kullanıcıları `OIDC_DEFAULT_ROLE` rolünü alır, yöneticiler rolleri **Settings > Users** altından değiştirir ve `OIDC_SCOPES` aracılığıyla grup istemleri talep etmenin bir etkisi yoktur.
 
 ## Kullanıcı sağlama {#user-provisioning}
 

--- a/apps/docs/uk/guide/oidc.md
+++ b/apps/docs/uk/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "Налаштуйте єдиний вхід за допомогою OpenID Connect. Покрокові інструкції для Keycloak, Authentik, Google та інших постачальників OIDC."
-i18n_source_hash: 4296343b3cc5
+description: "Налаштуйте єдиний вхід за допомогою OpenID Connect. Покрокові інструкції для Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta та інших постачальників OIDC."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: e4ed1e4c58ab
 ---
 
 # OIDC / Єдиний вхід {#oidc-single-sign-on}
 
-SnapOtter підтримує OpenID Connect (OIDC) для єдиного входу. Користувачі можуть входити через зовнішнього постачальника ідентифікації, такого як Keycloak, Authentik чи Google, замість (або разом із) локальної автентифікації за іменем користувача та паролем.
+SnapOtter підтримує OpenID Connect (OIDC) для єдиного входу. Користувачі можуть входити через зовнішнього постачальника ідентифікації, такого як Keycloak, Authentik, Google чи Microsoft Entra ID, замість (або разом із) локальної автентифікації за іменем користувача та паролем.
 
 ::: tip Дивіться також
 [SAML SSO](/uk/guide/saml) | [Провізіювання SCIM](/uk/guide/scim) | [Користувачі, ролі та дозволи](/uk/guide/users-roles)
@@ -89,6 +89,29 @@ ${EXTERNAL_URL}/api/auth/oidc/callback
 5. Скопіюйте **Client ID** та **Client secret**.
 6. Встановіть `OIDC_ISSUER_URL` на `https://accounts.google.com`.
 7. Встановіть `OIDC_USERNAME_CLAIM` на `email` (Google не надає `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. На порталі Azure перейдіть до **Microsoft Entra ID > App registrations > New registration**.
+2. Назвіть застосунок "SnapOtter". У розділі **Redirect URI** виберіть платформу **Web** і введіть ваш URL зворотного виклику (наприклад, `https://photos.example.com/api/auth/oidc/callback`). Не вибирайте **Single-page application**: SnapOtter автентифікується за допомогою секрету клієнта, який Entra ID відхиляє для SPA-реєстрацій.
+3. Скопіюйте **Application (client) ID** та **Directory (tenant) ID** зі сторінки **Overview**.
+4. Перейдіть до **Certificates & secrets > New client secret** і одразу скопіюйте **Value** секрету. Значення показується лише один раз, а розташований поруч Secret ID не є секретом.
+5. Встановіть `OIDC_ISSUER_URL` на `https://login.microsoftonline.com/<tenant-id>/v2.0`, використовуючи Directory (tenant) ID із кроку 3.
+6. Залиште `OIDC_USERNAME_CLAIM` зі значенням за замовчуванням. Entra ID надає `preferred_username`, тому перевизначення `email` з інструкції для Google тут не потрібне.
+
+Завжди використовуйте в URL емітента ID вашого tenant, а не `common` чи `organizations`. Ці багатоорендні кінцеві точки оголошують буквальний шаблон `{tenantid}` як свого емітента, що не проходить перевірку OIDC Discovery.
+
+::: warning
+Претензія `preferred_username` в Entra ID відстежує ім'я учасника-користувача (user principal name), яке змінюється, коли користувача перейменовують або переносять до іншого tenant. SnapOtter зчитує претензію лише один раз, під час першого входу, тому обліковий запис надалі зберігає своє початкове ім'я користувача. Вхід у будь-якому разі продовжує працювати: користувачів, що повертаються, зіставляють за стабільним subject токена, а не за іменем користувача.
+:::
+
+Перехід на Entra ID не вимикає вхід за паролем. Див. [Вимкнення локального входу](#disabling-local-login).
+
+### Okta та інші постачальники {#okta-and-other-providers}
+
+Будь-який постачальник, що підтримує OIDC Discovery, працює так само: створіть конфіденційний веб-клієнт із вашим URL зворотного виклику, а потім вкажіть в `OIDC_ISSUER_URL` емітента. Для Okta створіть застосунок із методом входу **OIDC - OpenID Connect** і типом **Web Application**, а потім використайте ваш домен Okta як емітента (наприклад, `https://your-company.okta.com`).
+
+SnapOtter не зіставляє групи постачальника ідентифікації з ролями. Нові користувачі SSO отримують `OIDC_DEFAULT_ROLE`, адміністратори змінюють ролі в розділі **Settings > Users**, а запит претензій груп через `OIDC_SCOPES` не має ефекту.
 
 ## Провізіювання користувачів {#user-provisioning}
 

--- a/apps/docs/vi/guide/oidc.md
+++ b/apps/docs/vi/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "Thiết lập Đăng nhập một lần với OpenID Connect. Hướng dẫn từng bước cho Keycloak, Authentik, Google và các nhà cung cấp OIDC khác."
-i18n_source_hash: 4296343b3cc5
+description: "Thiết lập Đăng nhập một lần với OpenID Connect. Hướng dẫn từng bước cho Keycloak, Authentik, Google, Microsoft Entra ID (Azure AD), Okta và các nhà cung cấp OIDC khác."
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: 9a052c1bf9c8
 ---
 
 # OIDC / Đăng nhập một lần {#oidc-single-sign-on}
 
-SnapOtter hỗ trợ OpenID Connect (OIDC) cho đăng nhập một lần. Người dùng có thể đăng nhập bằng nhà cung cấp danh tính bên ngoài như Keycloak, Authentik hoặc Google thay cho (hoặc song song với) xác thực bằng tên đăng nhập/mật khẩu cục bộ.
+SnapOtter hỗ trợ OpenID Connect (OIDC) cho đăng nhập một lần. Người dùng có thể đăng nhập bằng nhà cung cấp danh tính bên ngoài như Keycloak, Authentik, Google hoặc Microsoft Entra ID thay cho (hoặc song song với) xác thực bằng tên đăng nhập/mật khẩu cục bộ.
 
 ::: tip Xem thêm
 [SAML SSO](/vi/guide/saml) | [Cấp phát SCIM](/vi/guide/scim) | [Người dùng, Vai trò & Quyền](/vi/guide/users-roles)
@@ -89,6 +89,29 @@ Ví dụ, nếu `EXTERNAL_URL` là `https://photos.example.com`, hãy cấu hìn
 5. Sao chép **Client ID** và **Client secret**.
 6. Đặt `OIDC_ISSUER_URL` thành `https://accounts.google.com`.
 7. Đặt `OIDC_USERNAME_CLAIM` thành `email` (Google không cung cấp `preferred_username`).
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. Trong Azure portal, vào **Microsoft Entra ID > App registrations > New registration**.
+2. Đặt tên ứng dụng là "SnapOtter". Ở mục **Redirect URI**, chọn nền tảng **Web** và nhập callback URL của bạn (ví dụ `https://photos.example.com/api/auth/oidc/callback`). Đừng chọn **Single-page application**: SnapOtter xác thực bằng client secret, thứ mà Entra ID từ chối trên các đăng ký SPA.
+3. Sao chép **Application (client) ID** và **Directory (tenant) ID** từ trang **Overview**.
+4. Vào **Certificates & secrets > New client secret** và sao chép ngay **Value** của secret. Giá trị này chỉ hiển thị một lần, và Secret ID nằm bên cạnh không phải là secret.
+5. Đặt `OIDC_ISSUER_URL` thành `https://login.microsoftonline.com/<tenant-id>/v2.0`, dùng Directory (tenant) ID từ bước 3.
+6. Giữ `OIDC_USERNAME_CLAIM` ở giá trị mặc định. Entra ID cung cấp `preferred_username`, nên ở đây không cần dùng cách ghi đè thành `email` như trong hướng dẫn cho Google.
+
+Luôn dùng tenant ID của bạn trong issuer URL, không dùng `common` hay `organizations`. Các endpoint đa tenant đó công bố nguyên văn chuỗi mẫu `{tenantid}` làm issuer, khiến bước xác thực OIDC discovery thất bại.
+
+::: warning
+`preferred_username` của Entra ID bám theo user principal name, giá trị này thay đổi khi người dùng bị đổi tên hoặc được chuyển sang tenant khác. SnapOtter chỉ đọc claim này một lần, tại lần đăng nhập đầu tiên, nên sau đó tài khoản giữ nguyên tên đăng nhập ban đầu. Dù thế nào thì việc đăng nhập vẫn hoạt động: người dùng quay lại được khớp bằng subject ổn định của token, chứ không phải bằng tên đăng nhập.
+:::
+
+Chuyển sang Entra ID không tắt đăng nhập bằng mật khẩu. Xem [Tắt đăng nhập cục bộ](#disabling-local-login).
+
+### Okta và các nhà cung cấp khác {#okta-and-other-providers}
+
+Bất kỳ nhà cung cấp nào hỗ trợ OIDC Discovery đều hoạt động theo cùng một cách: tạo một confidential web client với callback URL của bạn, rồi trỏ `OIDC_ISSUER_URL` đến issuer. Với Okta, tạo một ứng dụng với phương thức đăng nhập **OIDC - OpenID Connect** và loại **Web Application**, rồi dùng miền Okta của bạn làm issuer (ví dụ `https://your-company.okta.com`).
+
+SnapOtter không ánh xạ các nhóm của nhà cung cấp danh tính sang vai trò. Người dùng SSO mới nhận `OIDC_DEFAULT_ROLE`, admin thay đổi vai trò trong **Settings > Users**, và việc yêu cầu các claim nhóm qua `OIDC_SCOPES` không có tác dụng.
 
 ## Cấp phát người dùng {#user-provisioning}
 

--- a/apps/docs/zh-CN/guide/oidc.md
+++ b/apps/docs/zh-CN/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "使用 OpenID Connect 设置单点登录。提供 Keycloak、Authentik、Google 及其他 OIDC 提供商的分步指南。"
-i18n_source_hash: 4296343b3cc5
+description: "使用 OpenID Connect 设置单点登录。提供 Keycloak、Authentik、Google、Microsoft Entra ID (Azure AD)、Okta 及其他 OIDC 提供商的分步指南。"
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: 57678911503c
 ---
 
 # OIDC / 单点登录 {#oidc-single-sign-on}
 
-SnapOtter 支持使用 OpenID Connect（OIDC）进行单点登录。用户可以使用 Keycloak、Authentik 或 Google 等外部身份提供商登录，作为本地用户名/密码认证的替代方案（或与之并存）。
+SnapOtter 支持使用 OpenID Connect（OIDC）进行单点登录。用户可以使用 Keycloak、Authentik、Google 或 Microsoft Entra ID 等外部身份提供商登录，作为本地用户名/密码认证的替代方案（或与之并存）。
 
 ::: tip 另请参阅
 [SAML SSO](/zh-CN/guide/saml) | [SCIM 预置](/zh-CN/guide/scim) | [用户、角色与权限](/zh-CN/guide/users-roles)
@@ -89,6 +89,29 @@ ${EXTERNAL_URL}/api/auth/oidc/callback
 5. 复制 **Client ID** 和 **Client secret**。
 6. 将 `OIDC_ISSUER_URL` 设置为 `https://accounts.google.com`。
 7. 将 `OIDC_USERNAME_CLAIM` 设置为 `email`（Google 不提供 `preferred_username`）。
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. 在 Azure 门户中，进入 **Microsoft Entra ID > App registrations > New registration**。
+2. 将应用命名为“SnapOtter”。在 **Redirect URI** 下，选择 **Web** 平台并输入你的回调 URL（例如 `https://photos.example.com/api/auth/oidc/callback`）。不要选择 **Single-page application**：SnapOtter 使用客户端密钥进行认证，而 Entra ID 不接受 SPA 注册使用客户端密钥。
+3. 从 **Overview** 页面复制 **Application (client) ID** 和 **Directory (tenant) ID**。
+4. 进入 **Certificates & secrets > New client secret**，并立即复制密钥的 **Value**。该值只显示一次，旁边的 Secret ID 并不是密钥。
+5. 将 `OIDC_ISSUER_URL` 设置为 `https://login.microsoftonline.com/<tenant-id>/v2.0`，其中使用第 3 步中的 Directory (tenant) ID。
+6. 保持 `OIDC_USERNAME_CLAIM` 为默认值。Entra ID 提供 `preferred_username`，因此这里不需要 Google 指南中的 `email` 覆盖设置。
+
+在 issuer URL 中请始终使用你的租户 ID，而不是 `common` 或 `organizations`。这些多租户端点会将字面模板 `{tenantid}` 作为其 issuer 公布，这会导致 OIDC 发现验证失败。
+
+::: warning
+Entra ID 的 `preferred_username` 跟随用户主体名称，当用户被重命名或迁移到其他租户时该名称会改变。SnapOtter 只在首次登录时读取一次该声明，因此账户之后会保留其原始用户名。无论哪种情况，登录都能正常进行：回访用户通过令牌中稳定的 subject 进行匹配，而不是通过用户名。
+:::
+
+切换到 Entra ID 不会关闭密码登录。请参阅[禁用本地登录](#disabling-local-login)。
+
+### Okta 及其他提供商 {#okta-and-other-providers}
+
+任何支持 OIDC Discovery 的提供商都以同样的方式工作：使用你的回调 URL 创建一个保密型 Web 客户端，然后将 `OIDC_ISSUER_URL` 指向该 issuer。对于 Okta，创建一个使用 **OIDC - OpenID Connect** 登录方式和 **Web Application** 类型的应用，然后使用你的 Okta 域名作为 issuer（例如 `https://your-company.okta.com`）。
+
+SnapOtter 不会将身份提供商的组映射为角色。新的 SSO 用户会获得 `OIDC_DEFAULT_ROLE`，管理员可在 **Settings > Users** 下更改角色，通过 `OIDC_SCOPES` 请求组声明没有任何效果。
 
 ## 用户预置 {#user-provisioning}
 

--- a/apps/docs/zh-TW/guide/oidc.md
+++ b/apps/docs/zh-TW/guide/oidc.md
@@ -1,13 +1,13 @@
 ---
-description: "使用 OpenID Connect 設定單一登入。針對 Keycloak、Authentik、Google 及其他 OIDC 供應商的逐步指南。"
-i18n_source_hash: 4296343b3cc5
+description: "使用 OpenID Connect 設定單一登入。針對 Keycloak、Authentik、Google、Microsoft Entra ID（Azure AD）、Okta 及其他 OIDC 供應商的逐步指南。"
+i18n_source_hash: 438fff2ba4c6
 i18n_provenance: human
 i18n_output_hash: 0f8707e9765e
 ---
 
 # OIDC / 單一登入 {#oidc-single-sign-on}
 
-SnapOtter 支援 OpenID Connect（OIDC）進行單一登入。使用者可以透過外部身分供應商（例如 Keycloak、Authentik 或 Google）登入，取代本機使用者名稱／密碼驗證（或與之並用）。
+SnapOtter 支援 OpenID Connect（OIDC）進行單一登入。使用者可以透過外部身分供應商（例如 Keycloak、Authentik、Google 或 Microsoft Entra ID）登入，取代本機使用者名稱／密碼驗證（或與之並用）。
 
 ::: tip 另請參閱
 [SAML SSO](/zh-TW/guide/saml) | [SCIM 佈建](/zh-TW/guide/scim) | [使用者、角色與權限](/zh-TW/guide/users-roles)
@@ -89,6 +89,29 @@ ${EXTERNAL_URL}/api/auth/oidc/callback
 5. 複製 **Client ID** 與 **Client secret**。
 6. 將 `OIDC_ISSUER_URL` 設為 `https://accounts.google.com`。
 7. 將 `OIDC_USERNAME_CLAIM` 設為 `email`（Google 不提供 `preferred_username`）。
+
+### Azure AD / Entra ID {#azure-ad-entra-id}
+
+1. 在 Azure 入口網站中，前往 **Microsoft Entra ID > App registrations > New registration**。
+2. 將應用程式命名為「SnapOtter」。在 **Redirect URI** 下，選擇 **Web** 平台並輸入你的回呼 URL（例如 `https://photos.example.com/api/auth/oidc/callback`）。請勿選擇 **Single-page application**：SnapOtter 以用戶端密鑰進行驗證，而 Entra ID 在 SPA 註冊上會拒絕這種方式。
+3. 從 **Overview** 頁面複製 **Application (client) ID** 與 **Directory (tenant) ID**。
+4. 前往 **Certificates & secrets > New client secret**，並立即複製密鑰的 **Value**。它只會顯示一次，而旁邊的 Secret ID 並不是密鑰。
+5. 將 `OIDC_ISSUER_URL` 設為 `https://login.microsoftonline.com/<tenant-id>/v2.0`，使用步驟 3 中的 Directory (tenant) ID。
+6. 將 `OIDC_USERNAME_CLAIM` 保留為預設值。Entra ID 會提供 `preferred_username`，因此這裡不需要 Google 指南中的 `email` 覆寫。
+
+簽發者 URL 中請一律使用你的租用戶 ID，而不是 `common` 或 `organizations`。這些多租用戶端點會把字面上的範本 `{tenantid}` 公告為其簽發者，因而無法通過 OIDC Discovery 驗證。
+
+::: warning
+Entra ID 的 `preferred_username` 對應使用者主體名稱（user principal name），當使用者被重新命名或移轉到其他租用戶時，這個名稱會跟著改變。SnapOtter 只會在首次登入時讀取一次此宣告，因此帳號之後仍會保留原本的使用者名稱。無論哪種情況，登入都能持續運作：回訪的使用者是以權杖中穩定的 subject 比對，而不是使用者名稱。
+:::
+
+切換到 Entra ID 並不會關閉密碼登入。請參閱 [停用本機登入](#disabling-local-login)。
+
+### Okta 與其他供應商 {#okta-and-other-providers}
+
+任何支援 OIDC Discovery 的供應商運作方式都相同：建立一個機密（confidential）Web 用戶端並填入你的回呼 URL，然後將 `OIDC_ISSUER_URL` 指向其簽發者。對於 Okta，請建立一個使用 **OIDC - OpenID Connect** 登入方法與 **Web Application** 類型的應用程式，然後使用你的 Okta 網域作為簽發者（例如 `https://your-company.okta.com`）。
+
+SnapOtter 不會將身分供應商的群組對應到角色。新的 SSO 使用者會取得 `OIDC_DEFAULT_ROLE`，管理員可在 **Settings > Users** 下變更角色，而透過 `OIDC_SCOPES` 要求群組宣告不會有任何效果。
 
 ## 使用者佈建 {#user-provisioning}
 

--- a/tests/unit/infra/docs-oidc-providers.test.ts
+++ b/tests/unit/infra/docs-oidc-providers.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The pricing copy sells OIDC as working with "Google, Okta, any provider", and
+ * OIDC is ungated (apps/api/src/plugins/oidc.ts). But for a long time the only
+ * documented Entra ID path was the enterprise SAML guide, so Entra admins
+ * concluded SSO needed a paid license (#921). This pins the free OIDC guide to
+ * the providers the public copy names, under the anchors other pages link to.
+ */
+
+const ROOT = path.resolve(__dirname, "../../..");
+const GUIDE = readFileSync(path.join(ROOT, "apps/docs/guide/oidc.md"), "utf8");
+
+describe("OIDC guide provider coverage", () => {
+  it("documents Entra ID under the same anchor the SAML guide uses", () => {
+    expect(GUIDE).toMatch(/^### Azure AD \/ Entra ID \{#azure-ad-entra-id\}$/m);
+  });
+
+  it("gives the tenant-scoped issuer URL, the only form that passes discovery", () => {
+    // The multi-tenant `common`/`organizations` endpoints advertise the literal
+    // template {tenantid} as their issuer, which openid-client rejects.
+    expect(GUIDE).toContain("https://login.microsoftonline.com/<tenant-id>/v2.0");
+  });
+
+  it("names Entra ID in the frontmatter description search engines show", () => {
+    const description = GUIDE.match(/^description: (.*)$/m)?.[1] ?? "";
+    expect(description).toContain("Entra ID");
+  });
+
+  it("mentions Okta, which the free-tier pricing copy names explicitly", () => {
+    expect(GUIDE).toContain("Okta");
+  });
+});


### PR DESCRIPTION
Closes #921.

The OIDC guide documented Keycloak, Authentik, and Google. Entra ID appeared only in the SAML and SCIM guides, both enterprise-gated, so a self-hoster searching the docs for Entra concluded SSO needed a paid license. OIDC is ungated (`apps/api/src/plugins/oidc.ts` has no enterprise check) and works fine with Entra; it was only undocumented.

What's here:

- An Azure AD / Entra ID walkthrough in the same shape as the Google section: Web-platform app registration, client secret, tenant-scoped issuer. It says explicitly to keep `OIDC_USERNAME_CLAIM` at its default, since Entra provides `preferred_username` and pasting Google's `email` override makes usernames worse.
- The issuer warning from the issue, verified against the live endpoints before writing it down: `common` and `organizations` really do advertise the literal `{tenantid}` template as their issuer, which openid-client v6 rejects. A real tenant returns a concrete issuer.
- A short "Okta and other providers" section instead of a full Okta walkthrough (issue decision 1: landing copy names Okta, and a sentence beats a stub that never gets written). It also answers decision 2 out loud: SnapOtter doesn't map IdP groups to roles, so requesting group claims does nothing.
- The page description now names Entra ID and Okta. That string is what search engines show for the page.
- `tests/unit/infra/docs-oidc-providers.test.ts` pins the guide to the providers the public copy advertises. Written red first: all 4 assertions failed before the edit.
- The section carried into all 20 locale copies of `guide/oidc.md`.

On the translations: `pnpm i18n:translate` exports nothing for this file, because every locale copy carries `i18n_provenance: human` (stamped by the bulk translation commit 4963ab3b, the only commit that ever touched them) and `collectPending()` keeps human-stamped text when the English source moves. Overriding that guard wholesale is the deliberate pass #882 tracks, not this PR. So the second commit uses the targeted per-passage recipe from PR #580: one translator pass per locale over just the inserted block and the two provider-list lines, bumping `i18n_source_hash` to the value `i18n:check` reported and leaving `i18n_provenance` / `i18n_output_hash` untouched. The rest of each file's translation stays byte-identical.

Verified: `pnpm vitest run tests/unit/infra/docs-oidc-providers.test.ts` (4/4, red before the edit), `pnpm vitest run tests/unit/infra/` (286/286), `pnpm lint`, `pnpm typecheck`, `biome check` on the new test file, `pnpm i18n:check` (back to the 320 pre-existing stale entries from #882, 0 missing, no `guide/oidc.md` lines), the full 21-locale VitePress build (93s), and a diff-scope check that the only i18n frontmatter change across the 20 locale files is the source-hash bump, with anchors and code spans grep-verified byte-for-byte in every locale.