### PR TITLE
fix(api): validate TRUST_PROXY list at env-parse time instead of crashing Fastify (#999)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
     "@fastify/cors": "^11.3.0",
     "@fastify/http-proxy": "^11.6.0",
     "@fastify/multipart": "^9.0.0",
+    "@fastify/proxy-addr": "^5.0.0",
     "@fastify/rate-limit": "^10.2.0",
     "@fastify/static": "^10.1.2",
     "@neplex/vectorizer": "^0.1.0",

--- a/apps/api/src/lib/trust-proxy.ts
+++ b/apps/api/src/lib/trust-proxy.ts
@@ -9,6 +9,8 @@
  * pin this behaviour without booting the server.
  */
 
+import proxyAddr from "@fastify/proxy-addr";
+
 /**
  * The shipped TRUST_PROXY default: believe `X-Forwarded-For` only from a peer
  * on a private network.
@@ -40,7 +42,8 @@ export const DEFAULT_TRUST_PROXY = "loopback,linklocal,uniquelocal";
  * Two forms, both of which proxy-addr understands:
  *   "true" / "false" -> trust every peer / trust none
  *   anything else    -> a comma-separated list of CIDRs or named ranges
- *                       ("loopback", "linklocal", "uniquelocal")
+ *                       ("loopback", "linklocal", "uniquelocal"), validated
+ *                       here against proxy-addr before it is returned
  *
  * A hop count (a bare number) used to be a third form. fastify 5.12.1
  * (GHSA-3m5p-2c4r-xxw2) stopped honouring it: a hop count cannot validate the
@@ -69,5 +72,22 @@ export function parseTrustProxy(value: string): boolean | string {
         "address.",
     );
   }
-  return value; // CIDR list
+  // Validate the list against the exact parser Fastify will use, so a value
+  // that is neither a boolean nor a valid list fails here, at env-parse time,
+  // instead of throwing a bare `TypeError: invalid IP address: <x>` out of
+  // Fastify() after migrations and Redis are already up (that stack trace names
+  // neither TRUST_PROXY nor a fix, and s6 restarts the API into it forever).
+  // Fastify splits the string on commas and trims each token before compiling
+  // (fastify/lib/request.js getTrustProxyFn), so mirror that split exactly.
+  try {
+    proxyAddr.compile(value.split(",").map((token) => token.trim()));
+  } catch {
+    throw new Error(
+      `TRUST_PROXY=${value}: not a recognized trust value. Use "false" when ` +
+        "nothing proxies this instance, a comma-separated list of CIDRs or named " +
+        `ranges such as "${DEFAULT_TRUST_PROXY}" to name the proxies, or "true" ` +
+        "only when a proxy you control sits in front on a public address.",
+    );
+  }
+  return value; // validated CIDR / named-range list
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       '@fastify/multipart':
         specifier: ^9.0.0
         version: 9.4.0
+      '@fastify/proxy-addr':
+        specifier: ^5.0.0
+        version: 5.1.0
       '@fastify/rate-limit':
         specifier: ^10.2.0
         version: 10.3.0

--- a/tests/unit/security/trust-proxy-resolution.test.ts
+++ b/tests/unit/security/trust-proxy-resolution.test.ts
@@ -58,6 +58,33 @@ describe("parseTrustProxy", () => {
     expect(parseTrustProxy("")).toBe(false);
     expect(parseTrustProxy("   ")).toBe(false);
   });
+
+  it("rejects a malformed list at parse time instead of crashing Fastify (#999)", () => {
+    // A value that is neither a boolean nor a valid proxy-addr list used to be
+    // returned untouched and then threw a bare `TypeError: invalid IP address:
+    // <x>` out of Fastify() after migrations and Redis were already up, naming
+    // neither TRUST_PROXY nor a fix. These are the shapes from the report: a
+    // boolean typo, a boolean with a trailing space (common from a hand-edited
+    // .env), a trailing comma, a semicolon used as a separator, and a range
+    // proxy-addr refuses.
+    for (const value of [
+      "TRUE",
+      "yes",
+      "true ",
+      "10.0.0.0/8,",
+      "10.0.0.0/8;192.168.0.0/16",
+      "0.0.0.0/0",
+    ]) {
+      const attempt = () => parseTrustProxy(value);
+      expect(attempt, value).toThrow(`TRUST_PROXY=${value}:`);
+      // The same three replacement forms the hop-count message offers.
+      expect(attempt, value).toThrow(/"false"/);
+      expect(attempt, value).toThrow(/loopback,linklocal,uniquelocal/);
+      expect(attempt, value).toThrow(/"true"/);
+      // The bare proxy-addr TypeError text never reaches the operator.
+      expect(attempt, value).not.toThrow(/invalid IP address/);
+    }
+  });
 });
 
 /**
@@ -159,5 +186,16 @@ describe("the old default is what made request.ip client-controlled", () => {
     const ip = await resolveIp(2 as never, "172.18.0.1", FORGED);
     expect(ip).toBe("172.18.0.1");
     expect(ip).not.toBe(FORGED);
+  });
+
+  it("fastify itself crashes on a malformed trustProxy, which is why parseTrustProxy rejects it (#999)", () => {
+    // Pins the mechanism the parse-time guard exists for: each value the parser
+    // now rejects would, passed straight to Fastify the way it used to be,
+    // throw at construction (Request.buildRequest compiles trustProxy eagerly).
+    // If a future proxy-addr stops rejecting one of these, this breaks and the
+    // guard would silently start accepting it.
+    for (const value of ["TRUE", "true ", "10.0.0.0/8,", "0.0.0.0/0"]) {
+      expect(() => Fastify({ trustProxy: value }), value).toThrow();
+    }
   });
 });


### PR DESCRIPTION
## What does this PR do?

Makes a malformed `TRUST_PROXY` fail at env-parse time with an actionable message, instead of crashing inside `Fastify()` with a bare proxy-addr `TypeError`. Fixes #999.

Fixes #999

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] I have signed the CLA (the bot will prompt you if not)
- [x] My changes follow the project's code style (Biome passes)
- [x] I have added or updated tests for my changes
- [x] All existing tests pass locally (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] My PR is focused on a single concern (under 400 lines of change)
- [x] I have not modified CI, release, or linter configuration files

## Details

`parseTrustProxy` handles `true`, `false`, blank, and the rejected hop-count form, then its final `return value; // CIDR list` branch returned any other string untouched. A value that is neither a boolean nor a valid proxy-addr list (a boolean typo like `TRUE`, `true ` with a trailing space, `10.0.0.0/8,` with a trailing comma, `10.0.0.0/8;192.168.0.0/16` with a semicolon, or a range proxy-addr refuses like `0.0.0.0/0`) therefore reached `Fastify()`. Fastify builds the trustProxy predicate eagerly at construction (`getTrustProxyFn` splits on commas, trims each token, and calls `@fastify/proxy-addr` `compile`), so compile throws `TypeError: invalid IP address: <x>` there. Because `index.ts` constructs Fastify only after migrations, the Redis wait, the SQLite boot and OCR reconciliation, the throw surfaces late as a bare stack trace that names neither `TRUST_PROXY` nor a fix, and in the all-in-one image s6 restarts the API into it forever.

`env.ts` already calls `parseTrustProxy` from a zod `superRefine` (added in #835 for the hop-count case), so a check placed in the CIDR-list branch lands at env-parse time for free. This validates that branch with the same `@fastify/proxy-addr` `compile` Fastify will use, applying Fastify's exact `split(",").map(trim)` first, then throws a message naming `TRUST_PROXY=<value>` and listing the accepted forms, matching the hop-count message. Validating by hand would misjudge shorthands proxy-addr accepts (for example `127.1`), so it reuses proxy-addr rather than reinventing it.

`@fastify/proxy-addr` is added as a direct dependency at `^5.0.0`, which is Fastify's own range, so pnpm dedupes to the single already-installed instance (5.1.0) rather than pulling a second copy. It was previously only transitive via fastify; parse-time validation needs `compile` directly.

I kept this to the crash. The issue notes two low-priority misclassifications in the same function (`127.1` and `2130706433` hit the hop-count message because `Number()` parses them, and `2,10.0.0.0/8` sails past the `Number()` guard so proxy-addr trusts `0.0.0.2` next to `10/8`). Both are unchanged by this PR: the first two are caught by the pre-existing `Number()` guard before the new check runs, and `2,10.0.0.0/8` still compiles in proxy-addr so it passes through exactly as before. Happy to follow up on those separately if you would like.

Tests: two in `tests/unit/security/trust-proxy-resolution.test.ts`. One asserts each malformed value throws the actionable `TRUST_PROXY=<value>` message with the three accepted forms and never leaks the bare `invalid IP address` text; it fails if the fix is reverted. The other pins that `Fastify()` itself throws at construction on those same values, so the reproduction stays honest if a future proxy-addr changes what it rejects.

This change was prepared with AI assistance and reviewed by a human before submission.
