### PR TITLE
fix(doc-engine,ai): keep MuPDF damage noise off the docs JSON channel and classify it as user input

### DIFF
--- a/packages/ai/python/doc_flatten.py
+++ b/packages/ai/python/doc_flatten.py
@@ -11,6 +11,20 @@ def main():
         print(json.dumps({"error": "missing path/out"}))
         sys.exit(1)
     try:
+        # PyMuPDF's message system writes to sys.stdout by default, and MuPDF
+        # damage diagnostics ("error: cannot find object in xref (14 0 R)")
+        # are routed through it. This stdout is a one-JSON-line protocol; keep
+        # library messages on stderr (#843/#898, Sentry NODE-5M/NODE-60).
+        # Redirect before importing fitz so the alias deprecation notice lands
+        # on stderr too.
+        import pymupdf
+
+        pymupdf.set_messages(stream=sys.stderr)
+    except Exception as exc:  # noqa: BLE001
+        # Degraded mode: MuPDF noise will share the JSON channel. Leave a
+        # breadcrumb on stderr so the failed redirect is visible in bridge logs.
+        print(f"[doc_flatten] pymupdf message redirect unavailable: {exc}", file=sys.stderr)
+    try:
         import fitz
     except ImportError:
         print(json.dumps({"error": "PyMuPDF not installed"}))

--- a/packages/ai/python/doc_redact.py
+++ b/packages/ai/python/doc_redact.py
@@ -19,6 +19,20 @@ def main():
         print(json.dumps({"error": "missing path/out/terms"}))
         sys.exit(1)
     try:
+        # PyMuPDF's message system writes to sys.stdout by default, and MuPDF
+        # damage diagnostics ("error: cannot find object in xref (14 0 R)")
+        # are routed through it. This stdout is a one-JSON-line protocol; keep
+        # library messages on stderr (#843/#898, Sentry NODE-5M/NODE-60).
+        # Redirect before importing fitz so the alias deprecation notice lands
+        # on stderr too.
+        import pymupdf
+
+        pymupdf.set_messages(stream=sys.stderr)
+    except Exception as exc:  # noqa: BLE001
+        # Degraded mode: MuPDF noise will share the JSON channel. Leave a
+        # breadcrumb on stderr so the failed redirect is visible in bridge logs.
+        print(f"[doc_redact] pymupdf message redirect unavailable: {exc}", file=sys.stderr)
+    try:
         import fitz
     except ImportError:
         print(json.dumps({"error": "PyMuPDF not installed"}))

--- a/packages/ai/python/doc_scrub_meta.py
+++ b/packages/ai/python/doc_scrub_meta.py
@@ -15,6 +15,20 @@ def main():
         print(json.dumps({"error": "missing path/out"}))
         sys.exit(1)
     try:
+        # PyMuPDF's message system writes to sys.stdout by default, and MuPDF
+        # damage diagnostics ("error: cannot find object in xref (14 0 R)")
+        # are routed through it. This stdout is a one-JSON-line protocol; keep
+        # library messages on stderr (#843/#898, Sentry NODE-5M/NODE-60).
+        # Redirect before importing fitz so the alias deprecation notice lands
+        # on stderr too.
+        import pymupdf
+
+        pymupdf.set_messages(stream=sys.stderr)
+    except Exception as exc:  # noqa: BLE001
+        # Degraded mode: MuPDF noise will share the JSON channel. Leave a
+        # breadcrumb on stderr so the failed redirect is visible in bridge logs.
+        print(f"[doc_scrub_meta] pymupdf message redirect unavailable: {exc}", file=sys.stderr)
+    try:
         import fitz
     except ImportError:
         print(json.dumps({"error": "PyMuPDF not installed"}))

--- a/packages/ai/python/doc_sign.py
+++ b/packages/ai/python/doc_sign.py
@@ -18,6 +18,20 @@ def main():
         print(json.dumps({"error": "missing input/output/placements"}))
         sys.exit(1)
     try:
+        # PyMuPDF's message system writes to sys.stdout by default, and MuPDF
+        # damage diagnostics ("error: cannot find object in xref (14 0 R)")
+        # are routed through it. This stdout is a one-JSON-line protocol; keep
+        # library messages on stderr (#843/#898, Sentry NODE-5M/NODE-60).
+        # Redirect before importing fitz so the alias deprecation notice lands
+        # on stderr too.
+        import pymupdf
+
+        pymupdf.set_messages(stream=sys.stderr)
+    except Exception as exc:  # noqa: BLE001
+        # Degraded mode: MuPDF noise will share the JSON channel. Leave a
+        # breadcrumb on stderr so the failed redirect is visible in bridge logs.
+        print(f"[doc_sign] pymupdf message redirect unavailable: {exc}", file=sys.stderr)
+    try:
         import fitz
     except ImportError:
         print(json.dumps({"error": "PyMuPDF not installed"}))

