### PR TITLE
fix(docker): build embedded Redis with a page-size-agnostic jemalloc

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,60 @@ RUN go mod download all && go mod verify && \
     go build -trimpath -mod=readonly -o /tmp/pdfcpu github.com/pdfcpu/pdfcpu/cmd/pdfcpu
 
 # ============================================
+# Stage 0c: Redis 8 server + CLI for embedded mode
+# ============================================
+# Built from source because no prebuilt Redis 8 works here. jemalloc bakes in a
+# maximum page size and aborts on any kernel with larger pages, so the 4 KiB
+# packages.redis.io build killed redis-server AND redis-cli on 16 KiB hosts
+# (Asahi Linux, some Apple-silicon VMs) and 64 KiB hosts (aarch64 RHEL), hanging
+# the container in the redis-ready probe (#734). The official images are no help
+# either: redis:8-bookworm is frozen on 8.4.0, and redis:8-trixie needs glibc
+# 2.38 against this base's 2.36. Page flags follow Debian's jemalloc rules, the
+# same ones docker-library/redis copies: 4 KiB on x86, which is always 4 KiB
+# paged, and 64 KiB elsewhere so one arm64 binary covers 4/16/64 KiB kernels.
+# Tarball pinned and checksum-verified against the upstream release asset.
+# Deliberately no --platform=$BUILDPLATFORM, unlike the frontend builder above:
+# these binaries ship inside the runtime image, so they must be built for
+# TARGETPLATFORM. Pinning this to the build platform would put a foreign-arch
+# redis-server in the image, which fails the same way #734 did.
+FROM node:22-bookworm@sha256:5647be709086c696ff32edaaf1c70cd26d1da6ab2b39c32f3c7b4c4a31957e37 AS redis-builder
+ARG REDIS_VERSION=8.10.1
+RUN set -eux; \
+    for i in 1 2 3; do apt-get -o Acquire::Retries=3 update && break || sleep $((i * 15)); done; \
+    apt-get install -y --no-install-recommends ca-certificates gcc g++ libc6-dev make; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl --fail --location --silent --show-error --retry 3 \
+      --proto '=https' --tlsv1.2 \
+      "https://github.com/redis/redis/releases/download/${REDIS_VERSION}/redis-full.tar.gz" \
+      -o redis.tar.gz; \
+    echo "e5cae2686231290bf55ae5cc4da01e646c3424233cae7618ebf3a64250ef1583 *redis.tar.gz" \
+      | sha256sum -c -; \
+    mkdir -p /usr/src/redis; \
+    tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
+    case "$(dpkg --print-architecture)" in \
+      amd64 | i386) jemallocPage=12 ;; \
+      *) jemallocPage=16 ;; \
+    esac; \
+    # deps/Makefile appends JEMALLOC_CONFIGURE_OPTS to the bundled jemalloc's
+    # configure line. Pass it through the environment: a make-level definition
+    # would clobber the --host the same variable carries for cross-builds.
+    export JEMALLOC_CONFIGURE_OPTS="--with-lg-page=${jemallocPage} --with-lg-hugepage=21"; \
+    # Split so -j reaches the compile. Only `build` carries make's `+` prefix,
+    # so passing -j to `deploy` alone silently drops to -j1.
+    make -C /usr/src/redis -j "$(nproc)" build redis; \
+    make -C /usr/src/redis deploy redis; \
+    # configure exits 0 on an option it does not recognise, then falls back to
+    # probing the build host and answers 12 under emulation. So assert what it
+    # actually compiled, not what we asked for: without this the build stays
+    # green while shipping the 4 KiB Redis that caused #734.
+    grep -qx "#define LG_PAGE ${jemallocPage}" \
+      /usr/src/redis/deps/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h; \
+    # deploy.sh downgrades a failed core build to a warning on stdout, so the
+    # binaries existing is not implied by make succeeding.
+    test -x /usr/local/bin/redis-server; \
+    test -x /usr/local/bin/redis-cli
+
+# ============================================
 # Stage 1: Build the frontend (Vite + React)
 # ============================================
 # Run on the native build platform to avoid QEMU crashes with esbuild on
