### PR TITLE
fix(landing): quote the switch testimonial verbatim

### DIFF
--- a/apps/landing/src/data/testimonials.ts
+++ b/apps/landing/src/data/testimonials.ts
@@ -44,7 +44,7 @@ export const TESTIMONIALS: Testimonial[] = [
   },
   {
     quote:
-      "Fantastic software! I managed to replace [my old converter] and even got more features with SnapOtter.",
+      "Fantastic software! I managed to replace the old ass convertx and even got more features with SnapOtter.",
     author: "Self-hosted admin",
     context: "Shared via in-app feedback",
     hero: true,


### PR DESCRIPTION
The hero testimonial carried a bracketed placeholder, `[my old converter]`, in place of the product the reviewer actually named. Swapped in their verbatim wording so it reads as a real switch, not a redaction.

Source is the original in-app feedback. Attribution is unchanged (stays anonymous, since the feedback dialog never asked for publish consent). Only source occurrence is `apps/landing/src/data/testimonials.ts`; the `dist/` copy regenerates on build.