### PR TITLE
fix(ai): report bundle download progress while the accelerated transfer runs

### DIFF
--- a/apps/web/src/stores/features-store.ts
+++ b/apps/web/src/stores/features-store.ts
@@ -133,12 +133,19 @@ export const useFeaturesStore = create<FeaturesState>((set, get) => {
           // Now the active install: move queued -> installing and track progress.
           const current = get().installing[bundleId];
           const percent = Math.max(updated.progress?.percent ?? 0, current?.percent ?? 0);
+          // The ETA clock starts when the install starts, not when it was
+          // queued: dividing the first real percent by the whole queue wait
+          // read as an ETA of hundreds of minutes (#871).
+          const startTimes = current
+            ? get().startTimes
+            : { ...get().startTimes, [bundleId]: Date.now() };
           set({
             installing: {
               ...get().installing,
               [bundleId]: { percent, stage: updated.progress?.stage ?? current?.stage ?? "" },
             },
             queued: get().queued.filter((id) => id !== bundleId),
+            startTimes,
           });
           return;
         }

--- a/packages/ai/python/install_feature.py
+++ b/packages/ai/python/install_feature.py
@@ -233,22 +233,35 @@ def make_download_reporter(
     progress_start: int,
     progress_end: int,
     min_delta_bytes: int = 32 * 1024 * 1024,
+    min_interval_s: float = 5.0,
 ):
     """Return a (done_bytes, total) callback that emits a moving-percent frame
-    at most every min_delta_bytes of new transfer.
+    once every min_delta_bytes of new transfer, or every min_interval_s while
+    bytes keep arriving, whichever comes first.
 
     The percent walks from progress_start toward progress_end by the
     manifest's compressed size (falling back to the transport's own total when
     the manifest has none), with the same stage text as the sequential
     downloader so the UI cannot tell the transports apart. Each frame is real
     bytes received, so it doubles as the liveness signal the install watchdog
-    counts; a transfer that truly stalls stops emitting."""
+    counts; a transfer that truly stalls stops emitting. The time bound keeps
+    a slow link alive too: without it a trickle under 32 MB per stall budget
+    would look stalled."""
     last_emitted = [None]
+    last_emitted_at = [0.0]
 
     def report(done_bytes: int, total=None) -> None:
-        if last_emitted[0] is not None and done_bytes - last_emitted[0] < min_delta_bytes:
-            return
+        now = time.monotonic()
+        if last_emitted[0] is not None:
+            if done_bytes <= last_emitted[0]:
+                return
+            if (
+                done_bytes - last_emitted[0] < min_delta_bytes
+                and now - last_emitted_at[0] < min_interval_s
+            ):
+                return
         last_emitted[0] = done_bytes
+        last_emitted_at[0] = now
         size = expected_size if expected_size > 0 else (total or 0)
         if size > 0:
             pct = min(done_bytes / size, 1.0)
@@ -274,8 +287,28 @@ def hf_download_progress(on_bytes):
     assembles the file from its chunk cache, so the staged .incomplete file on
     disk stays at 0 bytes until the transfer is over (issue #871).
 
-    Progress is advisory. A venv whose client lacks the seam downloads exactly
-    as before, just without frames."""
+    Yields None once hooked, or the reason the seam could not be hooked, so
+    the caller can refuse to run a transfer it has no way to watch: the install
+    watchdog counts stderr frames as the only liveness signal, and a silent
+    multi-GB transfer is exactly what it kills."""
+    reporting_broken = [False]
+
+    def report(done: int, total) -> None:
+        # Progress is advisory: a reporter bug must not abort a multi-GB
+        # transfer from inside the client's callback. Stop reporting after
+        # the first failure and leave the reason on stderr for the install
+        # log (the Node side keeps the last lines for error reporting).
+        if reporting_broken[0]:
+            return
+        try:
+            on_bytes(done, total)
+        except Exception as e:
+            reporting_broken[0] = True
+            try:
+                sys.stderr.write(f"download progress reporting stopped: {e}\n")
+            except OSError:
+                pass
+
     try:
         hub_tqdm = importlib.import_module("huggingface_hub.utils.tqdm")
         base = hub_tqdm.tqdm
@@ -289,18 +322,17 @@ def hf_download_progress(on_bytes):
 
             def update(self, n=1):
                 self._bytes_done += n
-                on_bytes(self._bytes_done, self.total)
+                report(self._bytes_done, self.total)
                 return super().update(n)
 
-    except Exception:
-        # No module, or a tqdm that cannot be subclassed: download without
-        # frames rather than fail the install over progress reporting.
-        yield
+    except Exception as e:
+        # No module, or a tqdm that cannot be subclassed.
+        yield f"{type(e).__name__}: {e}"
         return
 
     hub_tqdm.tqdm = ReportingTqdm
     try:
-        yield
+        yield None
     finally:
         hub_tqdm.tqdm = base
 
@@ -420,7 +452,17 @@ def download_with_hf_hub(
     previous_progress = _set_env_temporarily("HF_HUB_DISABLE_PROGRESS_BARS", "1")
     report = make_download_reporter(expected_size, progress_start, progress_end)
     try:
-        with hf_download_progress(report):
+        with hf_download_progress(report) as unhooked:
+            if unhooked:
+                # The sequential downloader frames every chunk, so it is the
+                # transport that can be watched; a silent accelerated transfer
+                # would be killed as stalled after INSTALL_STALL_MS.
+                emit_progress(
+                    progress_start,
+                    f"Accelerated client cannot report progress ({unhooked}); "
+                    "using resumable download.",
+                )
+                return False
             downloaded_path = hf_hub_download(
                 repo_id=bundle_repo,
                 filename=archive_file,

--- a/packages/ai/python/install_feature.py
+++ b/packages/ai/python/install_feature.py
@@ -12,6 +12,7 @@ Progress is reported via JSON lines on stderr (parsed by the Node bridge).
 Final result is a JSON object on stdout.
 """
 
+import contextlib
 import csv
 import errno
 import glob
@@ -227,6 +228,80 @@ def make_copy_activity_reporter(percent: int, stage: str):
     return report
 
 
+def make_download_reporter(
+    expected_size: int,
+    progress_start: int,
+    progress_end: int,
+    min_delta_bytes: int = 32 * 1024 * 1024,
+):
+    """Return a (done_bytes, total) callback that emits a moving-percent frame
+    at most every min_delta_bytes of new transfer.
+
+    The percent walks from progress_start toward progress_end by the
+    manifest's compressed size (falling back to the transport's own total when
+    the manifest has none), with the same stage text as the sequential
+    downloader so the UI cannot tell the transports apart. Each frame is real
+    bytes received, so it doubles as the liveness signal the install watchdog
+    counts; a transfer that truly stalls stops emitting."""
+    last_emitted = [None]
+
+    def report(done_bytes: int, total=None) -> None:
+        if last_emitted[0] is not None and done_bytes - last_emitted[0] < min_delta_bytes:
+            return
+        last_emitted[0] = done_bytes
+        size = expected_size if expected_size > 0 else (total or 0)
+        if size > 0:
+            pct = min(done_bytes / size, 1.0)
+            progress = int(progress_start + pct * (progress_end - progress_start))
+        else:
+            progress = progress_start
+        gb = done_bytes / (1024**3)
+        emit_progress(min(progress, progress_end), f"Downloading... {gb:.1f} GB")
+
+    return report
+
+
+@contextlib.contextmanager
+def hf_download_progress(on_bytes):
+    """Route huggingface_hub's per-byte transfer updates to on_bytes(done, total)
+    for the duration of the block.
+
+    hf_hub_download takes no progress callback. Both of its transports
+    (xet_get for Xet-backed repos, http_get otherwise) build their bar through
+    huggingface_hub.utils.tqdm.tqdm, resolved on that module at call time, and
+    call update(bytes) as data lands. A subclass swapped in for the download is
+    the one seam that sees the bytes on both transports: the Xet client
+    assembles the file from its chunk cache, so the staged .incomplete file on
+    disk stays at 0 bytes until the transfer is over (issue #871).
+
+    Progress is advisory. A venv whose client lacks the seam downloads exactly
+    as before, just without frames."""
+    try:
+        hub_tqdm = importlib.import_module("huggingface_hub.utils.tqdm")
+        base = hub_tqdm.tqdm
+    except Exception:
+        yield
+        return
+
+    class ReportingTqdm(base):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            # tqdm seeds n with `initial` even when the bar is disabled, which
+            # is where a resumed transfer starts counting from.
+            self._bytes_done = self.n
+
+        def update(self, n=1):
+            self._bytes_done += n
+            on_bytes(self._bytes_done, self.total)
+            return super().update(n)
+
+    hub_tqdm.tqdm = ReportingTqdm
+    try:
+        yield
+    finally:
+        hub_tqdm.tqdm = base
+
+
 def _unlink_quietly(path: str) -> None:
     """Best-effort delete for cleanup on error paths; a failed unlink must
     never mask the error being reported."""
@@ -340,13 +415,15 @@ def download_with_hf_hub(
     emit_progress(progress_start, "Downloading with accelerated Hugging Face client...")
 
     previous_progress = _set_env_temporarily("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+    report = make_download_reporter(expected_size, progress_start, progress_end)
     try:
-        downloaded_path = hf_hub_download(
-            repo_id=bundle_repo,
-            filename=archive_file,
-            repo_type="model",
-            local_dir=local_dir,
-        )
+        with hf_download_progress(report):
+            downloaded_path = hf_hub_download(
+                repo_id=bundle_repo,
+                filename=archive_file,
+                repo_type="model",
+                local_dir=local_dir,
+            )
     except Exception as e:
         emit_progress(
             progress_start,

--- a/packages/ai/python/install_feature.py
+++ b/packages/ai/python/install_feature.py
@@ -279,21 +279,24 @@ def hf_download_progress(on_bytes):
     try:
         hub_tqdm = importlib.import_module("huggingface_hub.utils.tqdm")
         base = hub_tqdm.tqdm
+
+        class ReportingTqdm(base):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                # tqdm seeds n with `initial` even when the bar is disabled,
+                # which is where a resumed transfer starts counting from.
+                self._bytes_done = self.n
+
+            def update(self, n=1):
+                self._bytes_done += n
+                on_bytes(self._bytes_done, self.total)
+                return super().update(n)
+
     except Exception:
+        # No module, or a tqdm that cannot be subclassed: download without
+        # frames rather than fail the install over progress reporting.
         yield
         return
-
-    class ReportingTqdm(base):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            # tqdm seeds n with `initial` even when the bar is disabled, which
-            # is where a resumed transfer starts counting from.
-            self._bytes_done = self.n
-
-        def update(self, n=1):
-            self._bytes_done += n
-            on_bytes(self._bytes_done, self.total)
-            return super().update(n)
 
     hub_tqdm.tqdm = ReportingTqdm
     try:

--- a/packages/ai/python/tests/hf_download_scenarios.py
+++ b/packages/ai/python/tests/hf_download_scenarios.py
@@ -1,0 +1,227 @@
+"""Fakes and scenarios for the accelerated-download progress seam in
+install_feature.py (issue #871).
+
+Shared by two harnesses so the fake huggingface_hub has one owner:
+  - test_install_feature_download.py drives it under pytest (local depth);
+  - tests/unit/features/install-feature-download-progress.test.ts spawns
+    `python3 hf_download_scenarios.py <installer.py> <scenario>` and reads the
+    JSON on stdout. That one is the CI gate: the runners have python3 but no
+    pytest.
+
+No pytest import in this module, on purpose."""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+
+MIB = 1024 * 1024
+EXPECTED_SIZE = 512 * MIB
+ARCHIVE = "v2.0.0/upscale-enhance-amd64-gpu.tar.gz"
+BODY = b"archive"
+
+
+def load_installer(path):
+    spec = importlib.util.spec_from_file_location("install_feature_scenario_target", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class RecordingTqdm:
+    """Stand-in for huggingface_hub.utils.tqdm.tqdm: the class both xet_get and
+    http_get instantiate through _get_progress_bar_context and feed with
+    update(bytes) as the transfer moves. Mirrors the real constructor shape
+    (keyword-only bar settings, the `name` group) and the real disabled-bar
+    behaviour (n seeded from `initial`, update() returns early)."""
+
+    def __init__(self, *args, **kwargs):
+        self.n = kwargs.get("initial", 0)
+        self.total = kwargs.get("total")
+        self.disable = kwargs.get("disable", False)
+
+    def update(self, n=1):
+        if self.disable:
+            return
+        self.n += n
+
+    def close(self):
+        pass
+
+
+def fake_hub(transfer, seam="class", initial=0, total=None):
+    """Build the fake huggingface_hub modules.
+
+    `transfer(bar)` runs the simulated download against whatever class sits on
+    huggingface_hub.utils.tqdm at call time, exactly as the library would.
+    seam: "class" (RecordingTqdm), "not_a_class" (tqdm is the integer 42), or
+    "missing" (no utils.tqdm module at all). Returns (modules, tqdm_module)."""
+    hub = types.ModuleType("huggingface_hub")
+    modules = {"huggingface_hub": hub}
+    tqdm_mod = None
+    if seam != "missing":
+        utils = types.ModuleType("huggingface_hub.utils")
+        tqdm_mod = types.ModuleType("huggingface_hub.utils.tqdm")
+        tqdm_mod.tqdm = RecordingTqdm if seam == "class" else 42
+        utils.tqdm = tqdm_mod
+        hub.utils = utils
+        modules["huggingface_hub.utils"] = utils
+        modules["huggingface_hub.utils.tqdm"] = tqdm_mod
+
+    def hf_hub_download(repo_id, filename, repo_type, local_dir):
+        if transfer is not None:
+            bar = tqdm_mod.tqdm(
+                unit="B", unit_scale=True, total=total, initial=initial,
+                desc=filename, disable=True, name="huggingface_hub.xet_get",
+            )
+            transfer(bar)
+            bar.close()
+        target = os.path.join(local_dir, filename)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "wb") as f:
+            f.write(BODY)
+        return target
+
+    hub.hf_hub_download = hf_hub_download
+    return modules, tqdm_mod
+
+
+HUB_MODULE_NAMES = ("huggingface_hub", "huggingface_hub.utils", "huggingface_hub.utils.tqdm")
+
+
+def run_download(
+    installer,
+    transfer,
+    seam="class",
+    expected_size=EXPECTED_SIZE,
+    initial=0,
+    total=None,
+    reporter=None,
+    clock=None,
+):
+    """Run installer.download_with_hf_hub against the fakes and return a
+    JSON-able record: return value, every emitted frame, whether the seam was
+    restored, and the archive body if one was written. Restores sys.modules
+    and the installer's patched attributes afterwards."""
+    modules, tqdm_mod = fake_hub(transfer, seam=seam, initial=initial, total=total)
+    saved_modules = {name: sys.modules.get(name) for name in HUB_MODULE_NAMES}
+    for name in HUB_MODULE_NAMES:
+        sys.modules.pop(name, None)
+    sys.modules.update(modules)
+
+    frames = []
+    saved_emit = installer.emit_progress
+    saved_reporter = installer.make_download_reporter
+    saved_monotonic = installer.time.monotonic
+    installer.emit_progress = lambda p, s: frames.append([p, s])
+    if reporter is not None:
+        installer.make_download_reporter = lambda *a, **k: reporter
+    if clock is not None:
+        installer.time.monotonic = clock
+
+    work = tempfile.mkdtemp()
+    dest = os.path.join(work, "staging", os.path.basename(ARCHIVE))
+    os.makedirs(os.path.dirname(dest))
+    try:
+        ok = installer.download_with_hf_hub(
+            "deepsafe/feature-bundles", ARCHIVE, dest, expected_size, 2, 85
+        )
+    finally:
+        installer.emit_progress = saved_emit
+        installer.make_download_reporter = saved_reporter
+        installer.time.monotonic = saved_monotonic
+        for name in HUB_MODULE_NAMES:
+            sys.modules.pop(name, None)
+            if saved_modules[name] is not None:
+                sys.modules[name] = saved_modules[name]
+
+    if tqdm_mod is None:
+        seam_restored = True
+    else:
+        seam_restored = tqdm_mod.tqdm is (RecordingTqdm if seam == "class" else 42)
+    archive = None
+    if os.path.exists(dest):
+        with open(dest, "rb") as f:
+            archive = f.read().decode()
+    return {"ok": ok, "frames": frames, "seamRestored": seam_restored, "archive": archive}
+
+
+def in_flight(frames):
+    """The frames between the "starting" frame and the "downloaded" frame:
+    the transfer itself. Raises if either boundary is missing, so a renamed
+    stage text fails loudly instead of yielding an empty window."""
+    start = next(i for i, (_, s) in enumerate(frames) if "accelerated" in s.lower())
+    end = next(i for i, (_, s) in enumerate(frames) if s.startswith("Downloaded"))
+    return frames[start + 1 : end]
+
+
+def steps(count, size):
+    def transfer(bar):
+        for _ in range(count):
+            bar.update(size)
+
+    return transfer
+
+
+def _raising_transfer(bar):
+    raise RuntimeError("xet CAS unreachable")
+
+
+def _raising_reporter(done, total=None):
+    raise ValueError("reporter bug")
+
+
+def _ticking_clock(step_s):
+    now = [0.0]
+
+    def monotonic():
+        now[0] += step_s
+        return now[0]
+
+    return monotonic
+
+
+SCENARIOS = {
+    # The reported bug: bytes in flight must surface as moving-percent frames.
+    "inflight": lambda inst: run_download(inst, steps(16, 32 * MIB)),
+    # 12 x 10 MiB under the 32 MiB byte throttle with a frozen clock: only
+    # the 1st, 5th and 9th updates cross the threshold.
+    "throttle": lambda inst: run_download(inst, steps(12, 10 * MIB), clock=lambda: 0.0),
+    # A trickle of 1 MiB updates spaced 6 s apart must still frame each one,
+    # or a slow link reads as stalled to the watchdog.
+    "trickle": lambda inst: run_download(
+        inst, steps(8, 1 * MIB), expected_size=8 * MIB, clock=_ticking_clock(6.0)
+    ),
+    # http_get resumes with initial=resume_size; the percent must count from
+    # there, not from zero.
+    "resume": lambda inst: run_download(
+        inst, steps(1, 16 * MIB), expected_size=128 * MIB, initial=96 * MIB
+    ),
+    # No manifest size: fall back to the bar's own total.
+    "no_expected_size": lambda inst: run_download(
+        inst, steps(4, 32 * MIB), expected_size=0, total=128 * MIB
+    ),
+    # The transfer raises: the caller falls back, and the seam is restored.
+    "raises": lambda inst: run_download(inst, _raising_transfer),
+    # A transfer that never delivers bytes must never frame (watchdog contract).
+    "no_bytes": lambda inst: run_download(inst, lambda bar: None),
+    # The reporter itself blows up: the transfer must still complete.
+    "reporter_raises": lambda inst: run_download(
+        inst, steps(4, 32 * MIB), reporter=_raising_reporter
+    ),
+    # Drifted clients: no seam module, or a seam that is not a class. The
+    # transfer cannot be watched, so the caller must decline it.
+    "seam_missing": lambda inst: run_download(inst, None, seam="missing"),
+    "not_a_class": lambda inst: run_download(inst, None, seam="not_a_class"),
+}
+
+
+def run_scenario(name, installer_path):
+    return SCENARIOS[name](load_installer(installer_path))
+
+
+if __name__ == "__main__":
+    print(json.dumps(run_scenario(sys.argv[2], sys.argv[1])))

--- a/packages/ai/python/tests/test_install_feature_download.py
+++ b/packages/ai/python/tests/test_install_feature_download.py
@@ -117,6 +117,172 @@ def test_download_with_hf_hub_cleans_cache_when_download_raises(monkeypatch, tmp
     assert not (staging / "v2.0.0").exists()
 
 
+class _RecordingTqdm:
+    """Stand-in for huggingface_hub.utils.tqdm.tqdm: the class both xet_get and
+    http_get instantiate through _get_progress_bar_context and feed with
+    update(bytes) as the transfer moves. Mirrors the real constructor shape
+    (keyword-only bar settings, `name` group) so a subclass installed by the
+    installer sees exactly what the library would hand it."""
+
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        self.n = kwargs.get("initial", 0)
+        self.total = kwargs.get("total")
+        self.disable = kwargs.get("disable", False)
+        _RecordingTqdm.instances.append(self)
+
+    def update(self, n=1):
+        # Real tqdm returns early when disabled, without touching self.n.
+        if self.disable:
+            return
+        self.n += n
+
+    def close(self):
+        pass
+
+
+def _fake_hub_with_progress(monkeypatch, transfer):
+    """Install a fake huggingface_hub whose hf_hub_download drives the
+    library's tqdm seam the way the real client does. `transfer(bar)` runs
+    the simulated download against the bar the installer's hook sees."""
+    hub = types.ModuleType("huggingface_hub")
+    utils = types.ModuleType("huggingface_hub.utils")
+    tqdm_mod = types.ModuleType("huggingface_hub.utils.tqdm")
+    tqdm_mod.tqdm = _RecordingTqdm
+    utils.tqdm = tqdm_mod
+    hub.utils = utils
+
+    def hf_hub_download(repo_id, filename, repo_type, local_dir):
+        # Whatever class sits on the module at call time is what the library
+        # would construct; a hook that swapped it in must therefore be live now.
+        bar = tqdm_mod.tqdm(
+            unit="B", unit_scale=True, total=None, initial=0, desc=filename,
+            disable=True, name="huggingface_hub.xet_get",
+        )
+        transfer(bar)
+        bar.close()
+        target = os.path.join(local_dir, filename)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "wb") as f:
+            f.write(b"archive")
+        return target
+
+    hub.hf_hub_download = hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+    monkeypatch.setitem(sys.modules, "huggingface_hub.utils", utils)
+    monkeypatch.setitem(sys.modules, "huggingface_hub.utils.tqdm", tqdm_mod)
+    return tqdm_mod
+
+
+def test_download_with_hf_hub_reports_bytes_while_transfer_is_in_flight(
+    monkeypatch, tmp_path
+):
+    """Issue #871: the accelerated download emitted one frame at the start
+    and one at the end, so a multi-GB transfer sat at the start percent for
+    its whole duration. The UI extrapolated an ETA of hours from that frozen
+    percent and the stall watchdog (20 min, no frames) killed slow-but-live
+    transfers. The download must report bytes as they arrive, with the
+    percent walking from progress_start toward progress_end."""
+    installer = load_installer()
+    expected_size = 512 * 1024 * 1024
+    step = 32 * 1024 * 1024
+
+    def transfer(bar):
+        for _ in range(expected_size // step):
+            bar.update(step)
+
+    tqdm_mod = _fake_hub_with_progress(monkeypatch, transfer)
+
+    frames = []
+    monkeypatch.setattr(installer, "emit_progress", lambda p, s: frames.append((p, s)))
+
+    dest = tmp_path / "staging" / "upscale-enhance-amd64-gpu.tar.gz"
+    dest.parent.mkdir()
+    assert installer.download_with_hf_hub(
+        "deepsafe/feature-bundles",
+        "v2.0.0/upscale-enhance-amd64-gpu.tar.gz",
+        str(dest),
+        expected_size,
+        2,
+        85,
+    ) is True
+
+    # Frames between the "starting" frame and the "downloaded" frame are the
+    # in-flight ones; before the fix this list was empty.
+    start = next(i for i, (_, s) in enumerate(frames) if "accelerated" in s.lower())
+    end = next(i for i, (_, s) in enumerate(frames) if s.startswith("Downloaded"))
+    inflight = frames[start + 1 : end]
+    assert len(inflight) >= 8, frames
+
+    percents = [p for p, _ in inflight]
+    assert percents == sorted(percents), "download percent must be monotonic"
+    assert all(2 <= p <= 85 for p in percents)
+    assert percents[-1] >= 80, "reported percent must track the bytes received"
+    assert all("GB" in s for _, s in inflight), "stage carries the byte counter"
+
+    # The hook is scoped to the transfer: the library's class is restored.
+    assert tqdm_mod.tqdm is _RecordingTqdm
+
+
+def test_download_with_hf_hub_restores_tqdm_seam_when_download_raises(
+    monkeypatch, tmp_path
+):
+    installer = load_installer()
+
+    def transfer(bar):
+        raise RuntimeError("xet CAS unreachable")
+
+    tqdm_mod = _fake_hub_with_progress(monkeypatch, transfer)
+    monkeypatch.setattr(installer, "emit_progress", lambda p, s: None)
+
+    dest = tmp_path / "staging" / "upscale-enhance-amd64-gpu.tar.gz"
+    dest.parent.mkdir()
+    assert installer.download_with_hf_hub(
+        "deepsafe/feature-bundles",
+        "v2.0.0/upscale-enhance-amd64-gpu.tar.gz",
+        str(dest),
+        100,
+        2,
+        85,
+    ) is False
+    assert tqdm_mod.tqdm is _RecordingTqdm
+
+
+def test_download_with_hf_hub_still_downloads_when_progress_seam_is_missing(
+    monkeypatch, tmp_path
+):
+    """A drifted venv whose huggingface_hub has no utils.tqdm module must keep
+    downloading (silently, as before), never fail the install over progress."""
+    installer = load_installer()
+    hub = types.ModuleType("huggingface_hub")
+
+    def hf_hub_download(repo_id, filename, repo_type, local_dir):
+        target = os.path.join(local_dir, filename)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "wb") as f:
+            f.write(b"archive")
+        return target
+
+    hub.hf_hub_download = hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+    monkeypatch.delitem(sys.modules, "huggingface_hub.utils", raising=False)
+    monkeypatch.delitem(sys.modules, "huggingface_hub.utils.tqdm", raising=False)
+    monkeypatch.setattr(installer, "emit_progress", lambda p, s: None)
+
+    dest = tmp_path / "staging" / "face-detection-arm64-cpu.tar.gz"
+    dest.parent.mkdir()
+    assert installer.download_with_hf_hub(
+        "deepsafe/feature-bundles",
+        "v2.0.0/face-detection-arm64-cpu.tar.gz",
+        str(dest),
+        7,
+        2,
+        85,
+    ) is True
+    assert dest.read_bytes() == b"archive"
+
+
 def test_ensure_hf_hub_noops_when_client_already_importable(monkeypatch, tmp_path):
     installer = load_installer()
     fake_module = types.ModuleType("huggingface_hub")

--- a/packages/ai/python/tests/test_install_feature_download.py
+++ b/packages/ai/python/tests/test_install_feature_download.py
@@ -283,6 +283,47 @@ def test_download_with_hf_hub_still_downloads_when_progress_seam_is_missing(
     assert dest.read_bytes() == b"archive"
 
 
+def test_download_with_hf_hub_still_downloads_when_tqdm_cannot_be_subclassed(
+    monkeypatch, tmp_path
+):
+    """The seam module exists but its tqdm is not a class (a drifted client
+    that stubs it out): the download must still complete, silently, rather
+    than fall through to the sequential downloader or fail the install."""
+    installer = load_installer()
+    hub = types.ModuleType("huggingface_hub")
+    utils = types.ModuleType("huggingface_hub.utils")
+    tqdm_mod = types.ModuleType("huggingface_hub.utils.tqdm")
+    tqdm_mod.tqdm = 42
+    utils.tqdm = tqdm_mod
+    hub.utils = utils
+
+    def hf_hub_download(repo_id, filename, repo_type, local_dir):
+        target = os.path.join(local_dir, filename)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "wb") as f:
+            f.write(b"archive")
+        return target
+
+    hub.hf_hub_download = hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+    monkeypatch.setitem(sys.modules, "huggingface_hub.utils", utils)
+    monkeypatch.setitem(sys.modules, "huggingface_hub.utils.tqdm", tqdm_mod)
+    monkeypatch.setattr(installer, "emit_progress", lambda p, s: None)
+
+    dest = tmp_path / "staging" / "face-detection-arm64-cpu.tar.gz"
+    dest.parent.mkdir()
+    assert installer.download_with_hf_hub(
+        "deepsafe/feature-bundles",
+        "v2.0.0/face-detection-arm64-cpu.tar.gz",
+        str(dest),
+        7,
+        2,
+        85,
+    ) is True
+    assert dest.read_bytes() == b"archive"
+    assert tqdm_mod.tqdm == 42
+
+
 def test_ensure_hf_hub_noops_when_client_already_importable(monkeypatch, tmp_path):
     installer = load_installer()
     fake_module = types.ModuleType("huggingface_hub")

--- a/packages/ai/python/tests/test_install_feature_download.py
+++ b/packages/ai/python/tests/test_install_feature_download.py
@@ -17,6 +17,23 @@ def load_installer():
     return module
 
 
+def _install_fake_hub_with_seam(monkeypatch, fake_module):
+    """Register a fake huggingface_hub that also carries the progress seam
+    (utils.tqdm.tqdm): a client without one is declined by design, see
+    test_download_with_hf_hub_declines_a_transfer_it_cannot_watch."""
+    sys.path.insert(0, os.path.dirname(__file__))
+    from hf_download_scenarios import RecordingTqdm
+
+    utils = types.ModuleType("huggingface_hub.utils")
+    tqdm_mod = types.ModuleType("huggingface_hub.utils.tqdm")
+    tqdm_mod.tqdm = RecordingTqdm
+    utils.tqdm = tqdm_mod
+    fake_module.utils = utils
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_module)
+    monkeypatch.setitem(sys.modules, "huggingface_hub.utils", utils)
+    monkeypatch.setitem(sys.modules, "huggingface_hub.utils.tqdm", tqdm_mod)
+
+
 def test_main_temporarily_lifts_hugging_face_offline_flags(monkeypatch):
     """An explicit bundle install stays online while runtime remains fail-closed."""
     installer = load_installer()
@@ -51,7 +68,7 @@ def test_download_with_hf_hub_uses_accelerated_client(monkeypatch, tmp_path):
 
     fake_module = types.ModuleType("huggingface_hub")
     fake_module.hf_hub_download = fake_hf_hub_download
-    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_module)
+    _install_fake_hub_with_seam(monkeypatch, fake_module)
 
     progress = []
     monkeypatch.setattr(installer, "emit_progress", lambda p, s: progress.append((p, s)))
@@ -96,7 +113,7 @@ def test_download_with_hf_hub_cleans_cache_when_download_raises(monkeypatch, tmp
 
     fake_module = types.ModuleType("huggingface_hub")
     fake_module.hf_hub_download = fake_hf_hub_download
-    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_module)
+    _install_fake_hub_with_seam(monkeypatch, fake_module)
     monkeypatch.setattr(installer, "emit_progress", lambda p, s: None)
 
     dest = staging / "object-eraser-colorize-amd64-gpu.tar.gz"
@@ -117,211 +134,132 @@ def test_download_with_hf_hub_cleans_cache_when_download_raises(monkeypatch, tmp
     assert not (staging / "v2.0.0").exists()
 
 
-class _RecordingTqdm:
-    """Stand-in for huggingface_hub.utils.tqdm.tqdm: the class both xet_get and
-    http_get instantiate through _get_progress_bar_context and feed with
-    update(bytes) as the transfer moves. Mirrors the real constructor shape
-    (keyword-only bar settings, `name` group) so a subclass installed by the
-    installer sees exactly what the library would hand it."""
+# -- download_with_hf_hub: progress while the transfer is in flight (#871) --
+#
+# The fakes and scenarios live in hf_download_scenarios.py so the vitest CI
+# gate (tests/unit/features/install-feature-download-progress.test.ts) runs
+# the same code; this file adds the pytest-side assertions.
 
-    instances = []
+sys.path.insert(0, os.path.dirname(__file__))
+import hf_download_scenarios as scenarios  # noqa: E402
 
-    def __init__(self, *args, **kwargs):
-        self.n = kwargs.get("initial", 0)
-        self.total = kwargs.get("total")
-        self.disable = kwargs.get("disable", False)
-        _RecordingTqdm.instances.append(self)
-
-    def update(self, n=1):
-        # Real tqdm returns early when disabled, without touching self.n.
-        if self.disable:
-            return
-        self.n += n
-
-    def close(self):
-        pass
+INSTALLER_PATH = os.path.join(os.path.dirname(__file__), "..", "install_feature.py")
 
 
-def _fake_hub_with_progress(monkeypatch, transfer):
-    """Install a fake huggingface_hub whose hf_hub_download drives the
-    library's tqdm seam the way the real client does. `transfer(bar)` runs
-    the simulated download against the bar the installer's hook sees."""
-    hub = types.ModuleType("huggingface_hub")
-    utils = types.ModuleType("huggingface_hub.utils")
-    tqdm_mod = types.ModuleType("huggingface_hub.utils.tqdm")
-    tqdm_mod.tqdm = _RecordingTqdm
-    utils.tqdm = tqdm_mod
-    hub.utils = utils
-
-    def hf_hub_download(repo_id, filename, repo_type, local_dir):
-        # Whatever class sits on the module at call time is what the library
-        # would construct; a hook that swapped it in must therefore be live now.
-        bar = tqdm_mod.tqdm(
-            unit="B", unit_scale=True, total=None, initial=0, desc=filename,
-            disable=True, name="huggingface_hub.xet_get",
-        )
-        transfer(bar)
-        bar.close()
-        target = os.path.join(local_dir, filename)
-        os.makedirs(os.path.dirname(target), exist_ok=True)
-        with open(target, "wb") as f:
-            f.write(b"archive")
-        return target
-
-    hub.hf_hub_download = hf_hub_download
-    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
-    monkeypatch.setitem(sys.modules, "huggingface_hub.utils", utils)
-    monkeypatch.setitem(sys.modules, "huggingface_hub.utils.tqdm", tqdm_mod)
-    return tqdm_mod
+def run(name):
+    return scenarios.run_scenario(name, INSTALLER_PATH)
 
 
-def test_download_with_hf_hub_reports_bytes_while_transfer_is_in_flight(
-    monkeypatch, tmp_path
-):
+def test_download_with_hf_hub_reports_bytes_while_transfer_is_in_flight():
     """Issue #871: the accelerated download emitted one frame at the start
     and one at the end, so a multi-GB transfer sat at the start percent for
     its whole duration. The UI extrapolated an ETA of hours from that frozen
     percent and the stall watchdog (20 min, no frames) killed slow-but-live
     transfers. The download must report bytes as they arrive, with the
     percent walking from progress_start toward progress_end."""
-    installer = load_installer()
-    expected_size = 512 * 1024 * 1024
-    step = 32 * 1024 * 1024
+    result = run("inflight")
+    assert result["ok"] is True
+    assert result["archive"] == "archive"
 
-    def transfer(bar):
-        for _ in range(expected_size // step):
-            bar.update(step)
-
-    tqdm_mod = _fake_hub_with_progress(monkeypatch, transfer)
-
-    frames = []
-    monkeypatch.setattr(installer, "emit_progress", lambda p, s: frames.append((p, s)))
-
-    dest = tmp_path / "staging" / "upscale-enhance-amd64-gpu.tar.gz"
-    dest.parent.mkdir()
-    assert installer.download_with_hf_hub(
-        "deepsafe/feature-bundles",
-        "v2.0.0/upscale-enhance-amd64-gpu.tar.gz",
-        str(dest),
-        expected_size,
-        2,
-        85,
-    ) is True
-
-    # Frames between the "starting" frame and the "downloaded" frame are the
-    # in-flight ones; before the fix this list was empty.
-    start = next(i for i, (_, s) in enumerate(frames) if "accelerated" in s.lower())
-    end = next(i for i, (_, s) in enumerate(frames) if s.startswith("Downloaded"))
-    inflight = frames[start + 1 : end]
-    assert len(inflight) >= 8, frames
-
+    inflight = scenarios.in_flight(result["frames"])
+    assert len(inflight) >= 8, result["frames"]
     percents = [p for p, _ in inflight]
     assert percents == sorted(percents), "download percent must be monotonic"
     assert all(2 <= p <= 85 for p in percents)
     assert percents[-1] >= 80, "reported percent must track the bytes received"
-    assert all("GB" in s for _, s in inflight), "stage carries the byte counter"
-
-    # The hook is scoped to the transfer: the library's class is restored.
-    assert tqdm_mod.tqdm is _RecordingTqdm
+    assert all(s.startswith("Downloading... ") and s.endswith(" GB") for _, s in inflight)
+    assert result["seamRestored"], "the library's tqdm class must come back"
 
 
-def test_download_with_hf_hub_restores_tqdm_seam_when_download_raises(
-    monkeypatch, tmp_path
-):
+def test_download_with_hf_hub_throttles_frames_by_bytes():
+    # 12 x 10 MiB with a frozen clock: only the 1st, 5th and 9th updates
+    # cross the 32 MiB threshold. Every frame is a DB write on the Node side.
+    result = run("throttle")
+    percents = [p for p, _ in scenarios.in_flight(result["frames"])]
+    assert len(percents) == 3, result["frames"]
+    assert percents == sorted(percents)
+
+
+def test_download_with_hf_hub_keeps_a_slow_link_alive_by_time():
+    # 1 MiB updates 6 s apart never reach the byte threshold; the time bound
+    # must frame each one or the watchdog reads the trickle as a stall.
+    result = run("trickle")
+    assert len(scenarios.in_flight(result["frames"])) == 8, result["frames"]
+
+
+def test_download_with_hf_hub_counts_a_resumed_transfer_from_its_offset():
+    # http_get hands tqdm initial=resume_size; 96 + 16 of 128 MiB is 87%.
+    result = run("resume")
+    percents = [p for p, _ in scenarios.in_flight(result["frames"])]
+    assert percents == [74], result["frames"]
+
+
+def test_download_with_hf_hub_uses_the_bar_total_without_a_manifest_size():
+    result = run("no_expected_size")
+    percents = [p for p, _ in scenarios.in_flight(result["frames"])]
+    assert percents == [22, 43, 64, 85], result["frames"]
+
+
+def test_download_with_hf_hub_restores_tqdm_seam_when_download_raises():
+    result = run("raises")
+    assert result["ok"] is False
+    assert result["seamRestored"]
+
+
+def test_download_with_hf_hub_never_frames_without_bytes():
+    # The watchdog contract: a frame means bytes moved, never a timer.
+    result = run("no_bytes")
+    assert result["ok"] is True
+    assert scenarios.in_flight(result["frames"]) == []
+
+
+def test_download_with_hf_hub_survives_a_reporter_bug():
+    # Progress is advisory: a raise inside the reporter must not abort the
+    # transfer or demote it to the sequential downloader.
+    result = run("reporter_raises")
+    assert result["ok"] is True
+    assert result["archive"] == "archive"
+    assert scenarios.in_flight(result["frames"]) == []
+
+
+@pytest.mark.parametrize("scenario", ["seam_missing", "not_a_class"])
+def test_download_with_hf_hub_declines_a_transfer_it_cannot_watch(scenario):
+    """A drifted client with no usable progress seam would download silently,
+    and a silent multi-GB transfer is exactly what the stall watchdog kills.
+    Decline it with a frame that says why, so download_and_verify falls back
+    to the sequential downloader, which frames every chunk."""
+    result = run(scenario)
+    assert result["ok"] is False
+    assert result["archive"] is None, "hf_hub_download must not have run"
+    assert result["seamRestored"]
+    stages = [s for _, s in result["frames"]]
+    assert any("cannot report progress" in s and "resumable" in s for s in stages), stages
+
+
+def test_download_with_hf_hub_seam_hooks_the_real_client():
+    """Drive the real huggingface_hub progress-bar factory (the one xet_get and
+    http_get call) through hf_download_progress. Runs only where the client
+    is installed, which is the venv the installer ships in, not CI; it is the
+    only check that the subclass survives real tqdm's constructor."""
+    hub_tqdm = pytest.importorskip("huggingface_hub.utils.tqdm")
     installer = load_installer()
-
-    def transfer(bar):
-        raise RuntimeError("xet CAS unreachable")
-
-    tqdm_mod = _fake_hub_with_progress(monkeypatch, transfer)
-    monkeypatch.setattr(installer, "emit_progress", lambda p, s: None)
-
-    dest = tmp_path / "staging" / "upscale-enhance-amd64-gpu.tar.gz"
-    dest.parent.mkdir()
-    assert installer.download_with_hf_hub(
-        "deepsafe/feature-bundles",
-        "v2.0.0/upscale-enhance-amd64-gpu.tar.gz",
-        str(dest),
-        100,
-        2,
-        85,
-    ) is False
-    assert tqdm_mod.tqdm is _RecordingTqdm
-
-
-def test_download_with_hf_hub_still_downloads_when_progress_seam_is_missing(
-    monkeypatch, tmp_path
-):
-    """A drifted venv whose huggingface_hub has no utils.tqdm module must keep
-    downloading (silently, as before), never fail the install over progress."""
-    installer = load_installer()
-    hub = types.ModuleType("huggingface_hub")
-
-    def hf_hub_download(repo_id, filename, repo_type, local_dir):
-        target = os.path.join(local_dir, filename)
-        os.makedirs(os.path.dirname(target), exist_ok=True)
-        with open(target, "wb") as f:
-            f.write(b"archive")
-        return target
-
-    hub.hf_hub_download = hf_hub_download
-    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
-    monkeypatch.delitem(sys.modules, "huggingface_hub.utils", raising=False)
-    monkeypatch.delitem(sys.modules, "huggingface_hub.utils.tqdm", raising=False)
-    monkeypatch.setattr(installer, "emit_progress", lambda p, s: None)
-
-    dest = tmp_path / "staging" / "face-detection-arm64-cpu.tar.gz"
-    dest.parent.mkdir()
-    assert installer.download_with_hf_hub(
-        "deepsafe/feature-bundles",
-        "v2.0.0/face-detection-arm64-cpu.tar.gz",
-        str(dest),
-        7,
-        2,
-        85,
-    ) is True
-    assert dest.read_bytes() == b"archive"
-
-
-def test_download_with_hf_hub_still_downloads_when_tqdm_cannot_be_subclassed(
-    monkeypatch, tmp_path
-):
-    """The seam module exists but its tqdm is not a class (a drifted client
-    that stubs it out): the download must still complete, silently, rather
-    than fall through to the sequential downloader or fail the install."""
-    installer = load_installer()
-    hub = types.ModuleType("huggingface_hub")
-    utils = types.ModuleType("huggingface_hub.utils")
-    tqdm_mod = types.ModuleType("huggingface_hub.utils.tqdm")
-    tqdm_mod.tqdm = 42
-    utils.tqdm = tqdm_mod
-    hub.utils = utils
-
-    def hf_hub_download(repo_id, filename, repo_type, local_dir):
-        target = os.path.join(local_dir, filename)
-        os.makedirs(os.path.dirname(target), exist_ok=True)
-        with open(target, "wb") as f:
-            f.write(b"archive")
-        return target
-
-    hub.hf_hub_download = hf_hub_download
-    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
-    monkeypatch.setitem(sys.modules, "huggingface_hub.utils", utils)
-    monkeypatch.setitem(sys.modules, "huggingface_hub.utils.tqdm", tqdm_mod)
-    monkeypatch.setattr(installer, "emit_progress", lambda p, s: None)
-
-    dest = tmp_path / "staging" / "face-detection-arm64-cpu.tar.gz"
-    dest.parent.mkdir()
-    assert installer.download_with_hf_hub(
-        "deepsafe/feature-bundles",
-        "v2.0.0/face-detection-arm64-cpu.tar.gz",
-        str(dest),
-        7,
-        2,
-        85,
-    ) is True
-    assert dest.read_bytes() == b"archive"
-    assert tqdm_mod.tqdm == 42
+    frames = []
+    reporter = installer.make_download_reporter(100 * 1024 * 1024, 2, 85)
+    installer.emit_progress = lambda p, s: frames.append((p, s))
+    os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
+    try:
+        with installer.hf_download_progress(reporter) as unhooked:
+            assert unhooked is None
+            with hub_tqdm._get_progress_bar_context(
+                desc="bundle.tar.gz", log_level=20, total=100 * 1024 * 1024,
+                initial=0, name="huggingface_hub.xet_get",
+            ) as bar:
+                bar.update(50 * 1024 * 1024)
+                bar.update(50 * 1024 * 1024)
+    finally:
+        os.environ.pop("HF_HUB_DISABLE_PROGRESS_BARS", None)
+    assert [p for p, _ in frames] == [43, 85], frames
+    assert hub_tqdm.tqdm.__name__ == "tqdm", "seam restored to the library class"
 
 
 def test_ensure_hf_hub_noops_when_client_already_importable(monkeypatch, tmp_path):

--- a/tests/unit/features/install-feature-download-progress.test.ts
+++ b/tests/unit/features/install-feature-download-progress.test.ts
@@ -1,0 +1,121 @@
+// Issue #871: the accelerated (huggingface_hub) bundle download emitted one
+// progress frame before the transfer and one after it, so a multi-GB download
+// sat at 2% for its whole duration. The UI extrapolated an ETA of hours from
+// the frozen percent and the install watchdog killed slow-but-live transfers
+// as "no progress for 20 minutes". This drives install_feature.py's
+// download_with_hf_hub under python3 with a fake huggingface_hub that feeds
+// the library's tqdm seam the way xet_get/http_get do, and checks that bytes
+// in flight become moving-percent frames. Lives in vitest (not pytest) so it
+// runs in CI, which has python3 but no pytest.
+
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { hasPython } from "../../helpers/python-gate.js";
+
+const SCRIPT = join(process.cwd(), "packages", "ai", "python", "install_feature.py");
+
+const DRIVER = `
+import importlib.util, json, os, sys, tempfile, types
+
+spec = importlib.util.spec_from_file_location("installer", sys.argv[1])
+installer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(installer)
+
+class RecordingTqdm:
+    def __init__(self, *args, **kwargs):
+        self.n = kwargs.get("initial", 0)
+        self.total = kwargs.get("total")
+        self.disable = kwargs.get("disable", False)
+    def update(self, n=1):
+        if self.disable:
+            return
+        self.n += n
+    def close(self):
+        pass
+
+hub = types.ModuleType("huggingface_hub")
+utils = types.ModuleType("huggingface_hub.utils")
+tqdm_mod = types.ModuleType("huggingface_hub.utils.tqdm")
+tqdm_mod.tqdm = RecordingTqdm
+utils.tqdm = tqdm_mod
+hub.utils = utils
+
+EXPECTED = 512 * 1024 * 1024
+STEP = 32 * 1024 * 1024
+
+def hf_hub_download(repo_id, filename, repo_type, local_dir):
+    bar = tqdm_mod.tqdm(unit="B", unit_scale=True, total=None, initial=0,
+                        desc=filename, disable=True, name="huggingface_hub.xet_get")
+    for _ in range(EXPECTED // STEP):
+        bar.update(STEP)
+    bar.close()
+    target = os.path.join(local_dir, filename)
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    with open(target, "wb") as f:
+        f.write(b"archive")
+    return target
+
+hub.hf_hub_download = hf_hub_download
+sys.modules["huggingface_hub"] = hub
+sys.modules["huggingface_hub.utils"] = utils
+sys.modules["huggingface_hub.utils.tqdm"] = tqdm_mod
+
+frames = []
+installer.emit_progress = lambda p, s: frames.append([p, s])
+
+staging = os.path.join(tempfile.mkdtemp(), "staging")
+os.makedirs(staging)
+dest = os.path.join(staging, "upscale-enhance-amd64-gpu.tar.gz")
+ok = installer.download_with_hf_hub(
+    "deepsafe/feature-bundles", "v2.0.0/upscale-enhance-amd64-gpu.tar.gz",
+    dest, EXPECTED, 2, 85,
+)
+print(json.dumps({
+    "ok": ok,
+    "frames": frames,
+    "seamRestored": tqdm_mod.tqdm is RecordingTqdm,
+    "archive": open(dest, "rb").read().decode(),
+}))
+`;
+
+interface DriverResult {
+  ok: boolean;
+  frames: Array<[number, string]>;
+  seamRestored: boolean;
+  archive: string;
+}
+
+function runDriver(): DriverResult {
+  const res = spawnSync("python3", ["-c", DRIVER, SCRIPT], { encoding: "utf8", timeout: 20000 });
+  if (res.status !== 0) throw new Error(`python3 failed: ${res.stderr}`);
+  return JSON.parse(res.stdout.trim()) as DriverResult;
+}
+
+describe.skipIf(!hasPython)("install_feature.py accelerated download progress (#871)", () => {
+  it("reports bytes as moving-percent frames while the transfer is in flight", () => {
+    const result = runDriver();
+    expect(result.ok).toBe(true);
+    expect(result.archive).toBe("archive");
+
+    const start = result.frames.findIndex(([, stage]) => /accelerated/i.test(stage));
+    const end = result.frames.findIndex(([, stage]) => stage.startsWith("Downloaded"));
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    // Everything between the "starting" and "downloaded" frames is the
+    // transfer itself; before the fix this slice was empty.
+    const inflight = result.frames.slice(start + 1, end);
+    expect(inflight.length).toBeGreaterThanOrEqual(8);
+
+    const percents = inflight.map(([percent]) => percent);
+    expect(percents).toEqual([...percents].sort((a, b) => a - b));
+    expect(Math.min(...percents)).toBeGreaterThanOrEqual(2);
+    expect(Math.max(...percents)).toBeLessThanOrEqual(85);
+    expect(percents[percents.length - 1]).toBeGreaterThanOrEqual(80);
+    for (const [, stage] of inflight) expect(stage).toMatch(/Downloading\.\.\. [0-9.]+ GB/);
+
+    // The seam is scoped to the download: the library's class comes back.
+    expect(result.seamRestored).toBe(true);
+  });
+});

--- a/tests/unit/features/install-feature-download-progress.test.ts
+++ b/tests/unit/features/install-feature-download-progress.test.ts
@@ -2,110 +2,55 @@
 // progress frame before the transfer and one after it, so a multi-GB download
 // sat at 2% for its whole duration. The UI extrapolated an ETA of hours from
 // the frozen percent and the install watchdog killed slow-but-live transfers
-// as "no progress for 20 minutes". This drives install_feature.py's
-// download_with_hf_hub under python3 with a fake huggingface_hub that feeds
-// the library's tqdm seam the way xet_get/http_get do, and checks that bytes
-// in flight become moving-percent frames. Lives in vitest (not pytest) so it
-// runs in CI, which has python3 but no pytest.
+// as "no progress for 20 minutes".
+//
+// The fakes and scenarios live in packages/ai/python/tests/hf_download_scenarios.py
+// and are shared with the pytest file next to it. This spec is the CI gate:
+// the runners have python3 but no pytest, so it spawns each scenario and
+// asserts on the JSON record it prints.
 
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { hasPython } from "../../helpers/python-gate.js";
+import { hasPython, pythonBin } from "../../helpers/python-gate.js";
 
-const SCRIPT = join(process.cwd(), "packages", "ai", "python", "install_feature.py");
+const PYTHON_DIR = join(process.cwd(), "packages", "ai", "python");
+const INSTALLER = join(PYTHON_DIR, "install_feature.py");
+const SCENARIOS = join(PYTHON_DIR, "tests", "hf_download_scenarios.py");
 
-const DRIVER = `
-import importlib.util, json, os, sys, tempfile, types
-
-spec = importlib.util.spec_from_file_location("installer", sys.argv[1])
-installer = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(installer)
-
-class RecordingTqdm:
-    def __init__(self, *args, **kwargs):
-        self.n = kwargs.get("initial", 0)
-        self.total = kwargs.get("total")
-        self.disable = kwargs.get("disable", False)
-    def update(self, n=1):
-        if self.disable:
-            return
-        self.n += n
-    def close(self):
-        pass
-
-hub = types.ModuleType("huggingface_hub")
-utils = types.ModuleType("huggingface_hub.utils")
-tqdm_mod = types.ModuleType("huggingface_hub.utils.tqdm")
-tqdm_mod.tqdm = RecordingTqdm
-utils.tqdm = tqdm_mod
-hub.utils = utils
-
-EXPECTED = 512 * 1024 * 1024
-STEP = 32 * 1024 * 1024
-
-def hf_hub_download(repo_id, filename, repo_type, local_dir):
-    bar = tqdm_mod.tqdm(unit="B", unit_scale=True, total=None, initial=0,
-                        desc=filename, disable=True, name="huggingface_hub.xet_get")
-    for _ in range(EXPECTED // STEP):
-        bar.update(STEP)
-    bar.close()
-    target = os.path.join(local_dir, filename)
-    os.makedirs(os.path.dirname(target), exist_ok=True)
-    with open(target, "wb") as f:
-        f.write(b"archive")
-    return target
-
-hub.hf_hub_download = hf_hub_download
-sys.modules["huggingface_hub"] = hub
-sys.modules["huggingface_hub.utils"] = utils
-sys.modules["huggingface_hub.utils.tqdm"] = tqdm_mod
-
-frames = []
-installer.emit_progress = lambda p, s: frames.append([p, s])
-
-staging = os.path.join(tempfile.mkdtemp(), "staging")
-os.makedirs(staging)
-dest = os.path.join(staging, "upscale-enhance-amd64-gpu.tar.gz")
-ok = installer.download_with_hf_hub(
-    "deepsafe/feature-bundles", "v2.0.0/upscale-enhance-amd64-gpu.tar.gz",
-    dest, EXPECTED, 2, 85,
-)
-print(json.dumps({
-    "ok": ok,
-    "frames": frames,
-    "seamRestored": tqdm_mod.tqdm is RecordingTqdm,
-    "archive": open(dest, "rb").read().decode(),
-}))
-`;
-
-interface DriverResult {
+interface ScenarioResult {
   ok: boolean;
   frames: Array<[number, string]>;
   seamRestored: boolean;
-  archive: string;
+  archive: string | null;
 }
 
-function runDriver(): DriverResult {
-  const res = spawnSync("python3", ["-c", DRIVER, SCRIPT], { encoding: "utf8", timeout: 20000 });
-  if (res.status !== 0) throw new Error(`python3 failed: ${res.stderr}`);
-  return JSON.parse(res.stdout.trim()) as DriverResult;
+function runScenario(name: string): ScenarioResult {
+  const res = spawnSync(pythonBin as string, [SCENARIOS, INSTALLER, name], {
+    encoding: "utf8",
+    timeout: 20000,
+  });
+  if (res.status !== 0) throw new Error(`python3 failed for ${name}: ${res.stderr}`);
+  return JSON.parse(res.stdout.trim()) as ScenarioResult;
+}
+
+/** The frames between the "starting" and "downloaded" frames: the transfer itself. */
+function inFlight(frames: Array<[number, string]>): Array<[number, string]> {
+  const start = frames.findIndex(([, stage]) => /accelerated/i.test(stage));
+  const end = frames.findIndex(([, stage]) => stage.startsWith("Downloaded"));
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return frames.slice(start + 1, end);
 }
 
 describe.skipIf(!hasPython)("install_feature.py accelerated download progress (#871)", () => {
   it("reports bytes as moving-percent frames while the transfer is in flight", () => {
-    const result = runDriver();
+    const result = runScenario("inflight");
     expect(result.ok).toBe(true);
     expect(result.archive).toBe("archive");
 
-    const start = result.frames.findIndex(([, stage]) => /accelerated/i.test(stage));
-    const end = result.frames.findIndex(([, stage]) => stage.startsWith("Downloaded"));
-    expect(start).toBeGreaterThanOrEqual(0);
-    expect(end).toBeGreaterThan(start);
-
-    // Everything between the "starting" and "downloaded" frames is the
-    // transfer itself; before the fix this slice was empty.
-    const inflight = result.frames.slice(start + 1, end);
+    // Before the fix this slice was empty.
+    const inflight = inFlight(result.frames);
     expect(inflight.length).toBeGreaterThanOrEqual(8);
 
     const percents = inflight.map(([percent]) => percent);
@@ -113,9 +58,56 @@ describe.skipIf(!hasPython)("install_feature.py accelerated download progress (#
     expect(Math.min(...percents)).toBeGreaterThanOrEqual(2);
     expect(Math.max(...percents)).toBeLessThanOrEqual(85);
     expect(percents[percents.length - 1]).toBeGreaterThanOrEqual(80);
-    for (const [, stage] of inflight) expect(stage).toMatch(/Downloading\.\.\. [0-9.]+ GB/);
+    for (const [, stage] of inflight) expect(stage).toMatch(/^Downloading\.\.\. [0-9.]+ GB$/);
 
     // The seam is scoped to the download: the library's class comes back.
     expect(result.seamRestored).toBe(true);
   });
+
+  it("throttles frames by bytes so a transfer does not flood the progress store", () => {
+    // 12 x 10 MiB with a frozen clock: only the 1st, 5th and 9th cross 32 MiB.
+    const percents = inFlight(runScenario("throttle").frames).map(([percent]) => percent);
+    expect(percents).toHaveLength(3);
+    expect(percents).toEqual([...percents].sort((a, b) => a - b));
+  });
+
+  it("keeps a slow link alive by time when the byte threshold is never reached", () => {
+    // 1 MiB updates 6 s apart: each one must frame or the watchdog sees a stall.
+    expect(inFlight(runScenario("trickle").frames)).toHaveLength(8);
+  });
+
+  it("counts a resumed transfer from its offset", () => {
+    // http_get hands tqdm initial=resume_size; 96 + 16 of 128 MiB is 87%.
+    expect(inFlight(runScenario("resume").frames).map(([percent]) => percent)).toEqual([74]);
+  });
+
+  it("never frames without bytes, so a dead transfer still reads as stalled", () => {
+    const result = runScenario("no_bytes");
+    expect(result.ok).toBe(true);
+    expect(inFlight(result.frames)).toEqual([]);
+  });
+
+  it("survives a reporter bug without losing the transfer", () => {
+    const result = runScenario("reporter_raises");
+    expect(result.ok).toBe(true);
+    expect(result.archive).toBe("archive");
+  });
+
+  it("restores the seam when the transfer raises", () => {
+    const result = runScenario("raises");
+    expect(result.ok).toBe(false);
+    expect(result.seamRestored).toBe(true);
+  });
+
+  for (const scenario of ["seam_missing", "not_a_class"]) {
+    it(`declines a transfer it cannot watch (${scenario})`, () => {
+      // A silent accelerated transfer is exactly what the watchdog kills, so
+      // a client with no usable seam hands off to the sequential downloader.
+      const result = runScenario(scenario);
+      expect(result.ok).toBe(false);
+      expect(result.archive).toBeNull();
+      expect(result.seamRestored).toBe(true);
+      expect(result.frames.some(([, stage]) => /cannot report progress/.test(stage))).toBe(true);
+    });
+  }
 });

--- a/tests/unit/web/features-store.test.ts
+++ b/tests/unit/web/features-store.test.ts
@@ -811,55 +811,64 @@ describe("useFeaturesStore", () => {
       const clickedAt = 1_000;
       const startedAt = clickedAt + 40 * 60_000;
       const nowSpy = vi.spyOn(Date, "now").mockReturnValue(clickedAt);
-      try {
-        useFeaturesStore.setState({
-          bundles: [makeBundleState({ id: "eta-bundle" })],
-          loaded: true,
-          startTimes: {},
-        });
-        apiPostMock.mockResolvedValueOnce({ jobId: "job-eta", queued: true });
+      useFeaturesStore.setState({
+        bundles: [makeBundleState({ id: "eta-bundle" })],
+        loaded: true,
+        startTimes: {},
+      });
+      apiPostMock.mockResolvedValueOnce({ jobId: "job-eta", queued: true });
 
-        let status: FeatureBundleState["status"] = "queued";
-        apiGetMock.mockImplementation(() =>
-          Promise.resolve({
-            bundles: [
-              makeBundleState({
-                id: "eta-bundle",
-                status,
-                progress: status === "installing" ? { percent: 3, stage: "Downloading..." } : null,
-              }),
-            ],
-          }),
-        );
+      let status: FeatureBundleState["status"] = "queued";
+      let percent = 3;
+      apiGetMock.mockImplementation(() =>
+        Promise.resolve({
+          bundles: [
+            makeBundleState({
+              id: "eta-bundle",
+              status,
+              progress: status === "installing" ? { percent, stage: "Downloading..." } : null,
+            }),
+          ],
+        }),
+      );
 
-        await useFeaturesStore.getState().installBundle("eta-bundle");
-        expect(useFeaturesStore.getState().queued).toContain("eta-bundle");
-        expect(useFeaturesStore.getState().startTimes["eta-bundle"]).toBe(clickedAt);
+      await useFeaturesStore.getState().installBundle("eta-bundle");
+      expect(useFeaturesStore.getState().queued).toContain("eta-bundle");
+      expect(useFeaturesStore.getState().startTimes["eta-bundle"]).toBe(clickedAt);
 
-        // Forty minutes later the queue reaches this bundle; the next poll
-        // moves it queued -> installing and must reset its clock.
-        nowSpy.mockReturnValue(startedAt);
-        status = "installing";
-        await vi.waitFor(
-          () => {
-            expect(useFeaturesStore.getState().installing["eta-bundle"]).toBeDefined();
-          },
-          { timeout: 8000 },
-        );
-        expect(useFeaturesStore.getState().queued).not.toContain("eta-bundle");
-        expect(useFeaturesStore.getState().startTimes["eta-bundle"]).toBe(startedAt);
+      // Forty minutes later the queue reaches this bundle; the next poll
+      // moves it queued -> installing and must reset its clock.
+      nowSpy.mockReturnValue(startedAt);
+      status = "installing";
+      await vi.waitFor(
+        () => {
+          expect(useFeaturesStore.getState().installing["eta-bundle"]).toBeDefined();
+        },
+        { timeout: 8000 },
+      );
+      expect(useFeaturesStore.getState().queued).not.toContain("eta-bundle");
+      expect(useFeaturesStore.getState().startTimes["eta-bundle"]).toBe(startedAt);
 
-        // Let the poll observe the terminal state so it stops.
-        status = "installed";
-        await vi.waitFor(
-          () => {
-            expect(useFeaturesStore.getState().installing["eta-bundle"]).toBeUndefined();
-          },
-          { timeout: 8000 },
-        );
-      } finally {
-        nowSpy.mockRestore();
-      }
-    }, 25000);
+      // Later polls of the same install must leave the clock alone, or the
+      // ETA would read "less than a minute" for the whole install.
+      nowSpy.mockReturnValue(startedAt + 3 * 60_000);
+      percent = 10;
+      await vi.waitFor(
+        () => {
+          expect(useFeaturesStore.getState().installing["eta-bundle"]?.percent).toBe(10);
+        },
+        { timeout: 8000 },
+      );
+      expect(useFeaturesStore.getState().startTimes["eta-bundle"]).toBe(startedAt);
+
+      // Let the poll observe the terminal state so it stops.
+      status = "installed";
+      await vi.waitFor(
+        () => {
+          expect(useFeaturesStore.getState().installing["eta-bundle"]).toBeUndefined();
+        },
+        { timeout: 8000 },
+      );
+    }, 30000);
   });
 });

--- a/tests/unit/web/features-store.test.ts
+++ b/tests/unit/web/features-store.test.ts
@@ -800,4 +800,66 @@ describe("useFeaturesStore", () => {
       expect(useFeaturesStore.getState().bundles).toEqual([makeBundleState({ id: "existing" })]);
     });
   });
