### PR TITLE
fix(api): stop concurrent user creates from exceeding MAX_USERS

### DIFF
--- a/apps/api/src/lib/external-auth-resolver.ts
+++ b/apps/api/src/lib/external-auth-resolver.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { FastifyBaseLogger } from "fastify";
-import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { isDisabledRole } from "../permissions.js";
 import { auditLog, sanitizeAuditInput } from "./audit.js";
+import { userLimitReached } from "./user-limit.js";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -179,15 +179,6 @@ export async function resolveExternalUser(params: ExternalAuthParams): Promise<E
       return { user: null, action: "denied", deniedReason: "user_disabled" };
     }
 
-    // Check user limit
-    if (env.MAX_USERS > 0) {
-      const [countResult] = await db.select({ count: sql<number>`COUNT(*)` }).from(schema.users);
-      if (countResult && countResult.count >= env.MAX_USERS) {
-        logger.warn(`${provider} auto-create blocked: user limit reached`);
-        return { user: null, action: "denied", deniedReason: "user_limit_reached" };
-      }
-    }
-
     // The username scan can't close the race: two concurrent logins both
     // pass it before either insert commits (issue #927), so the insert
     // carries a conflict guard and the loser recovers below.
@@ -203,22 +194,29 @@ export async function resolveExternalUser(params: ExternalAuthParams): Promise<E
         .where(eq(schema.teams.name, "Default"));
       const teamId = defaultTeam?.id ?? "default-team-00000000";
 
-      const inserted = await db
-        .insert(schema.users)
-        .values({
-          id: newUserId,
-          username: uniqueUsername,
-          passwordHash: null,
-          role: defaultRole,
-          team: teamId,
-          mustChangePassword: false,
-          authProvider: provider,
-          externalId,
-          email: email ?? null,
-        })
-        .onConflictDoNothing({ target: schema.users.username });
+      // A plain count check can't enforce MAX_USERS either: two concurrent
+      // auto-creates both pass it before their inserts commit (issue #928).
+      // The locked count and the guarded insert share one transaction so the
+      // loser sees the winner's committed row.
+      const inserted = await db.transaction(async (tx) => {
+        if (await userLimitReached(tx)) return "limit" as const;
+        return tx
+          .insert(schema.users)
+          .values({
+            id: newUserId,
+            username: uniqueUsername,
+            passwordHash: null,
+            role: defaultRole,
+            team: teamId,
+            mustChangePassword: false,
+            authProvider: provider,
+            externalId,
+            email: email ?? null,
+          })
+          .onConflictDoNothing({ target: schema.users.username });
+      });
 
-      if (inserted.rowCount) {
+      if (inserted !== "limit" && inserted.rowCount) {
         await audit(`${providerUpper}_USER_CREATED`, {
           userId: newUserId,
           username: uniqueUsername,
@@ -237,14 +235,17 @@ export async function resolveExternalUser(params: ExternalAuthParams): Promise<E
         };
       }
 
-      logger.info(
-        { attempt: attempt + 1, username: uniqueUsername },
-        `${provider} auto-create lost a username race, recovering`,
-      );
+      if (inserted !== "limit") {
+        logger.info(
+          { attempt: attempt + 1, username: uniqueUsername },
+          `${provider} auto-create lost a username race, recovering`,
+        );
+      }
 
-      // Race lost. If this same external identity won it in a concurrent
-      // login (say, two tabs finishing first login at once), hand back the
-      // winner's user instead of failing the login.
+      // Create refused: the username raced (issue #927) or the cap is
+      // reached (issue #928). Either way this same external identity may
+      // have just won a concurrent login (say, two tabs finishing first
+      // login at once); hand back the winner's user instead of failing it.
       const [winner] = await db
         .select()
         .from(schema.users)
@@ -265,6 +266,11 @@ export async function resolveExternalUser(params: ExternalAuthParams): Promise<E
           user: { id: winner.id, username: winner.username, role: winner.role, team: winner.team },
           action: "matched",
         };
+      }
+
+      if (inserted === "limit") {
+        logger.warn(`${provider} auto-create blocked: user limit reached`);
+        return { user: null, action: "denied", deniedReason: "user_limit_reached" };
       }
       // A different user took the name; rescan and retry.
     }

