### PR TITLE
test(docker): keep the compose example policy spec out of the container unit run

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -30,6 +30,8 @@ services:
         "--exclude",
         "**/tests/unit/infra/public-tool-counts.test.ts",
         "--exclude",
+        "**/tests/unit/infra/compose-example-policy.test.ts",
+        "--exclude",
         "**/tests/unit/infra/lint-coverage.test.ts",
         "--exclude",
         "**/tests/unit/infra/docs-dev-ports.test.ts",


### PR DESCRIPTION
## What broke

The nightly dispatched after #1037 (run 34499218506) went red on the Docker Container E2E job. The container's unit run failed one test:

```
FAIL tests/unit/infra/compose-example-policy.test.ts > compose example policy > keeps every public Compose example bootable on the published image
Error: ENOENT: no such file or directory, open '/app/DOCKERHUB.md'
```

That spec came in with #1031 and reads `DOCKERHUB.md`, which `Dockerfile.test.dockerignore` strips from the build context. The previous nightly ran on 983a94ac, before #1031 landed, so this is the first nightly that could see it. Nothing in #1037 touches it; the editor job in that same nightly is green.

## What changed

`docker/docker-compose.test.yml` only: the spec joins the existing exclude list for repo-audit specs (next to `public-tool-counts.test.ts`, which reads the same file). Host CI keeps running it on every PR, which is where it belongs.

## Verification

- `pnpm vitest run tests/unit/infra/compose-example-policy.test.ts` on the host: 4 passed.
- Same command with the new `--exclude` glob: "No test files found", so the container command no longer collects it.
- The other five entries in that list are excluded the same way and the container job was green on them in the nightly above. I'll dispatch nightly again after this merges and check the Docker job.