+
+  describe("ETA clock for queued installs (#871)", () => {
+    it("restarts the bundle's start time when the server actually begins installing it", async () => {
+      // The ETA in the AI Features panel is a linear extrapolation from
+      // startTimes[bundleId]. A bundle queued behind other installs kept the
+      // time it was clicked, so once it finally started, its first real
+      // percent was divided by the whole queue wait and the ETA read as
+      // hundreds of minutes.
+      const clickedAt = 1_000;
+      const startedAt = clickedAt + 40 * 60_000;
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(clickedAt);
+      try {
+        useFeaturesStore.setState({
+          bundles: [makeBundleState({ id: "eta-bundle" })],
+          loaded: true,
+          startTimes: {},
+        });
+        apiPostMock.mockResolvedValueOnce({ jobId: "job-eta", queued: true });
+
+        let status: FeatureBundleState["status"] = "queued";
+        apiGetMock.mockImplementation(() =>
+          Promise.resolve({
+            bundles: [
+              makeBundleState({
+                id: "eta-bundle",
+                status,
+                progress: status === "installing" ? { percent: 3, stage: "Downloading..." } : null,
+              }),
+            ],
+          }),
+        );
+
+        await useFeaturesStore.getState().installBundle("eta-bundle");
+        expect(useFeaturesStore.getState().queued).toContain("eta-bundle");
+        expect(useFeaturesStore.getState().startTimes["eta-bundle"]).toBe(clickedAt);
+
+        // Forty minutes later the queue reaches this bundle; the next poll
+        // moves it queued -> installing and must reset its clock.
+        nowSpy.mockReturnValue(startedAt);
+        status = "installing";
+        await vi.waitFor(
+          () => {
+            expect(useFeaturesStore.getState().installing["eta-bundle"]).toBeDefined();
+          },
+          { timeout: 8000 },
+        );
+        expect(useFeaturesStore.getState().queued).not.toContain("eta-bundle");
+        expect(useFeaturesStore.getState().startTimes["eta-bundle"]).toBe(startedAt);
+
+        // Let the poll observe the terminal state so it stops.
+        status = "installed";
+        await vi.waitFor(
+          () => {
+            expect(useFeaturesStore.getState().installing["eta-bundle"]).toBeUndefined();
+          },
+          { timeout: 8000 },
+        );
+      } finally {
+        nowSpy.mockRestore();
+      }
+    }, 25000);
+  });
 });


