### PR TITLE
fix(web): show the session username in the avatar dropdown for OIDC logins

### DIFF
--- a/apps/web/src/components/layout/avatar-dropdown.tsx
+++ b/apps/web/src/components/layout/avatar-dropdown.tsx
@@ -12,11 +12,17 @@ interface AvatarDropdownProps {
 
 export function AvatarDropdown({ onSettingsClick, variant = "light" }: AvatarDropdownProps) {
   const { t } = useTranslation();
-  const { authEnabled } = useAuth();
+  const { authEnabled, loading, username: sessionUsername } = useAuth();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  const username = localStorage.getItem("snapotter-username") || "admin";
+  // The session is the source of truth: OIDC/SAML logins never run the login
+  // form, so the localStorage copy it writes doesn't exist for them (#862).
+  // localStorage only bridges the gap until the session fetch resolves, and
+  // the "admin" terminal fallback (no-auth mode has no session to name) must
+  // wait for that fetch; flashing it mid-load is #862's symptom again.
+  const username =
+    sessionUsername || localStorage.getItem("snapotter-username") || (loading ? "" : "admin");
   const initial = username.charAt(0).toUpperCase();
 
   useEffect(() => {

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -7,6 +7,7 @@ interface AuthState {
   authEnabled: boolean;
   isAuthenticated: boolean;
   mustChangePassword: boolean;
+  username: string | null;
   role: string | null;
   permissions: string[];
   oidcEnabled: boolean;
@@ -69,6 +70,7 @@ export function useAuth() {
     authEnabled: false,
     isAuthenticated: false,
     mustChangePassword: false,
+    username: null,
     role: null,
     permissions: [],
     oidcEnabled: false,
@@ -95,6 +97,7 @@ export function useAuth() {
               authEnabled: false,
               isAuthenticated: true,
               mustChangePassword: false,
+              username: null,
               role: "admin",
               permissions: ANON_ADMIN_PERMISSIONS,
               oidcEnabled: false,
@@ -124,6 +127,7 @@ export function useAuth() {
               authEnabled: true,
               isAuthenticated: true,
               mustChangePassword: mustChange,
+              username: session.user?.username ?? null,
               role: session.user?.role ?? null,
               permissions: session.user?.permissions ?? [],
               oidcEnabled: config.oidcEnabled ?? false,
@@ -143,6 +147,7 @@ export function useAuth() {
               authEnabled: true,
               isAuthenticated: false,
               mustChangePassword: false,
+              username: null,
               role: null,
               permissions: [],
               oidcEnabled: config.oidcEnabled ?? false,

--- a/tests/unit/web/avatar-dropdown-noauth.test.tsx
+++ b/tests/unit/web/avatar-dropdown-noauth.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AvatarDropdown } from "@/components/layout/avatar-dropdown";
+
+/**
+ * Separate file from avatar-dropdown-session-username.test.tsx on purpose:
+ * use-auth.ts caches the /api/v1/config/auth response at module level, so a
+ * test needing authEnabled:false can't share a module registry with tests
+ * that cached authEnabled:true.
+ */
+
+const storageMap = vi.hoisted(() => new Map<string, string>());
+const localStorageMock = vi.hoisted(() => ({
+  getItem: vi.fn((key: string) => storageMap.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => storageMap.set(key, value)),
+  removeItem: vi.fn((key: string) => storageMap.delete(key)),
+  clear: vi.fn(() => storageMap.clear()),
+  key: vi.fn((_index: number) => null),
+  get length() {
+    return storageMap.size;
+  },
+}));
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", localStorageMock);
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("AvatarDropdown with auth disabled", () => {
+  it("settles on the admin label without ever calling the session endpoint", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/v1/config/auth")) {
+        return { ok: true, status: 200, json: async () => ({ authEnabled: false }) };
+      }
+      // In strict no-auth deployments the session route may not even exist;
+      // reaching it from the anon branch would be a regression.
+      throw new Error(`unexpected fetch in no-auth mode: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AvatarDropdown onSettingsClick={() => {}} />);
+
+    const button = screen.getByTestId("user-menu");
+    await waitFor(() => expect(button).toHaveAttribute("aria-label", "admin"));
+
+    const urls = fetchMock.mock.calls.map((call) => String(call[0]));
+    expect(urls.length).toBeGreaterThan(0);
+    expect(urls.every((url) => url.includes("/api/v1/config/auth"))).toBe(true);
+  });
+});

--- a/tests/unit/web/avatar-dropdown-session-username.test.tsx
+++ b/tests/unit/web/avatar-dropdown-session-username.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AvatarDropdown } from "@/components/layout/avatar-dropdown";
+
+// This jsdom setup has no working localStorage; same Map-backed stub as
+// tool-feedback-prompt.test.tsx.
+const storageMap = vi.hoisted(() => new Map<string, string>());
+const localStorageMock = vi.hoisted(() => ({
+  getItem: vi.fn((key: string) => storageMap.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => storageMap.set(key, value)),
+  removeItem: vi.fn((key: string) => storageMap.delete(key)),
+  clear: vi.fn(() => storageMap.clear()),
+  key: vi.fn((_index: number) => null),
+  get length() {
+    return storageMap.size;
+  },
+}));
+
+/**
+ * Issue #862: the avatar dropdown showed "admin" for every OIDC user. The
+ * localStorage key it read ("snapotter-username") is written only by the
+ * password login form; an OIDC login round-trips through the IdP and lands
+ * back with just a session cookie, so the key stays unset forever and the
+ * "admin" fallback wins. The dropdown must read the username from the
+ * session endpoint, which knows it for every login method.
+ *
+ * These tests use the real useAuth hook against a stubbed fetch, so they
+ * cover the whole client chain: /api/auth/session -> useAuth -> dropdown.
+ */
+
+const AUTH_CONFIG = {
+  authEnabled: true,
+  oidcEnabled: true,
+  oidcProviderName: "Microsoft",
+  samlEnabled: false,
+  samlProviderName: null,
+  ssoEnforced: false,
+};
+
+function sessionPayload(username: string) {
+  return {
+    user: {
+      id: "user-oidc-1",
+      username,
+      role: "user",
+      mustChangePassword: false,
+      permissions: ["tools:use", "files:own"],
+      authProvider: "oidc",
+      loginMethod: "oidc",
+      email: "alex.bauer@contoso.com",
+      hasLocalPassword: false,
+      hasOidcLink: true,
+      totpEnabled: false,
+    },
+    expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  };
+}
+
+function stubFetch(sessionImpl: () => Promise<unknown>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/v1/config/auth")) {
+        return { ok: true, status: 200, json: async () => AUTH_CONFIG };
+      }
+      if (url.includes("/api/auth/session")) {
+        return sessionImpl();
+      }
+      throw new Error(`unexpected fetch in test: ${url}`);
+    }),
+  );
+}
+
+const okSession = (body: unknown) => () =>
+  Promise.resolve({ ok: true, status: 200, json: async () => body });
+
+const failedSession = (status: number) => () =>
+  Promise.resolve({ ok: false, status, json: async () => ({ error: "no session" }) });
+
+/**
+ * The logout item renders only once useAuth's 401/session branch has set
+ * authEnabled, so waiting for it proves the post-fetch render committed.
+ * Waiting on fetch call counts alone can resolve on the config fetch and
+ * assert against the pre-settle render.
+ */
+async function waitForSessionSettled() {
+  await waitFor(() => expect(screen.getByText("Log out")).toBeInTheDocument());
+}
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", localStorageMock);
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("AvatarDropdown username source (#862)", () => {
+  it("shows the session username after an OIDC login that never wrote localStorage", async () => {
+    stubFetch(okSession(sessionPayload("alex.bauer_contoso.com")));
+
+    render(<AvatarDropdown onSettingsClick={() => {}} />);
+
+    const button = screen.getByTestId("user-menu");
+    await waitFor(() => expect(button).toHaveAttribute("aria-label", "alex.bauer_contoso.com"));
+
+    fireEvent.click(button);
+    expect(screen.getByText("alex.bauer_contoso.com")).toBeInTheDocument();
+    expect(screen.queryByText("admin")).not.toBeInTheDocument();
+  });
+
+  it("prefers the session username over a stale localStorage value", async () => {
+    localStorage.setItem("snapotter-username", "renamed-away");
+    stubFetch(okSession(sessionPayload("alex.bauer_contoso.com")));
+
+    render(<AvatarDropdown onSettingsClick={() => {}} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("user-menu")).toHaveAttribute(
+        "aria-label",
+        "alex.bauer_contoso.com",
+      ),
+    );
+  });
+
+  it("still falls back to the localStorage username when no session is available", async () => {
+    localStorage.setItem("snapotter-username", "carol");
+    stubFetch(failedSession(401));
+
+    render(<AvatarDropdown onSettingsClick={() => {}} />);
+
+    const button = screen.getByTestId("user-menu");
+    // Pre-fetch render: localStorage bridges the loading gap.
+    expect(button).toHaveAttribute("aria-label", "carol");
+
+    // The settled 401 must not knock the dropdown back to the "admin" fallback.
+    fireEvent.click(button);
+    await waitForSessionSettled();
+    expect(button).toHaveAttribute("aria-label", "carol");
+  });
+
+  it("shows no name rather than the admin fallback while the session is loading", async () => {
+    // Session fetch never resolves: an OIDC user (empty localStorage) on a slow
+    // link must not be labeled "admin" in the meantime; that is the #862
+    // symptom flashing back.
+    stubFetch(() => new Promise(() => {}));
+
+    render(<AvatarDropdown onSettingsClick={() => {}} />);
+
+    const button = screen.getByTestId("user-menu");
+    expect(button).toHaveAttribute("aria-label", "");
+    expect(screen.queryByText("admin")).not.toBeInTheDocument();
+  });
+
+  it("falls back past a session payload that carries no username", async () => {
+    // Not producible by today's API (users.username is NOT NULL and the session
+    // route always sends it); pins that a trimmed payload degrades to the
+    // fallback chain instead of a blank or crashed dropdown.
+    localStorage.setItem("snapotter-username", "carol");
+    stubFetch(okSession({ user: { id: "user-1", role: "user" }, expiresAt: null }));
+
+    render(<AvatarDropdown onSettingsClick={() => {}} />);
+
+    const button = screen.getByTestId("user-menu");
+    fireEvent.click(button);
+    await waitForSessionSettled();
+    expect(button).toHaveAttribute("aria-label", "carol");
+  });
+});


### PR DESCRIPTION
Closes #862.

Every OIDC login showed "admin" as the profile name. The avatar dropdown read the username from localStorage ("snapotter-username"), and only the password login form writes that key: an OIDC login round-trips through the IdP and comes back with nothing but a session cookie, so the key never exists and the "admin" fallback wins forever. The issue's own screenshots show the split: the dropdown says "admin" while the settings dialog, which asks `/api/auth/session`, shows the real name.

`useAuth()` now exposes `username` from the session response it already fetches, and the dropdown prefers it: session, then localStorage, then "admin". localStorage still bridges the pre-fetch render, so password logins keep their instant name. The terminal "admin" fallback also waits for the session fetch to settle now, so it cannot flash for OIDC users mid-load; no-auth mode still ends up at "admin" once the config fetch resolves. No API changes, and SAML logins get the same fix for free.

Found nearby, filed instead of fixed: #946 (change-password page has the same localStorage read; the browser saves the new credential under "admin" on a narrow OIDC path) and #947 (a stray local `*.test.mjs` file fails `pnpm test` collection).

Verification, against a green-CI baseline on main at 7af45ea5:

- Six new tests across two files, real `useAuth` and real `AvatarDropdown` with only fetch and localStorage stubbed. Written red-first: two fail on unfixed code (revert-verified), one fails without the loading gate.
- `pnpm lint` and `pnpm typecheck` pass.
- Full vitest run: 19790 passed, zero test failures. Two collection errors come from local-only scratch files that reproduce identically on clean main (that is #947), so the baseline diff is zero new failures.
- All 1655 web unit tests pass, covering every `useAuth` consumer.
- Targeted chromium e2e over the touched surfaces (navigation, gui-navigation, gui-settings-general, login-security, settings): 154 passed.
- Review agents (silent-failure-hunter, code-reviewer, pr-test-analyzer) ran on the diff. Their two real findings, the loading-window "admin" flash and a settle race in the 401 regression test, are fixed here. One dismissed: client telemetry for a 200 session response with no `username`, which today's API cannot produce (NOT NULL column, the session route always sends it); pinned with a unit test instead.
