### PR TITLE
docs: list the current sponsors in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ If SnapOtter has replaced a paid subscription or two in your workflow, a small s
 </a>
 
 <!-- sponsors -->
+<p align="center">
+  <a href="https://github.com/dominic427"><img src="https://github.com/dominic427.png?size=72" width="72" height="72" alt="Dominic Lopez"></a>
+  <a href="https://github.com/highb"><img src="https://github.com/highb.png?size=72" width="72" height="72" alt="Brandon High"></a>
+  <a href="https://github.com/CSP-Tom"><img src="https://github.com/CSP-Tom.png?size=72" width="72" height="72" alt="Tom"></a>
+</p>
+
+<p align="center">
+  Backed by <a href="https://github.com/dominic427">@dominic427</a>, <a href="https://github.com/highb">@highb</a>, <a href="https://github.com/CSP-Tom">@CSP-Tom</a>. Thank you.
+</p>
 <!-- sponsors -->
 
 <p align="center">


### PR DESCRIPTION
The `<!-- sponsors -->` block in the README has been empty since e316dff2. Nothing populates it, and the $15/month sponsor tier promises "Your name listed in the SnapOtter README as a backer," so @dominic427 has been owed a listing since subscribing on 11 Sep.

This fills the block by hand with the three current sponsors: @dominic427 ($15/month), @highb ($5/month), and @CSP-Tom (one-time). Avatars link to their profiles, and the line underneath names them in text, since the promise is a name rather than a picture.

Verified all three avatar URLs return 200 (`https://github.com/<login>.png?size=72`). Markdown only, so no tests are affected.

Follow-ups filed: #1076 to keep the list current without hand edits, #1075 for the logo placement the $150 and $500 tiers promise, #1077 for the perks that need setting up rather than code.