### PR DESCRIPTION
Closes #871

The report, translated from German: "feature download doesn't work, always sits at over 200 minutes despite fast internet." Reproduced on main against the real client. Two causes, both fixed here.

## What broke

`download_with_hf_hub` emitted one progress frame at 2% before calling `hf_hub_download` and one at 85% after it. Nothing in between. A 4.5 GB bundle sat at 2% (5% in the UI, which seeds an optimistic frame) for the whole transfer, and a frozen percent does two things:

- The AI Features panel extrapolates its ETA from percent over elapsed time, so at 5% the estimate is 19x the time spent. After ten and a half minutes it reads "~200 minutes left" and keeps growing.
- The install watchdog counts stderr JSON frames as the only sign of life (`INSTALL_STALL_MS`, 20 minutes by default). A live transfer that takes longer is killed with "Installation made no progress for 20 minutes". That is the "doesn't work" half. inpaint-hq is 6.8 GB on amd64, so anything under roughly 45 Mbit/s of real throughput to the Hub died this way.

Same family as the second report on #505, which fixed the silent verify, extract and move stages and left the download stage alone.

The second cause only shows under Install All: a queued bundle kept its click-time start, so when the queue reached it forty minutes later its first real percent was divided by the whole wait. Hundreds of minutes again, from a different direction.

