### PR TITLE
fix(api): log the caught error when an audit write or HMAC step fails (#1012)

### DIFF
--- a/apps/api/src/lib/audit.ts
+++ b/apps/api/src/lib/audit.ts
@@ -71,8 +71,8 @@ export async function auditLog(
       ipAddress: ip,
       requestId,
     });
-  } catch {
-    logger.warn({ event }, "Failed to write audit log to DB");
+  } catch (err) {
+    logger.warn({ err, event }, "Failed to write audit log to DB");
     return;
   }
 
@@ -100,8 +100,8 @@ export async function auditLog(
         const integrity = computeHmac(rowData, hmacKey);
         await db.update(schema.auditLog).set({ integrity }).where(eq(schema.auditLog.id, id));
       }
-    } catch {
-      logger.warn({ event }, "Failed to compute audit HMAC");
+    } catch (err) {
+      logger.warn({ err, event }, "Failed to compute audit HMAC");
     }
   }
 }

--- a/tests/unit/api/audit-mutation.test.ts
+++ b/tests/unit/api/audit-mutation.test.ts
@@ -365,7 +365,11 @@ describe("auditLog failure handling", () => {
       auditLog(logger as never, "SETTINGS_UPDATED", { userId: "u1" }),
     ).resolves.toBeUndefined();
     expect(logger.warn).toHaveBeenCalledTimes(1);
-    expect(logger.warn.mock.calls[0][0]).toEqual({ event: "SETTINGS_UPDATED" });
+    // #1012: the caught error rides along under `err` (nothing else leaks in).
+    expect(logger.warn.mock.calls[0][0]).toEqual({
+      event: "SETTINGS_UPDATED",
+      err: expect.any(Error),
+    });
   });
 
   it("does not attempt the HMAC branch after an insert failure", async () => {
@@ -437,7 +441,11 @@ describe("auditLog tamper-resistant integrity", () => {
         auditLog(logger as never, "USER_CREATED", { userId: "u1" }),
       ).resolves.toBeUndefined();
       expect(logger.warn).toHaveBeenCalledTimes(1);
-      expect(logger.warn.mock.calls[0][0]).toEqual({ event: "USER_CREATED" });
+      // #1012: the caught error rides along under `err` (nothing else leaks in).
+      expect(logger.warn.mock.calls[0][0]).toEqual({
+        event: "USER_CREATED",
+        err: expect.any(Error),
+      });
     } finally {
       (dbModule.db as { update: unknown }).update = original;
     }


### PR DESCRIPTION
## What does this PR do?

Attaches the caught error to the warning when an audit write fails, so a failure can be diagnosed from the log instead of only naming the event. Fixes #1012.

Fixes #1012

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] I have signed the CLA (the bot will prompt you if not)
- [x] My changes follow the project's code style (Biome passes)
- [x] I have added or updated tests for my changes
- [x] All existing tests pass locally (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] My PR is focused on a single concern (under 400 lines of change)
- [x] I have not modified CI, release, or linter configuration files

## Details

`auditLog` in `apps/api/src/lib/audit.ts` caught both of its failure paths with a bare `catch {}` and warned with only `{ event }`:

- the DB insert into `audit_log`
- the tamper-resistant HMAC step (settings read, HMAC compute, integrity update)

The error object was dropped, so when rows go missing from `audit_log` the operator gets `{ event: "LOGIN_FAILED" } Failed to write audit log to DB` with no Postgres code, no constraint, and no message: a full disk, a permissions change, and an HMAC key problem all look identical.

This changes both catches to `catch (err)` and adds `err` to the pino context, which is the `{ err, ... }` shape already used elsewhere in the API (for example `enterprise-feature.ts`), so pino's default `err` serializer renders type, message, stack, and enumerable fields like pg's SQLSTATE `code`. It is the fix sketched in the issue.

Control flow is unchanged. The dual-write design stays (stdout line first, DB row second), the insert catch still returns and the HMAC catch still continues, so the request never fails because auditing failed. The only change is that the warning now carries the error.

Tests: `tests/unit/api/audit-mutation.test.ts` already drove both catches ("logs a warning and returns without throwing when the insert fails" and "warns but does not throw when the HMAC update fails") and pinned the warn payload as exactly `{ event }`. Both now expect `{ event, err: expect.any(Error) }`, which keeps the exact-keys guarantee (nothing else leaks in) while asserting the error rides along. Both fail against the pre-fix `catch {}`.

This change was prepared with AI assistance and reviewed by a human before submission.
