### PR TITLE
fix(editor): keep blur, sharpen and smudge strokes to the brushed pixels

### DIFF
--- a/apps/web/src/components/editor/tools/pixel-brush-tool.tsx
+++ b/apps/web/src/components/editor/tools/pixel-brush-tool.tsx
@@ -13,6 +13,7 @@ interface StrokeState {
   objectId: string;
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
+  working: CanvasRenderingContext2D;
   sourceSnapshot: ImageData;
   lastX: number;
   lastY: number;
@@ -41,24 +42,25 @@ export function usePixelBrushTool(stageRef: React.RefObject<Konva.Stage | null>)
       const y = Math.floor((pointer.y - panOffset.y) / zoom);
       if (x < 0 || x >= canvasSize.width || y < 0 || y >= canvasSize.height) return;
 
-      // Snapshot the document pixels at document resolution.
-      const stageCanvas = captureDocumentCanvas(stage, canvasSize.width, canvasSize.height);
+      // Snapshot the document pixels at document resolution. The capture doubles as
+      // the working buffer: the brush reads from it and writes each pass back into it.
+      const working = captureDocumentCanvas(stage, canvasSize.width, canvasSize.height).getContext(
+        "2d",
+      );
+      if (!working) return;
 
-      const stageCtx = stageCanvas.getContext("2d");
-      if (!stageCtx) return;
+      const sourceSnapshot = working.getImageData(0, 0, canvasSize.width, canvasSize.height);
 
-      const sourceSnapshot = stageCtx.getImageData(0, 0, canvasSize.width, canvasSize.height);
-
-      // Create output canvas
+      // The stroke object starts fully transparent and only ever receives the pixels
+      // the brush touches. Seeding it with the whole snapshot stacked an opaque copy
+      // of the entire document on top of the image (#829).
       const canvas = document.createElement("canvas");
       canvas.width = canvasSize.width;
       canvas.height = canvasSize.height;
       const ctx = canvas.getContext("2d");
       if (!ctx) return;
 
-      ctx.putImageData(sourceSnapshot, 0, 0);
-
-      applyPixelBrush(ctx, sourceSnapshot, x, y, canvasSize);
+      applyPixelBrush(working, ctx, sourceSnapshot, x, y, canvasSize);
 
       const id = generateId();
       const dataUrl = canvas.toDataURL();
@@ -79,7 +81,15 @@ export function usePixelBrushTool(stageRef: React.RefObject<Konva.Stage | null>)
       };
 
       useEditorStore.getState().addObject(obj);
-      strokeRef.current = { objectId: id, canvas, ctx, sourceSnapshot, lastX: x, lastY: y };
+      strokeRef.current = {
+        objectId: id,
+        canvas,
+        ctx,
+        working,
+        sourceSnapshot,
+        lastX: x,
+        lastY: y,
+      };
     },
     [stageRef],
   );
@@ -98,12 +108,12 @@ export function usePixelBrushTool(stageRef: React.RefObject<Konva.Stage | null>)
     const x = Math.floor((pointer.x - panOffset.x) / zoom);
     const y = Math.floor((pointer.y - panOffset.y) / zoom);
 
-    const { ctx, sourceSnapshot, canvas, objectId } = strokeRef.current;
+    const { ctx, working, sourceSnapshot, canvas, objectId } = strokeRef.current;
 
-    applyPixelBrush(ctx, sourceSnapshot, x, y, canvasSize);
+    applyPixelBrush(working, ctx, sourceSnapshot, x, y, canvasSize);
 
     // Update source snapshot for smudge continuity
-    const updatedData = ctx.getImageData(0, 0, canvasSize.width, canvasSize.height);
+    const updatedData = working.getImageData(0, 0, canvasSize.width, canvasSize.height);
     strokeRef.current.sourceSnapshot = updatedData;
     strokeRef.current.lastX = x;
     strokeRef.current.lastY = y;
