### PR TITLE
fix(api): keep one account per external identity with a partial unique index

### DIFF
--- a/apps/api/drizzle/0008_users_identity_unique.sql
+++ b/apps/api/drizzle/0008_users_identity_unique.sql
@@ -1,0 +1,22 @@
+-- Existing installs may already hold twin accounts for one external identity,
+-- minted by the #969 race (two tabs finishing a first login at once). Keep the
+-- oldest row of each (auth_provider, external_id) group linked and detach the
+-- rest by clearing external_id, so the index below can build. Detached rows
+-- keep their files, sessions and provider; they just stop answering to the
+-- identity, which from here on resolves to exactly one account. A migration
+-- cannot write the audit log (rows there carry an HMAC), so to list what this
+-- detached afterwards: auth_provider <> 'local' AND external_id IS NULL AND
+-- password_hash IS NULL, with updated_at at the time this ran.
+UPDATE "users" u
+SET "external_id" = NULL, "updated_at" = now()
+WHERE u."external_id" IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM "users" older
+    WHERE older."auth_provider" = u."auth_provider"
+      AND older."external_id" = u."external_id"
+      AND older."id" <> u."id"
+      AND (older."created_at" < u."created_at"
+        OR (older."created_at" = u."created_at" AND older."id" < u."id"))
+  );
+--> statement-breakpoint
+CREATE UNIQUE INDEX "users_auth_provider_external_id_unique" ON "users" USING btree ("auth_provider","external_id") WHERE "users"."external_id" IS NOT NULL;

