### PR TITLE
test(e2e): fix strict-mode violations from the #799 failure screen

### DIFF
--- a/tests/e2e/ai-canvas-expand.spec.ts
+++ b/tests/e2e/ai-canvas-expand.spec.ts
@@ -138,6 +138,9 @@ test.describe("AI Canvas Expand", () => {
     const download = page.getByTestId("ai-canvas-expand-download");
     const error = page.getByText(/failed|not available|not installed|requires.*feature|error/i);
 
-    await expect(download.or(error)).toBeVisible({ timeout: 300_000 });
+    // .first(): a failed run renders the error in the settings banner, the
+    // sr-only live region, and the failure screen (#799), so the tolerant
+    // locator matches more than one element.
+    await expect(download.or(error).first()).toBeVisible({ timeout: 300_000 });
   });
 });

--- a/tests/e2e/content-aware-resize.spec.ts
+++ b/tests/e2e/content-aware-resize.spec.ts
@@ -175,7 +175,10 @@ test.describe("Content-Aware Resize", () => {
     const download = page.getByTestId("resize-download");
     const error = page.getByText(/failed|not available|not found|error/i);
 
-    await expect(download.or(error)).toBeVisible({ timeout: 120_000 });
+    // .first(): a failed run renders the error in the settings banner, the
+    // sr-only live region, and the failure screen (#799), so the tolerant
+    // locator matches more than one element.
+    await expect(download.or(error).first()).toBeVisible({ timeout: 120_000 });
   });
 
   test("HEIC input with content-aware resize", async ({ loggedInPage: page }) => {
@@ -190,6 +193,9 @@ test.describe("Content-Aware Resize", () => {
     const download = page.getByTestId("resize-download");
     const error = page.getByText(/failed|not available|not found|error/i);
 
-    await expect(download.or(error)).toBeVisible({ timeout: 120_000 });
+    // .first(): a failed run renders the error in the settings banner, the
+    // sr-only live region, and the failure screen (#799), so the tolerant
+    // locator matches more than one element.
+    await expect(download.or(error).first()).toBeVisible({ timeout: 120_000 });
   });
 });


### PR DESCRIPTION
The #799 fix (#931) makes a failed single-file run render its error in three places: the settings-panel banner, the sr-only live region, and the per-entry failure screen. Three nightly tests use a tolerant `download.or(error)` locator that assumed exactly one match, so Playwright strict mode now kills them. That broke E2E Full (1/4) in the nightly dispatched on the merge commit (`7a34cae7`): `ai-canvas-expand.spec.ts` "processes image" and both content-aware-resize processing tests.

The change is `.first()` on the three assertions, with a comment saying why. The specs' intent (a download or a visible error, whichever comes) is unchanged.

Verified by reproducing on a clean main checkout first: `content-aware-resize.spec.ts` fails locally with the same strict-mode violation, 3 elements. With the fix, both spec files pass in full, 25/25 (the caire-missing error path is what runs locally, which is exactly the path that trips in CI).

The other four red nightly lanes match last night's pre-merge run: the "Attention" and "All files failed processing" violations are tracked in #919, and the Firefox/WebKit churn in the cross-browser and device lanes is #912. Not touched here.