### PR TITLE
fix(web): stop self-hosted instances sending heatmap and dead-click data to PostHog

### DIFF
--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -69,6 +69,15 @@ export async function initAnalytics(config: AnalyticsConfig): Promise<void> {
           api_host: apiHost,
           ...(uiHost ? { ui_host: uiHost } : {}),
           autocapture: false,
+          // Unset, posthog-js obeys the PostHog project's server-side capture
+          // toggles, which stay on for the public sites, so a self-hosted
+          // instance would report every click and dead click (#1022). Set them
+          // explicitly so the client decides: heatmaps and dead clicks off, and
+          // capture_performance limited to web vitals (documented in TELEMETRY.md),
+          // not network timing.
+          capture_heatmaps: false,
+          capture_dead_clicks: false,
+          capture_performance: { web_vitals: true, network_timing: false },
           // Fire $pageview on SPA history changes, not just the initial hard
           // load, so react-router route changes (tool pages, editor, automate,
           // files) are captured. capture_pageleave gives accurate time-on-page.
@@ -89,6 +98,15 @@ export async function initAnalytics(config: AnalyticsConfig): Promise<void> {
               const strip = (u: unknown) => (typeof u === "string" ? u.replace(/[?#].*$/, "") : u);
               props.$current_url = strip(props.$current_url);
               props.$referrer = strip(props.$referrer);
+              // $web_vitals_*_event objects nest their own $current_url, which
+              // skips the top-level strip above, so walk them too (#1022).
+              for (const key of Object.keys(props)) {
+                if (!key.startsWith("$web_vitals_")) continue;
+                const nested = props[key] as Record<string, unknown>;
+                if (nested && typeof nested === "object" && "$current_url" in nested) {
+                  nested.$current_url = strip(nested.$current_url);
+                }
+              }
             }
             return event;
           },

--- a/tests/unit/web/analytics.test.ts
+++ b/tests/unit/web/analytics.test.ts
@@ -287,3 +287,60 @@ describe("analytics lib (baked model)", () => {
     });
   });
 });
+
+describe("privacy invariants (#1022)", () => {
+  it("pins heatmap, dead-click and performance capture so project toggles cannot re-enable them", async () => {
+    await mod.initAnalytics(enabledConfig);
+    expect(mockInit).toHaveBeenCalledWith(
+      "phc_test",
+      expect.objectContaining({
+        capture_heatmaps: false,
+        capture_dead_clicks: false,
+        capture_performance: { web_vitals: true, network_timing: false },
+      }),
+    );
+  });
+
+  it("strips query and fragment from the nested $web_vitals_*_event $current_url", async () => {
+    await mod.initAnalytics(enabledConfig);
+    const [, options] = mockInit.mock.calls[0] as unknown as [
+      string,
+      { before_send: (e: unknown) => { properties: Record<string, unknown> } },
+    ];
+    const result = options.before_send({
+      properties: {
+        $current_url: "https://x.test/login?token=abc#frag",
+        $web_vitals_LCP_event: {
+          $current_url: "https://x.test/login?token=abc#frag",
+          name: "LCP",
+        },
+      },
+    });
+    expect(result.properties.$current_url).toBe("https://x.test/login");
+    expect((result.properties.$web_vitals_LCP_event as { $current_url: string }).$current_url).toBe(
+      "https://x.test/login",
+    );
+  });
+
+  it("strips every $web_vitals event's nested url and tolerates malformed entries", async () => {
+    await mod.initAnalytics(enabledConfig);
+    const [, options] = mockInit.mock.calls[0] as unknown as [
+      string,
+      { before_send: (e: unknown) => { properties: Record<string, unknown> } },
+    ];
+    const result = options.before_send({
+      properties: {
+        $web_vitals_LCP_event: { $current_url: "https://x.test/a?q=1" },
+        $web_vitals_CLS_event: { $current_url: "https://x.test/b#f" },
+        $web_vitals_FCP_event: null,
+        $web_vitals_INP_event: "not-an-object",
+      },
+    });
+    expect((result.properties.$web_vitals_LCP_event as { $current_url: string }).$current_url).toBe(
+      "https://x.test/a",
+    );
+    expect((result.properties.$web_vitals_CLS_event as { $current_url: string }).$current_url).toBe(
+      "https://x.test/b",
+    );
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Stops self-hosted instances from sending heatmap and dead-click data to PostHog, and strips URLs nested in web-vitals events. Fixes #1022.

Fixes #1022

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] I have signed the CLA (the bot will prompt you if not)
- [x] My changes follow the project's code style (Biome passes)
- [x] I have added or updated tests for my changes
- [x] All existing tests pass locally (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] My PR is focused on a single concern (under 400 lines of change)
- [x] I have not modified CI, release, or linter configuration files

## Details

TELEMETRY.md promises autocapture and session replay are off and only web vitals are captured, but `apps/web/src/lib/analytics.ts` set `autocapture: false` and `disable_session_recording: true` without ever setting `capture_heatmaps`, `capture_dead_clicks`, or `capture_performance`. When those are unset posthog-js obeys the PostHog project's server-side toggles, which stay on for the public sites, so every self-hosted instance reported every click (x/y, viewport, `current_url`, session id).

This sets them explicitly: `capture_heatmaps: false`, `capture_dead_clicks: false`, and `capture_performance: { web_vitals: true, network_timing: false }` so web vitals stay on (as documented) while heatmaps, dead clicks, and network timing do not. It also extends `before_send` to strip the query and fragment from the `$current_url` nested inside `$web_vitals_*_event` objects, which the existing top-level strip missed.

I scoped the nested strip to `$web_vitals_*` per the issue rather than recursively walking every event, to avoid mutating unrelated event structures. Happy to broaden it if you would prefer that.

Tests: two cases in `tests/unit/web/analytics.test.ts`, one asserting the pinned init options and one asserting the nested `$web_vitals` URL is stripped (including multiple and malformed entries). Both fail if the init change is reverted.

This change was prepared with AI assistance and reviewed by a human before submission.
