### PR TITLE
fix(auth): send SSO logins back to the login page when auto-create exhausts its username-race retries

### DIFF
--- a/apps/api/src/lib/external-auth-resolver.ts
+++ b/apps/api/src/lib/external-auth-resolver.ts
@@ -28,6 +28,18 @@ export interface ExternalAuthResult {
   deniedReason?: "user_not_authorized" | "user_limit_reached" | "user_disabled";
 }
 
+/**
+ * Auto-create lost the username race on every retry. The SSO callbacks catch
+ * this one type and turn it into a login failure (issue #978); any other
+ * throw out of the resolver is a fault and keeps surfacing as one.
+ */
+export class UsernameRaceExhaustedError extends Error {
+  constructor(provider: string, username: string, attempts: number) {
+    super(`${provider} auto-create lost the username race ${attempts} times for "${username}"`);
+    this.name = "UsernameRaceExhaustedError";
+  }
+}
+
 // ── Username helpers ──────────────────────────────────────────────
 
 export function sanitizeUsername(raw: string): string {
@@ -286,9 +298,7 @@ export async function resolveExternalUser(params: ExternalAuthParams): Promise<E
       // A different user took the name; rescan and retry.
     }
 
-    throw new Error(
-      `${provider} auto-create lost the username race ${MAX_USERNAME_RACE_RETRIES} times for "${username}"`,
-    );
+    throw new UsernameRaceExhaustedError(provider, username, MAX_USERNAME_RACE_RETRIES);
   }
 
   // 4. Denied: no matching user, auto-link did not match, auto-create disabled

--- a/apps/api/src/plugins/oidc.ts
+++ b/apps/api/src/plugins/oidc.ts
@@ -10,7 +10,12 @@ import { sharedRedis } from "../jobs/connection.js";
 import { trackEvent } from "../lib/analytics.js";
 import { auditFromRequest, sanitizeAuditInput } from "../lib/audit.js";
 import { reportError } from "../lib/error-report.js";
-import { resolveExternalUser, sanitizeUsername } from "../lib/external-auth-resolver.js";
+import {
+  type ExternalAuthResult,
+  resolveExternalUser,
+  sanitizeUsername,
+  UsernameRaceExhaustedError,
+} from "../lib/external-auth-resolver.js";
 import { authAttempts } from "../lib/metrics.js";
 import { isSecureRequest } from "../lib/secure-cookie.js";
 import { createSessionToken } from "./auth.js";
