### PR TITLE
fix(api): surface S3 storage faults on library download as 500, not 404

### DIFF
--- a/apps/api/src/lib/file-storage.ts
+++ b/apps/api/src/lib/file-storage.ts
@@ -183,15 +183,18 @@ export async function readStoredFile(storedName: string): Promise<Buffer> {
 }
 
 /**
- * True when a readStoredFile/streamStoredFile rejection is an S3 service
- * fault (auth failure, bucket policy, S3 5xx) rather than the object simply
- * not existing. Those must keep reaching the error handler instead of
- * folding into the missing-blob 404 (#937). Local-backend faults carry an
- * errno shape the callers already recognize, so this returns false for them.
+ * True when a readStoredFile/streamStoredFile rejection in S3 mode is a
+ * storage fault that must keep reaching the error handler (#937): anything
+ * except S3 reporting the object missing or this module's own SafeError
+ * validation (a poisoned stored_name keeps its long-standing 404 mapping).
+ * The inversion is deliberate: a fault mistaken for a missing blob presents
+ * an outage as mass deletion, so only proven-missing maps to 404. Local
+ * -backend rejections return false; their errno shape already routes them.
  */
 export function isStorageServiceFault(error: unknown): boolean {
-  if (!isS3Enabled() || !s3Mod) return false;
-  return s3Mod.isS3ServiceError(error) && !s3Mod.isMissingObjectError(error);
+  if (!isS3Enabled()) return false;
+  if (error instanceof SafeError) return false;
+  return !s3Mod || !s3Mod.isMissingObjectError(error);
 }
 
 export async function streamStoredFile(storedName: string): Promise<Readable> {

--- a/apps/api/src/lib/file-storage.ts
+++ b/apps/api/src/lib/file-storage.ts
@@ -182,6 +182,18 @@ export async function readStoredFile(storedName: string): Promise<Buffer> {
   return readFile(join(env.FILES_STORAGE_PATH, storedName));
 }
 
+/**
+ * True when a readStoredFile/streamStoredFile rejection is an S3 service
+ * fault (auth failure, bucket policy, S3 5xx) rather than the object simply
+ * not existing. Those must keep reaching the error handler instead of
+ * folding into the missing-blob 404 (#937). Local-backend faults carry an
+ * errno shape the callers already recognize, so this returns false for them.
+ */
+export function isStorageServiceFault(error: unknown): boolean {
+  if (!isS3Enabled() || !s3Mod) return false;
+  return s3Mod.isS3ServiceError(error) && !s3Mod.isMissingObjectError(error);
+}
+
 export async function streamStoredFile(storedName: string): Promise<Readable> {
   assertSafeStoredName(storedName);
   if (isS3Enabled()) {

--- a/apps/api/src/routes/user-files.ts
+++ b/apps/api/src/routes/user-files.ts
@@ -22,6 +22,7 @@ import {
   deleteStoredFile,
   deleteThumbnail,
   getCachedThumbnail,
+  isStorageServiceFault,
   readStoredFile,
   saveFile,
   saveThumbnail,
@@ -485,11 +486,13 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
       } catch (e) {
         // streamStoredFile rejects for every open-time fault, not only a
         // missing blob. A syscall failure other than ENOENT (EACCES, ENOTDIR)
-        // is a storage fault that must keep reaching the global handler and
-        // Sentry. Errors without a syscall (S3 NoSuchKey, a poisoned
-        // stored_name) keep their long-standing 404 mapping.
+        // and an S3 service fault other than a missing object (AccessDenied,
+        // rotated credentials, S3 5xx) are storage faults that must keep
+        // reaching the global handler and Sentry (#937). A missing blob and a
+        // poisoned stored_name keep their long-standing 404 mapping.
         const { code, syscall } = e as NodeJS.ErrnoException;
         if (syscall && code !== "ENOENT") throw e;
+        if (isStorageServiceFault(e)) throw e;
         request.log.warn(
           { fileId: id, storedName: file.storedName },
           "library download: stored blob missing",

--- a/packages/enterprise/src/storage-s3.ts
+++ b/packages/enterprise/src/storage-s3.ts
@@ -74,6 +74,28 @@ export async function checkConnection(): Promise<void> {
   await getClient().send(new HeadBucketCommand({ Bucket: cfg().bucket }));
 }
 
+/**
+ * True when the error came from the S3 service layer at all: the SDK stamps
+ * every dispatched error with $metadata. Combined with isMissingObjectError
+ * this lets callers split "object gone" from "storage down" without
+ * inspecting AWS error shapes themselves.
+ */
+export function isS3ServiceError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "$metadata" in error;
+}
+
+/**
+ * True when a getObject/getObjectStream rejection is S3 reporting the object
+ * missing: NoSuchKey, or an unmodeled 404 from an S3-compatible store.
+ * Service faults (AccessDenied, credential rejection, 5xx) and errors that
+ * did not come from the SDK return false.
+ */
+export function isMissingObjectError(error: unknown): boolean {
+  if (!isS3ServiceError(error)) return false;
+  const e = error as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return e.name === "NoSuchKey" || e.$metadata?.httpStatusCode === 404;
+}
+
 export async function putObject(storedName: string, buffer: Buffer): Promise<void> {
   await getClient().send(
     new PutObjectCommand({

--- a/packages/enterprise/src/storage-s3.ts
+++ b/packages/enterprise/src/storage-s3.ts
@@ -75,24 +75,18 @@ export async function checkConnection(): Promise<void> {
 }
 
 /**
- * True when the error came from the S3 service layer at all: the SDK stamps
- * every dispatched error with $metadata. Combined with isMissingObjectError
- * this lets callers split "object gone" from "storage down" without
- * inspecting AWS error shapes themselves.
- */
-export function isS3ServiceError(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "$metadata" in error;
-}
-
-/**
  * True when a getObject/getObjectStream rejection is S3 reporting the object
- * missing: NoSuchKey, or an unmodeled 404 from an S3-compatible store.
- * Service faults (AccessDenied, credential rejection, 5xx) and errors that
- * did not come from the SDK return false.
+ * missing: NoSuchKey, or an unmodeled 404 from an S3-compatible store (the
+ * SDK stamps every dispatched error with $metadata). NoSuchBucket also
+ * arrives as HTTP 404 but means the whole bucket is gone, a storage outage
+ * rather than a missing file, so it stays a fault. Service faults
+ * (AccessDenied, credential rejection, 5xx) and errors that did not come
+ * from the SDK return false.
  */
 export function isMissingObjectError(error: unknown): boolean {
-  if (!isS3ServiceError(error)) return false;
+  if (typeof error !== "object" || error === null || !("$metadata" in error)) return false;
   const e = error as { name?: string; $metadata?: { httpStatusCode?: number } };
+  if (e.name === "NoSuchBucket") return false;
   return e.name === "NoSuchKey" || e.$metadata?.httpStatusCode === 404;
 }
 

--- a/tests/integration/platform/s3-download-fault.test.ts
+++ b/tests/integration/platform/s3-download-fault.test.ts
@@ -1,0 +1,166 @@
+/**
+ * S3-mode download fault classification (#937).
+ *
+ * PR #926 taught the local backend to rethrow non-ENOENT storage faults from
+ * the download route instead of folding them into 404. The S3 backend still
+ * mapped every SDK rejection to 404 "File not found in storage": rotated
+ * credentials or a bucket-policy change made the whole library read as
+ * deleted. These tests pin the split: an object S3 reports missing stays a
+ * 404, a storage service fault surfaces as a 500 for the error handler.
+ *
+ * Requires MinIO on port 19000 (same harness as s3-storage.test.ts):
+ *   docker run -d --name snapotter-minio-test -p 19000:9000 \
+ *     -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+ *     minio/minio server /data
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  CreateBucketCommand,
+  DeleteBucketCommand,
+  DeleteObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { loadS3Storage, type S3StorageModule } from "@snapotter/enterprise";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { env } from "../../../apps/api/src/config.js";
+import { db, schema } from "../../../apps/api/src/db/index.js";
+import { fixtures, readFixture } from "../../fixtures/index.js";
+import {
+  buildTestApp,
+  createMultipartPayload,
+  loginAsAdmin,
+  type TestApp,
+} from "../test-server.js";
+
+const PNG = readFixture(fixtures.image.base.png200);
+
+const S3_ENDPOINT = "http://localhost:19000";
+const BUCKET = `snapotter-dlfault-${Date.now()}`;
+const CREDS = { accessKeyId: "minioadmin", secretAccessKey: "minioadmin" };
+
+const minioAvailable = (() => {
+  const result = spawnSync("curl", ["-sf", "http://localhost:19000/minio/health/live"], {
+    timeout: 2000,
+    stdio: "ignore",
+  });
+  return result.status === 0;
+})();
+
+function s3Config(overrides: Partial<Parameters<S3StorageModule["configureS3"]>[0]> = {}) {
+  return {
+    bucket: BUCKET,
+    region: "us-east-1",
+    endpoint: S3_ENDPOINT,
+    accessKeyId: CREDS.accessKeyId,
+    secretAccessKey: CREDS.secretAccessKey,
+    forcePathStyle: true,
+    prefix: "",
+    ...overrides,
+  };
+}
+
+describe.skipIf(!minioAvailable)("S3-mode download fault classification", () => {
+  let testApp: TestApp;
+  let adminToken: string;
+  let s3Client: S3Client;
+  let s3Storage: S3StorageModule;
+  let originalStorageMode: string;
+
+  beforeAll(async () => {
+    s3Client = new S3Client({
+      region: "us-east-1",
+      endpoint: S3_ENDPOINT,
+      forcePathStyle: true,
+      credentials: CREDS,
+    });
+    await s3Client.send(new CreateBucketCommand({ Bucket: BUCKET }));
+
+    s3Storage = await loadS3Storage();
+
+    originalStorageMode = env.STORAGE_MODE;
+    const e = env as Record<string, unknown>;
+    e.STORAGE_MODE = "s3";
+    e.S3_BUCKET = BUCKET;
+    e.S3_REGION = "us-east-1";
+    e.S3_ENDPOINT = S3_ENDPOINT;
+    e.S3_ACCESS_KEY_ID = CREDS.accessKeyId;
+    e.S3_SECRET_ACCESS_KEY = CREDS.secretAccessKey;
+    e.S3_FORCE_PATH_STYLE = true;
+    e.S3_PREFIX = "";
+    s3Storage.configureS3(s3Config());
+
+    testApp = await buildTestApp();
+    adminToken = await loginAsAdmin(testApp.app);
+  }, 30_000);
+
+  afterAll(async () => {
+    (env as Record<string, unknown>).STORAGE_MODE = originalStorageMode;
+    try {
+      const objects = await s3Client.send(new ListObjectsV2Command({ Bucket: BUCKET }));
+      for (const obj of objects.Contents ?? []) {
+        await s3Client.send(new DeleteObjectCommand({ Bucket: BUCKET, Key: obj.Key! }));
+      }
+      await s3Client.send(new DeleteBucketCommand({ Bucket: BUCKET }));
+    } catch {
+      // Best-effort cleanup
+    }
+    await testApp?.cleanup();
+  }, 15_000);
+
+  async function uploadLibraryFile(filename: string): Promise<{ id: string; storedName: string }> {
+    const { body, contentType } = createMultipartPayload([
+      { name: "file", filename, contentType: "image/png", content: PNG },
+    ]);
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/files/upload",
+      headers: { "content-type": contentType, authorization: `Bearer ${adminToken}` },
+      body,
+    });
+    expect(res.statusCode).toBe(201);
+    const id = JSON.parse(res.body).files[0].id as string;
+    const [row] = await db
+      .select({ storedName: schema.userFiles.storedName })
+      .from(schema.userFiles)
+      .where(eq(schema.userFiles.id, id));
+    return { id, storedName: row.storedName };
+  }
+
+  it("keeps the 404 mapping when S3 reports the object missing", async () => {
+    const { id, storedName } = await uploadLibraryFile("s3-gone.png");
+    await s3Client.send(new DeleteObjectCommand({ Bucket: BUCKET, Key: `files/${storedName}` }));
+
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: `/api/v1/files/${id}/download`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body).error).toMatch(/not found in storage/i);
+  });
+
+  // #937: an S3 service fault (rotated credentials, bucket-policy change,
+  // S3 5xx) is a storage outage, not a missing file. It must keep reaching
+  // the error handler as a 500, never fold into the missing-blob 404 that
+  // presents an outage as everyone's files being deleted.
+  it("returns 500, not 404, when S3 rejects the read with an auth fault", async () => {
+    const { id } = await uploadLibraryFile("s3-denied.png");
+    s3Storage.configureS3(s3Config({ secretAccessKey: "rotated-away" }));
+
+    try {
+      const res = await testApp.app.inject({
+        method: "GET",
+        url: `/api/v1/files/${id}/download`,
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+
+      expect(res.statusCode).toBe(500);
+    } finally {
+      s3Storage.configureS3(s3Config());
+    }
+  });
+});

--- a/tests/integration/platform/s3-download-fault.test.ts
+++ b/tests/integration/platform/s3-download-fault.test.ts
@@ -38,7 +38,7 @@ import {
 const PNG = readFixture(fixtures.image.base.png200);
 
 const S3_ENDPOINT = "http://localhost:19000";
-const BUCKET = `snapotter-dlfault-${Date.now()}`;
+const BUCKET = `snapotter-dlfault-${process.pid}-${Date.now()}`;
 const CREDS = { accessKeyId: "minioadmin", secretAccessKey: "minioadmin" };
 
 const minioAvailable = (() => {
@@ -159,8 +159,31 @@ describe.skipIf(!minioAvailable)("S3-mode download fault classification", () => 
       });
 
       expect(res.statusCode).toBe(500);
+      expect(JSON.parse(res.body).error).not.toMatch(/not found/i);
     } finally {
       s3Storage.configureS3(s3Config());
     }
+  });
+
+  // A vanished bucket (deleted, recreated elsewhere, or S3_BUCKET fat-fingered
+  // in a config edit) is the same outage class: NoSuchBucket arrives as HTTP
+  // 404 but must not read as per-file deletion. Kept last in the file because
+  // it destroys the bucket; afterAll tolerates the missing bucket.
+  it("returns 500 when the whole bucket is gone", async () => {
+    const { id } = await uploadLibraryFile("s3-bucket-gone.png");
+    const objects = await s3Client.send(new ListObjectsV2Command({ Bucket: BUCKET }));
+    for (const obj of objects.Contents ?? []) {
+      await s3Client.send(new DeleteObjectCommand({ Bucket: BUCKET, Key: obj.Key! }));
+    }
+    await s3Client.send(new DeleteBucketCommand({ Bucket: BUCKET }));
+
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: `/api/v1/files/${id}/download`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body).error).not.toMatch(/not found/i);
   });
 });

--- a/tests/unit/api/s3-error-classification.test.ts
+++ b/tests/unit/api/s3-error-classification.test.ts
@@ -1,9 +1,9 @@
 /**
- * S3 error classification predicates (#937).
+ * S3 error classification (#937).
  *
  * The download route needs to tell "S3 says the object is gone" (keep the
  * 404 mapping) apart from "S3 is refusing or failing the read" (a storage
- * fault that must reach the error handler). The predicates live on the
+ * fault that must reach the error handler). The predicate lives on the
  * enterprise S3 module so core never inspects AWS error shapes. The minio
  * harness in tests/integration/platform/s3-download-fault.test.ts covers the
  * route end to end; CI has no minio, so the shapes are pinned here.
@@ -27,8 +27,18 @@ describe("isMissingObjectError", () => {
     expect(s3.isMissingObjectError(sdkError("NoSuchKey", 404))).toBe(true);
   });
 
+  it("recognizes NoSuchKey even without an HTTP status", () => {
+    expect(s3.isMissingObjectError(sdkError("NoSuchKey", undefined))).toBe(true);
+  });
+
   it("recognizes an unmodeled 404 from an S3-compatible store", () => {
     expect(s3.isMissingObjectError(sdkError("NotFound", 404))).toBe(true);
+  });
+
+  it("treats a vanished bucket as a fault, not a missing object", () => {
+    // NoSuchBucket arrives as HTTP 404 but means the whole bucket is gone:
+    // a storage outage that must not read as per-file deletion (#937).
+    expect(s3.isMissingObjectError(sdkError("NoSuchBucket", 404))).toBe(false);
   });
 
   it("rejects auth faults", () => {
@@ -42,27 +52,15 @@ describe("isMissingObjectError", () => {
     expect(s3.isMissingObjectError(sdkError("SlowDown", 503))).toBe(false);
   });
 
+  it("rejects SDK network faults, which carry $metadata but no status", () => {
+    expect(s3.isMissingObjectError(sdkError("TimeoutError", undefined))).toBe(false);
+  });
+
   it("rejects non-SDK errors", () => {
     expect(s3.isMissingObjectError(new Error("boom"))).toBe(false);
+    expect(s3.isMissingObjectError({ code: "ENOENT", syscall: "open" })).toBe(false);
     expect(s3.isMissingObjectError(null)).toBe(false);
     expect(s3.isMissingObjectError(undefined)).toBe(false);
     expect(s3.isMissingObjectError("NoSuchKey")).toBe(false);
-  });
-});
-
-describe("isS3ServiceError", () => {
-  it("recognizes SDK-shaped errors by their $metadata", () => {
-    expect(s3.isS3ServiceError(sdkError("AccessDenied", 403))).toBe(true);
-    expect(s3.isS3ServiceError(sdkError("NoSuchKey", 404))).toBe(true);
-    // Network faults dispatched by the SDK carry $metadata without a status
-    expect(s3.isS3ServiceError(sdkError("TimeoutError", undefined))).toBe(true);
-  });
-
-  it("rejects everything that did not come from the SDK", () => {
-    expect(s3.isS3ServiceError(new Error("boom"))).toBe(false);
-    expect(s3.isS3ServiceError({ code: "ENOENT", syscall: "open" })).toBe(false);
-    expect(s3.isS3ServiceError(null)).toBe(false);
-    expect(s3.isS3ServiceError(undefined)).toBe(false);
-    expect(s3.isS3ServiceError(42)).toBe(false);
   });
 });

--- a/tests/unit/api/s3-error-classification.test.ts
+++ b/tests/unit/api/s3-error-classification.test.ts
@@ -1,0 +1,68 @@
+/**
+ * S3 error classification predicates (#937).
+ *
+ * The download route needs to tell "S3 says the object is gone" (keep the
+ * 404 mapping) apart from "S3 is refusing or failing the read" (a storage
+ * fault that must reach the error handler). The predicates live on the
+ * enterprise S3 module so core never inspects AWS error shapes. The minio
+ * harness in tests/integration/platform/s3-download-fault.test.ts covers the
+ * route end to end; CI has no minio, so the shapes are pinned here.
+ */
+
+import { loadS3Storage, type S3StorageModule } from "@snapotter/enterprise";
+import { beforeAll, describe, expect, it } from "vitest";
+
+let s3: S3StorageModule;
+
+beforeAll(async () => {
+  s3 = await loadS3Storage();
+});
+
+function sdkError(name: string, httpStatusCode?: number): Error {
+  return Object.assign(new Error(name), { name, $metadata: { httpStatusCode } });
+}
+
+describe("isMissingObjectError", () => {
+  it("recognizes NoSuchKey", () => {
+    expect(s3.isMissingObjectError(sdkError("NoSuchKey", 404))).toBe(true);
+  });
+
+  it("recognizes an unmodeled 404 from an S3-compatible store", () => {
+    expect(s3.isMissingObjectError(sdkError("NotFound", 404))).toBe(true);
+  });
+
+  it("rejects auth faults", () => {
+    expect(s3.isMissingObjectError(sdkError("AccessDenied", 403))).toBe(false);
+    expect(s3.isMissingObjectError(sdkError("SignatureDoesNotMatch", 403))).toBe(false);
+    expect(s3.isMissingObjectError(sdkError("InvalidAccessKeyId", 403))).toBe(false);
+  });
+
+  it("rejects S3 5xx", () => {
+    expect(s3.isMissingObjectError(sdkError("InternalError", 500))).toBe(false);
+    expect(s3.isMissingObjectError(sdkError("SlowDown", 503))).toBe(false);
+  });
+
+  it("rejects non-SDK errors", () => {
+    expect(s3.isMissingObjectError(new Error("boom"))).toBe(false);
+    expect(s3.isMissingObjectError(null)).toBe(false);
+    expect(s3.isMissingObjectError(undefined)).toBe(false);
+    expect(s3.isMissingObjectError("NoSuchKey")).toBe(false);
+  });
+});
+
+describe("isS3ServiceError", () => {
+  it("recognizes SDK-shaped errors by their $metadata", () => {
+    expect(s3.isS3ServiceError(sdkError("AccessDenied", 403))).toBe(true);
+    expect(s3.isS3ServiceError(sdkError("NoSuchKey", 404))).toBe(true);
+    // Network faults dispatched by the SDK carry $metadata without a status
+    expect(s3.isS3ServiceError(sdkError("TimeoutError", undefined))).toBe(true);
+  });
+
+  it("rejects everything that did not come from the SDK", () => {
+    expect(s3.isS3ServiceError(new Error("boom"))).toBe(false);
+    expect(s3.isS3ServiceError({ code: "ENOENT", syscall: "open" })).toBe(false);
+    expect(s3.isS3ServiceError(null)).toBe(false);
+    expect(s3.isS3ServiceError(undefined)).toBe(false);
+    expect(s3.isS3ServiceError(42)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #937

`GET /api/v1/files/:id/download` mapped every `streamStoredFile` rejection without a Node syscall to 404 "File not found in storage". AWS SDK errors carry no syscall. So on `STORAGE_MODE=s3`, a rotated credential, a bucket-policy change, or an S3 5xx made the whole library read as deleted: per-file 404s, no log, no Sentry event.

The classification is now inverted for S3 mode, following the sketch in #937. Only an error S3 itself reports as a missing object keeps the 404 mapping (`NoSuchKey`, or an unmodeled 404 from an S3-compatible store), plus the stored-name validation SafeError that #926 deliberately left at 404. Everything else rethrows to the global handler and reaches Sentry. `NoSuchBucket` arrives as HTTP 404 too, but it means the bucket is gone, not the file, so it counts as a fault; without that carve-out a deleted or fat-fingered bucket would still present as mass deletion. The predicate lives on the enterprise module (`isMissingObjectError` on the `S3StorageModule` surface) so core never inspects AWS error shapes, and the inversion means the rare rejections with neither a syscall nor SDK metadata now fail toward 500 instead of a silent 404.

Local mode is untouched: the errno logic from #926 short-circuits before the new check, and its pins still pass.

How it was proven:

- `tests/integration/platform/s3-download-fault.test.ts` (minio harness, same `skipIf` gate as `s3-storage.test.ts`): missing object stays 404, auth fault returns 500, deleted bucket returns 500. Both fault cases were watched red against the unfixed route (they got the 404) before the fix went in.
- `tests/unit/api/s3-error-classification.test.ts` pins the predicate shapes. CI has no minio, so this is what enforces the split there; the route wiring was exercised against a live MinIO locally.
- `pnpm lint`, `pnpm typecheck`, `pnpm check:license-boundary` green, re-run after rebasing onto d6f071c1. Two local full-suite attempts both lost their testcontainers mid-run to the shared Docker VM getting OOM-killed (known on this box today); every non-infra failure passes in isolation and none is near this path. The clean-environment full-suite check is this PR's CI against the green run for 30a7ab01.
- Three independent review passes probed the predicates against the installed SDK and a live MinIO. The one blocking finding was the `NoSuchBucket` hole, fixed here with tests.

Not run, on purpose: e2e and docker suites. The diff touches no web code and no container packaging; the local-mode download path e2e exercises is behaviorally unchanged.