--- a/apps/api/src/lib/user-limit.ts
+++ b/apps/api/src/lib/user-limit.ts
@@ -1,0 +1,30 @@
+import { sql } from "drizzle-orm";
+import { env } from "../config.js";
+import { type db, schema } from "../db/index.js";
+
+// Every path that enforces MAX_USERS (register route, external-auth
+// auto-create) must serialize on this one lock or two concurrent creates can
+// each pass the count and overshoot the cap by one (issue #928). SCIM
+// provisioning does not enforce the cap at all today (issue #966). Lock ids
+// are scoped per database, so parallel test forks with their own DB clones
+// never contend.
+const USER_LIMIT_LOCK_KEY = 7_421_003;
+
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Inside `tx`, take the user-limit advisory lock and report whether the
+ * MAX_USERS cap is already met. The caller must insert the new user on the
+ * same `tx` so the count stays authoritative until commit; the xact lock is
+ * released automatically on commit or rollback. Always false when MAX_USERS
+ * is 0 (unlimited); no lock is taken in that case.
+ */
+export async function userLimitReached(tx: Tx): Promise<boolean> {
+  if (env.MAX_USERS <= 0) return false;
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(${USER_LIMIT_LOCK_KEY})`);
+  const [row] = await tx.select({ count: sql<number>`COUNT(*)::int` }).from(schema.users);
+  // COUNT(*) always yields one row; if that ever stops being true, fail
+  // closed instead of admitting everyone with a phantom count of 0.
+  if (!row) throw new Error("user count query returned no rows");
+  return row.count >= env.MAX_USERS;
+}

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -20,6 +20,7 @@ import {
 import { authAttempts } from "../lib/metrics.js";
 import { isSecureRequest } from "../lib/secure-cookie.js";
 import { getSettingNumber, getSettingString } from "../lib/settings-helpers.js";
+import { userLimitReached } from "../lib/user-limit.js";
 import {
   canAssignRole,
   canManageTargetRole,
@@ -39,8 +40,6 @@ export interface AuthUser {
   role: string;
   apiKeyPermissions?: string[];
 }
-
-const MAX_USERS = env.MAX_USERS;
 
 // ── Password hashing ──────────────────────────────────────────────
 
@@ -842,7 +841,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         hasOidcLink: !!u.externalId,
         createdAt: u.createdAt.toISOString(),
       })),
-      maxUsers: MAX_USERS,
+      maxUsers: env.MAX_USERS,
     });
   });
 
@@ -940,34 +939,37 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       });
     }
 
-    // Check user limit (0 = unlimited)
-    if (MAX_USERS > 0) {
-      const allUsers = await db.select().from(schema.users);
-      const userCount = allUsers.length;
-      if (userCount >= MAX_USERS) {
-        return reply.status(403).send({
-          error: `User limit reached (${MAX_USERS} max)`,
-          code: "USER_LIMIT_REACHED",
-        });
-      }
-    }
-
     const id = randomUUID();
+    // Hash before the transaction: scrypt takes ~100ms and must not extend
+    // the user-limit lock window.
     const passwordHash = await hashPassword(body.password);
 
-    // The duplicate pre-check above can't close the race: two concurrent
-    // registers both pass the SELECT before either insert commits (issue #900).
-    const inserted = await db
-      .insert(schema.users)
-      .values({
-        id,
-        username: body.username,
-        passwordHash,
-        role,
-        team: teamId,
-        mustChangePassword: true,
-      })
-      .onConflictDoNothing({ target: schema.users.username });
+    // The duplicate pre-check above can't close the username race (issue
+    // #900), and a plain count check can't close the limit race: two
+    // concurrent registers both pass it before either insert commits (issue
+    // #928). The locked count and the insert share one transaction so the
+    // loser sees the winner's committed row.
+    const inserted = await db.transaction(async (tx) => {
+      if (await userLimitReached(tx)) return "limit" as const;
+      return tx
+        .insert(schema.users)
+        .values({
+          id,
+          username: body.username,
+          passwordHash,
+          role,
+          team: teamId,
+          mustChangePassword: true,
+        })
+        .onConflictDoNothing({ target: schema.users.username });
+    });
+
+    if (inserted === "limit") {
+      return reply.status(403).send({
+        error: `User limit reached (${env.MAX_USERS} max)`,
+        code: "USER_LIMIT_REACHED",
+      });
+    }
 
     if (!inserted.rowCount) {
       return reply.status(409).send({

--- a/tests/integration/platform/user-limit-race.test.ts
+++ b/tests/integration/platform/user-limit-race.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Issue #928: the MAX_USERS cap was enforced with a plain count-then-insert,
+ * so two concurrent creates could both pass the check and overshoot the cap
+ * by one, with no error anywhere. Covers both counted paths: POST
+ * /api/auth/register and the external-auth resolver's auto-create (OIDC/SAML).
+ *
+ * The requests genuinely race: register has scrypt hashing between check and
+ * insert, the resolver has username/team lookups, so both requests pass the
+ * count before either insert commits unless the two are serialized.
+ */
+import { sql } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { env } from "../../../apps/api/src/config.js";
+import { db, schema } from "../../../apps/api/src/db/index.js";
+import { resolveExternalUser } from "../../../apps/api/src/lib/external-auth-resolver.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "../test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+
+const uid = () => `limit_race_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+
+async function userCount(): Promise<number> {
+  const [row] = await db.select({ count: sql<number>`COUNT(*)::int` }).from(schema.users);
+  return row?.count ?? 0;
+}
+
+const origMaxUsers = env.MAX_USERS;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+}, 30_000);
+
+afterAll(async () => {
+  (env as Record<string, unknown>).MAX_USERS = origMaxUsers;
+  // Optional chaining so a beforeAll boot failure surfaces instead of being
+  // buried under a TypeError from the cleanup.
+  await testApp?.cleanup();
+}, 10_000);
+
+describe("MAX_USERS under concurrency (issue #928)", () => {
+  it("concurrent registers get one 201 and one 403, never overshoot the cap", async () => {
+    const cap = (await userCount()) + 1;
+    (env as Record<string, unknown>).MAX_USERS = cap;
+    try {
+      const register = (username: string) =>
+        testApp.app.inject({
+          method: "POST",
+          url: "/api/auth/register",
+          headers: { authorization: `Bearer ${adminToken}` },
+          payload: { username, password: "ValidPass1" },
+        });
+
+      const [first, second] = await Promise.all([register(uid()), register(uid())]);
+      const statuses = [first.statusCode, second.statusCode].sort();
+      expect(statuses).toEqual([201, 403]);
+
+      const denied = first.statusCode === 403 ? first : second;
+      expect(JSON.parse(denied.body)).toEqual({
+        error: `User limit reached (${cap} max)`,
+        code: "USER_LIMIT_REACHED",
+      });
+
+      expect(await userCount()).toBe(cap);
+    } finally {
+      (env as Record<string, unknown>).MAX_USERS = origMaxUsers;
+    }
+  });
+
+  it("concurrent auto-creates stop at the cap with one denied user_limit_reached", async () => {
+    const cap = (await userCount()) + 1;
+    (env as Record<string, unknown>).MAX_USERS = cap;
+    try {
+      const resolve = (name: string) =>
+        resolveExternalUser({
+          provider: "oidc",
+          externalId: `ext-${name}`,
+          email: `${name}@example.com`,
+          emailVerified: true,
+          username: name,
+          autoCreate: true,
+          autoLink: false,
+          defaultRole: "user",
+          logger: testApp.app.log,
+          ip: "127.0.0.1",
+          requestId: `req-${name}`,
+        });
+
+      const [first, second] = await Promise.all([resolve(uid()), resolve(uid())]);
+      const actions = [first.action, second.action].sort();
+      expect(actions).toEqual(["created", "denied"]);
+
+      const denied = first.action === "denied" ? first : second;
+      expect(denied.deniedReason).toBe("user_limit_reached");
+
+      expect(await userCount()).toBe(cap);
+    } finally {
+      (env as Record<string, unknown>).MAX_USERS = origMaxUsers;
+    }
+  });
+
+  it("register racing an auto-create still stops at the cap (shared lock)", async () => {
+    // Pins the invariant that both counted paths serialize on the SAME lock.
+    // If one path ever moves to its own key or an inlined check, the two
+    // same-path tests above stay green while this mixed race overshoots.
+    const cap = (await userCount()) + 1;
+    (env as Record<string, unknown>).MAX_USERS = cap;
+    try {
+      const registerName = uid();
+      const [reg, sso] = await Promise.all([
+        testApp.app.inject({
+          method: "POST",
+          url: "/api/auth/register",
+          headers: { authorization: `Bearer ${adminToken}` },
+          payload: { username: registerName, password: "ValidPass1" },
+        }),
+        resolveExternalUser({
+          provider: "oidc",
+          externalId: `ext-${registerName}`,
+          email: `${registerName}@example.com`,
+          emailVerified: true,
+          username: `sso_${registerName}`,
+          autoCreate: true,
+          autoLink: false,
+          defaultRole: "user",
+          logger: testApp.app.log,
+          ip: "127.0.0.1",
+          requestId: `req-${registerName}`,
+        }),
+      ]);
+
+      const registerWon = reg.statusCode === 201;
+      if (registerWon) {
+        expect(sso.action).toBe("denied");
+        expect(sso.deniedReason).toBe("user_limit_reached");
+      } else {
+        expect(reg.statusCode).toBe(403);
+        expect(sso.action).toBe("created");
+      }
+
+      expect(await userCount()).toBe(cap);
+    } finally {
+      (env as Record<string, unknown>).MAX_USERS = origMaxUsers;
+    }
+  });
+});