@@ -274,19 +279,48 @@ export async function oidcRoutes(app: FastifyInstance): Promise<void> {
       const idToken = tokenResponse.id_token ?? null;
 
       // 4. User resolution (delegated to shared resolver)
-      const result = await resolveExternalUser({
-        provider: "oidc",
-        externalId: sub,
-        email,
-        emailVerified,
-        username: derivedUsername,
-        autoCreate: env.OIDC_AUTO_CREATE_USERS,
-        autoLink: env.OIDC_AUTO_LINK_USERS,
-        defaultRole: env.OIDC_DEFAULT_ROLE,
-        logger: request.log,
-        ip: request.ip,
-        requestId: request.id,
-      });
+      let result: ExternalAuthResult;
+      try {
+        result = await resolveExternalUser({
+          provider: "oidc",
+          externalId: sub,
+          email,
+          emailVerified,
+          username: derivedUsername,
+          autoCreate: env.OIDC_AUTO_CREATE_USERS,
+          autoLink: env.OIDC_AUTO_LINK_USERS,
+          defaultRole: env.OIDC_DEFAULT_ROLE,
+          logger: request.log,
+          ip: request.ip,
+          requestId: request.id,
+        });
+      } catch (err) {
+        // Losing the username race on every retry is a login outcome, not a
+        // server fault (#978): the user lands on the login page with an error
+        // like every other denial instead of a bare 500 mid-redirect. Anything
+        // else the resolver throws is a fault and keeps surfacing as one.
+        if (!(err instanceof UsernameRaceExhaustedError)) throw err;
+        request.log.error(
+          { err, externalId: sub },
+          "OIDC callback: auto-create exhausted its username-race retries",
+        );
+        // Caught here, the error never reaches the global handler's
+        // reportError; report explicitly so the contention stays visible.
+        void reportError(err, {
+          source: "http",
+          route: request.routeOptions?.url,
+          method: request.method,
+          subsystem: "external-auth",
+        });
+        recordOidcFailure();
+        await audit("OIDC_LOGIN_FAILED", {
+          reason: "auto_create_race_exhausted",
+          externalId: sanitizeAuditInput(String(sub)),
+          // Not `username`: auditLog reads that key as the actor.
+          attemptedUsername: derivedUsername,
+        });
+        return redirectToLogin(reply, "oidc_auth_failed");
+      }
 
       if (result.action === "denied" || !result.user) {
         recordOidcFailure();

--- a/apps/api/src/plugins/saml.ts
+++ b/apps/api/src/plugins/saml.ts
@@ -7,13 +7,15 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { sharedRedis } from "../jobs/connection.js";
-import { auditFromRequest } from "../lib/audit.js";
+import { auditFromRequest, sanitizeAuditInput } from "../lib/audit.js";
 import { isEnterpriseFeatureEnabled } from "../lib/enterprise-feature.js";
 import { reportError } from "../lib/error-report.js";
 import {
+  type ExternalAuthResult,
   findUniqueUsername,
   resolveExternalUser,
   sanitizeUsername,
+  UsernameRaceExhaustedError,
 } from "../lib/external-auth-resolver.js";
 import { authAttempts } from "../lib/metrics.js";
 import { makeRedisSamlCacheProvider } from "../lib/saml-cache.js";
@@ -148,19 +150,48 @@ export async function registerSaml(app: FastifyInstance): Promise<void> {
       username = await findUniqueUsername(username);
 
       // Resolve user via shared external-auth resolver
-      const result = await resolveExternalUser({
-        provider: "saml",
-        externalId,
-        email,
-        emailVerified: true, // SAML assertions from a trusted IdP are considered verified
-        username,
-        autoCreate: env.SAML_AUTO_CREATE_USERS,
-        autoLink: env.SAML_AUTO_LINK_USERS,
-        defaultRole: env.SAML_DEFAULT_ROLE,
-        logger: request.log,
-        ip: request.ip,
-        requestId: request.id,
-      });
+      let result: ExternalAuthResult;
+      try {
+        result = await resolveExternalUser({
+          provider: "saml",
+          externalId,
+          email,
+          emailVerified: true, // SAML assertions from a trusted IdP are considered verified
+          username,
+          autoCreate: env.SAML_AUTO_CREATE_USERS,
+          autoLink: env.SAML_AUTO_LINK_USERS,
+          defaultRole: env.SAML_DEFAULT_ROLE,
+          logger: request.log,
+          ip: request.ip,
+          requestId: request.id,
+        });
+      } catch (err) {
+        // Losing the username race on every retry is a login outcome, not a
+        // server fault (#978): the user lands on the login page with an error
+        // like every other denial instead of a bare 500 mid-redirect. Anything
+        // else the resolver throws is a fault and keeps surfacing as one.
+        if (!(err instanceof UsernameRaceExhaustedError)) throw err;
+        request.log.error(
+          { err, externalId },
+          "SAML callback: auto-create exhausted its username-race retries",
+        );
+        // Caught here, the error never reaches the global handler's
+        // reportError; report explicitly so the contention stays visible.
+        void reportError(err, {
+          source: "http",
+          route: request.routeOptions?.url,
+          method: request.method,
+          subsystem: "external-auth",
+        });
+        authAttempts.inc({ method: "saml", result: "failure" });
+        await audit("SAML_LOGIN_FAILED", {
+          reason: "auto_create_race_exhausted",
+          externalId: sanitizeAuditInput(String(externalId)),
+          // Not `username`: auditLog reads that key as the actor.
+          attemptedUsername: username,
+        });
+        return redirectToLogin(reply, "saml_auth_failed");
+      }
 
       if (result.action === "denied" || !result.user) {
         authAttempts.inc({ method: "saml", result: "failure" });

--- a/tests/integration/platform/oidc-callback-coverage.test.ts
+++ b/tests/integration/platform/oidc-callback-coverage.test.ts
@@ -17,11 +17,14 @@
  *   - the optional-MFA-plugin catch (oidc.ts:325-327): the MFA policy lookup
  *     throwing must fail *open* (login proceeds) because MFA is an optional
  *     enterprise plugin.
+ *   - the resolver's retry-exhaustion throw (#978): caught and turned into a
+ *     login failure, while any other resolver throw still surfaces as a 500.
  *
  * Like oidc-mfa-callback.test.ts, the cryptographic token exchange is mocked
  * at the `openid-client` boundary (only `authorizationCodeGrant`; discovery,
  * PKCE, and URL building stay real) so the REAL callback route, REAL signed
- * state cookie, REAL resolver, and REAL session creation run end to end.
+ * state cookie, REAL resolver (passthrough-wrapped so two tests can make it
+ * throw), and REAL session creation run end to end.
  *
  * This is a new sibling rather than an extension of oidc-auth.test.ts on
  * purpose: that file drives real login handshakes whose token exchange is
@@ -31,7 +34,7 @@
  */
 import { createServer, type Server } from "node:http";
 import { sign } from "@fastify/cookie";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 const authorizationCodeGrantMock = vi.hoisted(() => vi.fn());
@@ -49,11 +52,35 @@ vi.mock("../../../apps/api/src/lib/analytics.js", async (importOriginal) => {
   return { ...actual, trackEvent: trackEventSpy };
 });
 
+// resolveExternalUser stays REAL by default. The #978 tests swap in a throw for
+// one call each: the retry-exhaustion error the resolver raises after three
+// lost username races (three different identities taking the scanned name
+// between scan and insert, which isn't worth staging against a real DB), and a
+// plain fault that must keep surfacing as a 500.
+const resolverFailure = vi.hoisted(() => ({ next: null as Error | null }));
+vi.mock("../../../apps/api/src/lib/external-auth-resolver.js", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  const realResolve = actual.resolveExternalUser as (...args: unknown[]) => Promise<unknown>;
+  return {
+    ...actual,
+    resolveExternalUser: async (...args: unknown[]) => {
+      const err = resolverFailure.next;
+      if (err) {
+        resolverFailure.next = null;
+        throw err;
+      }
+      return realResolve(...args);
+    },
+  };
+});
+
 vi.resetModules();
 
 const { env } = await import("../../../apps/api/src/config.js");
 const { db, schema } = await import("../../../apps/api/src/db/index.js");
-const { sanitizeUsername } = await import("../../../apps/api/src/lib/external-auth-resolver.js");
+const { sanitizeUsername, UsernameRaceExhaustedError } = await import(
+  "../../../apps/api/src/lib/external-auth-resolver.js"
+);
 const mfaModule = await import("../../../apps/api/src/plugins/mfa.js");
 const { buildTestApp } = await import("../test-server.js");
 
@@ -237,6 +264,7 @@ describe("OIDC callback claim handling and resolver outcomes", () => {
   afterEach(() => {
     authorizationCodeGrantMock.mockReset();
     trackEventSpy.mockClear();
+    resolverFailure.next = null;
     // Reset the knobs individual tests tweak back to the describe defaults.
     (env as any).OIDC_AUTO_CREATE_USERS = true;
     (env as any).OIDC_USERNAME_CLAIM = "preferred_username";
@@ -376,6 +404,49 @@ describe("OIDC callback claim handling and resolver outcomes", () => {
     expect(res.headers.location).toBe("/login?error=oidc_user_limit_reached");
     expect(trackEventSpy).toHaveBeenCalledWith("auth_login_failed", { method: "oidc" });
     expect(await findUserByExternalId(sub)).toBeUndefined();
+  });
+
+  it("redirects to oidc_auth_failed instead of a raw 500 when auto-create exhausts its username-race retries (#978)", async () => {
+    const sub = `sub-raced-${Math.random().toString(36).slice(2, 10)}`;
+    resolverFailure.next = new UsernameRaceExhaustedError("oidc", "raced", 3);
+    const res = await callbackWithClaims({ sub, preferred_username: "raced" });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe("/login?error=oidc_auth_failed");
+    expect(trackEventSpy).toHaveBeenCalledWith("auth_login_failed", { method: "oidc" });
+    const setCookie = res.headers["set-cookie"];
+    expect(String(setCookie ?? "")).not.toContain("snapotter-session=");
+
+    // Exhaustion gets the same audit trail as every other terminal denial.
+    const auditRows = await db
+      .select()
+      .from(schema.auditLog)
+      .where(
+        sql`${schema.auditLog.action} = 'OIDC_LOGIN_FAILED' AND ${schema.auditLog.details}->>'reason' = 'auto_create_race_exhausted' AND ${schema.auditLog.details}->>'externalId' = ${sub}`,
+      );
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0].details).toMatchObject({ attemptedUsername: "raced" });
+  });
+
+  it("still surfaces any other resolver throw as a 500 with no misclassified audit row", async () => {
+    // The catch is narrow on purpose: only the resolver's own retry-exhaustion
+    // signal is a login outcome. A fault (DB down, a leaked constraint error)
+    // must keep reaching the global handler instead of being audited as a race.
+    const sub = `sub-fault-${Math.random().toString(36).slice(2, 10)}`;
+    resolverFailure.next = new Error("simulated resolver fault");
+    const res = await callbackWithClaims({ sub, preferred_username: "faulty" });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.headers.location).toBeUndefined();
+    const setCookie = res.headers["set-cookie"];
+    expect(String(setCookie ?? "")).not.toContain("snapotter-session=");
+    const auditRows = await db
+      .select()
+      .from(schema.auditLog)
+      .where(
+        sql`${schema.auditLog.action} = 'OIDC_LOGIN_FAILED' AND ${schema.auditLog.details}->>'externalId' = ${sub}`,
+      );
+    expect(auditRows).toHaveLength(0);
   });
 
   it("fails closed with a distinct error when the MFA policy lookup throws (#815)", async () => {

--- a/tests/integration/platform/saml-auth.test.ts
+++ b/tests/integration/platform/saml-auth.test.ts
@@ -6,13 +6,16 @@
  * SP metadata, the login redirect, and the ACS callback's provisioning,
  * session, denial, and MFA branches. Follows the enterprise-gated integration
  * pattern: reset modules, doMock the enterprise gate + @node-saml + mfa, then
- * import buildTestApp so it registers the (licensed) SAML routes.
+ * import buildTestApp so it registers the (licensed) SAML routes. The
+ * external-auth resolver stays real behind a passthrough wrapper that two
+ * tests (#978) use to make one call throw.
  */
 import { randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { env } from "../../../apps/api/src/config.js";
 import { db, schema } from "../../../apps/api/src/db/index.js";
+import { UsernameRaceExhaustedError } from "../../../apps/api/src/lib/external-auth-resolver.js";
 import { buildTestApp, type TestApp } from "../test-server.js";
 
 // Hoisted so the vi.mock factories (which vitest hoists above the imports) can
@@ -30,6 +33,27 @@ const mfaOutcomeMock = vi.hoisted(() => vi.fn(() => "proceed"));
 // "unavailable" sentinel to the outcome resolver, which denies unenrolled
 // users with a distinct retryable error instead of waving them through.
 const getMfaPolicyMock = vi.hoisted(() => vi.fn().mockResolvedValue({}));
+
+// resolveExternalUser stays REAL by default. The #978 tests swap in a throw for
+// one call each: the retry-exhaustion error the resolver raises after three
+// lost username races (not worth staging against a real DB) and a plain fault
+// that must keep surfacing as a 500.
+const resolverFailure = vi.hoisted(() => ({ next: null as Error | null }));
+vi.mock("../../../apps/api/src/lib/external-auth-resolver.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  const realResolve = actual.resolveExternalUser as (...args: unknown[]) => Promise<unknown>;
+  return {
+    ...actual,
+    resolveExternalUser: async (...args: unknown[]) => {
+      const err = resolverFailure.next;
+      if (err) {
+        resolverFailure.next = null;
+        throw err;
+      }
+      return realResolve(...args);
+    },
+  };
+});
 
 vi.mock("@node-saml/node-saml", () => ({
   ValidateInResponseTo: { ifPresent: "ifPresent", always: "always", never: "never" },
@@ -93,6 +117,12 @@ afterAll(async () => {
   }
   await testApp.cleanup();
 }, 10_000);
+
+afterEach(() => {
+  // An armed throw is consumed only if the ACS route reaches the resolver;
+  // never let one leak into the next test.
+  resolverFailure.next = null;
+});
 
 function postCallback() {
   return testApp.app.inject({
@@ -253,6 +283,52 @@ describe("SAML callback", () => {
     } finally {
       (env as Record<string, unknown>).MAX_USERS = origMaxUsers;
     }
+  });
+
+  it("redirects to saml_auth_failed instead of a raw 500 when auto-create exhausts its username-race retries (#978)", async () => {
+    const email = `raced-${randomUUID().slice(0, 8)}@example.com`;
+    samlMock.validatePostResponseAsync.mockResolvedValue({ profile: { nameID: email, email } });
+    resolverFailure.next = new UsernameRaceExhaustedError("saml", "raced", 3);
+
+    const res = await postCallback();
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe("/login?error=saml_auth_failed");
+    const setCookie = res.headers["set-cookie"];
+    expect(String(setCookie ?? "")).not.toContain("snapotter-session=");
+
+    // Exhaustion gets the same audit trail as every other terminal denial.
+    const auditRows = await db
+      .select()
+      .from(schema.auditLog)
+      .where(
+        sql`${schema.auditLog.action} = 'SAML_LOGIN_FAILED' AND ${schema.auditLog.details}->>'reason' = 'auto_create_race_exhausted' AND ${schema.auditLog.details}->>'externalId' = ${email}`,
+      );
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0].details).toMatchObject({ attemptedUsername: email.split("@")[0] });
+  });
+
+  it("still surfaces any other resolver throw as a 500 with no misclassified audit row", async () => {
+    // The catch is narrow on purpose: only the resolver's own retry-exhaustion
+    // signal is a login outcome. A fault (DB down, a leaked constraint error)
+    // must keep reaching the global handler instead of being audited as a race.
+    const email = `fault-${randomUUID().slice(0, 8)}@example.com`;
+    samlMock.validatePostResponseAsync.mockResolvedValue({ profile: { nameID: email, email } });
+    resolverFailure.next = new Error("simulated resolver fault");
+
+    const res = await postCallback();
+
+    expect(res.statusCode).toBe(500);
+    expect(res.headers.location).toBeUndefined();
+    const setCookie = res.headers["set-cookie"];
+    expect(String(setCookie ?? "")).not.toContain("snapotter-session=");
+    const auditRows = await db
+      .select()
+      .from(schema.auditLog)
+      .where(
+        sql`${schema.auditLog.action} = 'SAML_LOGIN_FAILED' AND ${schema.auditLog.details}->>'externalId' = ${email}`,
+      );
+    expect(auditRows).toHaveLength(0);
   });
 
   it("fails the login closed when the MFA enrollment-status read throws", async () => {

--- a/tests/unit/api/external-auth-resolver-mutation.test.ts
+++ b/tests/unit/api/external-auth-resolver-mutation.test.ts
@@ -118,7 +118,10 @@ vi.mock("../../../apps/api/src/db/index.js", () => {
   };
 });
 
-import { resolveExternalUser } from "../../../apps/api/src/lib/external-auth-resolver.js";
+import {
+  resolveExternalUser,
+  UsernameRaceExhaustedError,
+} from "../../../apps/api/src/lib/external-auth-resolver.js";
 
 function makeLogger() {
   return { info: vi.fn(), warn: vi.fn() };
@@ -471,9 +474,11 @@ describe("resolveExternalUser: auto-create username race", () => {
       [{ id: "team-default" }], // attempt 3: team
       [], // attempt 3: re-check miss
     ];
-    await expect(resolveExternalUser(baseParams({ autoCreate: true }))).rejects.toThrow(
-      /username race/,
-    );
+    const exhausted = resolveExternalUser(baseParams({ autoCreate: true }));
+    await expect(exhausted).rejects.toThrow(/username race/);
+    // The SSO callbacks catch this one error by type (issue #978), so the
+    // resolver has to keep throwing exactly it, not a plain Error.
+    await expect(exhausted).rejects.toBeInstanceOf(UsernameRaceExhaustedError);
     expect(state.inserts).toHaveLength(3);
   });
 });


### PR DESCRIPTION
Closes #978

`resolveExternalUser` throws after it loses the username race three times in a row during SSO auto-create. Neither the OIDC nor the SAML callback caught that throw, so it rode up to the global error handler and the browser, mid-redirect, landed on a bare `500 {"error":"Internal server error"}` page. No `LOGIN_FAILED` audit row was written, and the 500 spike read as a server fault when it was contention.

## What changed

The resolver now throws a typed `UsernameRaceExhaustedError`. Same message as before, so the retry-budget test in `external-auth-resolver-mutation.test.ts` still matches; it now pins the type too, since the callers depend on it.

Each callback wraps only the `resolveExternalUser` call. It catches that one type, logs it with the externalId, calls `reportError` explicitly (a caught error never reaches the global handler's Sentry report), bumps the failure metric, writes `OIDC_LOGIN_FAILED` / `SAML_LOGIN_FAILED` with `reason: "auto_create_race_exhausted"`, the sanitized externalId and the contended username (under `attemptedUsername`, because `auditLog` reads `username` as the actor), and redirects to `/login?error=oidc_auth_failed` or `saml_auth_failed`. Anything else the resolver throws is rethrown and still surfaces as a 500. The shape mirrors the MFA-policy catch a few lines further down in each file.

One tradeoff left as is: `classifyError` has no branch for the new type, so Sentry files it as bug class, hourly throttled, same as the old 500 did. Contention that beats three retries is worth a look, so that seems right for now.

## Tests

Three lost username races need three different identities taking the scanned name between scan and insert, which isn't worth staging against a real DB. The two integration files instead hook the resolver module with a passthrough `vi.mock` that throws for exactly one call and delegates to the real function everywhere else. Per callback: one test throws the typed error and asserts the 302, the location, no session cookie, and exactly one audit row carrying the reason, externalId and attempted username (the OIDC one also checks the `auth_login_failed` analytics event); a second throws a plain `Error` and asserts the 500 still comes through with no redirect and no misclassified audit row.

Reproduced on main first: both exhaustion tests failed with `expected 500 to be 302`. Teeth checks after the fix: callers swapped back to main's version, both fail the same way; `instanceof` guard and username detail removed, all four tests fail. Restored, all pass.

## Verification

Baseline is the green CI run on main at 3f75a82a (nothing landed since).

- `pnpm vitest run` on the two SSO callback files: 28/28
- Resolver and callback consumers (external-auth-race, user-limit-race, external-auth-resolver, oidc-auth, oidc-mfa-callback, sso-enforcement-login, saml-license-gate, saml-cache, docs-oidc-providers): 9 files, 90 tests pass
- `pnpm lint`: exit 0, warning count unchanged
- `pnpm typecheck`: clean
- `VITEST_MAX_FORKS=3 pnpm test` (full unit + integration): 866 files and 19915 tests pass, 3 files fail. Two are the local-only `twitter/*.test.mjs` scratch files that aren't in the repo. The third is the SCIM duplicate-group race that gets a licence-gate 403 on local macOS main (#980, #990, #1000): it fails 2 of 2 runs with this PR's source files swapped back to main's, so it isn't from this diff.
- pr-review-toolkit silent-failure-hunter, code-reviewer and pr-test-analyzer: no must-fix findings. Took the `afterEach` reset in the SAML file, the two negative tests, the `attemptedUsername` audit detail and the header-comment fixes from their lists; left the Sentry class as noted above.

No web or i18n changes; the `oidc_auth_failed` and `saml_auth_failed` codes already exist on the login page.
