### PR TITLE
fix(api): stop reporting a qpdf check timeout as a damaged PDF

### DIFF
--- a/apps/api/src/modality/document-input.ts
+++ b/apps/api/src/modality/document-input.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, open, rm, writeFile } from "node:fs/promises";
+import { mkdir, open, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
+  QpdfTimeoutError,
   qpdfAvailable,
   qpdfCheck,
   qpdfPageCount,
@@ -11,6 +12,13 @@ import { env } from "../config.js";
 import { type InputHandler, InputValidationError, type PreparedInput } from "./contract.js";
 
 const ZIP_MAGIC = Buffer.from("PK");
+
+/** instanceof plus a name check, so a future dual copy of doc-engine cannot silently revert timeouts to "damaged". */
+function isQpdfTimeout(err: unknown): boolean {
+  return (
+    err instanceof QpdfTimeoutError || (err instanceof Error && err.name === "QpdfTimeoutError")
+  );
+}
 
 export interface PdfPathValidationOptions {
   lenient?: boolean;
@@ -54,14 +62,40 @@ export async function validatePdfPath(
   try {
     await qpdfCheck(filePath);
   } catch (err) {
-    throw new InputValidationError(
-      `Damaged PDF: ${err instanceof Error ? err.message.slice(0, 300) : "structural check failed"}`,
+    if (!isQpdfTimeout(err)) {
+      throw new InputValidationError(
+        `Damaged PDF: ${err instanceof Error ? err.message.slice(0, 300) : "structural check failed"}`,
+      );
+    }
+    // A big-but-healthy PDF on a slow host can outlive the check budget
+    // (issue #920). That is inconclusive, not damage: proceed like the
+    // password-protected branch above, where qpdf also cannot inspect the
+    // structure. Tradeoff: a file crafted to stall qpdf passes this gate,
+    // but every downstream engine (qpdf, ghostscript, LibreOffice, ...)
+    // runs under its own timeout and fails loudly on a broken file.
+    const size = await stat(filePath)
+      .then((s) => s.size)
+      .catch(() => 0);
+    console.warn(
+      `[document-input] ${(err as Error).message} for ${filePath} (${size} bytes); skipping structural validation`,
     );
   }
   opts.signal?.throwIfAborted();
 
   if (env.MAX_PDF_PAGES > 0) {
-    const pages = await qpdfPageCount(filePath);
+    let pages: number;
+    try {
+      pages = await qpdfPageCount(filePath);
+    } catch (err) {
+      if (isQpdfTimeout(err)) {
+        // Fail closed: the cap is a resource guard, so a file that stalls the
+        // page-count probe must not slip past it. Say so instead of a 500.
+        throw new InputValidationError(
+          `Could not count this PDF's pages within the time limit, and this server caps PDFs at ${env.MAX_PDF_PAGES} pages. Try a smaller file.`,
+        );
+      }
+      throw err;
+    }
     opts.signal?.throwIfAborted();
     if (pages > env.MAX_PDF_PAGES) {
       throw new InputValidationError(

--- a/packages/doc-engine/src/index.ts
+++ b/packages/doc-engine/src/index.ts
@@ -50,4 +50,4 @@ export {
   pdfTextPy,
   pdfToWordPy,
 } from "./python-docs.js";
-export { qpdfCheck, qpdfPageCount, qpdfRequiresPassword } from "./qpdf.js";
+export { QpdfTimeoutError, qpdfCheck, qpdfPageCount, qpdfRequiresPassword } from "./qpdf.js";

--- a/packages/doc-engine/src/qpdf.ts
+++ b/packages/doc-engine/src/qpdf.ts
@@ -2,6 +2,18 @@ import { spawn } from "node:child_process";
 import { wrapWithMemoryLimit } from "@snapotter/shared";
 import { resolveQpdf } from "./binaries.js";
 
+/**
+ * A qpdf invocation outlived its time budget and was killed. Distinct from a
+ * structural failure: the file may be perfectly healthy, just slow to process
+ * on this host.
+ */
+export class QpdfTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QpdfTimeoutError";
+  }
+}
+
 /** @internal Shared qpdf CLI runner for doc-engine modules; not part of the public package API. */
 export function runQpdf(args: string[], timeoutMs = 30_000): Promise<string> {
   const bin = resolveQpdf();
@@ -16,7 +28,7 @@ export function runQpdf(args: string[], timeoutMs = 30_000): Promise<string> {
       if (settled) return;
       settled = true;
       child.kill("SIGKILL");
-      reject(new Error(`qpdf timed out after ${Math.round(timeoutMs / 1000)}s`));
+      reject(new QpdfTimeoutError(`qpdf timed out after ${Math.round(timeoutMs / 1000)}s`));
     }, timeoutMs);
     child.stdout.on("data", (c: Buffer) => {
       out += c.toString("utf8");
@@ -74,7 +86,7 @@ export async function qpdfRequiresPassword(filePath: string): Promise<boolean> {
       if (settled) return;
       settled = true;
       child.kill("SIGKILL");
-      reject(new Error("qpdf timed out after 30s"));
+      reject(new QpdfTimeoutError("qpdf timed out after 30s"));
     }, 30_000);
     child.on("error", (e) => {
       if (settled) return;

--- a/packages/doc-engine/tests/qpdf.test.ts
+++ b/packages/doc-engine/tests/qpdf.test.ts
@@ -164,6 +164,21 @@ describe("runQpdf timeout", () => {
       vi.useRealTimers();
     }
   });
+
+  it("rejects with QpdfTimeoutError so callers can tell a timeout from damage", async () => {
+    const mod = await import("../src/qpdf.js");
+    vi.useFakeTimers();
+    try {
+      nextManualChild();
+      const settled = expect(mod.qpdfCheck("/doc.pdf")).rejects.toBeInstanceOf(
+        mod.QpdfTimeoutError,
+      );
+      await vi.advanceTimersByTimeAsync(30_000);
+      await settled;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("qpdfCheck argument shape", () => {
@@ -232,6 +247,21 @@ describe("qpdfRequiresPassword", () => {
       await vi.advanceTimersByTimeAsync(30_000);
       await settled;
       expect(child.killSignals).toContain("SIGKILL");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects timeouts with QpdfTimeoutError, matching runQpdf", async () => {
+    const mod = await import("../src/qpdf.js");
+    vi.useFakeTimers();
+    try {
+      nextManualChild();
+      const settled = expect(mod.qpdfRequiresPassword("/enc.pdf")).rejects.toBeInstanceOf(
+        mod.QpdfTimeoutError,
+      );
+      await vi.advanceTimersByTimeAsync(30_000);
+      await settled;
     } finally {
       vi.useRealTimers();
     }

--- a/tests/unit/api/document-input.test.ts
+++ b/tests/unit/api/document-input.test.ts
@@ -11,13 +11,15 @@ const qpdf = vi.hoisted(() => ({
   requiresPassword: vi.fn(),
 }));
 
-vi.mock("@snapotter/doc-engine", () => ({
+vi.mock("@snapotter/doc-engine", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@snapotter/doc-engine")>()),
   qpdfAvailable: qpdf.available,
   qpdfCheck: qpdf.check,
   qpdfPageCount: qpdf.pageCount,
   qpdfRequiresPassword: qpdf.requiresPassword,
 }));
 
+import { QpdfTimeoutError } from "@snapotter/doc-engine";
 import {
   DocumentInputHandler,
   validatePdfPath,
@@ -121,6 +123,64 @@ describe("path-backed PDF validation", () => {
       /Damaged PDF.*xref table is corrupt/i,
     );
     expect(qpdf.pageCount).not.toHaveBeenCalled();
+  });
+
+  it("treats a qpdf check timeout as inconclusive rather than damage", async () => {
+    const inputPath = join(scratchDir, "big-but-healthy.pdf");
+    writeFileSync(inputPath, "%PDF-path-backed");
+    qpdf.requiresPassword.mockResolvedValueOnce(false);
+    qpdf.check.mockRejectedValueOnce(new QpdfTimeoutError("qpdf timed out after 30s"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await expect(
+        validatePdfPath(inputPath, { rejectPasswordProtected: true }),
+      ).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("timed out"));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("still enforces the page cap when the structural check timed out", async () => {
+    const inputPath = join(scratchDir, "big-and-long.pdf");
+    writeFileSync(inputPath, "%PDF-path-backed");
+    qpdf.requiresPassword.mockResolvedValueOnce(false);
+    qpdf.check.mockRejectedValueOnce(new QpdfTimeoutError("qpdf timed out after 30s"));
+    qpdf.pageCount.mockResolvedValueOnce(11);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const originalMaxPages = env.MAX_PDF_PAGES;
+    env.MAX_PDF_PAGES = 10;
+
+    try {
+      await expect(validatePdfPath(inputPath, { rejectPasswordProtected: true })).rejects.toThrow(
+        /11 pages.*maximum of 10/i,
+      );
+    } finally {
+      env.MAX_PDF_PAGES = originalMaxPages;
+      warn.mockRestore();
+    }
+  });
+
+  it("fails closed with a clear error when the page-count probe times out under a page cap", async () => {
+    const inputPath = join(scratchDir, "stalls-page-count.pdf");
+    writeFileSync(inputPath, "%PDF-path-backed");
+    qpdf.requiresPassword.mockResolvedValueOnce(false);
+    qpdf.check.mockResolvedValueOnce(undefined);
+    qpdf.pageCount.mockRejectedValueOnce(new QpdfTimeoutError("qpdf timed out after 30s"));
+    const originalMaxPages = env.MAX_PDF_PAGES;
+    env.MAX_PDF_PAGES = 10;
+
+    try {
+      await expect(
+        validatePdfPath(inputPath, { rejectPasswordProtected: true }),
+      ).rejects.toMatchObject({
+        name: "InputValidationError",
+        message: expect.stringMatching(/count this PDF's pages within the time limit/i),
+      });
+    } finally {
+      env.MAX_PDF_PAGES = originalMaxPages;
+    }
   });
 
   it("stops before invoking qpdf when path validation is canceled", async () => {


### PR DESCRIPTION
Closes #920

A 90-page, ~30 MB PDF that every other program opens fine came back as "Damaged PDF: qpdf timed out after 30s" from remove-pages. Two things stacked: input validation runs `qpdf --check` under a 30s kill budget, and `--check` parses every content stream, far more work than the page-copy operation it guards (which gets 60s). On a slow host a big healthy file blows the budget, and `validatePdfPath` wrapped that timeout in the same "Damaged PDF" rejection as a real structural failure. The file was then unusable in every PDF tool.

What changed:

- `runQpdf` and `qpdfRequiresPassword` reject timeouts with a typed `QpdfTimeoutError` (message unchanged).
- `validatePdfPath` treats a `--check` timeout as inconclusive: log a warning with the file size and continue, the same call the password-protected branch already makes when qpdf can't inspect a file. Real damage still rejects fast with qpdf's diagnostics.
- With `MAX_PDF_PAGES` set, a timeout in the page-count probe now fails closed with a clear message instead of escaping as a 500. The cap is a resource guard; a file that stalls the probe shouldn't slip past it.

The tradeoff: a file crafted to stall `--check` past 30s now gets through the gate and dies later in the tool's own engine run, with a less friendly error than the old upfront 400. Every engine keeps its own timeout and the subprocess memory cap still applies. The old behavior also rejected every legitimate large file on slow hardware, which is the bug.

Verification:

- Reproduced on main with a slowed qpdf standing in for a big file on slow hardware: a valid fixture returned the exact reported error after 30.4s. The same setup on this branch passes validation with a warning logged.
- A truncated PDF still rejects as "Damaged PDF: qpdf exited 2: ..." with real qpdf 12.
- Five new tests across doc-engine and the api unit suite. All five fail with the fix reverted and pass with it.
- `pnpm lint` clean, `pnpm typecheck` 9/9. Unit suite fully green locally after rebasing onto d6f071c1 (8679 passed). Document-area integration subset (44 files: document tools, modality-input, hostile inputs, drift guards) green locally with real qpdf. Two full-suite attempts on the shared dev box died to Docker VM restarts from a concurrent workload, so the integration shards on this PR are the authoritative full comparison against the green CI run on d6f071c1.
- Callers audited: `runQpdf` (10 pdf-ops sites), `qpdfPageCount` (remove-pages, split-pdf, pdf-to-image), `validatePdfPath` (tool factory, ocr-pdf, ocr-pdf-ingress). Nothing matches on the timeout class or message.

A follow-up issue tracks the remaining tail where `--requires-password` itself times out and still surfaces as a 500. It reads only the encryption dictionary, so a 30s stall there is anomalous rather than big-file slow, and it needs its own decision.
