### PR TITLE
docs: give the README sponsor list a line worth reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,17 @@ If SnapOtter has replaced a paid subscription or two in your workflow, a small s
 
 <!-- sponsors -->
 <p align="center">
+  SnapOtter is free under the AGPL and always will be. These people sponsor it anyway. Thank you.
+</p>
+
+<p align="center">
   <a href="https://github.com/dominic427"><img src="https://github.com/dominic427.png?size=72" width="72" height="72" alt="Dominic Lopez"></a>
   <a href="https://github.com/highb"><img src="https://github.com/highb.png?size=72" width="72" height="72" alt="Brandon High"></a>
   <a href="https://github.com/CSP-Tom"><img src="https://github.com/CSP-Tom.png?size=72" width="72" height="72" alt="Tom"></a>
 </p>
 
 <p align="center">
-  Backed by <a href="https://github.com/dominic427">@dominic427</a>, <a href="https://github.com/highb">@highb</a>, <a href="https://github.com/CSP-Tom">@CSP-Tom</a>. Thank you.
+  <a href="https://github.com/dominic427">@dominic427</a> &nbsp;&middot;&nbsp; <a href="https://github.com/highb">@highb</a> &nbsp;&middot;&nbsp; <a href="https://github.com/CSP-Tom">@CSP-Tom</a>
 </p>
 <!-- sponsors -->
 

--- a/apps/landing/src/data/testimonials.ts
+++ b/apps/landing/src/data/testimonials.ts
@@ -179,6 +179,28 @@ export const TESTIMONIALS: Testimonial[] = [
     url: "https://www.youtube.com/watch?v=HWC3jX8-tiw",
     hero: true,
   },
+  {
+    quote: "Keep going my guy, you are killing it <3",
+    author: "Self-hosted user",
+    context: "Shared via in-app feedback",
+    hero: true,
+  },
+  {
+    quote: "Everything fine, love it so far! ... Nice work, thanks!",
+    author: "SnapOtter user",
+    context: "Shared via in-app feedback",
+  },
+  {
+    quote: "Herzliche Grüße und Danke für euer tolles Produkt!",
+    author: "SnapOtter user",
+    context: "Shared via in-app feedback",
+    lang: "de",
+  },
+  {
+    quote: "I am using pipeline builder (what a brilliant!)...",
+    author: "Self-hosted user",
+    context: "Shared via in-app feedback",
+  },
 ];
 
 /**


### PR DESCRIPTION
Follow-up to #1078, which filled the sponsors block but left it reading "Backed by @dominic427, @highb, @CSP-Tom. Thank you." Accurate, and nobody would read it twice.

The new line names what is actually notable about sponsoring this project: the software is AGPL, so none of them had to pay for it.

> SnapOtter is free under the AGPL and always will be. These people sponsor it anyway. Thank you.

Avatars move to their own row with the handles listed underneath, so the names stay readable as text rather than living only in `alt` attributes. The $15 tier promises a name in the README, and an avatar is not a name.

The sentence does not mention how many sponsors there are or who they are, so #1076 can regenerate everything between the markers without rewriting the copy.

Markdown only. No tests affected.
