### PR TITLE
fix(ai): extract Arabic PDFs as readable text instead of shaped forms

### DIFF
--- a/packages/ai/python/doc_text.py
+++ b/packages/ai/python/doc_text.py
@@ -1,6 +1,70 @@
 """Extract plain text. Args: {"path": in, "out": out-txt-path}. Prints {"chars": N, "hasText": bool}."""
 import json
+import re
 import sys
+import unicodedata
+
+# Arabic Presentation Forms-A (U+FB50..U+FDFF) and Forms-B (U+FE70..U+FEFF).
+# Unicode keeps these blocks for compatibility only: they hold one codepoint per
+# position-specific glyph shape, and real text is meant to store base letters and
+# let the renderer shape them. Producers that shape Arabic themselves before
+# drawing (common, since it sidesteps needing a shaping engine) write the shaped
+# forms into the font's ToUnicode map, so extraction hands back a string that
+# looks right but compares equal to nothing (#724).
+_PRESENTATION_FORMS_RE = re.compile("[\uFB50-\uFDFF\uFE70-\uFEFF]+")
+
+
+def normalize_presentation_forms(text):
+    """Fold Arabic presentation forms back to the base letters they stand for.
+
+    NFKC is applied per matched run rather than to the whole string so it cannot
+    rewrite unrelated content the caller expects verbatim: whole-string NFKC also
+    expands the fi ligature, fullwidth Latin and superscript digits. Characters in
+    these blocks that carry no compatibility mapping (the zero-width no-break
+    space at U+FEFF, the noncharacters at U+FDD0..U+FDEF) pass through unchanged,
+    because NFKC leaves them alone.
+
+    "Base letters" is exact for the letter forms and approximate for the harakat
+    forms at U+FE70..U+FE7F, which decompose to a carrier plus the mark rather
+    than to a letter: U+FE77 becomes U+0640 U+064E, so vocalized text comes back
+    with a tatweel where the shaped form used to be. That is still a large
+    improvement on an unmatchable presentation codepoint, and the alternative is
+    a hand-maintained mapping table, so NFKC stays.
+    """
+    return _PRESENTATION_FORMS_RE.sub(
+        lambda match: unicodedata.normalize("NFKC", match.group()), text
+    )
+
+
+def has_readable_text(text):
+    """True when extraction produced at least one character a human could read.
+
+    Rejects the two things MuPDF hands back when a glyph carries no Unicode
+    value: control codepoints, which is what a font with no ToUnicode map yields
+    for glyph ids below 0x20, and U+FFFD, its stand-in for a glyph it cannot map
+    at all. Those are not whitespace, so the older `.strip()` test accepted them
+    as real text and the user downloaded a .txt that renders blank (#724).
+    Format codepoints go too, so a page of nothing but bidi direction marks does
+    not count. Whitespace is tested separately because Zs/Zl/Zp are not C
+    categories, so a page of spaces would otherwise read as text.
+
+    Deliberately narrower than "any C* category". Private-use stays readable
+    because symbolic fonts decode legitimately to U+F0xx, and unassigned stays
+    readable because which codepoints are unassigned depends on the interpreter's
+    Unicode version, which differs between the arm64 and amd64 images. Judging
+    either unreadable would reject a PDF whose text layer decoded fine, on one
+    architecture only.
+
+    This does not catch every unmappable font, and cannot. A subset font with
+    more than 31 glyphs produces ids at or above 0x20, so "Hello" arrives as
+    "+HOOR": ordinary letters, indistinguishable from real text at this level.
+    """
+    return any(
+        not char.isspace()
+        and char != "\uFFFD"
+        and unicodedata.category(char) not in ("Cc", "Cf")
+        for char in text
+    )
 
 
 def main():
@@ -30,14 +94,16 @@ def main():
         sys.exit(1)
     try:
         doc = fitz.open(path)
-        parts = [page.get_text() for page in doc]
+        parts = [normalize_presentation_forms(page.get_text()) for page in doc]
         doc.close()
         text = "\n".join(parts)
