### PR TITLE
fix(api): return 409 instead of 500 when duplicate-name creates race

### DIFF
--- a/apps/api/src/lib/external-auth-resolver.ts
+++ b/apps/api/src/lib/external-auth-resolver.ts
@@ -188,44 +188,85 @@ export async function resolveExternalUser(params: ExternalAuthParams): Promise<E
       }
     }
 
-    const uniqueUsername = await findUniqueUsername(username);
-    const newUserId = randomUUID();
+    // The username scan can't close the race: two concurrent logins both
+    // pass it before either insert commits (issue #927), so the insert
+    // carries a conflict guard and the loser recovers below.
+    const MAX_USERNAME_RACE_RETRIES = 3;
+    for (let attempt = 0; attempt < MAX_USERNAME_RACE_RETRIES; attempt++) {
+      const uniqueUsername = await findUniqueUsername(username);
+      const newUserId = randomUUID();
 
-    // Look up the default team
-    const [defaultTeam] = await db
-      .select()
-      .from(schema.teams)
-      .where(eq(schema.teams.name, "Default"));
-    const teamId = defaultTeam?.id ?? "default-team-00000000";
+      // Look up the default team
+      const [defaultTeam] = await db
+        .select()
+        .from(schema.teams)
+        .where(eq(schema.teams.name, "Default"));
+      const teamId = defaultTeam?.id ?? "default-team-00000000";
 
-    await db.insert(schema.users).values({
-      id: newUserId,
-      username: uniqueUsername,
-      passwordHash: null,
-      role: defaultRole,
-      team: teamId,
-      mustChangePassword: false,
-      authProvider: provider,
-      externalId,
-      email: email ?? null,
-    });
+      const inserted = await db
+        .insert(schema.users)
+        .values({
+          id: newUserId,
+          username: uniqueUsername,
+          passwordHash: null,
+          role: defaultRole,
+          team: teamId,
+          mustChangePassword: false,
+          authProvider: provider,
+          externalId,
+          email: email ?? null,
+        })
+        .onConflictDoNothing({ target: schema.users.username });
 
-    await audit(`${providerUpper}_USER_CREATED`, {
-      userId: newUserId,
-      username: uniqueUsername,
-      email,
-      role: defaultRole,
-    });
+      if (inserted.rowCount) {
+        await audit(`${providerUpper}_USER_CREATED`, {
+          userId: newUserId,
+          username: uniqueUsername,
+          email,
+          role: defaultRole,
+        });
 
-    return {
-      user: {
-        id: newUserId,
-        username: uniqueUsername,
-        role: defaultRole,
-        team: teamId,
-      },
-      action: "created",
-    };
+        return {
+          user: {
+            id: newUserId,
+            username: uniqueUsername,
+            role: defaultRole,
+            team: teamId,
+          },
+          action: "created",
+        };
+      }
+
+      // Race lost. If this same external identity won it in a concurrent
+      // login (say, two tabs finishing first login at once), hand back the
+      // winner's user instead of failing the login.
+      const [winner] = await db
+        .select()
+        .from(schema.users)
+        .where(
+          and(eq(schema.users.externalId, externalId), eq(schema.users.authProvider, provider)),
+        )
+        .limit(1);
+
+      if (winner) {
+        if (isDisabledRole(winner.role)) {
+          await audit(`${providerUpper}_LOGIN_FAILED`, {
+            reason: "user_disabled",
+            userId: winner.id,
+          });
+          return { user: null, action: "denied", deniedReason: "user_disabled" };
+        }
+        return {
+          user: { id: winner.id, username: winner.username, role: winner.role, team: winner.team },
+          action: "matched",
+        };
+      }
+      // A different user took the name; rescan and retry.
+    }
+
+    throw new Error(
+      `${provider} auto-create lost the username race ${MAX_USERNAME_RACE_RETRIES} times for "${username}"`,
+    );
   }
 
   // 4. Denied: no matching user, auto-link did not match, auto-create disabled

--- a/apps/api/src/lib/external-auth-resolver.ts
+++ b/apps/api/src/lib/external-auth-resolver.ts
@@ -237,6 +237,11 @@ export async function resolveExternalUser(params: ExternalAuthParams): Promise<E
         };
       }
 
+      logger.info(
+        { attempt: attempt + 1, username: uniqueUsername },
+        `${provider} auto-create lost a username race, recovering`,
+      );
+
       // Race lost. If this same external identity won it in a concurrent
       // login (say, two tabs finishing first login at once), hand back the
       // winner's user instead of failing the login.

