### PR TITLE
fix(auth): audit SSO logins that the user limit turns away

### DIFF
--- a/apps/api/src/lib/external-auth-resolver.ts
+++ b/apps/api/src/lib/external-auth-resolver.ts
@@ -292,7 +292,11 @@ export async function resolveExternalUser(params: ExternalAuthParams): Promise<E
       }
 
       if (inserted === "limit") {
-        logger.warn(`${provider} auto-create blocked: user limit reached`);
+        logger.warn({ externalId, email }, `${provider} auto-create blocked: user limit reached`);
+        await audit(`${providerUpper}_LOGIN_FAILED`, {
+          reason: "user_limit_reached",
+          externalId: sanitizeAuditInput(String(externalId)),
+        });
         return { user: null, action: "denied", deniedReason: "user_limit_reached" };
       }
       // A different user took the name; rescan and retry.

--- a/tests/integration/platform/oidc-callback-coverage.test.ts
+++ b/tests/integration/platform/oidc-callback-coverage.test.ts
@@ -404,6 +404,15 @@ describe("OIDC callback claim handling and resolver outcomes", () => {
     expect(res.headers.location).toBe("/login?error=oidc_user_limit_reached");
     expect(trackEventSpy).toHaveBeenCalledWith("auth_login_failed", { method: "oidc" });
     expect(await findUserByExternalId(sub)).toBeUndefined();
+
+    // The denial leaves an audit row like every other one (issue #967).
+    const auditRows = await db
+      .select()
+      .from(schema.auditLog)
+      .where(
+        sql`${schema.auditLog.action} = 'OIDC_LOGIN_FAILED' AND ${schema.auditLog.details}->>'reason' = 'user_limit_reached' AND ${schema.auditLog.details}->>'externalId' = ${sub}`,
+      );
+    expect(auditRows).toHaveLength(1);
   });
 
   it("redirects to oidc_auth_failed instead of a raw 500 when auto-create exhausts its username-race retries (#978)", async () => {

--- a/tests/integration/platform/saml-auth.test.ts
+++ b/tests/integration/platform/saml-auth.test.ts
@@ -280,6 +280,15 @@ describe("SAML callback", () => {
         .from(schema.users)
         .where(eq(schema.users.externalId, email));
       expect(created).toBeUndefined();
+
+      // The denial leaves an audit row like every other one (issue #967).
+      const auditRows = await db
+        .select()
+        .from(schema.auditLog)
+        .where(
+          sql`${schema.auditLog.action} = 'SAML_LOGIN_FAILED' AND ${schema.auditLog.details}->>'reason' = 'user_limit_reached' AND ${schema.auditLog.details}->>'externalId' = ${email}`,
+        );
+      expect(auditRows).toHaveLength(1);
     } finally {
       (env as Record<string, unknown>).MAX_USERS = origMaxUsers;
     }

--- a/tests/unit/api/external-auth-resolver-mutation.test.ts
+++ b/tests/unit/api/external-auth-resolver-mutation.test.ts
@@ -343,9 +343,52 @@ describe("resolveExternalUser: auto-create", () => {
       [{ id: "team-default" }], // Default team lookup
       [{ count: 5 }], // locked count: exactly at the cap (>= limit)
     ];
-    const result = await resolveExternalUser(baseParams({ autoCreate: true }));
+    const logger = makeLogger();
+    const result = await resolveExternalUser(
+      baseParams({
+        autoCreate: true,
+        externalId: "ext<cap>1",
+        email: "capped@example.com",
+        logger: logger as never,
+      }),
+    );
     expect(result).toEqual({ user: null, action: "denied", deniedReason: "user_limit_reached" });
     expect(state.inserts).toHaveLength(0);
+    // Mirrors the user_not_authorized terminal (issue #967): an audit row with
+    // the sanitized externalId, plus a warn naming who was turned away.
+    expect(state.auditCalls.at(-1)).toEqual({
+      event: "OIDC_LOGIN_FAILED",
+      details: { reason: "user_limit_reached", externalId: "extcap1" },
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      { externalId: "ext<cap>1", email: "capped@example.com" },
+      expect.stringContaining("user limit reached"),
+    );
+  });
+
+  it("joins the concurrent winner at the cap without auditing a denial", async () => {
+    // Two tabs of one new identity finish first login at once while the
+    // instance sits at the cap: the loser's insert is refused by the limit,
+    // but the winner re-check finds the row this same identity just created,
+    // so the login is "matched". The limit audit must stay behind that
+    // re-check or this success would leave a false LOGIN_FAILED row.
+    state.maxUsers = 5;
+    const logger = makeLogger();
+    state.selectRows = [
+      [], // extId miss
+      [], // username free
+      [{ id: "team-default" }], // Default team lookup
+      [{ count: 5 }], // locked count: at the cap
+      [dbUser({ id: "u-winner", username: "alice", role: "user", team: "team-default" })],
+    ];
+    const result = await resolveExternalUser(
+      baseParams({ autoCreate: true, logger: logger as never }),
+    );
+    expect(result.action).toBe("matched");
+    expect(result.user?.id).toBe("u-winner");
+    expect(state.inserts).toHaveLength(0);
+    expect(state.auditCalls).toHaveLength(0);
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("allows auto-create when the count is one below the limit (boundary)", async () => {


### PR DESCRIPTION
Closes #967

When SSO auto-create is refused because the instance sits at `MAX_USERS`, `resolveExternalUser` returned `user_limit_reached` after a bare `logger.warn("oidc auto-create blocked: user limit reached")`. No audit row, no identity in the log line. Five bounced logins over a week looked like five identical warn lines, and the audit log, the thing a compliance review reads, showed nothing. Every sibling denial in the same function (`user_disabled` at three sites, `user_not_authorized`) already dual-writes.

## What changed

The limit branch now writes `OIDC_LOGIN_FAILED` / `SAML_LOGIN_FAILED` with `reason: "user_limit_reached"` and the sanitized externalId, and the warn carries `{ externalId, email }`, the same shape as the `user_not_authorized` terminal. Four lines in `external-auth-resolver.ts`, no new audit event names.

The admin create route's `403 USER_LIMIT_REACHED` has the same gap. It stays unaudited here on purpose: there is no admin-action failure event yet, so it needs a new name in the shared `CORE_AUDIT_EVENTS` list and the settings filter list. That's a taxonomy call, tracked as #1011 with the sketch.

## Tests

The resolver unit harness (`external-auth-resolver-mutation.test.ts`) already drives this denial with a scripted locked count; its test now passes its own logger, an externalId with `<>` in it, and asserts the audit call (sanitized id) and the warn arguments (raw id, email). A new case pins that the audit sits behind the winner re-check: two tabs of one new identity at the cap resolve to "matched" with no audit row and no warn. The OIDC and SAML callback suites already hit the cap end to end; each now asserts exactly one audit row by action, reason and externalId.

Reproduced on main first: all three original assertions failed (no audit call, zero rows). Teeth checks after the fix: resolver reverted, the same three fail; audit hoisted above the re-check, the winner test fails. Restored, everything passes.

## Verification

Baseline: the post-merge CI run on main for #1010 (933c08c2), the previous issue in this queue.

- The three edited files: 54/54 (26 unit, 28 across the two callback suites)
- Resolver and callback consumers (external-auth-race, user-limit-race, external-auth-resolver, oidc-auth, oidc-mfa-callback, sso-enforcement-login, saml-license-gate, saml-cache): 8 files, 86 tests pass
- `pnpm lint`: exit 0, warning count unchanged
- `pnpm typecheck`: clean
- `VITEST_MAX_FORKS=3 pnpm test` (full unit + integration): 867 files and 19917 tests pass. The only two failing files are the local-only `twitter/*.test.mjs` scratch files that aren't in the repo.
- pr-review-toolkit silent-failure-hunter, code-reviewer and pr-test-analyzer: no must-fix findings. Took the winner-at-the-cap test, the sanitization assertion and a comment fix from their lists. Two pre-existing gaps they surfaced are filed as #1012 (auditLog drops the error in its catch) and #1013 (SAML events missing from the audit filter list). One nit left as is: the row carries the externalId only, like `user_not_authorized`; adding the email to both would be a separate change.

No web or i18n changes.
