### PR TITLE
fix(api): close the mixed-case team name race with a lower(name) unique index

### DIFF
--- a/apps/api/drizzle/0007_needy_fenris.sql
+++ b/apps/api/drizzle/0007_needy_fenris.sql
@@ -1,0 +1,16 @@
+-- Existing installs may already hold case-twin teams, minted by the #970
+-- race or by history predating the case-insensitive pre-check. Keep the
+-- oldest row of each lower(name) group and rename the rest by appending
+-- their id (unique), so the index below can build. Members are attached by
+-- team id, so renamed teams keep their members.
+UPDATE "teams" t
+SET "name" = t."name" || '-' || t."id"
+WHERE EXISTS (
+  SELECT 1 FROM "teams" older
+  WHERE lower(older."name") = lower(t."name")
+    AND older."id" <> t."id"
+    AND (older."created_at" < t."created_at"
+      OR (older."created_at" = t."created_at" AND older."id" < t."id"))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "teams_name_lower_unique" ON "teams" USING btree (lower("name"));

--- a/apps/api/drizzle/meta/0007_snapshot.json
+++ b/apps/api/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1008 @@
+{
+  "id": "a03bcdf6-a893-490b-b992-c3af8d8d9f34",
+  "prevId": "5634b76b-9b83-4a81-9307-bebc895cbf65",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default API Key'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_prefix_idx": {
+          "name": "api_keys_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_actor_id_idx": {
+          "name": "audit_log_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_id_users_id_fk": {
+          "name": "audit_log_actor_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pool": {
+          "name": "pool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_refs": {
+          "name": "input_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_refs": {
+          "name": "output_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes_in": {
+          "name": "bytes_in",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes_out": {
+          "name": "bytes_out",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_after": {
+          "name": "delete_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "jobs_created_at_idx": {
+          "name": "jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_status_idx": {
+          "name": "jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_user_id_users_id_fk": {
+          "name": "jobs_user_id_users_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipelines": {
+      "name": "pipelines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pipelines_user_id_users_id_fk": {
+          "name": "pipelines_user_id_users_id_fk",
+          "tableFrom": "pipelines",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_permissions": {
+          "name": "tool_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roles_created_by_users_id_fk": {
+          "name": "roles_created_by_users_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_hold": {
+          "name": "legal_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_quota": {
+          "name": "storage_quota",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retention_hours": {
+          "name": "retention_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "teams_name_lower_unique": {
+          "name": "teams_name_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_name_unique": {
+          "name": "teams_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_files": {
+      "name": "user_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_name": {
+          "name": "stored_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_chain": {
+          "name": "tool_chain",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_files_user_id_users_id_fk": {
+          "name": "user_files_user_id_users_id_fk",
+          "tableFrom": "user_files",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_preferences_user_id_key_pk": {
+          "name": "user_preferences_user_id_key_pk",
+          "columns": ["user_id", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_hold": {
+          "name": "legal_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_used": {
+          "name": "storage_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "storage_quota": {
+          "name": "storage_quota",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_enabled": {
+          "name": "totp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recovery_codes_hash": {
+          "name": "recovery_codes_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": ["queued", "processing", "completed", "failed", "canceled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1784729211461,
       "tag": "0006_majestic_sinister_six",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1788439313579,
+      "tag": "0007_needy_fenris",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   bigint,
   boolean,
@@ -9,6 +10,7 @@ import {
   primaryKey,
   text,
   timestamp,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 
 export const jobStatus = pgEnum("job_status", [
@@ -43,16 +45,26 @@ export const users = pgTable("users", {
   recoveryCodesHash: text("recovery_codes_hash"),
 });
 
-export const teams = pgTable("teams", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull().unique(),
-  legalHold: boolean("legal_hold").notNull().default(false),
-  storageQuota: bigint("storage_quota", { mode: "number" }),
-  retentionHours: integer("retention_hours"),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .$defaultFn(() => new Date()),
-});
+export const teams = pgTable(
+  "teams",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull().unique(),
+    legalHold: boolean("legal_hold").notNull().default(false),
+    storageQuota: bigint("storage_quota", { mode: "number" }),
+    retentionHours: integer("retention_hours"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    // Name uniqueness is case-insensitive everywhere the API compares names
+    // (create and rename pre-checks, SCIM group lookups). The plain unique
+    // constraint above is exact-case, so without this index two concurrent
+    // mixed-case creates could land a case-twin pair (issue #970).
+    uniqueIndex("teams_name_lower_unique").on(sql`lower(${table.name})`),
+  ],
+);
 
 export const sessions = pgTable("sessions", {
   id: text("id").primaryKey(),

--- a/apps/api/src/routes/enterprise/scim.ts
+++ b/apps/api/src/routes/enterprise/scim.ts
@@ -833,7 +833,9 @@ export async function registerScimRoutes(app: FastifyInstance): Promise<void> {
 
       // The pre-check above can't close the race: IdP retries can send the
       // same create twice, and both pass the SELECT before either insert
-      // commits (issue #927).
+      // commits (issue #927). Unqualified so it also covers the lower(name)
+      // index (issue #970): this pre-check is exact-case, so a mixed-case
+      // twin of an existing team only ever surfaces at the insert.
       const inserted = await db
         .insert(schema.teams)
         .values({
@@ -841,7 +843,7 @@ export async function registerScimRoutes(app: FastifyInstance): Promise<void> {
           name: displayName,
           createdAt: now,
         })
-        .onConflictDoNothing({ target: schema.teams.name });
+        .onConflictDoNothing();
 
       if (!inserted.rowCount) {
         return reply.status(409).send(scimError(409, "Group already exists"));

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -80,8 +80,10 @@ export async function teamsRoutes(app: FastifyInstance): Promise<void> {
     const id = randomUUID();
 
     // The pre-check above can't close the race: two concurrent creates both
-    // pass the SELECT before either insert commits (issue #927). This guard
-    // only covers exact-case twins; the unique constraint is case-sensitive.
+    // pass the SELECT before either insert commits (issue #927). Unqualified
+    // on purpose so it covers both the exact-case unique constraint and the
+    // lower(name) index that catches mixed-case twins (issue #970); the only
+    // other constraint here is the primary key on a fresh UUID.
     const inserted = await db
       .insert(schema.teams)
       .values({
@@ -90,7 +92,7 @@ export async function teamsRoutes(app: FastifyInstance): Promise<void> {
         storageQuota: storageQuota ?? null,
         retentionHours: retentionHours ?? null,
       })
-      .onConflictDoNothing({ target: schema.teams.name });
+      .onConflictDoNothing();
 
     if (!inserted.rowCount) {
       return reply.status(409).send({ error: "Team name already exists", code: "CONFLICT" });

--- a/tests/integration/platform/scim.test.ts
+++ b/tests/integration/platform/scim.test.ts
@@ -1630,6 +1630,29 @@ describe("SCIM licensed Users and Groups CRUD", () => {
       expect(rows).toHaveLength(1);
     });
 
+    it("rejects a group whose name differs from an existing team only by case", async () => {
+      // Issue #970: groups are teams rows, and the SCIM pre-check is
+      // exact-case. Before the lower(name) unique index, a mixed-case twin
+      // sailed through and split membership across two teams the rest of
+      // the API treats as the same name.
+      const base = uniqueName("scim-grp-case");
+      await createScimGroup({ displayName: base });
+
+      const res = await crudApp.app.inject({
+        method: "POST",
+        url: "/api/v1/scim/v2/Groups",
+        headers: authHeaders(),
+        payload: { displayName: base.toUpperCase() },
+      });
+
+      expect(res.statusCode).toBe(409);
+      expect(JSON.parse(res.body)).toMatchObject({
+        schemas: [SCIM_ERROR_SCHEMA],
+        status: 409,
+        detail: "Group already exists",
+      });
+    });
+
     it("creates a group, assigns members, and reflects it on the user resource", async () => {
       const memberA = await createScimUser({ userName: uniqueName("scim-grp-m1") });
       const memberB = await createScimUser({ userName: uniqueName("scim-grp-m2") });

--- a/tests/integration/platform/teams.test.ts
+++ b/tests/integration/platform/teams.test.ts
@@ -135,9 +135,7 @@ describe("POST /api/v1/teams", () => {
     // Issue #927: requests that pass the duplicate pre-check before the
     // winner's insert commits used to surface the 23505 unique violation
     // as a 500. raceInserts holds both requests at the insert so each one
-    // passes the pre-check. Exact-case duplicates only: teams.name is
-    // case-sensitive in Postgres, so the insert guard can't see a
-    // mixed-case twin.
+    // passes the pre-check. Mixed-case twins are the next test's job.
     const create = () =>
       app.inject({
         method: "POST",
@@ -161,6 +159,52 @@ describe("POST /api/v1/teams", () => {
       .from(schema.teams)
       .where(eq(schema.teams.name, "Race Condition"));
     expect(rows).toHaveLength(1);
+  });
+
+  it("concurrent mixed-case twins get one 201 and one 409, never two teams", async () => {
+    // Issue #970: the pre-check compares LOWER(name), but the exact-case
+    // unique constraint can't see a mixed-case twin, so "CaseTwin" and
+    // "casetwin" racing past the pre-check both landed. The lower(name)
+    // unique index makes the loser's insert conflict instead.
+    const create = (name: string) =>
+      app.inject({
+        method: "POST",
+        url: "/api/v1/teams",
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { name },
+      });
+
+    const results = await raceInserts("teams", 2, () =>
+      Promise.all([create("CaseTwin"), create("casetwin")]),
+    );
+    const statuses = results.map((r) => r.statusCode).sort();
+    expect(statuses).toEqual([201, 409]);
+
+    const conflict = results.find((r) => r.statusCode === 409);
+    expect(JSON.parse(conflict?.body ?? "{}")).toEqual({
+      error: "Team name already exists",
+      code: "CONFLICT",
+    });
+
+    const rows = await db
+      .select()
+      .from(schema.teams)
+      .where(sql`LOWER(${schema.teams.name}) = 'casetwin'`);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("teams carries exactly the unique constraints the create guard assumes", async () => {
+    // The POST insert uses an unqualified onConflictDoNothing and maps every
+    // conflict to "Team name already exists". That's only honest while the
+    // unique surface is the primary key (a fresh UUID) plus the two name
+    // constraints. If this test fails, a new unique constraint joined the
+    // table: give the insert guard an explicit story for it before widening
+    // this list.
+    const res = await db.execute(
+      sql`SELECT indexname FROM pg_indexes WHERE tablename = 'teams' AND indexdef ILIKE '%UNIQUE%' ORDER BY indexname`,
+    );
+    const names = res.rows.map((r) => (r as { indexname: string }).indexname);
+    expect(names).toEqual(["teams_name_lower_unique", "teams_name_unique", "teams_pkey"]);
   });
 
   it("rejects duplicate names (case-insensitive)", async () => {


### PR DESCRIPTION
Closes #970

Team name uniqueness was case-insensitive only in the pre-check SELECTs. The unique constraint on teams.name is exact-case, and so was the conflict guard #971 added, so concurrent creates of "Foo" and "foo" both passed the pre-check and both landed. The result is a case-twin pair the rest of the API treats as one name: renames 409 against either casing, SCIM group lookups match whichever casing they were sent with. #971 deferred this on purpose because it needs a migration, not just a guard.

The fix is the sketch from the issue: a unique index on lower(name). The migration (0007) first renames younger case-twins by appending their id, the oldest row keeps the name, then builds the index. Members hang off the team id, so renamed twins keep their members; nothing is deleted. The teams POST and SCIM Groups POST guards go unqualified so a conflict on the new index returns their existing 409 body instead of a 500. A schema drift-guard test pins the table's unique surface to exactly {pkey, name, lower(name)}, so the "any conflict here is a name conflict" assumption behind the unqualified guard breaks loudly if someone adds a fourth constraint.

One SCIM behavior change, worth a release-notes line: a group create whose displayName differs from an existing team only by case now 409s "Group already exists" instead of silently minting a twin, and on upgrade any pre-existing younger twin shows up renamed with its id suffix.

Decided tradeoffs:

- If a dedupe rename ever collides with an unrelated existing name (a team literally named "foo-<that-uuid>"), the index build fails and boot aborts with the raw 23505. Loud, astronomically unlikely, and a retry loop in migration SQL wasn't worth it.
- Rename races (teams PUT, SCIM group renames) can now hit the new index and still 500 until #968 maps update-side 23505s to 409s; exact-case renames already had that window.
- A hand-edited config import containing case-twin team names now fails its transaction instead of importing twins.
- SCIM group names still aren't trimmed, so whitespace twins remain possible; that asymmetry predates this change and is filed as #988.

Tests: a mixed-case create race through the pg-race harness (was [201, 201] with two rows, now [201, 409] with one), a sequential SCIM case-twin create (was 201, now the 409 envelope), and the drift guard. Both behavior tests fail again if the fix is reverted with the tests kept.

Verified: lint, typecheck, teams + scim suites (104 tests) on the rebased branch (9c68863b, includes #987), plus gdpr-lifecycle, config-export-import, custom-roles, auth-edge-cases for the other teams-table writers; ensureDefaultTeam already inserts unqualified and legal-hold never touches name. Full pnpm test on the rebased branch under the shared runner lock: 858 files, 19,845 tests, zero failures (the fresh main baseline's only failures are the two stray twitter/*.test.mjs files local to that checkout, #947, absent here).
