### PR TITLE
fix(api): stop scrubbing undecodable-image failures to "Error: Error"

### DIFF
--- a/apps/api/src/lib/image-error.ts
+++ b/apps/api/src/lib/image-error.ts
@@ -1,5 +1,10 @@
-import { isSafeMessageError, isToolInputError, SafeError } from "@snapotter/shared";
+import { isSafeMessageError, isToolInputError, SafeError, ToolInputError } from "@snapotter/shared";
+import sharp from "sharp";
 import type { ToolProcessCtx } from "../routes/tool-factory.js";
+
+/** Single line under 280 chars so friendlyError() passes it to the client verbatim. */
+export const UNDECODABLE_IMAGE_MESSAGE =
+  "This image can't be decoded. The file may be corrupt or use an unsupported encoding.";
 
 type ImageProcess<T> = (
   inputBuffer: Buffer,
@@ -20,6 +25,35 @@ type ImageProcess<T> = (
  * author (SafeError) or that flag bad user input (ToolInputError) pass through
  * untouched so their class is not masked.
  */
+/**
+ * Decide whether a Sharp failure was caused by undecodable input (the user's
+ * problem) or by our processing (our bug), and return the error to throw.
+ *
+ * Image intake only validates via metadata(), which parses headers without
+ * touching pixel data, so a structurally-valid-but-undecodable file (truncated
+ * scan data, broken IDAT) reaches the worker and blows up on the first full
+ * decode (#897). Probing a minimal 1x1 decode of the original input, the same
+ * probe image-input.ts uses for AVIF, classifies behaviorally: if the probe
+ * also fails, the pixels can't be decoded and the failure becomes a
+ * ToolInputError ("expected": no error log, no Sentry). If the probe passes,
+ * the input was fine and the original error is returned so the caller's
+ * withImageEncodeContext wrapper classifies it as a bug with a real title.
+ */
+export async function asInputErrorIfUndecodable(inputBuffer: Buffer, err: unknown): Promise<Error> {
+  const alreadyClassified =
+    isSafeMessageError(err) ||
+    isToolInputError(err) ||
+    (err instanceof Error && err.name === "InputValidationError");
+  if (alreadyClassified) return err as Error;
+
+  try {
+    await sharp(inputBuffer).resize(1).raw().toBuffer();
+  } catch {
+    return new ToolInputError(UNDECODABLE_IMAGE_MESSAGE);
+  }
+  return err instanceof Error ? err : new Error(String(err));
+}
+
 export function withImageEncodeContext<T>(
   message: string,
   codeOf: (settings: T) => string,

--- a/apps/api/src/lib/image-error.ts
+++ b/apps/api/src/lib/image-error.ts
@@ -1,10 +1,14 @@
 import { isSafeMessageError, isToolInputError, SafeError, ToolInputError } from "@snapotter/shared";
 import sharp from "sharp";
+import { isPixelSafetyError } from "../modality/image-input.js";
 import type { ToolProcessCtx } from "../routes/tool-factory.js";
+import { logger } from "./logger.js";
 
-/** Single line under 280 chars so friendlyError() passes it to the client verbatim. */
+/** Short single-line messages so friendlyError() passes them to the client verbatim. */
 export const UNDECODABLE_IMAGE_MESSAGE =
   "This image can't be decoded. The file may be corrupt or use an unsupported encoding.";
+export const PIXEL_LIMIT_IMAGE_MESSAGE =
+  "This image is too large to process. Reduce its dimensions and try again.";
 
 type ImageProcess<T> = (
   inputBuffer: Buffer,
@@ -25,35 +29,6 @@ type ImageProcess<T> = (
  * author (SafeError) or that flag bad user input (ToolInputError) pass through
  * untouched so their class is not masked.
  */
-/**
- * Decide whether a Sharp failure was caused by undecodable input (the user's
- * problem) or by our processing (our bug), and return the error to throw.
- *
- * Image intake only validates via metadata(), which parses headers without
- * touching pixel data, so a structurally-valid-but-undecodable file (truncated
- * scan data, broken IDAT) reaches the worker and blows up on the first full
- * decode (#897). Probing a minimal 1x1 decode of the original input, the same
- * probe image-input.ts uses for AVIF, classifies behaviorally: if the probe
- * also fails, the pixels can't be decoded and the failure becomes a
- * ToolInputError ("expected": no error log, no Sentry). If the probe passes,
- * the input was fine and the original error is returned so the caller's
- * withImageEncodeContext wrapper classifies it as a bug with a real title.
- */
-export async function asInputErrorIfUndecodable(inputBuffer: Buffer, err: unknown): Promise<Error> {
-  const alreadyClassified =
-    isSafeMessageError(err) ||
-    isToolInputError(err) ||
-    (err instanceof Error && err.name === "InputValidationError");
-  if (alreadyClassified) return err as Error;
-
-  try {
-    await sharp(inputBuffer).resize(1).raw().toBuffer();
-  } catch {
-    return new ToolInputError(UNDECODABLE_IMAGE_MESSAGE);
-  }
-  return err instanceof Error ? err : new Error(String(err));
-}
-
 export function withImageEncodeContext<T>(
   message: string,
   codeOf: (settings: T) => string,
@@ -71,4 +46,42 @@ export function withImageEncodeContext<T>(
       });
     }
   };
+}
+
+/**
+ * Decide whether a Sharp failure was caused by undecodable input (the user's
+ * problem) or by our processing (our bug), and return the error to throw.
+ *
+ * Image intake only validates via metadata(), which parses headers without
+ * touching pixel data, so a structurally-valid-but-undecodable file (truncated
+ * scan data, broken IDAT) reaches the worker and blows up on the first full
+ * decode (#897). Probing a minimal 1x1 decode of the buffer the caller was
+ * processing, the same probe image-input.ts uses for AVIF, classifies
+ * behaviorally: if the probe also fails, the pixels can't be decoded and the
+ * failure becomes a ToolInputError ("expected": no error-level log, no Sentry).
+ * A probe failure that is really libvips' pixel-count cap gets its own message,
+ * since calling a valid panorama "corrupt" would mislead. If the probe passes,
+ * the input was fine and the original error is returned so the caller's
+ * withImageEncodeContext wrapper classifies it as a bug with a real title.
+ *
+ * Classifying as input suppresses the error-level log and Sentry, so the one
+ * info-level line here is the only place the real Sharp message survives; an
+ * upload-side truncation bug would otherwise be indistinguishable from users
+ * uploading corrupt files.
+ */
+export async function asInputErrorIfUndecodable(inputBuffer: Buffer, err: unknown): Promise<Error> {
+  const alreadyClassified =
+    isSafeMessageError(err) ||
+    isToolInputError(err) ||
+    (err instanceof Error && err.name === "InputValidationError");
+  if (alreadyClassified) return err as Error;
+
+  try {
+    await sharp(inputBuffer).resize(1).raw().toBuffer();
+  } catch (probeErr) {
+    logger.info({ err, probeErr }, "undecodable image input rejected");
+    if (isPixelSafetyError(probeErr)) return new ToolInputError(PIXEL_LIMIT_IMAGE_MESSAGE);
+    return new ToolInputError(UNDECODABLE_IMAGE_MESSAGE);
+  }
+  return err instanceof Error ? err : new Error(String(err));
 }

--- a/apps/api/src/modality/image-input.ts
+++ b/apps/api/src/modality/image-input.ts
@@ -202,7 +202,7 @@ function assertWithinImageLimits(
   }
 }
 
-function isPixelSafetyError(error: unknown): boolean {
+export function isPixelSafetyError(error: unknown): boolean {
   return (
     error instanceof Error &&
     /(?:pixel (?:dimension )?safety limit|input image exceeds pixel limit)/i.test(error.message)

--- a/apps/api/src/routes/tools/image-enhancement.ts
+++ b/apps/api/src/routes/tools/image-enhancement.ts
@@ -12,6 +12,7 @@ import { isToolInstalled } from "../../lib/feature-status.js";
 import { validateImageBuffer } from "../../lib/file-validation.js";
 import { decodeToSharpCompat, needsCliDecode } from "../../lib/format-decoders.js";
 import { decodeHeic } from "../../lib/heic-converter.js";
+import { asInputErrorIfUndecodable, withImageEncodeContext } from "../../lib/image-error.js";
 import { resolveOutputFormat } from "../../lib/output-format.js";
 import { createToolRoute } from "../tool-factory.js";
 
@@ -40,14 +41,20 @@ async function processImageEnhancement(
 ) {
   const outputFormat = await resolveOutputFormat(rawBuffer, filename);
 
-  // HDR/EXR decodes can produce 16-bit buffers; CLAHE requires 8-bit (VIPS_FORMAT_UCHAR)
   let inputBuffer = rawBuffer;
-  const inputMeta = await sharp(inputBuffer).metadata();
-  if (inputMeta.depth && inputMeta.depth !== "uchar") {
-    inputBuffer = await sharp(inputBuffer).toColourspace("srgb").png().toBuffer();
+  let analysis: Awaited<ReturnType<typeof analyzeImage>>;
+  try {
+    // HDR/EXR decodes can produce 16-bit buffers; CLAHE requires 8-bit (VIPS_FORMAT_UCHAR)
+    const inputMeta = await sharp(inputBuffer).metadata();
+    if (inputMeta.depth && inputMeta.depth !== "uchar") {
+      inputBuffer = await sharp(inputBuffer).toColourspace("srgb").png().toBuffer();
+    }
+    // analyzeImage() -> .stats() is the first full pixel decode; intake only
+    // parsed headers, so undecodable-but-well-formed files fail here (#897)
+    analysis = await analyzeImage(inputBuffer);
+  } catch (err) {
+    throw await asInputErrorIfUndecodable(inputBuffer, err);
   }
-
-  const analysis = await analyzeImage(inputBuffer);
   const meta = await sharp(inputBuffer).metadata();
   const hasAlpha = meta.hasAlpha === true;
 
@@ -106,7 +113,11 @@ export function registerImageEnhancement(app: FastifyInstance) {
   createToolRoute(app, {
     toolId: "image-enhancement",
     settingsSchema,
-    process: processImageEnhancement,
+    process: withImageEncodeContext<EnhancementSettings>(
+      "Image enhancement failed",
+      (s) => s.mode,
+      processImageEnhancement,
+    ),
   });
 
   app.post(

--- a/apps/api/src/routes/tools/strip-metadata.ts
+++ b/apps/api/src/routes/tools/strip-metadata.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import sharp from "sharp";
 import { z } from "zod";
 import { sanitizeFilename } from "../../lib/filename.js";
+import { asInputErrorIfUndecodable, withImageEncodeContext } from "../../lib/image-error.js";
 import { createToolRoute } from "../tool-factory.js";
 
 const settingsSchema = z.object({
@@ -190,45 +191,56 @@ export function registerStripMetadata(app: FastifyInstance) {
   createToolRoute(app, {
     toolId: "strip-metadata",
     settingsSchema,
-    process: async (inputBuffer, settings, filename) => {
-      const metadata = await sharp(inputBuffer).metadata();
-      const format = metadata.format ?? "png";
-      const image = sharp(inputBuffer);
-      const result = await stripMetadata(image, settings);
+    process: withImageEncodeContext<z.infer<typeof settingsSchema>>(
+      "Metadata strip failed",
+      () => "strip-metadata",
+      async (inputBuffer, settings, filename) => {
+        const metadata = await sharp(inputBuffer).metadata();
+        const format = metadata.format ?? "png";
+        const image = sharp(inputBuffer);
+        const result = await stripMetadata(image, settings);
 
-      // Re-encode in the original format so we don't inflate the file.
-      // Sharp re-encodes from scratch, so we pick settings that stay close
-      // to the original size while still stripping metadata.
-      switch (format) {
-        case "jpeg":
-          result.jpeg({ quality: 90, mozjpeg: true });
-          break;
-        case "png":
-          result.png({ compressionLevel: 9 });
-          break;
-        case "webp":
-          result.webp({ quality: 85 });
-          break;
-        case "heif":
-          result.avif({ quality: 50 });
-          break;
-        case "tiff":
-          result.tiff({ compression: "lzw" });
-          break;
-        default:
-          break;
-      }
+        // Re-encode in the original format so we don't inflate the file.
+        // Sharp re-encodes from scratch, so we pick settings that stay close
+        // to the original size while still stripping metadata.
+        switch (format) {
+          case "jpeg":
+            result.jpeg({ quality: 90, mozjpeg: true });
+            break;
+          case "png":
+            result.png({ compressionLevel: 9 });
+            break;
+          case "webp":
+            result.webp({ quality: 85 });
+            break;
+          case "heif":
+            result.avif({ quality: 50 });
+            break;
+          case "tiff":
+            result.tiff({ compression: "lzw" });
+            break;
+          default:
+            break;
+        }
 
-      const buffer = await result.toBuffer();
-      const mimeMap: Record<string, string> = {
-        jpeg: "image/jpeg",
-        png: "image/png",
-        webp: "image/webp",
-        avif: "image/avif",
-        tiff: "image/tiff",
-        gif: "image/gif",
-      };
-      return { buffer, filename, contentType: mimeMap[format] ?? "image/png" };
-    },
+        // First full decode + re-encode: intake only parsed headers, so a file
+        // with broken pixel data (truncated IDAT) fails right here (#897)
+        let buffer: Buffer;
+        try {
+          buffer = await result.toBuffer();
+        } catch (err) {
+          throw await asInputErrorIfUndecodable(inputBuffer, err);
+        }
+        const mimeMap: Record<string, string> = {
+          jpeg: "image/jpeg",
+          png: "image/png",
+          webp: "image/webp",
+          avif: "image/avif",
+          tiff: "image/tiff",
+          gif: "image/gif",
+        };
+        return { buffer, filename, contentType: mimeMap[format] ?? "image/png" };
+      },
+    ),
   });
 }

--- a/tests/integration/tools/image/image-enhancement.test.ts
+++ b/tests/integration/tools/image/image-enhancement.test.ts
@@ -6,9 +6,11 @@
  * intensity parameter, selective corrections, and the analyze endpoint.
  */
 
+import { isToolInputError } from "@snapotter/shared";
 import sharp from "sharp";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { UNDECODABLE_IMAGE_MESSAGE } from "../../../../apps/api/src/lib/image-error.js";
+import { getToolConfig } from "../../../../apps/api/src/routes/tool-factory.js";
 import { fixtures, readFixture } from "../../../fixtures/index.js";
 import { settleAsyncFallback } from "../../settle-job.js";
 import {
@@ -1327,5 +1329,41 @@ describe("Undecodable input", () => {
     expect(res.statusCode).toBe(422);
     const body = JSON.parse(res.body);
     expect(body.details).toBe(UNDECODABLE_IMAGE_MESSAGE);
+  });
+});
+
+// ── Opaque failure classification (#897) ──────────────────────────
+describe("Opaque failure classification", () => {
+  it("classifies an undecodable buffer as ToolInputError even when intake is bypassed", async () => {
+    // Calls the registered process fn directly (what pipelines and batch
+    // invoke). Garbage bytes fail the metadata()/analyzeImage prefix inside
+    // the guarded region, the 1x1 probe fails too, and the classifier must
+    // produce the authored ToolInputError rather than a raw Sharp error.
+    const config = getToolConfig("image-enhancement");
+    if (!config) throw new Error("image-enhancement missing from tool registry");
+    const rejection = await config
+      .process(
+        Buffer.from("not an image"),
+        {
+          mode: "auto",
+          intensity: 50,
+          corrections: {
+            exposure: true,
+            contrast: true,
+            whiteBalance: true,
+            saturation: true,
+            sharpness: true,
+            denoise: true,
+          },
+          deepEnhance: false,
+        },
+        "garbage.bin",
+      )
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+    expect(isToolInputError(rejection)).toBe(true);
+    expect((rejection as Error).message).toBe(UNDECODABLE_IMAGE_MESSAGE);
   });
 });

--- a/tests/integration/tools/image/image-enhancement.test.ts
+++ b/tests/integration/tools/image/image-enhancement.test.ts
@@ -8,6 +8,7 @@
 
 import sharp from "sharp";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { UNDECODABLE_IMAGE_MESSAGE } from "../../../../apps/api/src/lib/image-error.js";
 import { fixtures, readFixture } from "../../../fixtures/index.js";
 import { settleAsyncFallback } from "../../settle-job.js";
 import {
@@ -1313,5 +1314,18 @@ describe("Low-light image analysis", () => {
     const result = JSON.parse(res.body);
     expect(result.suggestedMode).toBe("low-light");
     expect(result.issues).toContain("underexposed");
+  });
+});
+
+// ── Undecodable input classification (#897) ───────────────────────
+describe("Undecodable input", () => {
+  it("rejects a truncated JPEG as bad input with a readable reason", async () => {
+    // Valid JPEG headers, truncated scan data: passes metadata-only intake,
+    // fails the full pixel decode that analyzeImage() forces via .stats().
+    const truncated = readFixture(fixtures.image.hostile.truncated);
+    const res = await postTool({}, truncated, "truncated.jpg", "image/jpeg");
+    expect(res.statusCode).toBe(422);
+    const body = JSON.parse(res.body);
+    expect(body.details).toBe(UNDECODABLE_IMAGE_MESSAGE);
   });
 });

--- a/tests/integration/tools/image/strip-metadata.test.ts
+++ b/tests/integration/tools/image/strip-metadata.test.ts
@@ -6,9 +6,11 @@
  * metadata is actually removed from the output.
  */
 
+import { isSafeMessageError, type SafeError } from "@snapotter/shared";
 import sharp from "sharp";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { UNDECODABLE_IMAGE_MESSAGE } from "../../../../apps/api/src/lib/image-error.js";
+import { getToolConfig } from "../../../../apps/api/src/routes/tool-factory.js";
 import { fixtures, readFixture } from "../../../fixtures/index.js";
 import {
   buildTestApp,
@@ -731,5 +733,32 @@ describe("Undecodable input", () => {
     const res = await postTool({ stripAll: true }, truncated, "truncated.png", "image/png");
     expect(res.statusCode).toBe(422);
     expect(JSON.parse(res.body).details).toBe(UNDECODABLE_IMAGE_MESSAGE);
+  });
+});
+
+// ── Opaque failure classification (#897) ──────────────────────────
+describe("Opaque failure classification", () => {
+  it("surfaces a non-input process failure as a titled SafeError bug", async () => {
+    // Calls the registered process fn directly (what pipelines and batch
+    // invoke), bypassing intake. Garbage bytes fail the leading metadata()
+    // call, which sits outside the input-probe guard on purpose: on the
+    // normal path intake already ran the identical call, so a worker-side
+    // metadata() failure is anomalous. The withImageEncodeContext wrapper
+    // must title it instead of letting Sentry scrub it to "Error: Error".
+    const config = getToolConfig("strip-metadata");
+    if (!config) throw new Error("strip-metadata missing from tool registry");
+    const rejection = await config
+      .process(
+        Buffer.from("not an image"),
+        { stripExif: false, stripGps: false, stripIcc: false, stripXmp: false, stripAll: true },
+        "garbage.bin",
+      )
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+    expect(isSafeMessageError(rejection)).toBe(true);
+    expect((rejection as SafeError).message).toBe("Metadata strip failed");
+    expect((rejection as SafeError).kind).toBe("bug");
   });
 });

--- a/tests/integration/tools/image/strip-metadata.test.ts
+++ b/tests/integration/tools/image/strip-metadata.test.ts
@@ -8,6 +8,7 @@
 
 import sharp from "sharp";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { UNDECODABLE_IMAGE_MESSAGE } from "../../../../apps/api/src/lib/image-error.js";
 import { fixtures, readFixture } from "../../../fixtures/index.js";
 import {
   buildTestApp,
@@ -709,5 +710,26 @@ describe("AVIF fixture re-encoding", () => {
     expect(res.statusCode).toBe(200);
     const result = JSON.parse(res.body);
     expect(result.downloadUrl).toBeDefined();
+  });
+});
+
+// ── Undecodable input classification (#897) ───────────────────────
+describe("Undecodable input", () => {
+  it("rejects a PNG with truncated pixel data as bad input with a readable reason", async () => {
+    // Deterministic pseudo-noise so the PNG carries enough IDAT that cutting
+    // the buffer in half keeps the header intact (passes metadata-only intake)
+    // but breaks the pixel stream (fails the stripAll re-encode decode).
+    const raw = Buffer.alloc(64 * 64 * 3);
+    for (let i = 0; i < raw.length; i++) raw[i] = (i * 31 + 7) % 256;
+    const valid = await sharp(raw, { raw: { width: 64, height: 64, channels: 3 } })
+      .png()
+      .toBuffer();
+    const truncated = valid.subarray(0, Math.floor(valid.length / 2));
+    // Sanity: the header must still parse or this never reaches the worker path.
+    await expect(sharp(truncated).metadata()).resolves.toBeDefined();
+
+    const res = await postTool({ stripAll: true }, truncated, "truncated.png", "image/png");
+    expect(res.statusCode).toBe(422);
+    expect(JSON.parse(res.body).details).toBe(UNDECODABLE_IMAGE_MESSAGE);
   });
 });

--- a/tests/unit/api/image-error.test.ts
+++ b/tests/unit/api/image-error.test.ts
@@ -1,6 +1,17 @@
-import { isSafeMessageError, markToolInputError, SafeError } from "@snapotter/shared";
+import {
+  isSafeMessageError,
+  isToolInputError,
+  markToolInputError,
+  SafeError,
+} from "@snapotter/shared";
+import sharp from "sharp";
 import { describe, expect, it } from "vitest";
-import { withImageEncodeContext } from "../../../apps/api/src/lib/image-error.js";
+import {
+  asInputErrorIfUndecodable,
+  UNDECODABLE_IMAGE_MESSAGE,
+  withImageEncodeContext,
+} from "../../../apps/api/src/lib/image-error.js";
+import { fixtures, readFixture } from "../../fixtures/index.js";
 
 interface Settings {
   format: string;
@@ -68,5 +79,38 @@ describe("withImageEncodeContext", () => {
       },
     );
     await expect(wrapped(input, settings, "in.png")).rejects.toBe(inputErr);
+  });
+});
+
+describe("asInputErrorIfUndecodable", () => {
+  // Passes metadata-only intake but fails any full pixel decode (#897).
+  const truncatedJpg = readFixture(fixtures.image.hostile.truncated);
+
+  it("classifies a Sharp failure on an undecodable input as ToolInputError", async () => {
+    const sharpErr = new Error(
+      "VipsJpeg: premature end of JPEG image\njpegload_buffer: load error",
+    );
+    const err = await asInputErrorIfUndecodable(truncatedJpg, sharpErr);
+    expect(isToolInputError(err)).toBe(true);
+    expect(err.message).toBe(UNDECODABLE_IMAGE_MESSAGE);
+  });
+
+  it("returns the original error when the input decodes fine (downstream bugs stay bugs)", async () => {
+    const decodable = await sharp({
+      create: { width: 8, height: 8, channels: 3, background: { r: 10, g: 20, b: 30 } },
+    })
+      .png()
+      .toBuffer();
+    const bug = new TypeError("Cannot read properties of undefined (reading 'mean')");
+    const err = await asInputErrorIfUndecodable(decodable, bug);
+    expect(err).toBe(bug);
+  });
+
+  it("passes through already-classified errors without reclassifying", async () => {
+    const safe = new SafeError("Process killed (out of memory)", { kind: "operational" });
+    expect(await asInputErrorIfUndecodable(truncatedJpg, safe)).toBe(safe);
+
+    const inputErr = markToolInputError(new Error("Unsupported input"));
+    expect(await asInputErrorIfUndecodable(truncatedJpg, inputErr)).toBe(inputErr);
   });
 });

--- a/tests/unit/api/image-error.test.ts
+++ b/tests/unit/api/image-error.test.ts
@@ -8,6 +8,7 @@ import sharp from "sharp";
 import { describe, expect, it } from "vitest";
 import {
   asInputErrorIfUndecodable,
+  PIXEL_LIMIT_IMAGE_MESSAGE,
   UNDECODABLE_IMAGE_MESSAGE,
   withImageEncodeContext,
 } from "../../../apps/api/src/lib/image-error.js";
@@ -104,6 +105,17 @@ describe("asInputErrorIfUndecodable", () => {
     const bug = new TypeError("Cannot read properties of undefined (reading 'mean')");
     const err = await asInputErrorIfUndecodable(decodable, bug);
     expect(err).toBe(bug);
+  });
+
+  it("names the pixel limit when an oversized (not corrupt) image trips it", async () => {
+    // Valid PNG headers declaring 50000x50000: passes metadata-only intake but
+    // exceeds libvips' default limitInputPixels, in both the pipeline and the
+    // probe. Calling that "corrupt" would mislead; the message must say "large".
+    const bombPng = readFixture(fixtures.image.hostile.bomb);
+    const sharpErr = new Error("Input image exceeds pixel limit");
+    const err = await asInputErrorIfUndecodable(bombPng, sharpErr);
+    expect(isToolInputError(err)).toBe(true);
+    expect(err.message).toBe(PIXEL_LIMIT_IMAGE_MESSAGE);
   });
 
   it("passes through already-classified errors without reclassifying", async () => {


### PR DESCRIPTION
Closes #897

Two image tools threw raw Sharp errors from the worker. The Sentry scrubber type-scrubs any non-SafeError message, so every one of them landed as `Error: Error`, `error_class=bug`, nothing to triage: NODE-3T (image-enhancement, 10 events, all jpg) and NODE-3H (strip-metadata, 6 events). The trigger is a file that passes metadata-only intake but fails its first full pixel decode in the worker, which for these tools is `analyzeImage()`'s `.stats()` and the `stripAll` re-encode `toBuffer()` respectively.

## What changed

`apps/api/src/lib/image-error.ts` gets `asInputErrorIfUndecodable(inputBuffer, err)`: on a Sharp failure it probes a 1x1 decode of the buffer the tool was processing (same probe intake already uses for AVIF). Probe fails too: the input can't be decoded, so the failure becomes a `ToolInputError`, which the worker already treats as expected (no error-level log, no Sentry) and the client gets an authored message instead of a vips dump. Probe passes: the original error comes back and the tool's new `withImageEncodeContext` wrapper (the #534 guard, previously on convert and gif-tools only) surfaces it as a titled `SafeError { kind: "bug" }`. A downstream bug like the issue's `computeScores` example stays a bug behaviorally, no string matching.

Two refinements out of the adversarial review pass:

- A probe failure that is really libvips' default pixel cap (valid 269MP+ image, intake's `MAX_MEGAPIXELS` defaults to off) gets its own message. Telling someone their panorama "may be corrupt" would be wrong; `isPixelSafetyError` is now exported from image-input for this.
- Classifying quietly destroys the vips text everywhere, so the helper logs one info-level line with the original and probe errors. Without it, an upload-side truncation bug would be indistinguishable from users uploading corrupt files.

Known tradeoff: `ToolInputError` carries no `cause`, so that log line is the only place the raw message survives. Extending the shared class is weighed once in #949 rather than here.

## Tests

TDD throughout; every test was watched failing first.

- Unit (tests/unit/api/image-error.test.ts): the three classifier branches plus the pixel-cap branch, using the real `truncated.jpg` and `bomb-50000x50000.png` hostile fixtures.
- Integration, per tool: a truncated JPEG through image-enhancement and a deterministically truncated PNG through strip-metadata each settle as 422 with `details` equal to the authored constant. Both failed on main with the raw vips text in `details`.
- Registry pins (from the pr-test-analyzer pass): garbage bytes into the registered process fns must surface as the titled SafeError bug (strip-metadata) and the authored ToolInputError (image-enhancement). Verified by mutation: with main's route files checked out, both pins fail; a refactor that drops the wrapper now goes red.

## Verification

- Teeth: reverted the route wiring, watched the integration tests fail, restored.
- Blast radius: callers of the changed process fns are the worker, pipeline.ts, batch.ts, and conversion-presets (neither tool is a preset base). Ran pipeline-edge-cases, pipeline-multimodal, batch, convert-formats, gif-tools, tool-route-drift, and the hostile matrix rows for both tools: all green. LSP was unavailable in this session (no typescript-language-server on PATH), so references came from exact-identifier grep plus tracing the toolRegistry seam by hand.
- `pnpm lint` and `pnpm typecheck`: clean. Full `pnpm test` (VITEST_MAX_FORKS=3): 19799 passed, 0 test failures. The run exits 1 only because two gitignored local `twitter/*.test.mjs` strays trip the collector, which is #947, branch-independent, and can't happen in CI.
- Baseline: the green post-merge CI run on a6985f98 (PR #948), nothing landed since.
- Not run: `pnpm test:e2e` and `pnpm test:docker` (no web or container changes; API-only diff), `pnpm i18n:check` (worker error strings are server-side English by convention, no locale keys touched).

Review agents (silent-failure-hunter, code-reviewer, pr-test-analyzer) all ran on the diff. Everything they rated real is either folded in (pixel-cap message, evidence log, JSDoc adjacency, registry pins) or filed: #949 (the same unguarded pattern in ~30 more image tools, from the audit #897 asked for), #950 (deepEnhance's silent fallback), #951 (pipeline steps and batch children never reach Sentry). Dismissed: an environmental probe failure misclassifying a genuine bug as input (rare per the hunter's own assessment, and the evidence log plus pixel-cap branch cover the plausible cases; the residual is noted in #949), and per-tool e2e coverage (the failure UI path is unchanged).