@@ -133,7 +143,8 @@ export function usePixelBrushTool(stageRef: React.RefObject<Konva.Stage | null>)
 }
 
 function applyPixelBrush(
-  ctx: CanvasRenderingContext2D,
+  working: CanvasRenderingContext2D,
+  stroke: CanvasRenderingContext2D,
   source: ImageData,
   centerX: number,
   centerY: number,
@@ -152,10 +163,20 @@ function applyPixelBrush(
 
   if (w <= 0 || h <= 0) return;
 
-  const imageData = ctx.getImageData(left, top, w, h);
+  const imageData = working.getImageData(left, top, w, h);
 
   if (activeTool === "blur-brush") {
-    applyBoxBlur(imageData, source, left, top, canvasSize.width, halfSize, strength);
+    applyBoxBlur(
+      imageData,
+      source,
+      left,
+      top,
+      centerX,
+      centerY,
+      canvasSize.width,
+      halfSize,
+      strength,
+    );
   } else if (activeTool === "sharpen-brush") {
     applySharpen(
       imageData,
@@ -182,7 +203,33 @@ function applyPixelBrush(
     );
   }
 
-  ctx.putImageData(imageData, left, top);
+  working.putImageData(imageData, left, top);
+  copyBrushCircle(imageData, stroke, left, top, centerX, centerY, halfSize);
+}
+
+// Lift the brushed circle out of the working buffer onto the stroke canvas. Every
+// other pixel of the stroke keeps whatever it had: transparent unless an earlier
+// pass of the same stroke already touched it.
+function copyBrushCircle(
+  region: ImageData,
+  stroke: CanvasRenderingContext2D,
+  left: number,
+  top: number,
+  centerX: number,
+  centerY: number,
+  halfSize: number,
+): void {
+  const patch = stroke.getImageData(left, top, region.width, region.height);
+  for (let py = 0; py < region.height; py++) {
+    for (let px = 0; px < region.width; px++) {
+      const dx = left + px - centerX;
+      const dy = top + py - centerY;
+      if (dx * dx + dy * dy > halfSize * halfSize) continue;
+      const idx = (py * region.width + px) * 4;
+      patch.data.set(region.data.subarray(idx, idx + 4), idx);
+    }
+  }
+  stroke.putImageData(patch, left, top);
 }
 
 function applyBoxBlur(
@@ -190,6 +237,8 @@ function applyBoxBlur(
   source: ImageData,
   startX: number,
   startY: number,
+  centerX: number,
+  centerY: number,
   sourceWidth: number,
   halfSize: number,
   strength: number,
@@ -198,8 +247,10 @@ function applyBoxBlur(
 
   for (let py = 0; py < imageData.height; py++) {
     for (let px = 0; px < imageData.width; px++) {
-      const dx = startX + px - (startX + imageData.width / 2);
-      const dy = startY + py - (startY + imageData.height / 2);
+      // Same brush mask as sharpen and smudge (and as copyBrushCircle): centred on
+      // the click, not on the clipped region.
+      const dx = startX + px - centerX;
+      const dy = startY + py - centerY;
       if (dx * dx + dy * dy > halfSize * halfSize) continue;
 
       let sumR = 0;

--- a/apps/web/src/components/editor/tools/pixel-brush-tool.tsx
+++ b/apps/web/src/components/editor/tools/pixel-brush-tool.tsx
@@ -12,8 +12,8 @@ const PIXEL_BRUSH_TOOLS = new Set<ToolType>(["blur-brush", "sharpen-brush", "smu
 interface StrokeState {
   objectId: string;
   canvas: HTMLCanvasElement;
-  ctx: CanvasRenderingContext2D;
-  working: CanvasRenderingContext2D;
+  strokeCtx: CanvasRenderingContext2D;
+  workingCtx: CanvasRenderingContext2D;
   sourceSnapshot: ImageData;
   lastX: number;
   lastY: number;
@@ -44,12 +44,14 @@ export function usePixelBrushTool(stageRef: React.RefObject<Konva.Stage | null>)
 
       // Snapshot the document pixels at document resolution. The capture doubles as
       // the working buffer: the brush reads from it and writes each pass back into it.
-      const working = captureDocumentCanvas(stage, canvasSize.width, canvasSize.height).getContext(
-        "2d",
-      );
-      if (!working) return;
+      const workingCtx = captureDocumentCanvas(
+        stage,
+        canvasSize.width,
+        canvasSize.height,
+      ).getContext("2d");
+      if (!workingCtx) return;
 
-      const sourceSnapshot = working.getImageData(0, 0, canvasSize.width, canvasSize.height);
+      const sourceSnapshot = workingCtx.getImageData(0, 0, canvasSize.width, canvasSize.height);
 
       // The stroke object starts fully transparent and only ever receives the pixels
       // the brush touches. Seeding it with the whole snapshot stacked an opaque copy
@@ -57,10 +59,10 @@ export function usePixelBrushTool(stageRef: React.RefObject<Konva.Stage | null>)
       const canvas = document.createElement("canvas");
       canvas.width = canvasSize.width;
       canvas.height = canvasSize.height;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) return;
+      const strokeCtx = canvas.getContext("2d", { willReadFrequently: true });
+      if (!strokeCtx) return;
 
-      applyPixelBrush(working, ctx, sourceSnapshot, x, y, canvasSize);
+      applyPixelBrush(workingCtx, strokeCtx, sourceSnapshot, x, y, canvasSize);
 
       const id = generateId();
       const dataUrl = canvas.toDataURL();
@@ -84,8 +86,8 @@ export function usePixelBrushTool(stageRef: React.RefObject<Konva.Stage | null>)
       strokeRef.current = {
         objectId: id,
         canvas,
-        ctx,
-        working,
+        strokeCtx,
+        workingCtx,
         sourceSnapshot,
         lastX: x,
         lastY: y,
@@ -108,12 +110,12 @@ export function usePixelBrushTool(stageRef: React.RefObject<Konva.Stage | null>)
     const x = Math.floor((pointer.x - panOffset.x) / zoom);
     const y = Math.floor((pointer.y - panOffset.y) / zoom);
 
-    const { ctx, working, sourceSnapshot, canvas, objectId } = strokeRef.current;
+    const { strokeCtx, workingCtx, sourceSnapshot, canvas, objectId } = strokeRef.current;
 
-    applyPixelBrush(working, ctx, sourceSnapshot, x, y, canvasSize);
+    applyPixelBrush(workingCtx, strokeCtx, sourceSnapshot, x, y, canvasSize);
 
     // Update source snapshot for smudge continuity
-    const updatedData = working.getImageData(0, 0, canvasSize.width, canvasSize.height);
+    const updatedData = workingCtx.getImageData(0, 0, canvasSize.width, canvasSize.height);
     strokeRef.current.sourceSnapshot = updatedData;
     strokeRef.current.lastX = x;
     strokeRef.current.lastY = y;
@@ -143,8 +145,8 @@ export function usePixelBrushTool(stageRef: React.RefObject<Konva.Stage | null>)
 }
 
 function applyPixelBrush(
-  working: CanvasRenderingContext2D,
-  stroke: CanvasRenderingContext2D,
+  workingCtx: CanvasRenderingContext2D,
+  strokeCtx: CanvasRenderingContext2D,
   source: ImageData,
   centerX: number,
   centerY: number,
@@ -163,7 +165,7 @@ function applyPixelBrush(
 
   if (w <= 0 || h <= 0) return;
 
-  const imageData = working.getImageData(left, top, w, h);
+  const imageData = workingCtx.getImageData(left, top, w, h);
 
   if (activeTool === "blur-brush") {
     applyBoxBlur(
@@ -203,8 +205,8 @@ function applyPixelBrush(
     );
   }
 
-  working.putImageData(imageData, left, top);
-  copyBrushCircle(imageData, stroke, left, top, centerX, centerY, halfSize);
+  workingCtx.putImageData(imageData, left, top);
+  copyBrushCircle(imageData, strokeCtx, left, top, centerX, centerY, halfSize);
 }
 
 // Lift the brushed circle out of the working buffer onto the stroke canvas. Every
@@ -212,24 +214,27 @@ function applyPixelBrush(
 // pass of the same stroke already touched it.
 function copyBrushCircle(
   region: ImageData,
-  stroke: CanvasRenderingContext2D,
+  strokeCtx: CanvasRenderingContext2D,
   left: number,
   top: number,
   centerX: number,
   centerY: number,
   halfSize: number,
 ): void {
-  const patch = stroke.getImageData(left, top, region.width, region.height);
+  const patch = strokeCtx.getImageData(left, top, region.width, region.height);
   for (let py = 0; py < region.height; py++) {
     for (let px = 0; px < region.width; px++) {
       const dx = left + px - centerX;
       const dy = top + py - centerY;
       if (dx * dx + dy * dy > halfSize * halfSize) continue;
       const idx = (py * region.width + px) * 4;
-      patch.data.set(region.data.subarray(idx, idx + 4), idx);
+      patch.data[idx] = region.data[idx];
+      patch.data[idx + 1] = region.data[idx + 1];
+      patch.data[idx + 2] = region.data[idx + 2];
+      patch.data[idx + 3] = region.data[idx + 3];
     }
   }
-  stroke.putImageData(patch, left, top);
+  strokeCtx.putImageData(patch, left, top);
 }
 
 function applyBoxBlur(

--- a/tests/e2e-editor/editor-pixel-brush.spec.ts
+++ b/tests/e2e-editor/editor-pixel-brush.spec.ts
@@ -1,0 +1,107 @@
+import type { Page } from "@playwright/test";
+import { expect, loadTestImage, selectTool, test } from "./helpers";
+
+// Regression coverage for issue #829: the blur brush (and sharpen and smudge,
+// which share the same pixel-brush hook) snapshotted the whole document and
+// added that snapshot as a new full-size image object. A single click stacked
+// an opaque copy of the entire image on top of the original, and dragging it
+// with the move tool revealed the "duplicate" underneath. A stroke object must
+// carry only the pixels the brush touched and stay transparent everywhere else.
+
+type Rgba = { r: number; g: number; b: number; a: number };
+
+type StageView = {
+  Konva?: {
+    stages: Array<{
+      x(): number;
+      y(): number;
+      scaleX(): number;
+      find(selector: string): Array<{
+        id(): string;
+        image(): CanvasImageSource | undefined;
+        width(): number;
+        height(): number;
+      }>;
+    }>;
+  };
+};
+
+// Image *objects* carry their store id; the source image node has none.
+function countImageObjects(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const konva = (window as unknown as StageView).Konva;
+    if (!konva?.stages?.length) return 0;
+    return konva.stages[0].find("Image").filter((node) => node.id()).length;
+  });
+}
+
+// Read one document pixel from the newest image object's own bitmap.
+function readStrokeObjectPixel(page: Page, x: number, y: number): Promise<Rgba | null> {
+  return page.evaluate(
+    ({ x, y }) => {
+      const konva = (window as unknown as StageView).Konva;
+      if (!konva?.stages?.length) return null;
+      const objects = konva.stages[0].find("Image").filter((node) => node.id());
+      const node = objects[objects.length - 1];
+      const source = node?.image();
+      if (!node || !source) return null;
+      const scratch = document.createElement("canvas");
+      scratch.width = node.width();
+      scratch.height = node.height();
+      const ctx = scratch.getContext("2d");
+      if (!ctx) return null;
+      ctx.drawImage(source, 0, 0);
+      const d = ctx.getImageData(x, y, 1, 1).data;
+      return { r: d[0], g: d[1], b: d[2], a: d[3] };
+    },
+    { x, y },
+  );
+}
+
+// Screen position of a document pixel: the stage carries the editor's pan as
+// its position and the zoom as its scale.
+async function screenPointForDocumentPixel(page: Page, docX: number, docY: number) {
+  const canvas = page.locator('[data-testid="editor-canvas"] canvas').first();
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("editor canvas has no bounding box");
+  const view = await page.evaluate(() => {
+    const stage = (window as unknown as StageView).Konva?.stages[0];
+    if (!stage) return null;
+    return { x: stage.x(), y: stage.y(), zoom: stage.scaleX() };
+  });
+  if (!view) throw new Error("Konva stage not found");
+  return {
+    x: box.x + view.x + (docX + 0.5) * view.zoom,
+    y: box.y + view.y + (docY + 0.5) * view.zoom,
+  };
+}
+
+test.describe("Editor pixel brushes (issue #829)", () => {
+  test("a blur brush click adds only the brushed pixels, not a copy of the whole image", async ({
+    editorPage: page,
+  }) => {
+    // The fixture is a flat, fully opaque rgb(255,100,50) 200x150 image, so the
+    // blur leaves colours untouched and alpha is what tells a brushed pixel
+    // from an untouched one.
+    await loadTestImage(page);
+    await page.waitForTimeout(500);
+
+    await selectTool(page, "blur-brush");
+    const center = await screenPointForDocumentPixel(page, 100, 75);
+    await page.mouse.click(center.x, center.y);
+
+    // One click adds exactly one stroke object.
+    await expect.poll(() => countImageObjects(page), { timeout: 10_000 }).toBe(1);
+
+    // Under the click the stroke carries the (blurred) image pixel, opaque.
+    await expect
+      .poll(() => readStrokeObjectPixel(page, 100, 75), { timeout: 10_000 })
+      .toEqual({ r: 255, g: 100, b: 50, a: 255 });
+
+    // Far from the click the stroke object must be transparent. Before the fix
+    // it was an opaque copy of the entire document.
+    const corner = await readStrokeObjectPixel(page, 2, 2);
+    expect(corner).not.toBeNull();
+    expect(corner?.a).toBe(0);
+  });
+});

--- a/tests/e2e-editor/editor-pixel-brush.spec.ts
+++ b/tests/e2e-editor/editor-pixel-brush.spec.ts
@@ -7,6 +7,12 @@ import { expect, loadTestImage, selectTool, test } from "./helpers";
 // an opaque copy of the entire image on top of the original, and dragging it
 // with the move tool revealed the "duplicate" underneath. A stroke object must
 // carry only the pixels the brush touched and stay transparent everywhere else.
+//
+// The fixture is a flat, fully opaque rgb(255,100,50) 200x150 image, so the
+// blur leaves colours untouched and alpha is what tells a brushed pixel from an
+// untouched one.
+
+const ORANGE = { r: 255, g: 100, b: 50, a: 255 };
 
 type Rgba = { r: number; g: number; b: number; a: number };
 
@@ -33,6 +39,21 @@ function countImageObjects(page: Page): Promise<number> {
     if (!konva?.stages?.length) return 0;
     return konva.stages[0].find("Image").filter((node) => node.id()).length;
   });
+}
+
+// The brush captures the document on mouse down, so the source image must have
+// its bitmap before the first click.
+async function waitForSourceImage(page: Page): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const stage = (window as unknown as StageView).Konva?.stages[0];
+          return Boolean(stage?.find("Image").some((node) => !node.id() && node.image()));
+        }),
+      { timeout: 10_000 },
+    )
+    .toBe(true);
 }
 
 // Read one document pixel from the newest image object's own bitmap.
@@ -77,16 +98,15 @@ async function screenPointForDocumentPixel(page: Page, docX: number, docY: numbe
 }
 
 test.describe("Editor pixel brushes (issue #829)", () => {
+  test.beforeEach(async ({ editorPage: page }) => {
+    await loadTestImage(page);
+    await waitForSourceImage(page);
+    await selectTool(page, "blur-brush");
+  });
+
   test("a blur brush click adds only the brushed pixels, not a copy of the whole image", async ({
     editorPage: page,
   }) => {
-    // The fixture is a flat, fully opaque rgb(255,100,50) 200x150 image, so the
-    // blur leaves colours untouched and alpha is what tells a brushed pixel
-    // from an untouched one.
-    await loadTestImage(page);
-    await page.waitForTimeout(500);
-
-    await selectTool(page, "blur-brush");
     const center = await screenPointForDocumentPixel(page, 100, 75);
     await page.mouse.click(center.x, center.y);
 
@@ -96,10 +116,39 @@ test.describe("Editor pixel brushes (issue #829)", () => {
     // Under the click the stroke carries the (blurred) image pixel, opaque.
     await expect
       .poll(() => readStrokeObjectPixel(page, 100, 75), { timeout: 10_000 })
-      .toEqual({ r: 255, g: 100, b: 50, a: 255 });
+      .toEqual(ORANGE);
 
     // Far from the click the stroke object must be transparent. Before the fix
     // it was an opaque copy of the entire document.
+    const corner = await readStrokeObjectPixel(page, 2, 2);
+    expect(corner).not.toBeNull();
+    expect(corner?.a).toBe(0);
+
+    // The default brush is 10px wide, so the dab's bounding square runs to
+    // (105,80). That pixel sits outside the brush circle and must stay
+    // transparent too: copying the whole square would leave it opaque.
+    const outsideCircle = await readStrokeObjectPixel(page, 105, 80);
+    expect(outsideCircle?.a).toBe(0);
+  });
+
+  test("a blur brush drag keeps the image pixels along the whole stroke", async ({
+    editorPage: page,
+  }) => {
+    const start = await screenPointForDocumentPixel(page, 60, 75);
+    const end = await screenPointForDocumentPixel(page, 140, 75);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(end.x, end.y, { steps: 8 });
+    await page.mouse.up();
+
+    await expect.poll(() => countImageObjects(page), { timeout: 10_000 }).toBe(1);
+
+    // Later dabs read from the working buffer. Reading from the stroke canvas
+    // instead would blend transparent black into the far end of the stroke.
+    await expect
+      .poll(() => readStrokeObjectPixel(page, 140, 75), { timeout: 10_000 })
+      .toEqual(ORANGE);
+
     const corner = await readStrokeObjectPixel(page, 2, 2);
     expect(corner).not.toBeNull();
     expect(corner?.a).toBe(0);


### PR DESCRIPTION
Closes #829

## What broke

One click with the blur brush in the editor added a new full-size image object that was an opaque copy of the whole document, with the blur applied in the middle. Drag it with the move tool and the "duplicate" shows up underneath, exactly as reported. Sharpen and smudge share the same hook (`usePixelBrushTool`) and did the same thing.

Reproduced on main `8e194075` in the editor e2e harness before touching any code: the corner pixel of the stroke object had alpha 255. A visual run with `test-scene.png` showed the whole scene twice after a blur click and a move-tool drag.

## Why

`pixel-brush-tool.tsx` captured the document with `captureDocumentCanvas`, seeded the stroke's output canvas with that full snapshot, applied the brush to it, and added the canvas as an `image` object. Every pixel of the document ended up in the new object, not just the brushed circle. The clone stamp never had this problem: its output canvas starts empty and only the dabs get painted.

## What changed

`apps/web/src/components/editor/tools/pixel-brush-tool.tsx` only.

- The stroke canvas starts transparent. The captured document stays a separate working buffer that the brush reads from and writes each pass back into, so smudge continuity and repeated passes still accumulate.
- After each dab, `copyBrushCircle` lifts only the brushed circle from the working buffer onto the stroke canvas.
- The blur mask is now centred on the click, as sharpen and smudge already were. The old mask was centred on the clipped region, which drifted near the edges and sat half a pixel off elsewhere. It has to match so the copied circle is the blurred circle.
- Review nits: `strokeCtx`/`workingCtx` names at both sites, `willReadFrequently` on the stroke context, scalar copies instead of a `subarray` view per pixel.

The stroke is still its own object, like a paint stroke or a clone-stamp dab, so it can be moved or deleted on its own. Live preview during a drag was already not rendering before this change; that's one of the follow-ups.

## Tests

New `tests/e2e-editor/editor-pixel-brush.spec.ts`. It reads the newest image object's own bitmap through `window.Konva.stages[0]` and checks that the pixel under the click is the image colour and opaque, the far corner is transparent, a pixel inside the dab's bounding square but outside the brush circle is transparent, and after a drag the far end of the stroke still carries the image pixel. The fixture is a flat opaque orange, so blur can't change colour and alpha is the discriminator.

Teeth: the same spec run against unfixed main fails both tests at the corner-alpha assertion (received 255, expected 0). With the fix, both pass.

## Verification

Baseline is the CI run on main `8e194075` (34477911854): green, and nothing landed after it.

Run locally from the branch worktree:

- Full editor e2e suite (`playwright.editor.config.ts`) on 281403d4: 175 passed, 0 failed. The follow-up commit only renames locals, adds `willReadFrequently`, and replaces the subarray copy; the pixel-brush spec was re-run on it, 2 passed.
- `usePixelBrushTool` is the module's only export and has one caller, `editor-canvas.tsx`; the editor suite is its coverage.
- Main-app e2e specs that touch `/editor` (chromium and chromium-serial projects), `pnpm lint`, `pnpm typecheck` and `pnpm test` are running now; results go in a comment below before this merges.

Reviews on the diff: silent-failure-hunter, code-reviewer, pr-test-analyzer. Nothing blocking; the nits above are theirs. The pre-existing gaps they surfaced are filed as follow-up issues, linked in a comment below.
