### PR TITLE
fix(api): enforce MAX_USERS in SCIM user provisioning

### DIFF
--- a/apps/api/src/lib/user-limit.ts
+++ b/apps/api/src/lib/user-limit.ts
@@ -3,11 +3,10 @@ import { env } from "../config.js";
 import { type db, schema } from "../db/index.js";
 
 // Every path that enforces MAX_USERS (register route, external-auth
-// auto-create) must serialize on this one lock or two concurrent creates can
-// each pass the count and overshoot the cap by one (issue #928). SCIM
-// provisioning does not enforce the cap at all today (issue #966). Lock ids
-// are scoped per database, so parallel test forks with their own DB clones
-// never contend.
+// auto-create, SCIM user provisioning) must serialize on this one lock or two
+// concurrent creates can each pass the count and overshoot the cap by one
+// (issues #928, #966). Lock ids are scoped per database, so parallel test
+// forks with their own DB clones never contend.
 const USER_LIMIT_LOCK_KEY = 7_421_003;
 
 type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];

--- a/apps/api/src/routes/enterprise/scim.ts
+++ b/apps/api/src/routes/enterprise/scim.ts
@@ -1,11 +1,13 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import { and, eq, sql } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { env } from "../../config.js";
 import { db, schema } from "../../db/index.js";
 import { sharedRedis } from "../../jobs/connection.js";
 import { auditLog } from "../../lib/audit.js";
 import { isEnterpriseFeatureEnabled } from "../../lib/enterprise-feature.js";
 import { getSettingString, upsertSetting } from "../../lib/settings-helpers.js";
+import { userLimitReached } from "../../lib/user-limit.js";
 import { isDisabledRole, requireFullAdmin } from "../../permissions.js";
 import { hashPassword, verifyPassword } from "../../plugins/auth.js";
 