## What changed

`hf_hub_download` has no progress callback, and polling the staged `.incomplete` file is a dead end: the Xet client assembles the file from its chunk cache, so the file stays at 0 bytes until the transfer ends (measured, below). Both of the client's transports, `xet_get` and `http_get`, build their progress bar through `huggingface_hub.utils.tqdm.tqdm`, resolved on that module at call time, and call `update(bytes)` as data lands. `hf_download_progress` swaps a subclass onto that module for the duration of the download and routes the bytes to `make_download_reporter`, which emits a moving percent every 32 MB, or every 5 s while bytes keep arriving, with the stage text the sequential downloader already uses. The seam is restored in `finally`.

If the seam can't be hooked (a drifted client with no `utils.tqdm`, or one where it isn't a class), the accelerated path is declined with a frame saying so and `download_and_verify` falls through to the sequential downloader, which frames every 4 MB chunk. A silent transfer is the one thing the watchdog cannot tell from a hung one, so it is not a transport we run. A raise inside the reporter stops reporting instead of aborting the transfer.

Frames are only ever emitted for bytes actually received. The liveness contract from `test_install_feature_liveness.py` holds: a dead transfer stops framing and the watchdog still kills it.

On the web side, the poll that moves a bundle from queued to installing now resets its start time. Later polls of the same install leave it alone.