--- a/apps/api/src/routes/enterprise/scim.ts
+++ b/apps/api/src/routes/enterprise/scim.ts
@@ -390,18 +390,28 @@ export async function registerScimRoutes(app: FastifyInstance): Promise<void> {
       const teamId = defaultTeam?.id ?? "default-team-00000000";
 
       const now = new Date();
-      await db.insert(schema.users).values({
-        id,
-        username: userName,
-        email,
-        externalId: externalId ?? null,
-        role: active ? "user" : "disabled",
-        team: teamId,
-        authProvider: "scim",
-        mustChangePassword: false,
-        createdAt: now,
-        updatedAt: now,
-      });
+      // The pre-check above can't close the race: IdP retries can send the
+      // same create twice, and both pass the SELECT before either insert
+      // commits (issue #927).
+      const inserted = await db
+        .insert(schema.users)
+        .values({
+          id,
+          username: userName,
+          email,
+          externalId: externalId ?? null,
+          role: active ? "user" : "disabled",
+          team: teamId,
+          authProvider: "scim",
+          mustChangePassword: false,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoNothing({ target: schema.users.username });
+
+      if (!inserted.rowCount) {
+        return reply.status(409).send(scimError(409, "User already exists"));
+      }
 
       await auditLog(
         request.log,

--- a/apps/api/src/routes/enterprise/scim.ts
+++ b/apps/api/src/routes/enterprise/scim.ts
@@ -820,11 +820,21 @@ export async function registerScimRoutes(app: FastifyInstance): Promise<void> {
       const id = randomUUID();
       const now = new Date();
 
-      await db.insert(schema.teams).values({
-        id,
-        name: displayName,
-        createdAt: now,
-      });
+      // The pre-check above can't close the race: IdP retries can send the
+      // same create twice, and both pass the SELECT before either insert
+      // commits (issue #927).
+      const inserted = await db
+        .insert(schema.teams)
+        .values({
+          id,
+          name: displayName,
+          createdAt: now,
+        })
+        .onConflictDoNothing({ target: schema.teams.name });
+
+      if (!inserted.rowCount) {
+        return reply.status(409).send(scimError(409, "Group already exists"));
+      }
 
       // Assign members to the team
       if (members && members.length > 0) {

--- a/apps/api/src/routes/roles.ts
+++ b/apps/api/src/routes/roles.ts
@@ -132,15 +132,24 @@ export async function rolesRoutes(app: FastifyInstance): Promise<void> {
     }
 
     const id = randomUUID();
-    await db.insert(schema.roles).values({
-      id,
-      name,
-      description: description?.trim() ?? "",
-      permissions,
-      toolPermissions: toolPermissions ?? null,
-      isBuiltin: false,
-      createdBy: user.id,
-    });
+    // The pre-check above can't close the race: two concurrent creates both
+    // pass the SELECT before either insert commits (issue #927).
+    const inserted = await db
+      .insert(schema.roles)
+      .values({
+        id,
+        name,
+        description: description?.trim() ?? "",
+        permissions,
+        toolPermissions: toolPermissions ?? null,
+        isBuiltin: false,
+        createdBy: user.id,
+      })
+      .onConflictDoNothing({ target: schema.roles.name });
+
+    if (!inserted.rowCount) {
+      return reply.status(409).send({ error: "Role name already exists", code: "CONFLICT" });
+    }
 
     await auditFromRequest(request)("ROLE_CREATED", {
       adminId: user.id,

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -79,12 +79,22 @@ export async function teamsRoutes(app: FastifyInstance): Promise<void> {
 
     const id = randomUUID();
 
-    await db.insert(schema.teams).values({
-      id,
-      name: trimmedName,
-      storageQuota: storageQuota ?? null,
-      retentionHours: retentionHours ?? null,
-    });
+    // The pre-check above can't close the race: two concurrent creates both
+    // pass the SELECT before either insert commits (issue #927). This guard
+    // only covers exact-case twins; the unique constraint is case-sensitive.
+    const inserted = await db
+      .insert(schema.teams)
+      .values({
+        id,
+        name: trimmedName,
+        storageQuota: storageQuota ?? null,
+        retentionHours: retentionHours ?? null,
+      })
+      .onConflictDoNothing({ target: schema.teams.name });
+
+    if (!inserted.rowCount) {
+      return reply.status(409).send({ error: "Team name already exists", code: "CONFLICT" });
+    }
 
     return reply.status(201).send({
       id,

--- a/tests/helpers/pg-race.ts
+++ b/tests/helpers/pg-race.ts
@@ -1,0 +1,57 @@
+/**
+ * Deterministically widens a check-then-insert race (issue #927).
+ *
+ * Duplicate-name creation paths SELECT for a twin, then INSERT. The race
+ * only bites when every contender passes the SELECT before the winner's
+ * INSERT commits, a window too narrow to hit reliably with concurrent
+ * requests alone. This helper forces it: an EXCLUSIVE table lock lets the
+ * pre-check SELECTs through but parks every INSERT in the lock queue.
+ * Once `count` inserts are waiting, the lock is released and they all hit
+ * the unique index together.
+ *
+ * The `fire` callback must start the contenders and return a promise for
+ * their combined outcome (typically Promise.all of app.inject calls).
+ */
+
+import { sql } from "drizzle-orm";
+import { db } from "../../apps/api/src/db/index.js";
+
+export async function raceInserts<T>(
+  table: string,
+  count: number,
+  fire: () => Promise<T>,
+): Promise<T> {
+  let pending: Promise<T> | undefined;
+
+  await db.transaction(async (tx) => {
+    await tx.execute(sql.raw(`LOCK TABLE "${table}" IN EXCLUSIVE MODE`));
+
+    pending = fire();
+    // The outcome can reject before we await it below (a race loser dying
+    // on the constraint); pre-attach a handler so it never counts as an
+    // unhandled rejection in the meantime.
+    pending.catch(() => {});
+
+    // Wait until every contender is parked on the lock. Sessions from other
+    // vitest forks live in other per-fork databases, hence the datname
+    // filter. The transaction ending releases the lock.
+    const deadline = Date.now() + 10_000;
+    for (;;) {
+      const res = await db.execute(sql`
+        SELECT count(*)::int AS n
+        FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND wait_event_type = 'Lock'
+          AND query ILIKE ${`%insert into "${table}"%`}
+      `);
+      const n = Number((res.rows[0] as { n: number }).n);
+      if (n >= count) break;
+      if (Date.now() > deadline) {
+        throw new Error(`timed out: only ${n}/${count} inserts blocked on "${table}"`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  });
+
+  return pending as Promise<T>;
+}

--- a/tests/helpers/pg-race.ts
+++ b/tests/helpers/pg-race.ts
@@ -23,35 +23,65 @@ export async function raceInserts<T>(
 ): Promise<T> {
   let pending: Promise<T> | undefined;
 
-  await db.transaction(async (tx) => {
-    await tx.execute(sql.raw(`LOCK TABLE "${table}" IN EXCLUSIVE MODE`));
+  try {
+    await db.transaction(async (tx) => {
+      await tx.execute(sql.raw(`LOCK TABLE "${table}" IN EXCLUSIVE MODE`));
 
-    pending = fire();
-    // The outcome can reject before we await it below (a race loser dying
-    // on the constraint); pre-attach a handler so it never counts as an
-    // unhandled rejection in the meantime.
-    pending.catch(() => {});
+      pending = fire();
+      // The outcome can reject before we await it below (a race loser dying
+      // on the constraint); pre-attach a handler so it never counts as an
+      // unhandled rejection in the meantime.
+      pending.catch(() => {});
 
-    // Wait until every contender is parked on the lock. Sessions from other
-    // vitest forks live in other per-fork databases, hence the datname
-    // filter. The transaction ending releases the lock.
-    const deadline = Date.now() + 10_000;
-    for (;;) {
-      const res = await db.execute(sql`
-        SELECT count(*)::int AS n
-        FROM pg_stat_activity
-        WHERE datname = current_database()
-          AND wait_event_type = 'Lock'
-          AND query ILIKE ${`%insert into "${table}"%`}
-      `);
-      const n = Number((res.rows[0] as { n: number }).n);
-      if (n >= count) break;
-      if (Date.now() > deadline) {
-        throw new Error(`timed out: only ${n}/${count} inserts blocked on "${table}"`);
+      // Wait until every contender is parked on the lock. Sessions from other
+      // vitest forks live in other per-fork databases, hence the datname
+      // filter. The transaction ending releases the lock.
+      const deadline = Date.now() + 10_000;
+      for (;;) {
+        const res = await db.execute(sql`
+          SELECT count(*)::int AS n
+          FROM pg_stat_activity
+          WHERE datname = current_database()
+            AND wait_event_type = 'Lock'
+            AND query ILIKE ${`%insert into "${table}"%`}
+        `);
+        const n = Number((res.rows[0] as { n: number }).n);
+        if (n >= count) break;
+        if (Date.now() > deadline) {
+          throw new Error(`timed out: only ${n}/${count} inserts blocked on "${table}"`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
       }
-      await new Promise((resolve) => setTimeout(resolve, 25));
+    });
+  } catch (err) {
+    // The rollback above released the lock, so the contenders can now run
+    // to completion. Wait for them, both so a failing test doesn't leak
+    // writes past its end and because a contender that died before ever
+    // reaching its insert is usually the real story, not the timeout.
+    if (pending) {
+      const [settled] = await Promise.allSettled([pending]);
+      if (settled.status === "rejected") {
+        throw new Error(`${(err as Error).message}; a contender failed before blocking`, {
+          cause: settled.reason,
+        });
+      }
+      const value = settled.value as unknown;
+      const summary = Array.isArray(value)
+        ? value
+            .map((r) =>
+              r && typeof r === "object" && "statusCode" in r
+                ? String((r as { statusCode: number }).statusCode)
+                : "?",
+            )
+            .join(",")
+        : String(value);
+      throw new Error(
+        `${(err as Error).message}; contenders finished without blocking (outcome: ${summary})`,
+        { cause: err },
+      );
     }
-  });
+    throw err;
+  }
 
   return pending as Promise<T>;
 }

--- a/tests/integration/platform/custom-roles.test.ts
+++ b/tests/integration/platform/custom-roles.test.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { db, schema } from "../../../apps/api/src/db/index.js";
 import { raceInserts } from "../../helpers/pg-race.js";
@@ -87,6 +87,17 @@ describe("custom roles", () => {
 
     const rows = await db.select().from(schema.roles).where(eq(schema.roles.name, name));
     expect(rows).toHaveLength(1);
+
+    // The 409 loser must not leave a phantom audit row; ROLE_CREATED is
+    // only written after the insert guard.
+    const auditRows = await db
+      .select()
+      .from(schema.auditLog)
+      .where(
+        sql`${schema.auditLog.action} = 'ROLE_CREATED' AND ${schema.auditLog.details}->>'roleName' = ${name}`,
+      );
+    expect(auditRows).toHaveLength(1);
+
     await db.delete(schema.roles).where(eq(schema.roles.name, name));
   });
 

--- a/tests/integration/platform/custom-roles.test.ts
+++ b/tests/integration/platform/custom-roles.test.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { db, schema } from "../../../apps/api/src/db/index.js";
+import { raceInserts } from "../../helpers/pg-race.js";
 import { buildTestApp, loginAsAdmin, type TestApp } from "../test-server.js";
 
 let testApp: TestApp;
@@ -58,6 +59,35 @@ describe("custom roles", () => {
       payload: { name: "admin", permissions: ["tools:use"] },
     });
     expect(res.statusCode).toBe(409);
+  });
+
+  it("concurrent duplicate creates return one 201 and one 409, never 500", async () => {
+    // Issue #927: requests that pass the duplicate pre-check before the
+    // winner's insert commits used to surface the 23505 unique violation
+    // as a 500. raceInserts holds both requests at the insert so each one
+    // passes the pre-check.
+    const name = `race-role-${Date.now().toString(36)}`;
+    const create = () =>
+      testApp.app.inject({
+        method: "POST",
+        url: "/api/v1/roles",
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { name, permissions: ["tools:use"] },
+      });
+
+    const results = await raceInserts("roles", 2, () => Promise.all([create(), create()]));
+    const statuses = results.map((r) => r.statusCode).sort();
+    expect(statuses).toEqual([201, 409]);
+
+    const conflict = results.find((r) => r.statusCode === 409);
+    expect(JSON.parse(conflict?.body ?? "{}")).toEqual({
+      error: "Role name already exists",
+      code: "CONFLICT",
+    });
+
+    const rows = await db.select().from(schema.roles).where(eq(schema.roles.name, name));
+    expect(rows).toHaveLength(1);
+    await db.delete(schema.roles).where(eq(schema.roles.name, name));
   });
 
   it("can assign custom role to user", async () => {

--- a/tests/integration/platform/external-auth-race.test.ts
+++ b/tests/integration/platform/external-auth-race.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Concurrent auto-create race in the external auth resolver (issue #927).
+ *
+ * Two logins can pass the resolver's username scan before either inserts.
+ * The loser's insert hits the users.username unique constraint; it must
+ * recover (re-run the scan and pick a fresh username) instead of failing
+ * the login with an unhandled 23505.
+ *
+ * The same-identity flavor (one login racing itself in two tabs) can't be
+ * pinned deterministically against a real database, so its recovery branch
+ * is covered by scripted unit tests in
+ * tests/unit/api/external-auth-resolver-mutation.test.ts.
+ */
+
+import { inArray } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../../apps/api/src/db/index.js";
+import type { ExternalAuthParams } from "../../../apps/api/src/lib/external-auth-resolver.js";
+import { resolveExternalUser } from "../../../apps/api/src/lib/external-auth-resolver.js";
+import { raceInserts } from "../../helpers/pg-race.js";
+import { buildTestApp, type TestApp } from "../test-server.js";
+
+let testApp: TestApp;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+function baseParams(overrides: Partial<ExternalAuthParams>): ExternalAuthParams {
+  return {
+    provider: "oidc",
+    externalId: "race-ext",
+    username: "race_user",
+    autoCreate: true,
+    autoLink: false,
+    defaultRole: "user",
+    logger: testApp.app.log,
+    ip: "127.0.0.1",
+    requestId: "race-test",
+    ...overrides,
+  };
+}
+
+describe("external auth auto-create races", () => {
+  it("two identities racing for the same username get distinct suffixed usernames", async () => {
+    // Different identities, same derived username. Both pass the
+    // unique-username scan while raceInserts holds their inserts; the
+    // loser must re-run the scan and create its own account.
+    const [a, b] = await raceInserts("users", 2, () =>
+      Promise.all([
+        resolveExternalUser(baseParams({ externalId: "race-distinct-1", username: "race_shared" })),
+        resolveExternalUser(baseParams({ externalId: "race-distinct-2", username: "race_shared" })),
+      ]),
+    );
+
+    expect(a.user, JSON.stringify(a)).not.toBeNull();
+    expect(b.user, JSON.stringify(b)).not.toBeNull();
+    expect(a.action).toBe("created");
+    expect(b.action).toBe("created");
+    const usernames = [a.user?.username, b.user?.username].sort();
+    expect(usernames).toEqual(["race_shared", "race_shared_2"]);
+
+    const rows = await db
+      .select()
+      .from(schema.users)
+      .where(inArray(schema.users.username, ["race_shared", "race_shared_2"]));
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/tests/integration/platform/external-auth-race.test.ts
+++ b/tests/integration/platform/external-auth-race.test.ts
@@ -27,6 +27,9 @@ beforeAll(async () => {
 }, 30_000);
 
 afterAll(async () => {
+  await db
+    .delete(schema.users)
+    .where(inArray(schema.users.username, ["race_shared", "race_shared_2"]));
   await testApp.cleanup();
 }, 10_000);
 

--- a/tests/integration/platform/scim.test.ts
+++ b/tests/integration/platform/scim.test.ts
@@ -1519,6 +1519,34 @@ describe("SCIM licensed Users and Groups CRUD", () => {
       });
     });
 
+    it("concurrent duplicate group creates return one 201 and one SCIM 409, never 500", async () => {
+      // Issue #927: same race as Users create, one insert lower. Groups
+      // are teams rows, so the loser used to hit the teams.name unique
+      // constraint and 500.
+      const displayName = uniqueName("scim-group-race");
+      const create = () =>
+        crudApp.app.inject({
+          method: "POST",
+          url: "/api/v1/scim/v2/Groups",
+          headers: authHeaders(),
+          payload: { displayName },
+        });
+
+      const results = await raceInserts("teams", 2, () => Promise.all([create(), create()]));
+      const statuses = results.map((r) => r.statusCode).sort();
+      expect(statuses).toEqual([201, 409]);
+
+      const conflict = results.find((r) => r.statusCode === 409);
+      expect(JSON.parse(conflict?.body ?? "{}")).toMatchObject({
+        schemas: [SCIM_ERROR_SCHEMA],
+        status: 409,
+        detail: "Group already exists",
+      });
+
+      const rows = await db.select().from(schema.teams).where(eq(schema.teams.name, displayName));
+      expect(rows).toHaveLength(1);
+    });
+
     it("creates a group, assigns members, and reflects it on the user resource", async () => {
       const memberA = await createScimUser({ userName: uniqueName("scim-grp-m1") });
       const memberB = await createScimUser({ userName: uniqueName("scim-grp-m2") });

--- a/tests/integration/platform/scim.test.ts
+++ b/tests/integration/platform/scim.test.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { db, schema } from "../../../apps/api/src/db/index.js";
 import { hashPassword, verifyPassword } from "../../../apps/api/src/plugins/auth.js";
+import { raceInserts } from "../../helpers/pg-race.js";
 import { buildTestApp, type TestApp } from "../test-server.js";
 
 let testApp: TestApp;
@@ -969,6 +970,35 @@ describe("SCIM licensed Users and Groups CRUD", () => {
         status: 400,
         detail: "userName is required",
       });
+    });
+
+    it("concurrent duplicate creates return one 201 and one SCIM 409, never 500", async () => {
+      // Issue #927: IdP provisioning retries can race. Requests that pass
+      // the duplicate pre-check before the winner's insert commits used to
+      // surface the 23505 unique violation as a 500. raceInserts holds both
+      // requests at the insert so each one passes the pre-check.
+      const userName = uniqueName("scim-create-race");
+      const create = () =>
+        crudApp.app.inject({
+          method: "POST",
+          url: "/api/v1/scim/v2/Users",
+          headers: authHeaders(),
+          payload: { userName },
+        });
+
+      const results = await raceInserts("users", 2, () => Promise.all([create(), create()]));
+      const statuses = results.map((r) => r.statusCode).sort();
+      expect(statuses).toEqual([201, 409]);
+
+      const conflict = results.find((r) => r.statusCode === 409);
+      expect(JSON.parse(conflict?.body ?? "{}")).toMatchObject({
+        schemas: [SCIM_ERROR_SCHEMA],
+        status: 409,
+        detail: "User already exists",
+      });
+
+      const rows = await db.select().from(schema.users).where(eq(schema.users.username, userName));
+      expect(rows).toHaveLength(1);
     });
 
     it("rejects a duplicate userName with the SCIM 409 envelope", async () => {

--- a/tests/integration/platform/teams.test.ts
+++ b/tests/integration/platform/teams.test.ts
@@ -9,6 +9,7 @@ import { randomUUID } from "node:crypto";
 import { eq, sql } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { db, schema } from "../../../apps/api/src/db/index.js";
+import { raceInserts } from "../../helpers/pg-race.js";
 import { buildTestApp, loginAsAdmin, type TestApp } from "../test-server.js";
 
 let testApp: TestApp;
@@ -128,6 +129,38 @@ describe("POST /api/v1/teams", () => {
 
     // Cleanup
     await db.delete(schema.users).where(eq(schema.users.id, userId));
+  });
+
+  it("concurrent duplicate creates return one 201 and one 409, never 500", async () => {
+    // Issue #927: requests that pass the duplicate pre-check before the
+    // winner's insert commits used to surface the 23505 unique violation
+    // as a 500. raceInserts holds both requests at the insert so each one
+    // passes the pre-check. Exact-case duplicates only: teams.name is
+    // case-sensitive in Postgres, so the insert guard can't see a
+    // mixed-case twin.
+    const create = () =>
+      app.inject({
+        method: "POST",
+        url: "/api/v1/teams",
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { name: "Race Condition" },
+      });
+
+    const results = await raceInserts("teams", 2, () => Promise.all([create(), create()]));
+    const statuses = results.map((r) => r.statusCode).sort();
+    expect(statuses).toEqual([201, 409]);
+
+    const conflict = results.find((r) => r.statusCode === 409);
+    expect(JSON.parse(conflict?.body ?? "{}")).toEqual({
+      error: "Team name already exists",
+      code: "CONFLICT",
+    });
+
+    const rows = await db
+      .select()
+      .from(schema.teams)
+      .where(eq(schema.teams.name, "Race Condition"));
+    expect(rows).toHaveLength(1);
   });
 
   it("rejects duplicate names (case-insensitive)", async () => {

--- a/tests/unit/api/external-auth-resolver-mutation.test.ts
+++ b/tests/unit/api/external-auth-resolver-mutation.test.ts
@@ -418,17 +418,19 @@ describe("resolveExternalUser: auto-create username race", () => {
 
   it("throws after exhausting the retry budget instead of looping forever", async () => {
     state.insertRowCounts = [0, 0, 0];
+    // Three identical attempts, each consuming: username scan (base free),
+    // Default team lookup, then the post-conflict re-check (no winner).
     state.selectRows = [
       [], // extId miss
-      [],
-      [{ id: "team-default" }],
-      [], // attempt 1: scan, team, re-check miss
-      [],
-      [{ id: "team-default" }],
-      [], // attempt 2
-      [],
-      [{ id: "team-default" }],
-      [], // attempt 3
+      [], // attempt 1: scan
+      [{ id: "team-default" }], // attempt 1: team
+      [], // attempt 1: re-check miss
+      [], // attempt 2: scan
+      [{ id: "team-default" }], // attempt 2: team
+      [], // attempt 2: re-check miss
+      [], // attempt 3: scan
+      [{ id: "team-default" }], // attempt 3: team
+      [], // attempt 3: re-check miss
     ];
     await expect(resolveExternalUser(baseParams({ autoCreate: true }))).rejects.toThrow(
       /username race/,

--- a/tests/unit/api/external-auth-resolver-mutation.test.ts
+++ b/tests/unit/api/external-auth-resolver-mutation.test.ts
@@ -28,6 +28,9 @@ const state = vi.hoisted(() => ({
   selectIdx: 0,
   updates: [] as Record<string, unknown>[],
   inserts: [] as Record<string, unknown>[],
+  // rowCount returned by each insert, in call order (default 1). A 0 models
+  // losing a unique-constraint race under onConflictDoNothing.
+  insertRowCounts: [] as number[],
   maxUsers: 0,
   auditCalls: [] as { event: string; details: Record<string, unknown> }[],
 }));
@@ -83,8 +86,10 @@ vi.mock("../../../apps/api/src/db/index.js", () => ({
     }),
     insert: () => ({
       values: (v: Record<string, unknown>) => {
+        const rowCount = state.insertRowCounts[state.inserts.length] ?? 1;
         state.inserts.push(v);
-        return Promise.resolve();
+        const result = Promise.resolve({ rowCount });
+        return Object.assign(result, { onConflictDoNothing: () => result });
       },
     }),
   },
@@ -141,6 +146,7 @@ beforeEach(() => {
   state.selectIdx = 0;
   state.updates = [];
   state.inserts = [];
+  state.insertRowCounts = [];
   state.maxUsers = 0;
   state.auditCalls = [];
   vi.clearAllMocks();
@@ -345,6 +351,89 @@ describe("resolveExternalUser: auto-create", () => {
     ];
     const result = await resolveExternalUser(baseParams({ autoCreate: true }));
     expect(result.action).toBe("created");
+  });
+});
+
+// ── 3b. Auto-create username races (issue #927) ─────────────────────────
+//
+// The insert carries onConflictDoNothing, so losing a race surfaces as
+// rowCount 0 instead of a thrown 23505. The resolver must then re-check
+// whether the same external identity won (two-tabs case) and otherwise
+// re-run the username scan.
+
+describe("resolveExternalUser: auto-create username race", () => {
+  it("returns the winner's user when the same identity created it concurrently", async () => {
+    state.insertRowCounts = [0];
+    state.selectRows = [
+      [], // extId miss
+      [], // findUniqueUsername: base free
+      [{ id: "team-default" }], // Default team lookup
+      // Post-conflict re-check by externalId finds the winner.
+      [dbUser({ id: "u-winner", username: "alice", role: "user", team: "team-default" })],
+    ];
+    const result = await resolveExternalUser(baseParams({ autoCreate: true }));
+
+    expect(result).toEqual({
+      user: { id: "u-winner", username: "alice", role: "user", team: "team-default" },
+      action: "matched",
+    });
+    expect(state.inserts).toHaveLength(1);
+    expect(state.auditCalls.map((c) => c.event)).not.toContain("OIDC_USER_CREATED");
+  });
+
+  it("denies when the concurrently created winner is disabled", async () => {
+    state.insertRowCounts = [0];
+    state.selectRows = [
+      [], // extId miss
+      [], // base free
+      [{ id: "team-default" }],
+      [dbUser({ id: "u-winner", role: "disabled" })], // winner re-check
+    ];
+    const result = await resolveExternalUser(baseParams({ autoCreate: true }));
+    expect(result).toEqual({ user: null, action: "denied", deniedReason: "user_disabled" });
+    expect(state.auditCalls.at(-1)?.event).toBe("OIDC_LOGIN_FAILED");
+  });
+
+  it("re-runs the username scan and creates when a different user took the name", async () => {
+    state.insertRowCounts = [0, 1];
+    state.selectRows = [
+      [], // extId miss
+      [], // attempt 1: base "alice" free
+      [{ id: "team-default" }],
+      [], // winner re-check: not our identity
+      [{ username: "alice" }], // attempt 2 scan: base now taken
+      [], // attempt 2 scan: alice_2 free
+      [{ id: "team-default" }],
+    ];
+    const result = await resolveExternalUser(baseParams({ autoCreate: true }));
+
+    expect(result.action).toBe("created");
+    expect(result.user?.username).toBe("alice_2");
+    expect(state.inserts).toHaveLength(2);
+    expect(state.inserts[1].username).toBe("alice_2");
+    const created = state.auditCalls.at(-1);
+    expect(created?.event).toBe("OIDC_USER_CREATED");
+    expect(created?.details.username).toBe("alice_2");
+  });
+
+  it("throws after exhausting the retry budget instead of looping forever", async () => {
+    state.insertRowCounts = [0, 0, 0];
+    state.selectRows = [
+      [], // extId miss
+      [],
+      [{ id: "team-default" }],
+      [], // attempt 1: scan, team, re-check miss
+      [],
+      [{ id: "team-default" }],
+      [], // attempt 2
+      [],
+      [{ id: "team-default" }],
+      [], // attempt 3
+    ];
+    await expect(resolveExternalUser(baseParams({ autoCreate: true }))).rejects.toThrow(
+      /username race/,
+    );
+    expect(state.inserts).toHaveLength(3);
   });
 });
 

--- a/tests/unit/api/external-auth-resolver.test.ts
+++ b/tests/unit/api/external-auth-resolver.test.ts
@@ -31,7 +31,10 @@ vi.mock("../../../apps/api/src/db/index.js", () => ({
       }),
     }),
     insert: () => ({
-      values: () => Promise.resolve({ rowCount: 1 }),
+      values: () => {
+        const result = Promise.resolve({ rowCount: 1 });
+        return Object.assign(result, { onConflictDoNothing: () => result });
+      },
     }),
   },
   schema: {


### PR DESCRIPTION
Closes #927

Two concurrent creates with the same name both pass the duplicate pre-check SELECT before either INSERT commits. The loser hits the unique constraint, Postgres raises 23505, and the global handler turns it into a 500 plus a Sentry event. Same shape register had in #900, in five more places:

- POST /api/v1/teams
- POST /api/v1/roles
- SCIM POST /Users
- SCIM POST /Groups (surfaced in review; groups are teams rows, one insert below the Users fix)
- OIDC/SAML auto-create in external-auth-resolver.ts

The four route handlers now insert with onConflictDoNothing on the unique column and return the pre-check's exact 409 body when rowCount is 0. The resolver can't 409 a login, so the race loser re-checks whether its own external identity won (two tabs finishing first login at once) and returns that user as "matched", otherwise re-runs the username scan and retries, throwing a descriptive error after three straight losses. Each lost race logs before recovering.

Firing two concurrent requests doesn't reproduce the bug reliably; the window between pre-check and commit is under a millisecond, and 8-way request storms still lost to it. tests/helpers/pg-race.ts makes the race deterministic instead: an EXCLUSIVE table lock lets the pre-check SELECTs through but parks every INSERT in the lock queue, a pg_stat_activity poll waits until both contenders are parked, and releasing the lock slams them into the unique index together. All five new integration tests failed against unfixed code with the exact reported symptom ([201, 500], or the raw 23505 from the resolver) and pass with the fix. The resolver recovery branches that can't be ordered against a real database (same-identity winner returned, disabled winner denied, retry exhaustion) are pinned by scripted unit tests in external-auth-resolver-mutation.test.ts.

Verified locally: lint, typecheck, the full unit suite (8676 tests green), the six touched test files (159 tests), the resolver's caller suites (oidc, saml, roles, teams, rbac, scim: 326 tests), and a teeth check (reverting the src fix fails exactly the 8 new tests, nothing else). Two local full-suite runs died to testcontainer OOM kills from concurrent test runs on the same Docker host (Postgres exit 137, then ECONNREFUSED cascades across every file), so integration rides on CI here.

Decided tradeoffs:

- teams.name is case-sensitive, so the guard closes exact-case races only; concurrent "Foo"/"foo" still both insert. #927 deferred the LOWER(name) index on purpose. Filed #970.
- A same-identity double create that never conflicts (no unique index on auth_provider + external_id) can't be closed at the insert. Filed #969.
- The rename/update flavor of this race (teams PUT, SCIM user/group renames) needs a different mechanism than onConflictDoNothing. Filed #968.
- The five guards stay inline rather than behind a shared helper: each returns a different response envelope and the guard is three lines. #900's pg-code-to-HTTP helper idea gets real once #968 adds UPDATE-side handling.