@@ -392,22 +394,31 @@ export async function registerScimRoutes(app: FastifyInstance): Promise<void> {
       const now = new Date();
       // The pre-check above can't close the race: IdP retries can send the
       // same create twice, and both pass the SELECT before either insert
-      // commits (issue #927).
-      const inserted = await db
-        .insert(schema.users)
-        .values({
-          id,
-          username: userName,
-          email,
-          externalId: externalId ?? null,
-          role: active ? "user" : "disabled",
-          team: teamId,
-          authProvider: "scim",
-          mustChangePassword: false,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .onConflictDoNothing({ target: schema.users.username });
+      // commits (issue #927). MAX_USERS binds provisioning too (issue #966):
+      // the locked count and the insert share one transaction, same as the
+      // register route, so concurrent creates can't overshoot the cap.
+      const inserted = await db.transaction(async (tx) => {
+        if (await userLimitReached(tx)) return "limit" as const;
+        return tx
+          .insert(schema.users)
+          .values({
+            id,
+            username: userName,
+            email,
+            externalId: externalId ?? null,
+            role: active ? "user" : "disabled",
+            team: teamId,
+            authProvider: "scim",
+            mustChangePassword: false,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .onConflictDoNothing({ target: schema.users.username });
+      });
+
+      if (inserted === "limit") {
+        return reply.status(403).send(scimError(403, `User limit reached (${env.MAX_USERS} max)`));
+      }
 
       if (!inserted.rowCount) {
         return reply.status(409).send(scimError(409, "User already exists"));

--- a/tests/integration/platform/scim.test.ts
+++ b/tests/integration/platform/scim.test.ts
@@ -822,6 +822,9 @@ describe("SCIM licensed Users and Groups CRUD", () => {
   const DEFAULT_TEAM_ID = "default-team-00000000";
   const SCIM_ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";
   let crudApp: TestApp;
+  // The vi.resetModules() in beforeAll gives crudApp a fresh config module,
+  // so MAX_USERS tests must mutate THAT env instance, not a top-level import.
+  let crudEnv: typeof import("../../../apps/api/src/config.js").env;
   let crudSeq = 0;
 
   function uniqueName(prefix: string): string {
@@ -876,6 +879,7 @@ describe("SCIM licensed Users and Groups CRUD", () => {
     mockEnterpriseFeatures(["scim"]);
     const { buildTestApp: buildLicensedApp } = await import("../test-server.js");
     crudApp = await buildLicensedApp();
+    crudEnv = (await import("../../../apps/api/src/config.js")).env;
 
     const tokenHash = await hashPassword(SCIM_TOKEN);
     await db
@@ -1499,6 +1503,85 @@ describe("SCIM licensed Users and Groups CRUD", () => {
       const body = JSON.parse(res.body);
       expect(body.userName).toBe(userName);
       expect(body.active).toBe(true);
+    });
+  });
+
+  describe("Users create user limit (issue #966)", () => {
+    async function countUsers(): Promise<number> {
+      const rows = await db.select().from(schema.users);
+      return rows.length;
+    }
+
+    it("refuses to provision past MAX_USERS with the SCIM 403 envelope", async () => {
+      const origMaxUsers = crudEnv.MAX_USERS;
+      // Relies on the users table being non-empty (test-server seeds the
+      // default admin); a count of 0 would mean unlimited, not a full cap.
+      (crudEnv as Record<string, unknown>).MAX_USERS = await countUsers();
+      try {
+        const userName = uniqueName("scim-cap-full");
+        const res = await crudApp.app.inject({
+          method: "POST",
+          url: "/api/v1/scim/v2/Users",
+          headers: authHeaders(),
+          payload: { userName },
+        });
+
+        expect(res.statusCode).toBe(403);
+        expect(JSON.parse(res.body)).toMatchObject({
+          schemas: [SCIM_ERROR_SCHEMA],
+          status: 403,
+          detail: `User limit reached (${crudEnv.MAX_USERS} max)`,
+        });
+
+        const rows = await db
+          .select()
+          .from(schema.users)
+          .where(eq(schema.users.username, userName));
+        expect(rows).toHaveLength(0);
+      } finally {
+        (crudEnv as Record<string, unknown>).MAX_USERS = origMaxUsers;
+      }
+    });
+
+    it("still provisions while below the cap", async () => {
+      const origMaxUsers = crudEnv.MAX_USERS;
+      (crudEnv as Record<string, unknown>).MAX_USERS = (await countUsers()) + 1;
+      try {
+        const { id } = await createScimUser({ userName: uniqueName("scim-cap-below") });
+        expect(id).toBeTruthy();
+      } finally {
+        (crudEnv as Record<string, unknown>).MAX_USERS = origMaxUsers;
+      }
+    });
+
+    it("concurrent provisioning stops at the cap with one 201 and one 403", async () => {
+      // Cap enforcement rides the shared advisory lock from issue #928, so
+      // two concurrent creates with different names can't both pass the
+      // count. Without the lock (or with no check at all, the #966 bug)
+      // both come back 201 and the cap is exceeded.
+      const origMaxUsers = crudEnv.MAX_USERS;
+      const cap = (await countUsers()) + 1;
+      (crudEnv as Record<string, unknown>).MAX_USERS = cap;
+      try {
+        const create = (userName: string) =>
+          crudApp.app.inject({
+            method: "POST",
+            url: "/api/v1/scim/v2/Users",
+            headers: authHeaders(),
+            payload: { userName },
+          });
+
+        const [first, second] = await Promise.all([
+          create(uniqueName("scim-cap-race-a")),
+          create(uniqueName("scim-cap-race-b")),
+        ]);
+
+        const statuses = [first.statusCode, second.statusCode].sort();
+        expect(statuses).toEqual([201, 403]);
+        expect(await countUsers()).toBe(cap);
+      } finally {
+        (crudEnv as Record<string, unknown>).MAX_USERS = origMaxUsers;
+      }
     });
   });
 


### PR DESCRIPTION
Closes #966

SCIM POST /Users never checked the user cap. With MAX_USERS=5 and five users, an IdP provisioning run created a sixth: 201, nothing logged, People page showing 6/5. Register and the SSO auto-create have both enforced the cap since #928, so provisioning was the one door left open.

The issue floats the alternative reading, that IdP-driven provisioning should be exempt because the IdP is the source of truth. Decided against it: MAX_USERS is an instance-wide invariant, and an operator who set it expects it to hold whichever door a user comes through. Exempting SCIM would need documenting anyway; enforcing is the smaller surprise.

The insert now shares one transaction with the locked count from lib/user-limit.ts, the #928 advisory-lock helper register and the resolver already use, so concurrent provisioning can't overshoot either. Denial is a SCIM 403 error envelope with the same "User limit reached (N max)" detail the register route returns. No new mechanism, just one more caller of the existing one.

Tests (tests/integration/platform/scim.test.ts, licensed suite): an at-cap create is refused with the envelope shape and writes no row, a below-cap create still lands, and two concurrent creates at cap-1 come back [201, 403] with the count pinned at the cap. The first and third failed on unfixed code (201 past the cap, [201, 201] overshoot), and reverting the fix while keeping the tests fails exactly those two again.

Verified: lint, typecheck, the full scim suite (79 tests), and the other lock callers (user-limit-race, auth-edge-cases, external-auth-race, the resolver mutation units). Full pnpm test on this branch: 835 of 860 files green in one run; the other 25, all jsdom web unit files nowhere near this diff, died together when the shared test Postgres container was torn down mid-run ("the database system is shutting down") and all 25 pass on rerun. The fresh main baseline's only failures are the two stray twitter/*.test.mjs files local to that checkout (#947), which don't exist in this worktree.

#967 already tracks the missing audit row on limit denials; the new SCIM denial joins that list.