--- a/packages/ai/python/doc_text.py
+++ b/packages/ai/python/doc_text.py
@@ -10,6 +10,20 @@ def main():
         print(json.dumps({"error": "missing path/out"}))
         sys.exit(1)
     try:
+        # PyMuPDF's message system writes to sys.stdout by default, and MuPDF
+        # damage diagnostics ("error: cannot find object in xref (14 0 R)")
+        # are routed through it. This stdout is a one-JSON-line protocol; keep
+        # library messages on stderr (#843/#898, Sentry NODE-5M/NODE-60).
+        # Redirect before importing fitz so the alias deprecation notice lands
+        # on stderr too.
+        import pymupdf
+
+        pymupdf.set_messages(stream=sys.stderr)
+    except Exception as exc:  # noqa: BLE001
+        # Degraded mode: MuPDF noise will share the JSON channel. Leave a
+        # breadcrumb on stderr so the failed redirect is visible in bridge logs.
+        print(f"[doc_text] pymupdf message redirect unavailable: {exc}", file=sys.stderr)
+    try:
         import fitz
     except ImportError:
         print(json.dumps({"error": "PyMuPDF not installed"}))

--- a/packages/doc-engine/src/python-docs.ts
+++ b/packages/doc-engine/src/python-docs.ts
@@ -1,5 +1,18 @@
 import { runDocsScript } from "@snapotter/ai";
-import { SafeError, type SignPlacement } from "@snapotter/shared";
+import { SafeError, type SignPlacement, ToolInputError } from "@snapotter/shared";
+
+/**
+ * MuPDF's printer reports document damage as prefixed lines on the stream the
+ * scripts should have redirected to stderr ("error:" / "warning:", or "MuPDF
+ * error:" on newer releases): "error: cannot find object in xref (14 0 R)",
+ * "MuPDF error: syntax error: invalid key in dict". When such lines reach the
+ * JSON channel and nothing on it parses, the input PDF is broken (it passed
+ * `qpdf --check` only via recovery, exit 3), not our code (#898, NODE-60).
+ * The prefix requirement keeps Python tracebacks that merely mention these
+ * words classified as bugs.
+ */
+const MUPDF_DAMAGE_NOISE =
+  /(?:^|\n)(?:MuPDF error:|error:|warning:).*(?:xref|syntax error|format error|repair|corrupt|page tree)/i;
 
 /**
  * Parse the JSON line the docs dispatcher prints on stdout. Every doc_* script
@@ -28,6 +41,17 @@ function parseDocsJson<T>(script: string, stdout: string): T {
       } catch {
         // fall through to the earlier lines
       }
+    }
+    if (MUPDF_DAMAGE_NOISE.test(trimmed)) {
+      // Expected-class errors never reach Sentry or the worker's error log, so
+      // keep the raw output on the cause: it is the only artifact left to
+      // check when the classification itself is in question.
+      throw Object.assign(
+        new ToolInputError(
+          "This PDF is damaged (the PDF engine reported broken document structure). Run it through the Repair PDF tool, then try again.",
+        ),
+        { cause: new Error(`${script} stdout (first 200 chars): ${trimmed.slice(0, 200)}`) },
+      );
     }
     throw new SafeError("Document tool returned non-JSON output", {
       kind: "bug",

--- a/tests/unit/doc-engine/pymupdf-message-redirect.test.ts
+++ b/tests/unit/doc-engine/pymupdf-message-redirect.test.ts
@@ -1,0 +1,41 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * PyMuPDF's message system writes MuPDF's C-level diagnostics ("error: cannot
+ * find object in xref (14 0 R)") to sys.stdout by default. The docs sidecar's
+ * stdout is a one-JSON-line protocol, so any script that drives PyMuPDF must
+ * redirect those messages to stderr or a damaged PDF corrupts the JSON channel
+ * and a user-input problem surfaces as "Document tool returned non-JSON
+ * output" tagged as a code bug (#898, Sentry NODE-60; pattern from #843/#859).
+ */
+const PYTHON_DIR = path.resolve(__dirname, "../../../packages/ai/python");
+// pdf2docx drives MuPDF internally, so scripts that only import pdf2docx need
+// the redirect too (doc_to_word.py, the #843 incident). `from X import Y`
+// counts the same as `import X`.
+const IMPORTS_PYMUPDF = /^\s*(?:import|from) (?:fitz|pymupdf|pdf2docx)\b/m;
+const REDIRECT_MARKER = "set_messages(stream=sys.stderr)";
+// Only entrypoints own process-level stream config; helper modules (e.g.
+// pdf2docx_layout.py) run under an entrypoint that already redirected.
+const IS_ENTRYPOINT = /if __name__ == "__main__":/;
+
+describe("PyMuPDF docs scripts keep MuPDF diagnostics off the JSON stdout channel", () => {
+  const scripts = readdirSync(PYTHON_DIR).filter((f) => f.endsWith(".py"));
+  const pymupdfScripts = scripts.filter((f) => {
+    const src = readFileSync(path.join(PYTHON_DIR, f), "utf8");
+    return IS_ENTRYPOINT.test(src) && IMPORTS_PYMUPDF.test(src);
+  });
+
+  it("finds the PyMuPDF-driven scripts (guards against the directory moving)", () => {
+    expect(pymupdfScripts).toContain("doc_redact.py");
+    expect(pymupdfScripts).toContain("doc_to_word.py");
+  });
+
+  it("every script importing fitz/pymupdf redirects MuPDF messages to stderr", () => {
+    const missingRedirect = pymupdfScripts.filter(
+      (f) => !readFileSync(path.join(PYTHON_DIR, f), "utf8").includes(REDIRECT_MARKER),
+    );
+    expect(missingRedirect).toEqual([]);
+  });
+});

