### PR TITLE
fix(web): settle entries to "failed" on the remaining terminal failure paths

### DIFF
--- a/apps/web/src/hooks/use-tool-processor.ts
+++ b/apps/web/src/hooks/use-tool-processor.ts
@@ -178,6 +178,20 @@ export function useToolProcessor(toolId: string) {
     }
   }, []);
 
+  // A terminal failure must settle every entry its run left at "processing":
+  // the tool page derives the pulse from that status and gates the failure
+  // screen on "failed" (#799, #929). Same sweep as the batch failRun; the
+  // status guard leaves already-settled results alone, and sweeping instead
+  // of indexing works after clearActiveJob has nulled activeEntryIndexRef.
+  const settleProcessingEntries = useCallback((message: string) => {
+    const { entries, updateEntry } = useFileStore.getState();
+    for (let i = 0; i < entries.length; i++) {
+      if (entries[i]?.status === "processing") {
+        updateEntry(i, { status: "failed", error: message });
+      }
+    }
+  }, []);
+
   // Armed only when a dead POST degrades to the async path (#722): heartbeats
   // alone must not keep the client in "processing" forever for a job the
   // server never received.
@@ -196,13 +210,21 @@ export function useToolProcessor(toolId: string) {
       // behind would swallow a later run's cancel-404 settle (#767).
       batchRunRef.current = null;
       clearActiveJob();
-      setError(
-        "Processing was interrupted and the server never confirmed the job. Retry when reconnected.",
-      );
+      const message =
+        "Processing was interrupted and the server never confirmed the job. Retry when reconnected.";
+      settleProcessingEntries(message);
+      setError(message);
       setProcessing(false);
       setProgress(IDLE_PROGRESS);
     }, JOB_EVIDENCE_TIMEOUT_MS);