## Verified

Against the real `huggingface-hub==0.36.2` (the pin in `docker/Dockerfile` and `ensure_hf_hub`, same pin in v2.2.0) with `hf_xet`, downloading real archives from `deepsafe/feature-bundles`:

- Xet transport, fully cold cache, transcription arm64 (536 MB): frames at 22, 33, 43, 54, 74 and 85% over 17 s. The client reports per xorb fetch, so roughly every 64 MB.
- HTTP transport (`HF_HUB_DISABLE_XET=1`), face-detection arm64 (81 MB): 12% and 55% mid-transfer.
- The `.incomplete` file under `local_dir/.cache/huggingface/download/` stayed at 0 bytes, size and allocated blocks both, for a 107 s Xet transfer.
- The pytest case that drives the client's real progress-bar factory passes under that venv (28 passed, none skipped).

Each new test was shown to fail on main (revert the fix, run, restore):

- `tests/unit/features/install-feature-download-progress.test.ts` spawns python3 per scenario, since CI runners have python3 but not pytest. Nine scenarios: in-flight frames, byte throttle, time-based trickle, resume offset, no manifest size, transfer raises, no bytes, reporter bug, seam missing, seam not a class. Zero in-flight frames on main, sixteen on the branch.
- `packages/ai/python/tests/test_install_feature_download.py` runs the same scenarios through the shared `hf_download_scenarios.py`, plus the real-client seam test.
- `tests/unit/web/features-store.test.ts`: queued to installing resets the clock, later polls keep it. An always-reset mutant fails it.