--- a/tests/unit/doc-engine/python-docs-parse.test.ts
+++ b/tests/unit/doc-engine/python-docs-parse.test.ts
@@ -6,7 +6,7 @@ vi.mock("@snapotter/ai", () => ({
   runDocsScript: (...args: unknown[]) => runDocsScript(...args),
 }));
 
-import { isSafeMessageError } from "@snapotter/shared";
+import { isSafeMessageError, isToolInputError } from "@snapotter/shared";
 import {
   pdfPageCountPy,
   pdfRedactPy,
@@ -80,6 +80,102 @@ describe("python-docs sidecar JSON parsing", () => {
     expect(text).toContain("Traceback");
     // And it identifies which script produced it.
     expect(text).toContain("doc_redact");
+  });
+
+  // A damaged PDF (broken xref) passes the qpdf pre-check (exit 3 = recovered
+  // with warnings) and reaches the worker, where MuPDF's printer floods stdout
+  // with damage diagnostics. That is a user-input problem, not a code bug:
+  // it must classify as ToolInputError (error_class=expected, never Sentry),
+  // not SafeError kind:"bug" (issue #898, Sentry NODE-60).
+  it("classifies MuPDF xref damage noise as a user input error, not a bug", async () => {
+    runDocsScript.mockResolvedValue(
+      "error: cannot find object in xref (14 0 R)\n" + "error: cannot find object in xref (14 0 R)",
+    );
+
+    let caught: unknown;
+    try {
+      await pdfRedactPy("/in.pdf", "/out.pdf", ["secret"], false);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(isToolInputError(caught)).toBe(true);
+    expect(isSafeMessageError(caught)).toBe(false);
+    // The user gets an actionable pointer at the repair path.
+    expect((caught as Error).message).toContain("Repair PDF");
+    // The raw MuPDF output survives on the cause for local triage, mirroring
+    // the SafeError branch; without it a misclassification is unfalsifiable.
+    expect(String(((caught as Error).cause as Error)?.message)).toContain(
+      "cannot find object in xref",
+    );
+  });
+
+  // Ordering guard: the salvage walk must run BEFORE the damage classifier.
+  // MuPDF repairs many PDFs and completes the job while still printing damage
+  // lines; if the classifier ever moves ahead of the walk, every recovered
+  // PDF starts failing with "damaged" and NODE-5M comes back via the new path.
+  it("still salvages the JSON line when damage noise precedes it", async () => {
+    runDocsScript.mockResolvedValue(
+      'error: cannot find object in xref (14 0 R)\n{"found": 2, "verified": true}',
+    );
+    await expect(pdfRedactPy("/in.pdf", "/out.pdf", ["secret"], false)).resolves.toEqual({
+      found: 2,
+    });
+  });
+
+  it("classifies warning-prefixed repair noise as a user input error too", async () => {
+    runDocsScript.mockResolvedValue(
+      "warning: repairing PDF document\n" +
+        "warning: trying to repair broken xref\n" +
+        '{"found": ',
+    );
+
+    let caught: unknown;
+    try {
+      await pdfRedactPy("/in.pdf", "/out.pdf", ["secret"], false);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(isToolInputError(caught)).toBe(true);
+  });
+
+  it("classifies interleave-corrupted JSON with MuPDF damage noise as input error", async () => {
+    // Modern PyMuPDF prefixes the printer lines with "MuPDF error:"; a mid-line
+    // interleave can corrupt the JSON line itself so no line parses at all.
+    runDocsScript.mockResolvedValue(
+      "MuPDF error: syntax error: invalid key in dict\n" +
+        "MuPDF error: format error: non-page object in page tree\n" +
+        '{"found": MuPDF error: syntax error: invalid key in dict\n0}',
+    );
+
+    let caught: unknown;
+    try {
+      await pdfRedactPy("/in.pdf", "/out.pdf", ["secret"], false);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(isToolInputError(caught)).toBe(true);
+  });
+
+  it("keeps damage keywords without a MuPDF printer prefix classified as a bug", async () => {
+    // A Python traceback that merely mentions xref is not the MuPDF printer;
+    // it must stay a diagnosable bug, not silently become an input error.
+    runDocsScript.mockResolvedValue(
+      'Traceback (most recent call last):\n  File "doc_redact.py", line 27\n' +
+        "RuntimeError: internal xref cache invariant violated",
+    );
+
+    let caught: unknown;
+    try {
+      await pdfRedactPy("/in.pdf", "/out.pdf", ["secret"], false);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(isToolInputError(caught)).toBe(false);
+    expect(isSafeMessageError(caught)).toBe(true);
   });
 
   it("guards every helper, not only redact", async () => {


### PR DESCRIPTION
Closes #898.

A damaged PDF was reaching Sentry as our bug. A broken-xref file passes `qpdf --check` (exit 3, recovered with warnings), then MuPDF's C-level printer floods the docs sidecar's one-JSON-line stdout protocol with lines like `error: cannot find object in xref (14 0 R)`. `parseDocsJson` gives up and throws `SafeError kind "bug"`, which stamps `error_class=bug` and escalates on retry: NODE-60 was 10 events in 18 seconds from one user.

Reproduced live before writing the fix: a crafted broken-xref PDF run through `doc_redact.py` put about 50 MuPDF error lines on stdout, stderr empty.

Two layers, as the issue laid out:

- The five PyMuPDF entrypoints that lacked the #859 redirect (`doc_redact`, `doc_text`, `doc_flatten`, `doc_sign`, `doc_scrub_meta`) now call the guarded `pymupdf.set_messages(stream=sys.stderr)` before importing fitz, so damage diagnostics and the fitz deprecation notice land on stderr. If the redirect is unavailable (old pymupdf), the script prints a `[doc_*]` breadcrumb to stderr instead of degrading silently; the bridge forwards those lines to the Node logger.
- `parseDocsJson` classifies the terminal no-JSON case: when the noise matches MuPDF's printer signature (line-start `error:`, `warning:`, or `MuPDF error:` plus a damage keyword such as xref, syntax error, repair, page tree), it throws `ToolInputError` pointing the user at the Repair PDF tool, with the raw stdout excerpt kept on the cause. `ToolInputError` maps to `error_class=expected` and never reaches Sentry. Anything else keeps the existing `SafeError kind "bug"` path, so unrecognized failures still report.

Per the issue's call: no auto-repair (silently rewriting a document that's being redacted for privacy is worse than asking the user to repair it first) and no change to the global qpdf exit-3 tolerance.

After the redirect, the same broken PDF produces one clean JSON line on stdout and all 101 noise lines on stderr.

## Verification

- New tests, each watched failing first: a source-level drift guard requiring the redirect in every entrypoint that imports fitz, pymupdf, or pdf2docx, plus five classification cases in `python-docs-parse.test.ts` (xref noise becomes ToolInputError with the cause attached; warning-prefixed repair noise; interleave-corrupted JSON; a traceback that merely mentions xref stays a bug; the salvage walk still wins when a valid JSON line trails the noise).
- Mutation-checked the two orderings that matter: moving the classifier above the salvage walk and dropping `warning:` from the regex each fail exactly one test.
- 48/48 across `tests/unit/doc-engine/pymupdf-message-redirect.test.ts`, `tests/unit/doc-engine/python-docs-parse.test.ts`, and `packages/doc-engine/tests/python-docs.test.ts`. `pnpm lint` exit 0, `pnpm typecheck` 9 of 9.
- CI has no PyMuPDF lane, so the Python side was verified live in a local venv (pymupdf 1.28.2): before/after stdout capture on the broken PDF, plus a pymupdf-less run confirming the breadcrumb and the clean JSON error. The drift test is the CI-side guard, same tradeoff #859 made.

Pre-PR review ran silent-failure-hunter and pr-test-analyzer; their findings (redirect-failure breadcrumb, evidence on the ToolInputError cause, salvage-precedence pin, warning-prefix coverage, wider drift-guard import regex) are folded in.

One residual, filed as #938: a damaged PDF that makes a script raise instead of recover now exits 1 with a clean JSON error line, and the bridge's `pythonExitError` still classifies that as kind "bug".