-  }, [clearJobEvidenceTimer, clearStallTimer, clearActiveJob, setError, setProcessing]);
+  }, [
+    clearJobEvidenceTimer,
+    clearStallTimer,
+    clearActiveJob,
+    settleProcessingEntries,
+    setError,
+    setProcessing,
+  ]);
 
   const cancelCurrentJob = useCallback(async () => {
     const jobId = activeJobIdRef.current;
@@ -240,6 +262,10 @@ export function useToolProcessor(toolId: string) {
           eventSourceRef.current = null;
         }
         clearActiveJob();
+        // Same settle the batch failRun gives canceled entries: "failed"
+        // with "Canceled", so the failure screen renders instead of an
+        // eternal pulse (#929).
+        settleProcessingEntries("Canceled");
         setError("Canceled");
         setProcessing(false);
         setProgress(IDLE_PROGRESS);
@@ -247,7 +273,14 @@ export function useToolProcessor(toolId: string) {
     } catch {
       // Cancel request failed; SSE handler will clean up
     }
-  }, [clearJobEvidenceTimer, clearStallTimer, clearActiveJob, setError, setProcessing]);
+  }, [
+    clearJobEvidenceTimer,
+    clearStallTimer,
+    clearActiveJob,
+    settleProcessingEntries,
+    setError,
+    setProcessing,
+  ]);
 
   const reconnectSSE = useCallback(
     (force = false) => {
@@ -376,7 +409,9 @@ export function useToolProcessor(toolId: string) {
               // cannot replace this specific error with a generic one.
               xhrRef.current?.abort();
               clearActiveJob();
-              setError(data.error || "Processing failed");
+              const message = data.error || "Processing failed";
+              settleProcessingEntries(message);
+              setError(message);
               setProcessing(false);
               setProgress(IDLE_PROGRESS);
               return;
@@ -413,6 +448,7 @@ export function useToolProcessor(toolId: string) {
       clearStallTimer,
       clearJobEvidenceTimer,
       resetStallTimer,
+      settleProcessingEntries,
       setError,
       setProcessing,
     ],
@@ -642,7 +678,9 @@ export function useToolProcessor(toolId: string) {
                 : {}),
             });
           } catch {
-            setError("Invalid response from server");
+            const message = "Invalid response from server";
+            setError(message);
+            failEntry(message);
           }
         } else {
           let message: string;

--- a/apps/web/src/hooks/use-tool-processor.ts
+++ b/apps/web/src/hooks/use-tool-processor.ts
@@ -349,10 +349,13 @@ export function useToolProcessor(toolId: string) {
               } else {
                 // Unreachable by construction (async mode implies a batch run
                 // installed the handler); if the invariant ever breaks, fail
-                // visibly instead of leaving the run in silent limbo.
+                // visibly instead of leaving the run in silent limbo. That
+                // includes the entries: without the sweep this insurance
+                // still leaves them pulsing at "processing" (#929).
                 clearJobEvidenceTimer();
                 if (elapsedRef.current) clearInterval(elapsedRef.current);
                 clearActiveJob();
+                settleProcessingEntries("Processing was interrupted. Retry when reconnected.");
                 setError("Processing was interrupted. Retry when reconnected.");
                 setProcessing(false);
                 setProgress(IDLE_PROGRESS);

--- a/tests/unit/web/use-tool-processor-batch-evidence-timeout.test.ts
+++ b/tests/unit/web/use-tool-processor-batch-evidence-timeout.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/image-preview", () => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  formatHeaders: () => new Map<string, string>(),
+  parseApiError: () => "error",
+}));
+
+vi.mock("@/lib/utils", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  return { ...actual, generateId: () => "44444444-4444-4444-8444-444444444444" };
+});
+
+import { useToolProcessor } from "@/hooks/use-tool-processor";
+import { useFileStore } from "@/stores/file-store";
+
+interface MockXhr {
+  status: number;
+  responseText: string;
+  responseType: string;
+  response: unknown;
+  timeout: number;
+  upload: { onprogress?: unknown; onload?: (() => void) | null };
+  onload?: () => void;
+  onerror?: (() => void) | null;
+  ontimeout?: (() => void) | null;
+  open: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  setRequestHeader: ReturnType<typeof vi.fn>;
+  getResponseHeader: ReturnType<typeof vi.fn>;
+  abort: ReturnType<typeof vi.fn>;
+}
+
+class MockEventSource {
+  static OPEN = 1;
+  static instances: MockEventSource[] = [];
+
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = MockEventSource.OPEN;
+  close = vi.fn(() => {
+    this.readyState = 2;
+  });
+
+  constructor(readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+}
+
+let xhrs: MockXhr[];
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal("URL", {
+    ...globalThis.URL,
+    createObjectURL: vi.fn(() => "blob:fake-url"),
+    revokeObjectURL: vi.fn(),
+  });
+  useFileStore.getState().reset();
+  xhrs = [];
+  MockEventSource.instances = [];
+  vi.stubGlobal("EventSource", MockEventSource);
+  vi.stubGlobal(
+    "XMLHttpRequest",
+    vi.fn(() => {
+      const xhr: MockXhr = {
+        status: 0,
+        responseText: "",
+        responseType: "",
+        response: null,
+        timeout: 0,
+        upload: {},
+        open: vi.fn(),
+        send: vi.fn(),
+        setRequestHeader: vi.fn(),
+        getResponseHeader: vi.fn(() => null),
+        abort: vi.fn(),
+      };
+      xhrs.push(xhr);
+      return xhr;
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+/**
+ * #929: the job-evidence timeout is a terminal failure, not a recovery. When
+ * it tears down a degraded batch run it nulls batchRunRef without settling
+ * the entries, so every file keeps pulsing at "processing" with only the
+ * banner showing. Batch flavor of the single-file settles in the same issue.
+ */
+describe("useToolProcessor batch job-evidence timeout settle (#929)", () => {
+  it("settles all processing entries when the evidence timeout ends a degraded batch", () => {
+    const files = [
+      new File([new ArrayBuffer(16)], "first.png", { type: "image/png" }),
+      new File([new ArrayBuffer(16)], "second.jpg", { type: "image/jpeg" }),
+    ];
+    useFileStore.getState().setFiles(files);
+    const hook = renderHook(() => useToolProcessor("resize"));
+    act(() => {
+      void hook.result.current.processAllFiles(files, { width: 50 });
+    });
+
+    // Upload finished, POST died, no batch frame ever arrives: the degrade
+    // (#750) hands the run to the evidence timeout.
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    expect(useFileStore.getState().entries.map((e) => e.status)).toEqual([
+      "processing",
+      "processing",
+    ]);
+
+    act(() => {
+      vi.advanceTimersByTime(30_001);
+    });
+
+    const entries = useFileStore.getState().entries;
+    expect(entries[0]).toMatchObject({
+      status: "failed",
+      error:
+        "Processing was interrupted and the server never confirmed the job. Retry when reconnected.",
+    });
+    expect(entries[1].status).toBe("failed");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    hook.unmount();
+  });
+});

--- a/tests/unit/web/use-tool-processor-single-file-failure.test.ts
+++ b/tests/unit/web/use-tool-processor-single-file-failure.test.ts
@@ -322,6 +322,91 @@ describe("useToolProcessor single-file failure settle (#799)", () => {
     unmount();
   });
 
+  it("settles the entry to failed when the SSE reports the job failed", () => {
+    const { unmount } = startRun();
+
+    act(() => {
+      sendSingleFrame({ phase: "failed", percent: 0, error: "boom" });
+    });
+
+    expect(useFileStore.getState().entries[0]).toMatchObject({
+      status: "failed",
+      error: "boom",
+    });
+    expect(useFileStore.getState().error).toBe("boom");
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("settles the entry to failed on a 2xx with an unparseable body", () => {
+    const { unmount } = startRun();
+
+    act(() => {
+      xhrs[0].status = 200;
+      xhrs[0].responseText = "<html>not json</html>";
+      xhrs[0].onload?.();
+    });
+
+    expect(useFileStore.getState().entries[0]).toMatchObject({
+      status: "failed",
+      error: "Invalid response from server",
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("settles the entry to failed when the job-evidence timeout fires", () => {
+    const { unmount } = startRun();
+
+    // Degrade first (#722): upload finished, socket died, no frame ever
+    // proves the job exists, so the evidence timeout is the terminal path.
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+    expect(useFileStore.getState().entries[0].status).toBe("processing");
+
+    act(() => {
+      vi.advanceTimersByTime(30_001);
+    });
+
+    expect(useFileStore.getState().entries[0]).toMatchObject({
+      status: "failed",
+      error:
+        "Processing was interrupted and the server never confirmed the job. Retry when reconnected.",
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
+  it("settles the entry to failed when cancel finds no job server-side", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: false, status: 404 } as Response));
+    vi.stubGlobal("fetch", fetchMock);
+    const { unmount } = startRun();
+
+    act(() => {
+      xhrs[0].upload.onload?.();
+      xhrs[0].onerror?.();
+    });
+
+    const cancel = useFileStore.getState().cancelCurrentJob;
+    expect(cancel).not.toBeNull();
+    await act(async () => {
+      await cancel?.();
+    });
+
+    expect(useFileStore.getState().entries[0]).toMatchObject({
+      status: "failed",
+      error: "Canceled",
+    });
+    expect(useFileStore.getState().processing).toBe(false);
+
+    unmount();
+  });
+
   it("fails the entry the run started with, not the currently selected one", () => {
     const fileA = new File([new ArrayBuffer(64)], "a.mp4", { type: "video/mp4" });
     const fileB = new File([new ArrayBuffer(64)], "b.mp4", { type: "video/mp4" });

--- a/tests/unit/web/use-tool-processor-single-file-failure.test.ts
+++ b/tests/unit/web/use-tool-processor-single-file-failure.test.ts
@@ -407,6 +407,52 @@ describe("useToolProcessor single-file failure settle (#799)", () => {
     unmount();
   });
 
+  it("the failure sweep leaves completed and pending siblings alone", () => {
+    const files = ["a.mp4", "b.mp4", "c.mp4"].map(
+      (name) => new File([new ArrayBuffer(64)], name, { type: "video/mp4" }),
+    );
+    useFileStore.getState().setFiles(files);
+    // File A already carries a delivered result from an earlier run.
+    useFileStore.getState().updateEntry(0, { status: "completed", processedUrl: "blob:done" });
+    useFileStore.getState().setSelectedIndex(1);
+    const hook = renderHook(() => useToolProcessor("trim-video"));
+    act(() => {
+      hook.result.current.processFiles(files, { startS: 0, endS: 2 });
+    });
+
+    act(() => {
+      sendSingleFrame({ phase: "failed", percent: 0, error: "boom" });
+    });
+
+    expect(useFileStore.getState().entries[0]).toMatchObject({
+      status: "completed",
+      processedUrl: "blob:done",
+    });
+    expect(useFileStore.getState().entries[1]).toMatchObject({
+      status: "failed",
+      error: "boom",
+    });
+    expect(useFileStore.getState().entries[2].status).toBe("pending");
+
+    hook.unmount();
+  });
+
+  it("falls back to a generic message when the failed frame carries no error", () => {
+    const { unmount } = startRun();
+
+    act(() => {
+      sendSingleFrame({ phase: "failed", percent: 0 });
+    });
+
+    expect(useFileStore.getState().entries[0]).toMatchObject({
+      status: "failed",
+      error: "Processing failed",
+    });
+    expect(useFileStore.getState().error).toBe("Processing failed");
+
+    unmount();
+  });
+
   it("fails the entry the run started with, not the currently selected one", () => {
     const fileA = new File([new ArrayBuffer(64)], "a.mp4", { type: "video/mp4" });
     const fileB = new File([new ArrayBuffer(64)], "b.mp4", { type: "video/mp4" });


### PR DESCRIPTION
Closes #929

#931 fixed the three XHR failure paths, but four other terminal paths still left entries at the kickoff's `status: "processing"`: the SSE `phase === "failed"` frame (which is how every async single-file failure lands, including 202-path AI tools and #722 degraded runs), a 2xx response whose body doesn't parse, the job-evidence timeout teardown in both single and degraded-batch flavors, and the cancel-404 local settle. Same symptom as #799 on each: eternal pulse on the untouched original, failure screen never renders, only the settings-panel banner hints anything happened.

The fix is one hook-level `settleProcessingEntries(message)` helper, the batch `failRun` sweep with the same status guard, called from all four paths. Sweeping by status instead of capturing an index sidesteps the trap the issue flagged: `clearActiveJob()` nulls `activeEntryIndexRef` before some of these callbacks read it. The invalid-body catch reuses the closure-scoped `failEntry` from #931. Cancel settles to `failed` with "Canceled", matching what the batch `failRun` already does for canceled entries, so this follows the in-product precedent rather than inventing new cancel UX.

Verification: five new pin tests (four in the #799 suite, one new batch-flavor file), written first and watched fail on unmodified main (5 red / 11 green), then 16/16 with the fix; teeth re-verified by reverting the committed fix (5 red) and restoring (16 green). Full unit suite, all sibling hook suites, lint, and typecheck run locally; results in the PR checks and the thread below. Baseline is the green post-merge CI run on 4bddb923, with nothing landed on main since.

The two defense-in-depth notes from #929 (settle-by-entry-identity instead of index, and the missing `activeJobIdRef` guard on `xhr.onload`) have no constructible repro and are deliberately not in this diff; they're tracked in a follow-up issue.