--- a/tests/unit/api/external-auth-resolver-mutation.test.ts
+++ b/tests/unit/api/external-auth-resolver-mutation.test.ts
@@ -75,37 +75,46 @@ function makeSelectChain() {
   return node;
 }
 
-vi.mock("../../../apps/api/src/db/index.js", () => ({
-  db: {
-    select: () => makeSelectChain(),
-    update: () => ({
-      set: (v: Record<string, unknown>) => {
-        state.updates.push(v);
-        return { where: () => Promise.resolve() };
-      },
-    }),
-    insert: () => ({
-      values: (v: Record<string, unknown>) => {
-        const rowCount = state.insertRowCounts[state.inserts.length] ?? 1;
-        state.inserts.push(v);
-        const result = Promise.resolve({ rowCount });
-        return Object.assign(result, { onConflictDoNothing: () => result });
-      },
-    }),
-  },
-  schema: {
-    users: {
-      id: "id",
-      username: "username",
-      email: "email",
-      role: "role",
-      team: "team",
-      externalId: "external_id",
-      authProvider: "auth_provider",
+vi.mock("../../../apps/api/src/db/index.js", () => {
+  // Shared by db.insert and tx.insert: the auto-create insert runs inside
+  // the transaction (issue #928) and still needs the #927 rowCount machinery.
+  const insert = () => ({
+    values: (v: Record<string, unknown>) => {
+      const rowCount = state.insertRowCounts[state.inserts.length] ?? 1;
+      state.inserts.push(v);
+      const result = Promise.resolve({ rowCount });
+      return Object.assign(result, { onConflictDoNothing: () => result });
     },
-    teams: { id: "id", name: "name" },
-  },
-}));
+  });
+  return {
+    db: {
+      select: () => makeSelectChain(),
+      update: () => ({
+        set: (v: Record<string, unknown>) => {
+          state.updates.push(v);
+          return { where: () => Promise.resolve() };
+        },
+      }),
+      insert,
+      // The tx reuses the same canned select chain and insert recorder;
+      // execute() is the advisory lock, a no-op here.
+      transaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+        fn({ execute: () => Promise.resolve(), select: () => makeSelectChain(), insert }),
+    },
+    schema: {
+      users: {
+        id: "id",
+        username: "username",
+        email: "email",
+        role: "role",
+        team: "team",
+        externalId: "external_id",
+        authProvider: "auth_provider",
+      },
+      teams: { id: "id", name: "name" },
+    },
+  };
+});
 
 import { resolveExternalUser } from "../../../apps/api/src/lib/external-auth-resolver.js";
 
@@ -321,9 +330,13 @@ describe("resolveExternalUser: auto-create", () => {
 
   it("denies auto-create when the user count is at the MAX_USERS limit", async () => {
     state.maxUsers = 5;
+    // The count runs last, inside the transaction (issue #928), so the
+    // username and team lookups consume their slots first.
     state.selectRows = [
       [], // extId miss
-      [{ count: 5 }], // count query: exactly at the cap (>= limit)
+      [], // username free
+      [{ id: "team-default" }], // Default team lookup
+      [{ count: 5 }], // locked count: exactly at the cap (>= limit)
     ];
     const result = await resolveExternalUser(baseParams({ autoCreate: true }));
     expect(result).toEqual({ user: null, action: "denied", deniedReason: "user_limit_reached" });
@@ -334,9 +347,9 @@ describe("resolveExternalUser: auto-create", () => {
     state.maxUsers = 5;
     state.selectRows = [
       [], // extId miss
-      [{ count: 4 }], // below cap
       [], // username free
       [{ id: "team-default" }],
+      [{ count: 4 }], // locked count: below cap
     ];
     const result = await resolveExternalUser(baseParams({ autoCreate: true }));
     expect(result.action).toBe("created");


### PR DESCRIPTION
Closes #928

Two concurrent POST /api/auth/register calls with different usernames both counted MAX_USERS - 1 rows, both passed the check, both inserted. Cap exceeded by one, no error anywhere. The scrypt hash between check and insert keeps the window wide open; reproduced on main with two concurrent requests against a live API (MAX_USERS=2, one existing user: both 201, count landed at 3). The OIDC/SAML auto-create in external-auth-resolver had the same shape.

The fix is the sketch from the issue: a pg advisory lock around count+insert. New `apps/api/src/lib/user-limit.ts` exports `userLimitReached(tx)`, which takes `pg_advisory_xact_lock(7421003)` (extending the 7421001/7421002 key namespace from migrate.ts) and counts users inside the caller's transaction. Both paths wrap the locked count and the insert in one `db.transaction`, so the race loser waits on the lock, recounts after the winner commits, and gets the existing 403 / `user_limit_reached` denial. MAX_USERS=0 skips the lock entirely. scrypt runs before the transaction so the lock window is two fast statements.

The register route also stops capturing env.MAX_USERS at module load and reads it per request. Identical in production (env never changes at runtime); it's what makes the cap reachable from tests.

Tests: `tests/integration/platform/user-limit-race.test.ts` races register vs register, auto-create vs auto-create, and register vs auto-create (that one pins both paths onto the same lock). All three fail on main ([201, 201] / [created, created] / cap overshot) and pass here, stable across repeated runs. The resolver unit-test db mock learned the transaction contract; canned-row order moved because the count now runs last.

Verified locally: pnpm lint and pnpm typecheck clean; the race file plus every caller suite green (auth-edge-cases, oidc-auth, oidc-callback-coverage, oidc-mfa-callback, saml-auth, saml-cache, saml-license-gate, role-authority, scim: 219 integration tests, and the four auth/resolver unit files: 93 tests). Full local pnpm test runs kept losing their testcontainers to Docker VM restarts on a machine that was running a second test workload at the same time; the furthest run passed 11,416 tests with zero assertion failures before the cascade of connection errors, so the full-suite gate rides on CI here. No web, i18n, or docker surface in the diff.

Tradeoffs, documented rather than coded around:

- `pg_advisory_xact_lock` has no lock_timeout. A transaction wedged mid-commit would queue capped creates behind it; that takes an already-broken DB connection, and the locked window is a COUNT and an INSERT.
- The recount assumes read committed (Postgres default). An operator forcing `default_transaction_isolation = repeatable read` would reopen the race; nothing in our shipped stacks does.
- Two same-username registers racing at exactly the cap now resolve 201 + 403 instead of 201 + 409. Both were denied before, both are denied now, and the sequential duplicate case still 409s first.

Follow-ups filed while in here: #966 (SCIM provisioning ignores MAX_USERS), #967 (limit denials write no audit row).