-        # hasText distinguishes a PDF with a real text layer from a scanned or
-        # image-only PDF, where every page returns "" and only the join newlines
-        # remain. len(text) alone can't tell them apart, so the caller uses this
-        # to offer OCR instead of handing back an empty file (#589).
-        has_text = any(part.strip() for part in parts)
+        # hasText separates a PDF with a usable text layer from one that has
+        # nothing to give: a scanned or image-only page returns "" so only the
+        # join newlines remain (#589), and a page whose font carries no ToUnicode
+        # map returns raw glyph ids that render blank (#724). len(text) alone
+        # can't tell any of them apart, so the caller uses this to offer OCR
+        # instead of handing back a file the user will read as empty.
+        has_text = any(has_readable_text(part) for part in parts)
         with open(out, "w", encoding="utf-8") as fh:
             fh.write(text)
         print(json.dumps({"chars": len(text), "hasText": has_text}))

--- a/tests/unit/doc-engine/doc-text-arabic.test.ts
+++ b/tests/unit/doc-engine/doc-text-arabic.test.ts
@@ -1,0 +1,161 @@
+// Pure-Unicode unit tests for the text cleanup in doc_text.py.
+// Runs python3 against the actual module helpers (no PyMuPDF needed), the same
+// way ssrf-prescan-regex.test.ts exercises doc_html_pdf.py.
+// Invisible codepoints are written as \u escapes so they survive review and
+// reformatting; the Arabic literals are left as-is because they are the point.
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { hasPython } from "../../helpers/python-gate.js";
+
+const SCRIPT_DIR = join(process.cwd(), "packages", "ai", "python");
+
+/** Call one doc_text helper with a single string argument and return its result. */
+function callHelper<T>(fn: string, input: string): T {
+  const code = [
+    "import sys, json",
+    `sys.path.insert(0, ${JSON.stringify(SCRIPT_DIR)})`,
+    `from doc_text import ${fn}`,
+    `sys.stdout.write(json.dumps(${fn}(json.loads(sys.argv[1]))))`,
+  ].join("; ");
+  const res = spawnSync("python3", ["-c", code, JSON.stringify(input)], {
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  if (res.status !== 0) throw new Error(`python3 failed: ${res.stderr}`);
+  return JSON.parse(res.stdout) as T;
+}
+
+const normalize = (text: string) => callHelper<string>("normalize_presentation_forms", text);
+const hasReadable = (text: string) => callHelper<boolean>("has_readable_text", text);
+
+describe.skipIf(!hasPython)("doc_text.normalize_presentation_forms", () => {
+  it("folds shaped Arabic back to base letters", () => {
+    // What a self-shaping producer leaves in the ToUnicode map for the phrase below.
+    expect(normalize("ﻣﺮﺣﺒﺎ ﺑﺎﻟﻌﺎﻟﻢ")).toBe("مرحبا بالعالم");
+  });
+
+  it("expands the lam-alef ligature into its two letters", () => {
+    expect(normalize("ﻻ")).toBe("لا");
+  });
+
+  it("covers Presentation Forms-A as well as Forms-B", () => {
+    // U+FB50 (alef wasla isolated) sits in Forms-A, U+FEF4 (yeh medial) in Forms-B.
+    expect(normalize("ﭐﻴ")).toBe("ٱي");
+  });
+
+  it("leaves ordinary Arabic untouched", () => {
+    const arabic = "مرحبا بالعالم";
+    expect(normalize(arabic)).toBe(arabic);
+  });
+
+  it("leaves Latin, CJK and punctuation byte-for-byte identical", () => {
+    const mixed = "Hello, world! 日本語 (c) 2026, naive cafe";
+    expect(normalize(mixed)).toBe(mixed);
+  });
+
+  it("does not apply NFKC to the rest of the string", () => {
+    // Whole-string NFKC would also rewrite the fi ligature, the superscript and
+    // the fullwidth Latin. Only the Arabic run may change.
+    expect(normalize("ﬁ ² ｆｕｌｌ ﻣ")).toBe("ﬁ ² ｆｕｌｌ م");
+  });
+
+  it("carries harakat forms back as a carrier plus the mark", () => {
+    // U+FE77 (fatha medial) has no base letter to fold to, so NFKC yields
+    // tatweel + fatha. Pinned because it is the one case where the fold inserts
+    // a character instead of replacing one.
+    expect(normalize("ﹷ")).toBe("ـَ");
+  });
+
+  it("preserves the zero-width no-break space that shares the Forms-B block", () => {
+    expect(normalize("a\uFEFFb")).toBe("a\uFEFFb");
+  });
+
+  it("preserves noncharacters inside the Forms-A range", () => {
+    expect(normalize("\uFDD0")).toBe("\uFDD0");
+  });
+
+  it("keeps mixed Arabic and Latin in place", () => {
+    expect(normalize("Invoice ﻣﺮﺣﺒﺎ 2026")).toBe("Invoice مرحبا 2026");
+  });
+});
+
+describe.skipIf(!hasPython)("doc_text.has_readable_text", () => {
+  it("rejects the raw glyph ids a font with no ToUnicode map yields", () => {
+    // MuPDF emits one control codepoint per glyph, so the .txt renders blank (#724).
+    expect(hasReadable("\u0001\u0002\u0003\u0004\u0002\u000B\u000C\u0005")).toBe(false);
+  });
+
+  it("rejects the replacement character MuPDF uses for unmappable glyphs", () => {
+    expect(hasReadable("\uFFFD\uFFFD\uFFFD")).toBe(false);
+  });
+
+  it("rejects a page that is only whitespace", () => {
+    expect(hasReadable("   \n\t  ")).toBe(false);
+  });
+
+  it("rejects a page of only bidi direction marks", () => {
+    expect(hasReadable("\u200F\u200E\u061C")).toBe(false);
+  });
+
+  it("keeps private-use codepoints readable", () => {
+    // Symbolic TrueType fonts (Symbol, Wingdings) decode to U+F0xx through a
+    // (3,0) cmap. That text layer decoded fine, so it must not be sent to OCR.
+    expect(hasReadable("\uF041\uF042\uF043")).toBe(true);
+    expect(hasReadable("\uE000")).toBe(true);
+  });
+
+  it("keeps unassigned codepoints readable so the answer is arch-independent", () => {
+    // Which codepoints count as unassigned follows the interpreter Unicode
+    // version, and the arm64 and amd64 images ship different ones. Judging them
+    // unreadable would 422 the same PDF on one architecture only.
+    expect(hasReadable("\u0378")).toBe(true);
+  });
+
+  it("accepts Arabic", () => {
+    expect(hasReadable("مرحبا")).toBe(true);
+  });
+
+  it("accepts shaped Arabic presentation forms", () => {
+    expect(hasReadable("ﻣﺮ")).toBe(true);
+  });
+
+  it("accepts Latin, CJK and digits", () => {
+    expect(hasReadable("hello")).toBe(true);
+    expect(hasReadable("日本語")).toBe(true);
+    expect(hasReadable("2026")).toBe(true);
+  });
+
+  it("accepts a page whose only content is punctuation or symbols", () => {
+    expect(hasReadable("€ ± §")).toBe(true);
+  });
+
+  it("accepts real text that also carries control characters", () => {
+    expect(hasReadable(" total ")).toBe(true);
+  });
+});
+
+// The helpers above are only worth anything if extraction actually calls them,
+// and PyMuPDF is absent from CI so no test here can run main(). Guard the wiring
+// at the source level instead, the way pymupdf-message-redirect.test.ts does.
+describe("doc_text.main wiring", () => {
+  const source = readFileSync(join(SCRIPT_DIR, "doc_text.py"), "utf8");
+  const main = source.slice(source.indexOf("def main("));
+
+  it("normalizes every page it extracts", () => {
+    expect(main).toMatch(/normalize_presentation_forms\(page\.get_text\(\)\)/);
+  });
+
+  it("decides hasText with the readability test", () => {
+    expect(main).toMatch(/has_text = any\(has_readable_text\(part\) for part in parts\)/);
+  });
+
+  it("reports the character count of the text it actually wrote", () => {
+    // Folding a ligature changes the length, so chars must be measured after it.
+    expect(main).toMatch(/text = "\\n"\.join\(parts\)/);
+    expect(main).toMatch(/fh\.write\(text\)/);
+    expect(main).toMatch(/"chars": len\(text\)/);
+  });
+});


### PR DESCRIPTION
Closes #724.

Arabic PDFs came back two different kinds of unusable, and the issue could not tell them apart without a sample. Both turned out to be real and both reproduce on main.

## Shaped Arabic extracted as presentation forms

Arabic needs shaping: each letter takes a different glyph depending on its neighbours. Plenty of producers do that shaping themselves before drawing, because it saves them from carrying a shaping engine, and then they write the *shaped* codepoints into the font's ToUnicode map. So `مرحبا بالعالم` extracts as `ﻣﺮﺣﺒﺎ ﺑﺎﻟﻌﺎﻟﻢ`: U+FEE3 U+FEAE and friends out of the Arabic Presentation Forms blocks, which Unicode keeps for compatibility and nothing else. It renders almost identically and it equals nothing. Search misses it, copy-paste into any Arabic tool misses it, every downstream step misses it.

Fixed by folding both Presentation Forms blocks back to base letters with NFKC, applied per matched run rather than to the whole string. Whole-string NFKC would also rewrite the fi ligature, fullwidth Latin and superscript digits, and none of that is ours to touch.

Two side effects of the fold, both correct compatibility mappings, both pinned by tests: the harakat forms at U+FE70..U+FE7F decompose to a carrier plus the mark instead of to a letter (U+FE77 gives U+0640 U+064E), and U+FDFC RIAL SIGN expands to the spelled-out word.

## Glyph-id soup reported as a successful extraction

A font with no ToUnicode map still yields one "character" per glyph, except they are raw glyph ids. When they land below 0x20 they are control codepoints. Those are not whitespace, so the old `any(part.strip() ...)` check called the page text, `hasText` came back true, and the user downloaded a 200 and a .txt that renders **completely blank**. That is the "no text comes out" in the issue title, and it is worse than an error because it looks like it worked.

`hasText` now asks whether anything readable came out, which drops those into the existing "use PDF OCR" 422 from #589.

**This half is narrow and I want to be plain about it.** Glyph ids only land below 0x20 while the subset font has 31 or fewer glyphs. A normal paragraph is past that on the first line, and then `Hello` arrives as `+HOOR`: ordinary letters, indistinguishable from real text at the character level. Detecting the general case means reading the font dicts instead, which is #955.

The readability test also leaves private-use and unassigned codepoints alone on purpose. Symbolic fonts (Symbol, Wingdings) decode legitimately to U+F0xx through a (3,0) cmap, and which codepoints are unassigned follows the interpreter's Unicode version, which is not the same in the arm64 and amd64 images. Judging either unreadable would 422 a PDF whose text layer decoded fine, and on one architecture only.

## Verification

Reproduced first, on main, with four PDFs from different producers: a LibreOffice export, a self-shaping producer, a PyMuPDF htmlbox, and one with ToUnicode stripped.

| PDF | before | after |
| --- | --- | --- |
| LibreOffice export | already correct | unchanged |
| self-shaped | `ﻣﺮﺣﺒﺎ` presentation forms | `مرحبا بالعالم`, matches the source exactly |
| no ToUnicode | 200, .txt renders blank | 422, "use PDF OCR" |

Then against the runtime that actually ships: inside the container, PyMuPDF 1.27.2 with the current script reproduces the gibberish and the fixed script returns the source Arabic, with the already-correct export untouched.

- 24 new unit tests. They drive the real Python helpers through `python3`, needing no PyMuPDF, the way `ssrf-prescan-regex.test.ts` does, so they run in CI rather than skipping. Three of them source-scan `main()` so deleting the wiring cannot stay green.
- Teeth checked: restoring the pre-fix semantics fails 8, unwiring `main()` fails 2 more, and broadening the readability test back to all C\* categories fails 2 more. The tests that pass either way are the deliberate no-regression guards (Latin and CJK byte-identical, BOM preserved, ordinary Arabic untouched).
- `pnpm lint` 0, `pnpm typecheck` 0, `pnpm test` 19817 passed with no test-case failures. Baseline was CI run 33351012469 on 2da05736, green. **Zero new failures.**
- Blast radius: the JSON contract shape is unchanged, only its values. Sole production caller is `apps/api/src/routes/tools/pdf-to-text.ts:26`; `packages/doc-engine/tests/python-docs.test.ts` 36/36 and `document-route-processors` green.

Two local full-suite failures are `twitter/operations/*.test.mjs`, untracked scratch in `.git/info/exclude` that the root vitest glob picks up. "No test suite found in file", nothing to do with this and invisible to CI.

No i18n or e2e run: no strings and no web behaviour change.

## Left open

- #953, Arabic OCR. Scanned Arabic still dead ends, because the recognizer has no Arabic model. The per-language seam is already built (Korean swaps both model and dictionary), so the blocker is publishing the model into the OCR bundle, which is a maintainer step.
- #955, detecting glyph-id fallback from the font dicts.
- #954, saying which pages had no usable text layer instead of asserting "scanned or image-only" for every cause.

If the original reporter's PDF was scanned rather than text-layer, #953 is the one to watch.