--- a/apps/api/drizzle/meta/0008_snapshot.json
+++ b/apps/api/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1031 @@
+{
+  "id": "e075244f-4e56-4bb4-a855-51993f513f76",
+  "prevId": "a03bcdf6-a893-490b-b992-c3af8d8d9f34",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default API Key'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_prefix_idx": {
+          "name": "api_keys_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_actor_id_idx": {
+          "name": "audit_log_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_id_users_id_fk": {
+          "name": "audit_log_actor_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pool": {
+          "name": "pool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_refs": {
+          "name": "input_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_refs": {
+          "name": "output_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes_in": {
+          "name": "bytes_in",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes_out": {
+          "name": "bytes_out",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_after": {
+          "name": "delete_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "jobs_created_at_idx": {
+          "name": "jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_status_idx": {
+          "name": "jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_user_id_users_id_fk": {
+          "name": "jobs_user_id_users_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipelines": {
+      "name": "pipelines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pipelines_user_id_users_id_fk": {
+          "name": "pipelines_user_id_users_id_fk",
+          "tableFrom": "pipelines",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_permissions": {
+          "name": "tool_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roles_created_by_users_id_fk": {
+          "name": "roles_created_by_users_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_hold": {
+          "name": "legal_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_quota": {
+          "name": "storage_quota",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retention_hours": {
+          "name": "retention_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "teams_name_lower_unique": {
+          "name": "teams_name_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_name_unique": {
+          "name": "teams_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_files": {
+      "name": "user_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_name": {
+          "name": "stored_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_chain": {
+          "name": "tool_chain",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_files_user_id_users_id_fk": {
+          "name": "user_files_user_id_users_id_fk",
+          "tableFrom": "user_files",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_preferences_user_id_key_pk": {
+          "name": "user_preferences_user_id_key_pk",
+          "columns": ["user_id", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_hold": {
+          "name": "legal_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_used": {
+          "name": "storage_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "storage_quota": {
+          "name": "storage_quota",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_enabled": {
+          "name": "totp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recovery_codes_hash": {
+          "name": "recovery_codes_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_auth_provider_external_id_unique": {
+          "name": "users_auth_provider_external_id_unique",
+          "columns": [
+            {
+              "expression": "auth_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": ["queued", "processing", "completed", "failed", "canceled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1788439313579,
       "tag": "0007_needy_fenris",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1788594225746,
+      "tag": "0008_users_identity_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -21,29 +21,42 @@ export const jobStatus = pgEnum("job_status", [
   "canceled",
 ]);
 
-export const users = pgTable("users", {
-  id: text("id").primaryKey(),
-  username: text("username").notNull().unique(),
-  passwordHash: text("password_hash"),
-  role: text("role").notNull().default("user"),
-  team: text("team").notNull().default("Default"),
-  mustChangePassword: boolean("must_change_password").notNull().default(true),
-  authProvider: text("auth_provider").notNull().default("local"),
-  externalId: text("external_id"),
-  email: text("email"),
-  legalHold: boolean("legal_hold").notNull().default(false),
-  storageUsed: bigint("storage_used", { mode: "number" }).notNull().default(0),
-  storageQuota: bigint("storage_quota", { mode: "number" }),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .$defaultFn(() => new Date()),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .notNull()
-    .$defaultFn(() => new Date()),
-  totpSecret: text("totp_secret"),
-  totpEnabled: boolean("totp_enabled").notNull().default(false),
-  recoveryCodesHash: text("recovery_codes_hash"),
-});
+export const users = pgTable(
+  "users",
+  {
+    id: text("id").primaryKey(),
+    username: text("username").notNull().unique(),
+    passwordHash: text("password_hash"),
+    role: text("role").notNull().default("user"),
+    team: text("team").notNull().default("Default"),
+    mustChangePassword: boolean("must_change_password").notNull().default(true),
+    authProvider: text("auth_provider").notNull().default("local"),
+    externalId: text("external_id"),
+    email: text("email"),
+    legalHold: boolean("legal_hold").notNull().default(false),
+    storageUsed: bigint("storage_used", { mode: "number" }).notNull().default(0),
+    storageQuota: bigint("storage_quota", { mode: "number" }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    totpSecret: text("totp_secret"),
+    totpEnabled: boolean("totp_enabled").notNull().default(false),
+    recoveryCodesHash: text("recovery_codes_hash"),
+  },
+  (table) => [
+    // One account per external identity. The resolver's lookup-then-insert
+    // can't close the race on its own (issue #969): a login that passes the
+    // identity lookup and stalls while its twin commits picks a suffixed
+    // username and inserts a row nothing else refuses. Partial so local
+    // accounts, which carry no external id, stay outside it.
+    uniqueIndex("users_auth_provider_external_id_unique")
+      .on(table.authProvider, table.externalId)
+      .where(sql`${table.externalId} IS NOT NULL`),
+  ],
+);
 
 export const teams = pgTable(
   "teams",

--- a/apps/api/src/lib/external-auth-resolver.ts
+++ b/apps/api/src/lib/external-auth-resolver.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import type { FastifyBaseLogger } from "fastify";
 import { db, schema } from "../db/index.js";
 import { isDisabledRole } from "../permissions.js";
@@ -125,12 +125,16 @@ export async function resolveExternalUser(params: ExternalAuthParams): Promise<E
     };
   }
 
-  // 2. Auto-link by email
+  // 2. Auto-link by email. Nothing makes email unique, so when several rows
+  // carry it the pick has to be deterministic: two logins of one identity
+  // racing here must land on the same row, or the second one's link would
+  // trip the (auth_provider, external_id) index (issue #969). Oldest wins.
   if (autoLink && email && emailVerified) {
     const [existingByEmail] = await db
       .select()
       .from(schema.users)
       .where(eq(schema.users.email, email))
+      .orderBy(asc(schema.users.createdAt), asc(schema.users.id))
       .limit(1);
 
     if (existingByEmail) {
@@ -181,7 +185,11 @@ export async function resolveExternalUser(params: ExternalAuthParams): Promise<E
 
     // The username scan can't close the race: two concurrent logins both
     // pass it before either insert commits (issue #927), so the insert
-    // carries a conflict guard and the loser recovers below.
+    // carries a conflict guard and the loser recovers below. The guard is
+    // unqualified on purpose: it has to cover both the username constraint
+    // and the (auth_provider, external_id) index that refuses a second
+    // account for one identity (issue #969). The only other constraint on
+    // the table is the primary key, on a fresh UUID.
     const MAX_USERNAME_RACE_RETRIES = 3;
     for (let attempt = 0; attempt < MAX_USERNAME_RACE_RETRIES; attempt++) {
       const uniqueUsername = await findUniqueUsername(username);
@@ -213,7 +221,7 @@ export async function resolveExternalUser(params: ExternalAuthParams): Promise<E
             externalId,
             email: email ?? null,
           })
-          .onConflictDoNothing({ target: schema.users.username });
+          .onConflictDoNothing();
       });
 
       if (inserted !== "limit" && inserted.rowCount) {
@@ -236,16 +244,19 @@ export async function resolveExternalUser(params: ExternalAuthParams): Promise<E
       }
 
       if (inserted !== "limit") {
+        // The guard is unqualified, so this does not say which constraint
+        // refused: the username (issue #927) or the identity (issue #969).
         logger.info(
           { attempt: attempt + 1, username: uniqueUsername },
-          `${provider} auto-create lost a username race, recovering`,
+          `${provider} auto-create refused by a unique constraint (username or identity), recovering`,
         );
       }
 
-      // Create refused: the username raced (issue #927) or the cap is
-      // reached (issue #928). Either way this same external identity may
-      // have just won a concurrent login (say, two tabs finishing first
-      // login at once); hand back the winner's user instead of failing it.
+      // Create refused: the username raced (issue #927), this identity
+      // already has its row (issue #969), or the cap is reached (issue
+      // #928). In each case this same external identity may have just won
+      // a concurrent login (say, two tabs finishing first login at once);
+      // hand back the winner's user instead of failing it.
       const [winner] = await db
         .select()
         .from(schema.users)

--- a/apps/api/src/routes/enterprise/scim.ts
+++ b/apps/api/src/routes/enterprise/scim.ts
@@ -396,7 +396,10 @@ export async function registerScimRoutes(app: FastifyInstance): Promise<void> {
       // same create twice, and both pass the SELECT before either insert
       // commits (issue #927). MAX_USERS binds provisioning too (issue #966):
       // the locked count and the insert share one transaction, same as the
-      // register route, so concurrent creates can't overshoot the cap.
+      // register route, so concurrent creates can't overshoot the cap. The
+      // guard is unqualified so it also covers the (auth_provider,
+      // external_id) index (issue #969): a retry under a fresh userName but
+      // the same externalId is the same identity, and gets the same 409.
       const inserted = await db.transaction(async (tx) => {
         if (await userLimitReached(tx)) return "limit" as const;
         return tx
@@ -413,7 +416,7 @@ export async function registerScimRoutes(app: FastifyInstance): Promise<void> {
             createdAt: now,
             updatedAt: now,
           })
-          .onConflictDoNothing({ target: schema.users.username });
+          .onConflictDoNothing();
       });
 
       if (inserted === "limit") {

--- a/tests/integration/platform/external-auth-race.test.ts
+++ b/tests/integration/platform/external-auth-race.test.ts
@@ -1,20 +1,21 @@
 /**
- * Concurrent auto-create race in the external auth resolver (issue #927).
+ * Concurrent auto-create races in the external auth resolver.
  *
- * Two logins can pass the resolver's username scan before either inserts.
- * The loser's insert hits the users.username unique constraint; it must
- * recover (re-run the scan and pick a fresh username) instead of failing
+ * Issue #927: two logins can pass the resolver's username scan before either
+ * inserts. The loser's insert hits the users.username unique constraint; it
+ * must recover (re-run the scan and pick a fresh username) instead of failing
  * the login with an unhandled 23505.
  *
- * The same-identity flavor (one login racing itself in two tabs) can't be
- * pinned deterministically against a real database, so its recovery branch
- * is covered by scripted unit tests in
- * tests/unit/api/external-auth-resolver-mutation.test.ts.
+ * Issue #969: one identity racing itself (two tabs finishing first login at
+ * once) where the loser stalls between the identity lookup and the username
+ * scan. Its scan then sees the winner's username and picks a suffixed one, so
+ * the insert conflicts with nothing unless (auth_provider, external_id) is
+ * unique. holdNextQuery pins that interleaving against a real database.
  */
 
-import { inArray } from "drizzle-orm";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db, schema } from "../../../apps/api/src/db/index.js";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { db, pool, schema } from "../../../apps/api/src/db/index.js";
 import type { ExternalAuthParams } from "../../../apps/api/src/lib/external-auth-resolver.js";
 import { resolveExternalUser } from "../../../apps/api/src/lib/external-auth-resolver.js";
 import { raceInserts } from "../../helpers/pg-race.js";
@@ -22,14 +23,26 @@ import { buildTestApp, type TestApp } from "../test-server.js";
 
 let testApp: TestApp;
 
+const RACE_USERNAMES = [
+  "race_shared",
+  "race_shared_2",
+  "race_stall",
+  "race_stall_2",
+  "race_link_old",
+  "race_link_new",
+  "race_link",
+];
+
 beforeAll(async () => {
   testApp = await buildTestApp();
 }, 30_000);
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 afterAll(async () => {
-  await db
-    .delete(schema.users)
-    .where(inArray(schema.users.username, ["race_shared", "race_shared_2"]));
+  await db.delete(schema.users).where(inArray(schema.users.username, RACE_USERNAMES));
   await testApp.cleanup();
 }, 10_000);
 
@@ -46,6 +59,71 @@ function baseParams(overrides: Partial<ExternalAuthParams>): ExternalAuthParams 
     requestId: "race-test",
     ...overrides,
   };
+}
+
+type PoolQuery = (...args: unknown[]) => Promise<unknown>;
+
+/**
+ * Park the next pool query whose SQL matches `pattern` until release() is
+ * called. Every other query goes straight through, as does everything inside
+ * a transaction (those run on a checked-out client, not the pool). This is
+ * the stall a login can hit between two of its own queries, a GC pause or a
+ * slow replica, placed exactly where it matters.
+ */
+function holdNextQuery(pattern: RegExp): { held: Promise<void>; release: () => void } {
+  let release: () => void = () => {};
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let markHeld: () => void = () => {};
+  const held = new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`no pool query matched ${pattern} within 5s`)),
+      5_000,
+    );
+    markHeld = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+  });
+  const passThrough = (pool.query as PoolQuery).bind(pool);
+  const spy = vi.spyOn(pool, "query").mockImplementation(((...args: unknown[]) => {
+    const first = args[0];
+    const text = typeof first === "string" ? first : ((first as { text?: string })?.text ?? "");
+    if (!pattern.test(text)) return passThrough(...args);
+    spy.mockRestore();
+    markHeld();
+    return gate.then(() => passThrough(...args));
+  }) as never);
+  return { held, release };
+}
+
+/**
+ * Start `loser`, wait until it is parked on `pattern`, run `winner` to
+ * completion, then let the loser continue. A loser that settles before it is
+ * held (it died, or never issued the query) fails with its own error rather
+ * than the hold's timeout.
+ */
+async function raceStalled<T>(
+  pattern: RegExp,
+  loser: () => Promise<T>,
+  winner: () => Promise<T>,
+): Promise<{ loser: T; winner: T }> {
+  const hold = holdNextQuery(pattern);
+  const loserRun = loser();
+  const settledEarly = loserRun.then(() => {
+    throw new Error("loser finished before its query was held");
+  });
+  settledEarly.catch(() => {});
+  try {
+    await Promise.race([hold.held, settledEarly]);
+    const winnerResult = await winner();
+    hold.release();
+    return { winner: winnerResult, loser: await loserRun };
+  } finally {
+    // Also covers a winner that threw: the loser must not stay parked.
+    hold.release();
+  }
 }
 
 describe("external auth auto-create races", () => {
@@ -72,5 +150,104 @@ describe("external auth auto-create races", () => {
       .from(schema.users)
       .where(inArray(schema.users.username, ["race_shared", "race_shared_2"]));
     expect(rows).toHaveLength(2);
+  });
+
+  it("a login that stalls after the identity lookup joins the account its twin just created", async () => {
+    // Issue #969. The loser passed the externalId lookup (no row yet), then
+    // stalled while the winner created and committed. Its username scan now
+    // sees the winner's name and picks a suffixed one, so nothing but the
+    // (auth_provider, external_id) index can refuse the insert. Without that
+    // index this minted a second account for the same identity.
+    const params = baseParams({ externalId: "race-stall-ext", username: "race_stall" });
+
+    const { winner, loser } = await raceStalled(
+      /"users"\."username" = \$1/,
+      () => resolveExternalUser(params),
+      () => resolveExternalUser(params),
+    );
+
+    expect(winner.action, JSON.stringify(winner)).toBe("created");
+    const rows = await db
+      .select()
+      .from(schema.users)
+      .where(
+        and(eq(schema.users.externalId, "race-stall-ext"), eq(schema.users.authProvider, "oidc")),
+      );
+    expect(rows.map((r) => r.username)).toEqual(["race_stall"]);
+    expect(loser.action).toBe("matched");
+    expect(loser.user?.id).toBe(winner.user?.id);
+  });
+
+  it("two logins auto-linking one identity onto twin emails land on the same account", async () => {
+    // Issue #969, link flavor. Nothing makes email unique, so two local
+    // accounts can share one. Two first logins of the same identity both
+    // miss the externalId lookup; the winner links one twin and commits. If
+    // the loser then picked the other twin, its link UPDATE would trip the
+    // identity index and the login would die on a raw 23505. The pick has
+    // to be deterministic (oldest row) so both land on the same account.
+    const email = "race-link@example.com";
+    await db.insert(schema.users).values([
+      {
+        id: "race-link-old",
+        username: "race_link_old",
+        email,
+        passwordHash: null,
+        mustChangePassword: false,
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+      },
+      {
+        id: "race-link-new",
+        username: "race_link_new",
+        email,
+        passwordHash: null,
+        mustChangePassword: false,
+        createdAt: new Date("2026-02-01T00:00:00Z"),
+        updatedAt: new Date("2026-02-01T00:00:00Z"),
+      },
+    ]);
+    const params = baseParams({
+      externalId: "race-link-ext",
+      username: "race_link",
+      email,
+      emailVerified: true,
+      autoLink: true,
+    });
+
+    const { winner, loser } = await raceStalled(
+      /"users"\."email" = \$1/,
+      () => resolveExternalUser(params),
+      () => resolveExternalUser(params),
+    );
+
+    expect(winner.action, JSON.stringify(winner)).toBe("linked");
+    expect(winner.user?.id).toBe("race-link-old");
+    expect(loser.user?.id, JSON.stringify(loser)).toBe("race-link-old");
+    const linked = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(
+        and(eq(schema.users.externalId, "race-link-ext"), eq(schema.users.authProvider, "oidc")),
+      );
+    expect(linked.map((r) => r.id)).toEqual(["race-link-old"]);
+  });
+
+  it("users carries exactly the unique constraints the auto-create guard assumes", async () => {
+    // The resolver's insert and the SCIM Users POST use an unqualified
+    // onConflictDoNothing and read every refused insert as "someone else
+    // holds this username or this identity". That is only honest while the
+    // unique surface is the primary key (a fresh UUID), the username, and
+    // the (auth_provider, external_id) identity index. If this fails, a new
+    // unique constraint joined the table: give both guards an explicit story
+    // for it before widening this list.
+    const res = await db.execute(
+      sql`SELECT indexname FROM pg_indexes WHERE tablename = 'users' AND indexdef ILIKE '%UNIQUE%' ORDER BY indexname`,
+    );
+    const names = res.rows.map((r) => (r as { indexname: string }).indexname);
+    expect(names).toEqual([
+      "users_auth_provider_external_id_unique",
+      "users_pkey",
+      "users_username_unique",
+    ]);
   });
 });

--- a/tests/integration/platform/scim.test.ts
+++ b/tests/integration/platform/scim.test.ts
@@ -935,6 +935,34 @@ describe("SCIM licensed Users and Groups CRUD", () => {
       expect(row?.authProvider).toBe("scim");
     });
 
+    it("refuses a second create carrying an already-provisioned externalId with the SCIM 409 envelope", async () => {
+      // Issue #969: only the (auth_provider, external_id) index stops an IdP
+      // retry under a fresh userName from minting a second account for one
+      // identity. The insert guard is unqualified so that refusal lands as
+      // the pre-check's 409 rather than a 500.
+      const externalId = uniqueName("scim-dup-ext");
+      const first = await createScimUser({ userName: uniqueName("scim-dup-a"), externalId });
+
+      const res = await crudApp.app.inject({
+        method: "POST",
+        url: "/api/v1/scim/v2/Users",
+        headers: authHeaders(),
+        payload: { userName: uniqueName("scim-dup-b"), externalId },
+      });
+
+      expect(res.statusCode, res.body).toBe(409);
+      expect(JSON.parse(res.body)).toMatchObject({
+        schemas: [SCIM_ERROR_SCHEMA],
+        status: 409,
+        detail: "User already exists",
+      });
+      const rows = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.externalId, externalId));
+      expect(rows.map((r) => r.id)).toEqual([first.id]);
+    });
+
     it("creates a disabled user when active is false and falls back to the first email", async () => {
       const username = uniqueName("scim-create-inactive");
       const res = await crudApp.app.inject({

--- a/tests/integration/platform/users-identity-index-migration.test.ts
+++ b/tests/integration/platform/users-identity-index-migration.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The (auth_provider, external_id) unique index behind issue #969 lands on
+ * installs that may already hold twin accounts for one identity, minted by
+ * that very race. Their boot must not fail on the index build: the migration
+ * detaches every twin but the oldest first, and only that oldest row keeps
+ * the identity.
+ *
+ * Drives the real migrator over a scratch database: every migration that
+ * predates the index, the twins seeded straight into the table, then the
+ * rest of the folder. That is exactly what an upgrading install goes through.
+ */
+import { randomUUID } from "node:crypto";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import pg from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const MIGRATIONS = join(process.cwd(), "apps/api/drizzle");
+const IDENTITY_INDEX = "users_auth_provider_external_id_unique";
+
+interface JournalEntry {
+  idx: number;
+  tag: string;
+}
+interface Journal {
+  entries: JournalEntry[];
+}
+
+/** The migrations folder as it stood before the identity index. */
+function folderBeforeIndex(): string {
+  const journal = JSON.parse(
+    readFileSync(join(MIGRATIONS, "meta/_journal.json"), "utf8"),
+  ) as Journal;
+  const indexEntry = journal.entries.find((e) =>
+    readFileSync(join(MIGRATIONS, `${e.tag}.sql`), "utf8").includes(IDENTITY_INDEX),
+  );
+  if (!indexEntry) throw new Error(`no migration in ${MIGRATIONS} creates ${IDENTITY_INDEX}`);
+
+  const dir = mkdtempSync(join(tmpdir(), "snapotter-pre-identity-index-"));
+  mkdirSync(join(dir, "meta"));
+  const kept = journal.entries.filter((e) => e.idx < indexEntry.idx);
+  for (const entry of kept) {
+    cpSync(join(MIGRATIONS, `${entry.tag}.sql`), join(dir, `${entry.tag}.sql`));
+  }
+  writeFileSync(join(dir, "meta/_journal.json"), JSON.stringify({ ...journal, entries: kept }));
+  return dir;
+}
+
+// Superuser on the shared test server (tests/global-setup.ts); the fork's own
+// database is already fully migrated, so the scenario needs a fresh one.
+const baseUrl = process.env.TEST_PG_BASE_URL as string;
+const scratchName = `snapotter_test_mig_${process.pid}_${randomUUID().slice(0, 8).replace(/-/g, "")}`;
+
+let scratch: pg.Pool;
+let preIndexFolder: string;
+
+async function asAdmin(fn: (client: pg.Client) => Promise<unknown>): Promise<void> {
+  const admin = new pg.Client({ connectionString: baseUrl });
+  await admin.connect();
+  try {
+    await fn(admin);
+  } finally {
+    await admin.end();
+  }
+}
+
+const OLD = new Date("2026-01-01T00:00:00Z");
+const NEW = new Date("2026-02-01T00:00:00Z");
+
+interface SeedRow {
+  id: string;
+  provider: string;
+  externalId: string | null;
+  createdAt: Date;
+}
+
+const SEED: SeedRow[] = [
+  // The #969 shape: one oidc identity, three rows. The oldest keeps it, and
+  // its id sorts last on purpose so this pins created_at, not id order.
+  { id: "zz_keep", provider: "oidc", externalId: "ext-twin", createdAt: OLD },
+  { id: "aa_late", provider: "oidc", externalId: "ext-twin", createdAt: NEW },
+  { id: "ab_late", provider: "oidc", externalId: "ext-twin", createdAt: NEW },
+  // Same second, so the id breaks the tie: tie_a stays linked.
+  { id: "tie_a", provider: "saml", externalId: "ext-tie", createdAt: NEW },
+  { id: "tie_b", provider: "saml", externalId: "ext-tie", createdAt: NEW },
+  // Same external id under another provider is a different identity.
+  { id: "other_provider", provider: "saml", externalId: "ext-twin", createdAt: NEW },
+  // Local accounts carry no external id and are outside the index entirely.
+  { id: "local_a", provider: "local", externalId: null, createdAt: OLD },
+  { id: "local_b", provider: "local", externalId: null, createdAt: OLD },
+];
+
+async function seededRows(): Promise<
+  Map<string, { externalId: string | null; provider: string; updatedAt: Date }>
+> {
+  const { rows } = await scratch.query<{
+    id: string;
+    external_id: string | null;
+    auth_provider: string;
+    updated_at: Date;
+  }>("SELECT id, external_id, auth_provider, updated_at FROM users WHERE id = ANY($1)", [
+    SEED.map((r) => r.id),
+  ]);
+  return new Map(
+    rows.map((r) => [
+      r.id,
+      { externalId: r.external_id, provider: r.auth_provider, updatedAt: r.updated_at },
+    ]),
+  );
+}
+
+beforeAll(async () => {
+  preIndexFolder = folderBeforeIndex();
+  await asAdmin((admin) => admin.query(`CREATE DATABASE ${scratchName}`));
+  const url = new URL(baseUrl);
+  url.pathname = `/${scratchName}`;
+  scratch = new pg.Pool({ connectionString: url.toString(), max: 1 });
+
+  await migrate(drizzle(scratch), { migrationsFolder: preIndexFolder });
+  for (const row of SEED) {
+    await scratch.query(
+      `INSERT INTO users (id, username, auth_provider, external_id, created_at, updated_at)
+       VALUES ($1, $1, $2, $3, $4, $4)`,
+      [row.id, row.provider, row.externalId, row.createdAt],
+    );
+  }
+}, 60_000);
+
+afterAll(async () => {
+  await scratch?.end();
+  await asAdmin((admin) => admin.query(`DROP DATABASE IF EXISTS ${scratchName}`));
+  if (preIndexFolder) rmSync(preIndexFolder, { recursive: true, force: true });
+}, 30_000);
+
+describe("users identity index migration (issue #969)", () => {
+  it("detaches every twin but the oldest, then builds the partial unique index", async () => {
+    const before = await seededRows();
+    expect(before.get("aa_late")?.externalId).toBe("ext-twin");
+
+    await migrate(drizzle(scratch), { migrationsFolder: MIGRATIONS });
+
+    const after = await seededRows();
+    expect(after.get("zz_keep")?.externalId).toBe("ext-twin");
+    expect(after.get("aa_late")?.externalId).toBeNull();
+    expect(after.get("ab_late")?.externalId).toBeNull();
+    expect(after.get("tie_a")?.externalId).toBe("ext-tie");
+    expect(after.get("tie_b")?.externalId).toBeNull();
+    expect(after.get("other_provider")?.externalId).toBe("ext-twin");
+
+    // Detached rows keep their provider (they were SSO accounts and still
+    // read as such) and get a fresh updated_at; untouched rows keep theirs.
+    for (const id of ["aa_late", "ab_late", "tie_b"]) {
+      expect(after.get(id)?.provider, id).toBe(before.get(id)?.provider);
+      expect(after.get(id)?.updatedAt.getTime(), id).toBeGreaterThan(NEW.getTime());
+    }
+    for (const id of ["zz_keep", "tie_a", "other_provider", "local_a", "local_b"]) {
+      expect(after.get(id)?.updatedAt.getTime(), id).toBe(before.get(id)?.updatedAt.getTime());
+    }
+    expect(after.get("local_a")?.externalId).toBeNull();
+    expect(after.get("local_b")?.externalId).toBeNull();
+
+    const { rows: indexes } = await scratch.query<{ indexdef: string }>(
+      "SELECT indexdef FROM pg_indexes WHERE tablename = 'users' AND indexname = $1",
+      [IDENTITY_INDEX],
+    );
+    expect(indexes).toHaveLength(1);
+    expect(indexes[0].indexdef).toMatch(/UNIQUE INDEX/);
+    expect(indexes[0].indexdef).toMatch(/WHERE \(external_id IS NOT NULL\)/);
+  });
+
+  it("refuses a second row for a linked identity but still allows any number of local accounts", async () => {
+    const insert = (id: string, provider: string, externalId: string | null) =>
+      scratch.query(
+        `INSERT INTO users (id, username, auth_provider, external_id, created_at, updated_at)
+         VALUES ($1, $1, $2, $3, now(), now())`,
+        [id, provider, externalId],
+      );
+
+    await expect(insert("twin_again", "oidc", "ext-twin")).rejects.toMatchObject({ code: "23505" });
+    await expect(insert("local_c", "local", null)).resolves.toBeDefined();
+    await expect(insert("local_d", "local", null)).resolves.toBeDefined();
+  });
+});

--- a/tests/unit/api/external-auth-resolver-mutation.test.ts
+++ b/tests/unit/api/external-auth-resolver-mutation.test.ts
@@ -54,9 +54,10 @@ vi.mock("../../../apps/api/src/lib/audit.js", () => ({
 }));
 
 // A select chain that is both awaitable and chainable through
-// .from()/.where()/.limit(). resolveExternalUser awaits the terminal at three
-// different depths (.limit(1) for id/email matches, .from() for the COUNT, and
-// .where() for the username/team lookups), so every level is a thenable. Only
+// .from()/.where()/.orderBy()/.limit(). resolveExternalUser awaits the terminal
+// at three different depths (.limit(1) for id/email matches, .from() for the
+// COUNT, and .where() for the username/team lookups), so every level is a
+// thenable. Only
 // the terminal await consumes one canned row set (settle() increments the index
 // lazily), which keeps call-order pulls correct across the mixed shapes.
 function makeSelectChain() {
@@ -67,6 +68,7 @@ function makeSelectChain() {
   const node: Record<string, unknown> = {
     from: () => node,
     where: () => node,
+    orderBy: () => node,
     limit: () => settle(),
     // biome-ignore lint/suspicious/noThenProperty: intentional thenable mocking an awaitable Drizzle query builder
     then: (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) =>
@@ -405,6 +407,30 @@ describe("resolveExternalUser: auto-create username race", () => {
     const result = await resolveExternalUser(baseParams({ autoCreate: true }));
     expect(result).toEqual({ user: null, action: "denied", deniedReason: "user_disabled" });
     expect(state.auditCalls.at(-1)?.event).toBe("OIDC_LOGIN_FAILED");
+  });
+
+  it("joins the winner when the scan picked a suffixed name and the identity index refused the insert", async () => {
+    // Issue #969: the loser stalled after the externalId miss, so by the time
+    // its scan ran the winner's "alice" was committed and it went for
+    // "alice_2". Only the (auth_provider, external_id) index can refuse that
+    // insert, and the recovery has to land on the winner, not rescan.
+    state.insertRowCounts = [0];
+    state.selectRows = [
+      [], // extId miss
+      [{ username: "alice" }], // scan: base taken by the winner
+      [], // scan: alice_2 free
+      [{ id: "team-default" }],
+      [dbUser({ id: "u-winner", username: "alice", role: "user", team: "team-default" })], // winner re-check
+    ];
+    const result = await resolveExternalUser(baseParams({ autoCreate: true }));
+
+    expect(state.inserts).toHaveLength(1);
+    expect(state.inserts[0].username).toBe("alice_2");
+    expect(result).toEqual({
+      user: { id: "u-winner", username: "alice", role: "user", team: "team-default" },
+      action: "matched",
+    });
+    expect(state.auditCalls.map((c) => c.event)).not.toContain("OIDC_USER_CREATED");
   });
 
   it("re-runs the username scan and creates when a different user took the name", async () => {


### PR DESCRIPTION
Closes #969

Two tabs finishing a first OIDC or SAML login at once could end up with two accounts for one identity. Both pass the resolver's lookup by external id (no row yet). The winner creates and commits. The loser, having stalled for a moment, then runs its username scan, sees the winner's name taken, picks `alice_2`, and inserts a row nothing refuses. From then on that identity resolves through an un-ordered `.limit(1)`, so which account a login lands on is luck. The #927 guard only catches the neighbouring interleaving where both scans pick the same name and the loser trips on `username`.

## What changed

- `users` gets a partial unique index on `(auth_provider, external_id) WHERE external_id IS NOT NULL` (migration 0008, generated with drizzle-kit from the schema change). Local accounts carry no external id and stay outside it.
- The resolver's `onConflictDoNothing()` is unqualified, so a refusal from the identity index takes the recovery path #927 added: re-check by external id, hand back the winner as `matched`. The recovery log line now says "refused by a unique constraint (username or identity)" instead of blaming a username race it can no longer tell apart.
- The auto-link lookup by email orders by `created_at, id`. Nothing makes email unique, and with the index in place two logins of one identity racing onto twin emails would otherwise pick different rows, with the loser's link UPDATE dying on a raw 23505 in the callback. Oldest wins, both land on the same account.
- The SCIM Users POST guard is widened the same way, so an IdP retry under a fresh `userName` but the same `externalId` gets the pre-check's 409 instead of a 500.
- The migration detaches any twins an install already holds before the index builds: the oldest row of each group (by `created_at`, then `id`) keeps the identity, the rest get `external_id = NULL` and a fresh `updated_at`. They keep their files, sessions and provider; they just stop answering to that identity. Sessions already open on a detached twin stay valid until they expire. The rule is blind to disabled state on purpose: if an admin disabled the older twin, the identity now resolves to that disabled row and the login is refused, which is what disabling was meant to do. A migration can't write the audit log (rows there carry an HMAC), so the detached rows are findable afterwards with `auth_provider <> 'local' AND external_id IS NULL AND password_hash IS NULL`; worth a line in the release notes.
- A drift guard pins the users unique surface (`users_pkey`, `users_username_unique`, the new index), the same story as the teams guard from #989: a new unique constraint has to get an explicit story before the widened guards stay honest.

Left alone on purpose: the SCIM PUT/PATCH updates that set `externalId`. PR #992 is wrapping exactly those lines with a 23505 to 409 mapping, so touching them here guarantees a conflict. Until #992 lands, an IdP that moves an externalId onto a second user gets a 500 where it used to get a silent duplicate; filed as #1006.

There is a second, unpushed branch for this issue in a sibling worktree (`fix/969-sso-identity-dupes`, stacked on the #992 branch, last touched two days ago). It arrived at the same index and the same dedupe SQL under a different index name and migration tag, so only one of the two can land. This one is on main.

## How it was verified

Reproduced on main first: `tests/integration/platform/external-auth-race.test.ts` carries a `holdNextQuery` helper that parks one pool query (the loser's username scan) until the winner has committed. That is the stall from the issue placed exactly where it matters, and on main it minted `race_stall_2` every time.

Tests added:
- the stall reproduction above, the auto-link twin-email race (same helper parked on the email lookup), and the unique-surface drift guard
- `tests/integration/platform/users-identity-index-migration.test.ts`: runs the real drizzle migrator over a scratch database (everything before 0008, seed twins including a same-second tie and an id order that disagrees with time order, a same-id-other-provider row, and null-id locals, then the rest) and checks the keep-rule, the untouched rows, the partial index definition, and that a second linked row is refused while locals still insert
- `tests/integration/platform/scim.test.ts`: a second create with an already-provisioned externalId returns the SCIM 409 envelope and leaves one row
- `tests/unit/api/external-auth-resolver-mutation.test.ts`: the scripted recovery case where the scan picked a suffixed name and the identity index refused the insert (passes on main too; it is there for the mutation suite, not to pin the bug)

Teeth, all done by reverting and restoring:
- production files reverted: the stall test, drift guard, SCIM 409 test and migration test all fail
- index in place but the guards left qualified: the stall test throws 23505 and SCIM returns 500
- only the auto-link ORDER BY removed: the twin-email test fails 3 of 3 runs on `users_auth_provider_external_id_unique`

Blast radius: `resolveExternalUser` is called from the OIDC and SAML callbacks (LSP incoming calls); their suites (`oidc-auth`, `oidc-callback-coverage`, `oidc-mfa-callback`, `saml-auth`, `saml-license-gate`, `user-limit-race`) pass in the full run below.

Full suites on the branch: `pnpm lint` and `pnpm typecheck` clean. `pnpm test`: 867 files passed, 7 skipped, 19912 tests passed, no test failures. The two files vitest lists as failed are the untracked local `twitter/operations/*.test.mjs` suites ("No test suite found"), red in the main baseline too. Zero new failures against the baseline.

Baseline: CI on main at 3b920e8f was green and nothing landed since. The local main run had the same two steady-red local-only suites (`twitter/operations/*.test.mjs`, an untracked directory). The SCIM concurrent duplicate-group race test flaked under load with the 403 already tracked in #1000; it passes solo and it fails identically with main's production code, so it isn't this change.

Not run locally: `pnpm test:docker`. The migration path it would add is the same `runMigrations()` the integration suite drives against a fresh Postgres 17; the nightly docker job on main gets dispatched after merge.

Follow-ups filed: #1005 (1.x SQLite import fails on twin identities once the index exists), #1006 (SCIM PUT/PATCH externalId collision), #1007 (SCIM docs: the create 409 now also covers externalId), #1008 (empty externalId stored as a value).