@@ -378,13 +432,12 @@ RUN for i in 1 2 3; do apt-get -o Acquire::Retries=3 update && break || sleep $(
     && pandoc --version \
     && rm -rf /var/lib/apt/lists/*
 
-# Embedded-mode databases: PostgreSQL 17 (PGDG) + Redis 8 (packages.redis.io),
-# each pinned to the same major the Compose stack runs (postgres:17 / redis:8)
-# so embedded and external deployments behave identically and data hands off
-# cleanly. Distro repos would silently downgrade Redis to 7.x. Shipped in every
+# Embedded-mode database: PostgreSQL 17 (PGDG), pinned to the same major the
+# Compose stack runs (postgres:17) so embedded and external deployments behave
+# identically and data hands off cleanly. Distro repos lag. Shipped in every
 # image (single tag); unused in external/Compose mode, ~tens of MB against the
-# multi-GB base. They enter the Trivy CVE surface and ride the existing
-# apt-get upgrade patching.
+# multi-GB base. It enters the Trivy CVE surface and rides the existing
+# apt-get upgrade patching. Redis is handled below, from the redis-builder stage.
 RUN install -d /usr/share/postgresql-common/pgdg \
     && curl --fail --location --silent --show-error --retry 3 \
          --proto '=https' --tlsv1.2 \
@@ -394,24 +447,30 @@ RUN install -d /usr/share/postgresql-common/pgdg \
          "0144068502a1eddd2a0280ede10ef607d1ec592ce819940991203941564e8e76" \
          /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
          | sha256sum --check --strict - \
-    && curl --fail --location --silent --show-error --retry 3 \
-         --proto '=https' --tlsv1.2 \
-         https://packages.redis.io/gpg \
-         -o /usr/share/keyrings/redis-archive-keyring.asc \
-    && printf '%s  %s\n' \
-         "817b5a78358d00ed6b71884d70ad5d2eab9934badca1a34299fdc6a2e4a8ad20" \
-         /usr/share/keyrings/redis-archive-keyring.asc \
-         | sha256sum --check --strict - \
     && . /etc/os-release \
     && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
          > /etc/apt/sources.list.d/pgdg.list \
-    && echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.asc] https://packages.redis.io/deb ${VERSION_CODENAME} main" \
-         > /etc/apt/sources.list.d/redis.list \
     && for i in 1 2 3; do apt-get -o Acquire::Retries=3 update && break || sleep $((i * 15)); done \
-    && apt-get install -y --no-install-recommends postgresql-17 postgresql-client-17 redis-server \
-    && dpkg-query -W -f='${Version}\n' redis-server | grep -Eq '(^|:)8\.' \
+    && apt-get install -y --no-install-recommends postgresql-17 postgresql-client-17 \
     && rm -f /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/certs/ssl-cert-snakeoil.pem \
     && rm -rf /var/lib/apt/lists/*
+
+# Redis 8 for embedded mode, same major as the Compose stack (redis:8). Built
+# without BUILD_TLS (the server binds 127.0.0.1 with no TLS port), which leaves
+# it linking only libc and libm, so it does not depend on what Postgres happens
+# to drag in. Nothing here executes redis-server: PR #519 removed the one step
+# that did, because a cross-build emulates it and jemalloc is what falls over.
+#
+# Being a source build rather than a deb has two costs worth knowing. Redis
+# carries no package metadata now, so it drops out of the syft SBOM and Trivy's
+# package findings, and Dependabot only bumps FROM digests, never REDIS_VERSION.
+# Nothing will tell us the embedded Redis is stale; that needs a bump (#961).
+COPY --from=redis-builder /usr/local/bin/redis-server /usr/local/bin/redis-cli /usr/local/bin/
+# redis-server dispatches on argv[0], so these cost a symlink each. --appendonly
+# is on, and a truncated AOF makes redis-server tell the operator to run
+# redis-check-aof; the apt package used to supply it. COPY would deref them.
+RUN ln -s redis-server /usr/local/bin/redis-check-aof \
+    && ln -s redis-server /usr/local/bin/redis-check-rdb
 
 # s6-overlay supervises the embedded service tree (postgres + redis + app).
 # Pinned and checksum-verified against repository-controlled literal hashes.

--- a/tests/unit/features/ocr-runtime-build-contract.test.ts
+++ b/tests/unit/features/ocr-runtime-build-contract.test.ts
@@ -185,8 +185,19 @@ describe("OCR v3 runtime artifact contract", () => {
   });
 
   it("validates Redis without executing a target-architecture binary during cross-builds", () => {
-    expect(dockerfile).toContain("dpkg-query -W -f='${Version}\\n' redis-server");
+    // Redis is now built from source (#734), so the version comes from the
+    // pinned tarball rather than dpkg. The invariant is unchanged: nothing may
+    // run redis-server during the build, because a cross-build would have to
+    // emulate it and jemalloc is exactly what breaks under emulation.
+    expect(dockerfile).toMatch(/^ARG REDIS_VERSION=8\.\d+\.\d+$/m);
     expect(dockerfile).not.toContain("redis-server --version");
+    expect(dockerfile).not.toContain("redis-cli --version");
+    // The make goals matter too: `test` is a real target in Redis's Makefile
+    // and it starts a server, so it would reintroduce the emulated execution
+    // through a step that looks inert from outside.
+    for (const goals of dockerfile.match(/make -C \/usr\/src\/redis[^\n;]*/g) ?? []) {
+      expect(goals, "Redis make goals must stay build/deploy only").not.toMatch(/\btest\b/);
+    }
   });
 
   it("keeps Korean traineddata out of the official Fast OCR base image", () => {

--- a/tests/unit/security/container-policy.test.ts
+++ b/tests/unit/security/container-policy.test.ts
@@ -27,6 +27,7 @@ const cpuCompose = parseCompose("docker/docker-compose.yml");
 const gpuCompose = parseCompose("docker/docker-compose-gpu.yml");
 const qaComposeSource = read("tests/qa/docker-compose.qa.yml");
 const qaCompose = parseCompose("tests/qa/docker-compose.qa.yml");
+const dockerfile = read("docker/Dockerfile");
 
 describe("release container policy", () => {
   it("requires the QA application image by immutable SHA-256 digest", () => {
@@ -83,6 +84,80 @@ describe("release container policy", () => {
         expect(patterns, `${dockerignore} must exclude ${pattern}`).toContain(pattern);
       }
     }
+  });
+
+  // Issue #734. jemalloc refuses to start when the kernel's page size is larger
+  // than the one it was compiled for, and the packages.redis.io build assumes
+  // 4 KiB. That killed redis-server AND redis-cli on 16 KiB hosts (Asahi Linux,
+  // some Apple-silicon VMs) and 64 KiB hosts (aarch64 RHEL), so the embedded
+  // container hung forever in the redis-ready probe. No prebuilt Redis 8 fixes
+  // it on this base, so the image builds one and patches jemalloc itself.
+  it("builds embedded Redis with a page-size-agnostic jemalloc on ARM", () => {
+    expect(dockerfile).toMatch(/ AS redis-builder$/m);
+    // 64 KiB covers every aarch64 kernel in the wild; x86 is always 4 KiB paged,
+    // and widening it there would only waste memory. Same split Debian uses.
+    expect(dockerfile).toMatch(/amd64 \| i386\) jemallocPage=12 ;;/);
+    expect(dockerfile).toMatch(/\*\) jemallocPage=16 ;;/);
+    // Set through deps/Makefile's own JEMALLOC_CONFIGURE_OPTS seam. It has to
+    // be exported, not passed as a make argument: a command-line definition
+    // overrides the `+=` the same variable uses to carry --host on cross-builds.
+    expect(dockerfile).toMatch(
+      /export JEMALLOC_CONFIGURE_OPTS="--with-lg-page=\$\{jemallocPage\} /,
+    );
+    // The tarball is what gets built, so the pinned version has to be the one
+    // actually fetched, not just a declared ARG.
+    expect(dockerfile).toContain(
+      "https://github.com/redis/redis/releases/download/${REDIS_VERSION}/redis-full.tar.gz",
+    );
+
+    // Scope the COPY to the final stage: landing it in a builder would ship an
+    // image with no Redis at all and still match a whole-file regex.
+    const production = dockerfile.slice(dockerfile.indexOf("AS production"));
+    expect(production).toMatch(/COPY --from=redis-builder\b[\s\S]{0,200}?redis-server/);
+    expect(production).toMatch(/COPY --from=redis-builder\b[\s\S]{0,200}?redis-cli/);
+  });
+
+  it("never installs the 4 KiB-page Redis apt build into the embedded image", () => {
+    expect(dockerfile).not.toMatch(/sources\.list\.d\/redis\.list/);
+    expect(dockerfile).not.toMatch(/redis-archive-keyring/);
+    expect(dockerfile).not.toMatch(/packages\.redis\.io\/deb/);
+
+    // Join line continuations first: an unanchored regex would run past the end
+    // of the install command and match redis-server in a later shell step.
+    const aptInstalls = dockerfile
+      .replace(/\\\r?\n\s*/g, " ")
+      .split(/[\n;]|&&/)
+      .map((command) => command.trim())
+      .filter((command) => /(^|\s)apt-get\s[^|]*\binstall\b/.test(command));
+
+    expect(aptInstalls.length).toBeGreaterThan(0);
+    for (const command of aptInstalls) {
+      expect(command, "Redis must not come from an apt package").not.toMatch(/\bredis-server\b/);
+    }
+  });
+
+  it("asserts the page size jemalloc compiled, not the one it was asked for", () => {
+    // This is the guard that actually prevents a repeat of #734. jemalloc's
+    // configure exits 0 on an option it no longer recognises and then falls
+    // back to probing the build host, which answers 12 under emulation. So
+    // passing the flag proves nothing; LG_PAGE in the generated header is
+    // configure's own record of what it decided. Checked by reading the header
+    // rather than running Redis, keeping the PR #519 no-emulation invariant.
+    expect(dockerfile).toMatch(
+      /grep -qx "#define LG_PAGE \$\{jemallocPage\}"[\s\S]{0,120}?jemalloc_internal_defs\.h/,
+    );
+    // deploy.sh downgrades a failed core build to a warning on stdout, so the
+    // layer can succeed with no binaries to copy.
+    expect(dockerfile).toMatch(/test -x \/usr\/local\/bin\/redis-server/);
+    expect(dockerfile).toMatch(/test -x \/usr\/local\/bin\/redis-cli/);
+  });
+
+  it("checksum-pins the Redis source tarball to a literal, not an overridable ARG", () => {
+    // An ARG default is settable with --build-arg, which would hand the
+    // supply-chain pin to the caller. Every other hash in this Dockerfile is
+    // inline for the same reason.
+    expect(dockerfile).not.toMatch(/ARG REDIS_DOWNLOAD_SHA/);
+    expect(dockerfile).toMatch(/echo "[a-f0-9]{64} \*redis\.tar\.gz" \\?\s*\| sha256sum -c -/);
   });
 
   it("prevents privilege gains in every canonical runtime service", () => {

--- a/tests/unit/security/dockerfile-build-args.test.ts
+++ b/tests/unit/security/dockerfile-build-args.test.ts
@@ -124,7 +124,9 @@ describe("Dockerfile build args", () => {
       "d502599878eb29af3ae5f0cb5d559134df96534125d452c7a0674a5bad2c5ecf",
       "b651c8bfd5a0a2f6650d6c0830131747ef67a1d9c0475b1399626611419e2205",
       "0144068502a1eddd2a0280ede10ef607d1ec592ce819940991203941564e8e76",
-      "817b5a78358d00ed6b71884d70ad5d2eab9934badca1a34299fdc6a2e4a8ad20",
+      // Redis source tarball. Replaced the packages.redis.io keyring hash when
+      // Redis moved to a source build for larger kernel page sizes (#734).
+      "e5cae2686231290bf55ae5cc4da01e646c3424233cae7618ebf3a64250ef1583",
       "8b22a2eaca4bf0b27a43d36e65c89d2701738f628d1abd0cea5569619f66f785",
       "6dbcde158a3e78b9bb141d7bcb5ccb421e563523babbe2c64470e76f4fd02dae",
       "59289456ab1761e277bd456a95e737c06b03ede99158beb24f12b165a904f478",
@@ -203,7 +205,7 @@ describe("Dockerfile build args", () => {
 
   it("removes distro-generated snakeoil TLS material after embedded database install", () => {
     const production = stageBody("production");
-    const installIndex = production.indexOf("postgresql-17 postgresql-client-17 redis-server");
+    const installIndex = production.indexOf("postgresql-17 postgresql-client-17");
     const removeIndex = production.indexOf("/etc/ssl/private/ssl-cert-snakeoil.key");
 
     expect(installIndex).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
Closes #734.

## What broke

The all-in-one image installed `redis-server` from packages.redis.io. That build's bundled jemalloc is compiled for 4 KiB pages, and jemalloc refuses to start when the kernel's page size is larger:

```c
if (os_page > PAGE) {   /* PAGE is fixed at compile time */
    malloc_write("<jemalloc>: Unsupported system page size\n");
```

So on 16 KiB-page hosts (Asahi Linux, some Apple-silicon VMs) and 64 KiB-page hosts (aarch64 RHEL), `redis-server` died at startup. `redis-cli` too, since it links the same allocator. `redis-ready` loops on `until redis-cli ping | grep -q PONG`, and the app service depends on it, so the container hung at boot forever with the jemalloc line as the only clue.

The Compose stack was never affected: `redis:8-alpine` builds jemalloc at 64 KiB.

## Reproduced first

Confirmed against the shipped 2.x image rather than inferred, using an `LD_PRELOAD` shim that makes `sysconf(_SC_PAGESIZE)` report 16384, which is the exact value jemalloc branches on:

```
### CONTROL: shim reports 4096
Redis server v=8.8.1 ... malloc=jemalloc-5.3.0     exit=0

### REPRO: shim reports 16384
<jemalloc>: Unsupported system page size
<jemalloc>: Unsupported system page size
Segmentation fault                                 exit=139
```

Scanning the whole image for that guard string returns exactly three binaries: `redis-server`, `redis-cli`, `redis-benchmark`. Nothing else bundles jemalloc.

## Why a source build

Every prebuilt option is ruled out, checked rather than assumed:

| Source | Page size | Blocker |
| --- | --- | --- |
| packages.redis.io 8.10.1 | 4096 | still 4 KiB today, so the bug is live on latest |
| `redis:8-bookworm` | 65536 | frozen at 8.4.0 since February |
| `redis:8-trixie` | 65536 | needs `GLIBC_2.38`, base has 2.36 |
| `redis:8-alpine` | 65536 | musl |

So the image builds Redis 8.10.1 from a checksum-pinned tarball and sets the page flags through `deps/Makefile`'s own `JEMALLOC_CONFIGURE_OPTS` seam: 4 KiB on x86, 64 KiB elsewhere, the same split Debian and docker-library/redis use. Exported rather than passed to `make`, because a command-line definition would clobber the `--host` that variable also carries.

## The assertion that matters

The build checks `LG_PAGE` in jemalloc's generated header, not that the flag was passed:

```dockerfile
grep -qx "#define LG_PAGE ${jemallocPage}" \
  .../jemalloc_internal_defs.h
```

This is load-bearing. `configure` exits 0 on an option it does not recognise and then falls back to *probing* the build host, which answers 12 under emulation. Guarding the input would have let a future version bump ship the same bug from a green build. Review caught that; the first draft of this fix guarded only the input.

Nothing runs `redis-server` during the build, keeping the invariant PR #519 added.

## Also

Dropping `BUILD_TLS` (the server binds 127.0.0.1 with no TLS port) leaves the binary linking only `libc` and `libm`, so it no longer depends on Postgres happening to pull in libssl3. `-j` was reaching only `deploy`, which has no `+` prefix and silently degraded to `-j1`; splitting the goals halved the stage from 163s to 78s. `redis-check-aof`/`redis-check-rdb` are re-added as symlinks, since `--appendonly` is on and a truncated AOF tells the operator to run a tool the deb used to supply.

## Verified

- Built the stage verbatim: Redis 8.10.1, `Page size: 65536`, `NEEDED` is libc + libm only
- Same 16 KiB simulation that killed the old binary: starts at 4096, 16384 and 65536, and answers `PONG` at 16 KiB
- Guard teeth: feeding the old 4 KiB binaries to the page-size check fails the build; a no-op patch fails it too
- Test teeth: all four new assertions fail against main's Dockerfile
- Blast radius: every test reading `docker/Dockerfile`, which surfaced three contracts this broke, including PR #519's cross-build rule
- `pnpm lint` exit 0, `pnpm typecheck` 9/9, `pnpm test` 19825 passed

Baseline was CI run 33362314899 on `dbf5d3b9` (green). No new failures.

Filed separately: #961 (nothing signals when this Redis goes stale, since it leaves the SBOM and Dependabot cannot bump it), #962 (the readiness probes hang forever and discard stderr, which is why this presented as a silent hang), #963 (the arm64 image is never booted before release, and arm64 is the arch this fix is for).
