### PR TITLE
fix(api): surface S3 storage faults on tool-result download as 500, not 404

### DIFF
--- a/apps/api/src/lib/object-storage.ts
+++ b/apps/api/src/lib/object-storage.ts
@@ -34,8 +34,17 @@ export interface ObjectInfo {
 
 const VALID_KEY = /^(uploads|outputs)\/[A-Za-z0-9][A-Za-z0-9._-]*\/[^/\0]+$/;
 
+/**
+ * True when a key can name a stored object at all. Exported so routes can
+ * reject garbage input up front instead of catching assertValidKey's plain
+ * Error, which fault classification cannot tell apart from a storage fault.
+ */
+export function isValidObjectKey(key: string): boolean {
+  return VALID_KEY.test(key) && !key.includes("..");
+}
+
 function assertValidKey(key: string): void {
-  if (!VALID_KEY.test(key) || key.includes("..")) {
+  if (!isValidObjectKey(key)) {
     throw new Error(`Invalid object key: ${key}`);
   }
 }
@@ -274,6 +283,21 @@ export async function putObjectStream(
   } finally {
     opts.signal?.removeEventListener("abort", abortSource);
   }
+}
+
+/**
+ * True when a read-path rejection in S3 mode is a storage fault that must
+ * keep reaching the error handler (#974): anything except S3 reporting the
+ * object missing. Mirrors isStorageServiceFault in lib/file-storage.ts but
+ * is bound to this module's own lazy S3 singleton; the two cannot share one
+ * because either module may have loaded S3 while the other has not, and a
+ * null singleton must fail toward "fault", never toward 404. Local-backend
+ * rejections return false; their errno shape already routes them.
+ */
+export function isStorageServiceFault(error: unknown): boolean {
+  if (!isS3Enabled()) return false;
+  if (error instanceof SafeError) return false;
+  return !s3Mod || !s3Mod.isMissingObjectError(error);
 }
 
 export async function getObjectStream(

--- a/apps/api/src/lib/object-storage.ts
+++ b/apps/api/src/lib/object-storage.ts
@@ -291,12 +291,14 @@ export async function putObjectStream(
  * object missing. Mirrors isStorageServiceFault in lib/file-storage.ts but
  * is bound to this module's own lazy S3 singleton; the two cannot share one
  * because either module may have loaded S3 while the other has not, and a
- * null singleton must fail toward "fault", never toward 404. Local-backend
- * rejections return false; their errno shape already routes them.
+ * null singleton must fail toward "fault", never toward 404. Unlike
+ * file-storage there is no SafeError carve-out: this module throws none on
+ * the read path, and rethrowing one preserves its own statusCode at the
+ * global handler anyway. Local-backend rejections return false; their errno
+ * shape already routes them.
  */
 export function isStorageServiceFault(error: unknown): boolean {
   if (!isS3Enabled()) return false;
-  if (error instanceof SafeError) return false;
   return !s3Mod || !s3Mod.isMissingObjectError(error);
 }
 

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -8,7 +8,13 @@ import { validateImageBuffer } from "../lib/file-validation.js";
 import { sanitizeFilename } from "../lib/filename.js";
 import { decodeToSharpCompat, needsCliDecode } from "../lib/format-decoders.js";
 import { decodeHeic } from "../lib/heic-converter.js";
-import { getObjectSize, getObjectStream, putObject } from "../lib/object-storage.js";
+import {
+  getObjectSize,
+  getObjectStream,
+  isStorageServiceFault,
+  isValidObjectKey,
+  putObject,
+} from "../lib/object-storage.js";
 import { isSvgBuffer, sanitizeSvg } from "../lib/svg-sanitize.js";
 import { requireFileAccess, requirePermission } from "../permissions.js";
 
@@ -163,16 +169,37 @@ export async function fileRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(400).send({ error: "Invalid path" });
       }
 
+      // A key that cannot name a stored object (URL-decoded garbage that
+      // passes the traversal guard) keeps its long-standing 404 without
+      // touching storage; past this point a probe failure is meaningful.
+      if (!isValidObjectKey(`outputs/${jobId}/${filename}`)) {
+        return reply.status(404).send({ error: "File not found" });
+      }
+
+      // A size-probe rejection is only a miss when storage says the object
+      // is not there. A syscall fault other than ENOENT (EACCES, ENOTDIR)
+      // or an S3 service fault (AccessDenied, rotated credentials, S3 5xx)
+      // is a storage outage that must keep reaching the global handler and
+      // Sentry, not fold into "File not found" (#974, sibling of #937).
+      const rethrowIfStorageFault = (e: unknown): void => {
+        const { code, syscall } = e as NodeJS.ErrnoException;
+        if (syscall && code !== "ENOENT") throw e;
+        if (isStorageServiceFault(e)) throw e;
+      };
+
       // Resolve from object storage: outputs/ first, then uploads/
       let key = `outputs/${jobId}/${filename}`;
       let size: number;
       try {
         size = await getObjectSize(key);
-      } catch {
+      } catch (outputsErr) {
+        rethrowIfStorageFault(outputsErr);
         key = `uploads/${jobId}/${filename}`;
         try {
           size = await getObjectSize(key);
-        } catch {
+        } catch (uploadsErr) {
+          rethrowIfStorageFault(uploadsErr);
+          request.log.warn({ jobId, filename }, "result download: object missing in storage");
           return reply.status(404).send({ error: "File not found" });
         }
       }

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -181,9 +181,13 @@ export async function fileRoutes(app: FastifyInstance): Promise<void> {
       // or an S3 service fault (AccessDenied, rotated credentials, S3 5xx)
       // is a storage outage that must keep reaching the global handler and
       // Sentry, not fold into "File not found" (#974, sibling of #937).
+      // ENAMETOOLONG counts as a miss: no object can exist at such a key,
+      // and this route takes unauthenticated client-supplied names (params
+      // up to maxParamLength: 500 exceed the 255-byte filename limit), so
+      // long garbage must stay 404 instead of paging Sentry.
       const rethrowIfStorageFault = (e: unknown): void => {
         const { code, syscall } = e as NodeJS.ErrnoException;
-        if (syscall && code !== "ENOENT") throw e;
+        if (syscall && code !== "ENOENT" && code !== "ENAMETOOLONG") throw e;
         if (isStorageServiceFault(e)) throw e;
       };
 

--- a/packages/enterprise/src/storage-s3.ts
+++ b/packages/enterprise/src/storage-s3.ts
@@ -79,9 +79,12 @@ export async function checkConnection(): Promise<void> {
  * missing: NoSuchKey, or an unmodeled 404 from an S3-compatible store (the
  * SDK stamps every dispatched error with $metadata). NoSuchBucket also
  * arrives as HTTP 404 but means the whole bucket is gone, a storage outage
- * rather than a missing file, so it stays a fault. Service faults
- * (AccessDenied, credential rejection, 5xx) and errors that did not come
- * from the SDK return false.
+ * rather than a missing file, so it stays a fault. Caveat: that carve-out
+ * only works for GetObject callers. HEAD responses carry no body, so for
+ * HeadObject the SDK yields the same NotFound/404 shape whether the key or
+ * the whole bucket is missing, and this predicate cannot tell them apart.
+ * Service faults (AccessDenied, credential rejection, 5xx) and errors that
+ * did not come from the SDK return false.
  */
 export function isMissingObjectError(error: unknown): boolean {
   if (typeof error !== "object" || error === null || !("$metadata" in error)) return false;

--- a/tests/integration/platform/result-download-fault.test.ts
+++ b/tests/integration/platform/result-download-fault.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Local-mode tool-result download fault classification (#974).
+ *
+ * CI-runnable half of the #974 coverage: the minio-gated
+ * s3-result-download-fault.test.ts skips where MinIO is absent (all CI
+ * lanes), so the route's classification wiring is pinned here in local mode.
+ * A storage fault (EACCES) must reach the error handler as a 500; a key no
+ * object can exist at (ENOENT, ENAMETOOLONG, garbage that fails VALID_KEY)
+ * keeps its 404 without becoming Sentry noise on this unauthenticated route.
+ * The second rethrow site (uploads probe) is the same shared closure applied
+ * symmetrically; the fault cases here exercise the outputs site.
+ */
+
+import { chmod } from "node:fs/promises";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { env } from "../../../apps/api/src/config.js";
+import { deletePrefix, putObject } from "../../../apps/api/src/lib/object-storage.js";
+import { fixtures, readFixture } from "../../fixtures/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "../test-server.js";
+
+const PNG = readFixture(fixtures.image.base.png200);
+
+let testApp: TestApp;
+let adminToken: string;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp?.cleanup();
+}, 10_000);
+
+async function download(jobId: string, filename: string) {
+  return testApp.app.inject({
+    method: "GET",
+    url: `/api/v1/download/${encodeURIComponent(jobId)}/${encodeURIComponent(filename)}`,
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+}
+
+describe("tool-result download fault classification (local mode)", () => {
+  it("falls through to the uploads/ prefix when outputs/ has no object", async () => {
+    const jobId = "resfault-up";
+    await putObject(`uploads/${jobId}/original.png`, PNG);
+    try {
+      const res = await download(jobId, "original.png");
+      expect(res.statusCode).toBe(200);
+      expect(Buffer.compare(res.rawPayload, PNG)).toBe(0);
+    } finally {
+      await deletePrefix(`uploads/${jobId}`);
+    }
+  });
+
+  // An unreadable job directory is a storage fault (volume UID drift, botched
+  // restore), not a missing result. It must stay a 500 that reaches the error
+  // handler, never fold into the miss 404 (#974, mirroring the #926 pin for
+  // the library route).
+  const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+  it.skipIf(isRoot)("returns 500, not 404, when the size probe hits EACCES", async () => {
+    const jobId = "resfault-acc";
+    await putObject(`outputs/${jobId}/result.png`, PNG);
+    const jobDir = join(env.WORKSPACE_PATH, "outputs", jobId);
+    await chmod(jobDir, 0o000);
+    try {
+      const res = await download(jobId, "result.png");
+      expect(res.statusCode).toBe(500);
+      expect(JSON.parse(res.body).error).not.toMatch(/not found/i);
+    } finally {
+      await chmod(jobDir, 0o755);
+      await deletePrefix(`outputs/${jobId}`);
+    }
+  });
+
+  // A filename longer than the filesystem allows cannot name a stored object;
+  // ENAMETOOLONG is a miss like ENOENT. This route takes unauthenticated
+  // client-supplied names, so long garbage must stay 404, not turn into a
+  // client-triggerable Sentry event.
+  it("keeps 404 for a filename too long for the filesystem", async () => {
+    const res = await download("resfault-long", `${"a".repeat(300)}.png`);
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body).error).toMatch(/not found/i);
+  });
+
+  // A key that fails VALID_KEY (space in the jobId) must 404 before touching
+  // storage. The teeth are in S3 mode: without the pre-check, assertValidKey's
+  // plain Error classifies as a storage fault and every scanner probe becomes
+  // a 500. The pre-check returns before any storage call, so the bogus S3
+  // config set here is never read.
+  it("keeps 404 for a key that cannot name a stored object (S3 mode)", async () => {
+    const originalMode = env.STORAGE_MODE;
+    (env as Record<string, unknown>).STORAGE_MODE = "s3";
+    try {
+      const res = await download("bad job", "whatever.png");
+      expect(res.statusCode).toBe(404);
+      expect(JSON.parse(res.body).error).toMatch(/not found/i);
+    } finally {
+      (env as Record<string, unknown>).STORAGE_MODE = originalMode;
+    }
+  });
+});

--- a/tests/integration/platform/s3-result-download-fault.test.ts
+++ b/tests/integration/platform/s3-result-download-fault.test.ts
@@ -1,0 +1,149 @@
+/**
+ * S3-mode tool-result download fault classification (#974).
+ *
+ * GET /api/v1/download/:jobId/:filename resolved the object with two nested
+ * bare catches: any getObjectSize rejection fell through to the uploads/
+ * probe, and any rejection there returned 404 "File not found" with no log.
+ * On STORAGE_MODE=s3 getObjectSize is a HeadObject call, so AccessDenied,
+ * rotated credentials, and S3 5xx all took that path: an S3 outage made
+ * every job result look deleted. Sibling of #937 (PR #973), which fixed the
+ * library download route.
+ *
+ * Requires MinIO on port 19000 (same harness as s3-storage.test.ts):
+ *   docker run -d --name snapotter-minio-test -p 19000:9000 \
+ *     -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+ *     minio/minio server /data
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  CreateBucketCommand,
+  DeleteBucketCommand,
+  DeleteObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { loadS3Storage, type S3StorageModule } from "@snapotter/enterprise";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { env } from "../../../apps/api/src/config.js";
+import { putObject } from "../../../apps/api/src/lib/object-storage.js";
+import { fixtures, readFixture } from "../../fixtures/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "../test-server.js";
+
+const PNG = readFixture(fixtures.image.base.png200);
+
+const S3_ENDPOINT = "http://localhost:19000";
+const BUCKET = `snapotter-resfault-${process.pid}-${Date.now()}`;
+const CREDS = { accessKeyId: "minioadmin", secretAccessKey: "minioadmin" };
+
+const minioAvailable = (() => {
+  const result = spawnSync("curl", ["-sf", "http://localhost:19000/minio/health/live"], {
+    timeout: 2000,
+    stdio: "ignore",
+  });
+  return result.status === 0;
+})();
+
+function s3Config(overrides: Partial<Parameters<S3StorageModule["configureS3"]>[0]> = {}) {
+  return {
+    bucket: BUCKET,
+    region: "us-east-1",
+    endpoint: S3_ENDPOINT,
+    accessKeyId: CREDS.accessKeyId,
+    secretAccessKey: CREDS.secretAccessKey,
+    forcePathStyle: true,
+    prefix: "",
+    ...overrides,
+  };
+}
+
+describe.skipIf(!minioAvailable)("S3-mode tool-result download fault classification", () => {
+  let testApp: TestApp;
+  let adminToken: string;
+  let s3Client: S3Client;
+  let s3Storage: S3StorageModule;
+  let originalStorageMode: string;
+  const jobId = `resfault-${process.pid}`;
+
+  beforeAll(async () => {
+    s3Client = new S3Client({
+      region: "us-east-1",
+      endpoint: S3_ENDPOINT,
+      forcePathStyle: true,
+      credentials: CREDS,
+    });
+    await s3Client.send(new CreateBucketCommand({ Bucket: BUCKET }));
+
+    s3Storage = await loadS3Storage();
+
+    originalStorageMode = env.STORAGE_MODE;
+    const e = env as Record<string, unknown>;
+    e.STORAGE_MODE = "s3";
+    e.S3_BUCKET = BUCKET;
+    e.S3_REGION = "us-east-1";
+    e.S3_ENDPOINT = S3_ENDPOINT;
+    e.S3_ACCESS_KEY_ID = CREDS.accessKeyId;
+    e.S3_SECRET_ACCESS_KEY = CREDS.secretAccessKey;
+    e.S3_FORCE_PATH_STYLE = true;
+    e.S3_PREFIX = "";
+    s3Storage.configureS3(s3Config());
+
+    await putObject(`outputs/${jobId}/result.png`, PNG);
+
+    testApp = await buildTestApp();
+    adminToken = await loginAsAdmin(testApp.app);
+  }, 30_000);
+
+  afterAll(async () => {
+    (env as Record<string, unknown>).STORAGE_MODE = originalStorageMode;
+    try {
+      const objects = await s3Client.send(new ListObjectsV2Command({ Bucket: BUCKET }));
+      for (const obj of objects.Contents ?? []) {
+        await s3Client.send(new DeleteObjectCommand({ Bucket: BUCKET, Key: obj.Key! }));
+      }
+      await s3Client.send(new DeleteBucketCommand({ Bucket: BUCKET }));
+    } catch {
+      // Best-effort cleanup
+    }
+    await testApp?.cleanup();
+  }, 15_000);
+
+  it("downloads a stored result and 404s a genuinely missing one", async () => {
+    const ok = await testApp.app.inject({
+      method: "GET",
+      url: `/api/v1/download/${jobId}/result.png`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(ok.statusCode).toBe(200);
+    expect(Buffer.compare(ok.rawPayload, PNG)).toBe(0);
+
+    // HeadObject reports a missing key as "NotFound" (an unmodeled 404),
+    // not NoSuchKey; both probes miss and the route must keep its 404.
+    const missing = await testApp.app.inject({
+      method: "GET",
+      url: `/api/v1/download/${jobId}/never-existed.png`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+
+  // #974: an S3 service fault while resolving the object is a storage
+  // outage, not a missing result. It must reach the error handler as a 500
+  // instead of presenting every job result as deleted.
+  it("returns 500, not 404, when S3 rejects the size probe with an auth fault", async () => {
+    s3Storage.configureS3(s3Config({ secretAccessKey: "rotated-away" }));
+
+    try {
+      const res = await testApp.app.inject({
+        method: "GET",
+        url: `/api/v1/download/${jobId}/result.png`,
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+
+      expect(res.statusCode).toBe(500);
+      expect(JSON.parse(res.body).error).not.toMatch(/not found/i);
+    } finally {
+      s3Storage.configureS3(s3Config());
+    }
+  });
+});

--- a/tests/integration/test-server.ts
+++ b/tests/integration/test-server.ts
@@ -143,6 +143,9 @@ export async function buildTestApp(): Promise<TestApp> {
     // request.protocol) matches production. inject() peers on 127.0.0.1 are
     // trusted by the default policy; see tests/unit/security/trust-proxy-policy.test.ts.
     trustProxy: parseTrustProxy(env.TRUST_PROXY),
+    // Mirrors index.ts: find-my-way otherwise 414s any route param over 100
+    // chars, hiding prod-reachable long-parameter behavior from tests.
+    routerOptions: { maxParamLength: 500 },
   });
 
   // Plugins

--- a/tests/unit/api/object-storage-fault.test.ts
+++ b/tests/unit/api/object-storage-fault.test.ts
@@ -1,0 +1,52 @@
+/**
+ * object-storage isStorageServiceFault invariants (#974).
+ *
+ * The predicate classifies read-probe rejections for the tool-result
+ * download route. The load-bearing direction: in S3 mode, everything not
+ * proven missing is a fault, INCLUDING when the lazy enterprise singleton
+ * never loaded (a failed import must present as a storage fault, never as
+ * every file being deleted). This runs in an isolated fork where no S3
+ * operation has executed, so the singleton is genuinely null here; the
+ * minio harness cannot reach that state because its uploads populate it.
+ */
+
+import { SafeError } from "@snapotter/shared";
+import { afterEach, describe, expect, it } from "vitest";
+import { env } from "../../../apps/api/src/config.js";
+import { isStorageServiceFault } from "../../../apps/api/src/lib/object-storage.js";
+
+const originalMode = env.STORAGE_MODE;
+
+afterEach(() => {
+  (env as Record<string, unknown>).STORAGE_MODE = originalMode;
+});
+
+function inS3Mode<T>(fn: () => T): T {
+  (env as Record<string, unknown>).STORAGE_MODE = "s3";
+  return fn();
+}
+
+describe("isStorageServiceFault", () => {
+  it("classifies everything as a fault in S3 mode while the S3 module is unloaded", () => {
+    expect(inS3Mode(() => isStorageServiceFault(new Error("import failed")))).toBe(true);
+    expect(inS3Mode(() => isStorageServiceFault({ name: "NotFound" }))).toBe(true);
+  });
+
+  it("classifies a SafeError as a fault too: rethrowing preserves its own statusCode", () => {
+    const operational = new SafeError("circuit open", {
+      kind: "operational",
+      code: "s3-circuit",
+      statusCode: 503,
+    });
+    expect(inS3Mode(() => isStorageServiceFault(operational))).toBe(true);
+  });
+
+  it("never classifies local-mode rejections", () => {
+    expect(isStorageServiceFault(new Error("anything"))).toBe(false);
+    expect(
+      isStorageServiceFault(
+        Object.assign(new Error("denied"), { code: "EACCES", syscall: "stat" }),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #974

`GET /api/v1/download/:jobId/:filename` resolved the object with two nested bare catches: any `getObjectSize` rejection fell through to the uploads/ probe, and any rejection there returned 404 "File not found" with nothing logged. On `STORAGE_MODE=s3` the size probe is a HeadObject call, so AccessDenied, rotated credentials, and S3 5xx all took that path. An S3 outage made every job result look deleted. Same class as #937, which PR #973 fixed for the library download route.

What changed:

- `object-storage.ts` exports `isStorageServiceFault` with the #973 inversion: in S3 mode, anything not proven missing is a fault. It is deliberately a sibling of the one in `file-storage.ts`, not shared: each binds to its own lazy S3 singleton, and a null singleton must fail toward fault, never toward 404 (a unit test pins that direction).
- `object-storage.ts` also exports `isValidObjectKey`, and the route pre-rejects keys that fail it (404, same as before, but without touching storage). Load-bearing, not cosmetic: `assertValidKey` throws a plain Error that classification cannot tell from a storage fault, so without the pre-check every scanner probe would become a 500 and a Sentry event in S3 mode.
- The route rethrows storage faults at both probes (errno convention from #926 first, then the S3 predicate), logs a warn before the remaining genuine-miss 404, and treats `ENAMETOOLONG` as a miss: prod allows 500-char params on an unauthenticated route, past the 255-byte filename limit, and long garbage must stay 404 rather than page Sentry.
- The test harness now carries prod's `routerOptions: { maxParamLength: 500 }`. Its default 100-char cap was 414ing long params before the handler, which is exactly how the ENAMETOOLONG edge stayed invisible; the harness header already promises to mirror `index.ts`.
- The enterprise predicate docstring gains a HeadObject caveat: HEAD responses carry no body, so bucket-gone and key-gone reach the SDK as the same NotFound/404 shape there. Follow-up filed for disambiguating the double-miss path.

How it was proven:

- Reproduced on main first via the minio harness: rotated credentials made the route 404 every stored result.
- `tests/integration/platform/s3-result-download-fault.test.ts` (minio-gated, skips in CI like its #973 sibling): happy path, HeadObject NotFound miss stays 404, auth fault returns 500.
- CI-runnable coverage that does not need MinIO: `result-download-fault.test.ts` (local-mode EACCES 500 pin, uploads-prefix fallback, ENAMETOOLONG 404, VALID_KEY pre-rejection under a STORAGE_MODE=s3 flip) and `tests/unit/api/object-storage-fault.test.ts` (null-singleton and mode invariants).
- Teeth: with `files.ts` reverted to main, the two fault pins fail with the pre-fix 404 while the pure pins stay green. An independent review pass reproduced the same red.
- Blast radius via LSP find-refs: `getObjectSize` behavior is unchanged; its callers (worker, job-reconciliation) and the route's existing suites all pass, 304 tests across the widened net including `api.test.ts` after the harness router change.
- `pnpm lint`, `pnpm typecheck`, `pnpm check:license-boundary` green. Three review passes (silent-failure, code review, test coverage) probed the SDK shapes against live MinIO; findings folded in above, none outstanding.

Not run, on purpose: e2e and docker suites. No web code and no packaging changed; local-mode behavior on the happy and miss paths is byte-identical.