Baseline on main (26c00d49): CI run 34582266906 green, and a local `pnpm test` from a clean worktree: 869 files passed, 7 skipped, 0 failed. On the branch (7a71455b):

- `pnpm lint`, forced with 0 cached: green.
- `pnpm typecheck`, forced with 0 cached: green.
- `pnpm test`, VITEST_MAX_FORKS=3, clean worktree, run as `tests/unit` + `tests/integration` + `packages` because a local Docker Desktop watchdog kept restarting Docker mid-suite and taking the testcontainers Postgres with it (paused for the run): 869 files passed, 7 skipped, 1 failed. Tests: 19968 passed, 686 skipped, 1 failed. The one failure is `scim.test.ts` "concurrent duplicate group creates return one 201 and one SCIM 409", the load-dependent flake in #980, #990 and #1000 (loser gets a licence-gate 403). It passed 2/2 in isolation on the branch and 2/2 on main, and the same test was the only red on the first CI attempt of this PR; the rerun of that shard passed (every other required check was green on the first attempt). The other 10 new tests account for the delta from the baseline's 19959.
- Callers of the store (`features-store*`, `zustand-stores`, `feature-install-prompt`, `ai-features-import`, `ocr-korean-settings`, `ocr-quality-control`, `tool-card-pin`, `connection-store`) and of the installer (`install-feature-prebuilt`, `install-watchdog`): green.
- e2e, the two specs that drive the Settings dialog where the store change lands (`gui-settings-expanded`, `gui-settings-general`, chromium-serial): 132 passed. PR CI ran the smoke and mobile-smoke lanes.
- `pnpm test:docker`, twice, neither to a clean finish. First attempt: the in-container vitest run passed 815 files and 19633 tests; its only three failures were in an untracked local `twitter/` scratch dir the build context picked up, and compose aborted before the e2e container started. Second attempt from the clean worktree: the tmpfs-backed test Postgres hit ENOSPC 15 minutes in (8234 tests passed, 0 failed by then), a resource limit of this shared Docker VM rather than the code. The nightly Docker Container E2E job on main is the clean-runner check for this; it gets dispatched after the merge.

No i18n strings touched.

## Review

code-reviewer, silent-failure-hunter and pr-test-analyzer from the pr-review-toolkit ran on the diff. Landed from them: subclass creation moved inside the guard, the seam-less fallback (it was silent; it now declines), the time bound on the throttle, the reporter guard, the keep-clock assertion, and one shared scenario module so the pytest and vitest fakes have one owner. Not taken: a timer heartbeat inside the reporter (it would break the liveness contract), and the two pre-existing double-hyphen stand-ins in the `download_with_resume` comments (out of scope for this issue).

One observation, not acted on: the first Xet transfer of the 81 MB archive on this network took 107 s where plain HTTP took 9.9 s, and later Xet runs took 9 s. Single sample, probably CDN warm-up. Noted in case it turns up in reports.

Follow-up: #1050 covers the ETA reading "less than a minute" after a page reload and during the post-download stages.
