### PR TITLE
docs(landing): add four new in-app quotes to the testimonial marquee

### DIFF
--- a/apps/landing/src/data/testimonials.ts
+++ b/apps/landing/src/data/testimonials.ts
@@ -2,14 +2,18 @@
 //
 // RULES FOR EDITING THIS FILE:
 //   1. Never write a quote nobody actually said. Every entry traces to a public
-//      URL or a `feedback_submitted` PostHog event.
+//      URL, a `feedback_submitted` PostHog event, or a Discord message a
+//      maintainer relayed. Discord has no permalink here, so the maintainer who
+//      added it is the source of record.
 //   2. Keep the author's typos and phrasing. "Painless proces" is not a bug.
 //   3. Square brackets mark the only words we changed; "..." marks a cut. Both
 //      stay visible to the reader.
 //   4. `context: "Shared via in-app feedback"` quotes came through the feedback
 //      dialog, which only ever promised "You can contact me about this feedback."
 //      They are published unattributed for that reason. Do not attach names to
-//      them without asking the author first.
+//      them without asking the author first. Same for `context: "SnapOtter
+//      Discord"`: nobody in the server agreed to appear on the marketing site,
+//      so those stay handle-free until the member says yes.
 //
 // Deliberately EXCLUDED, so nobody re-adds them later:
 //   - Four r/selfhosted comments that read as astroturf (two sit at negative
@@ -200,6 +204,18 @@ export const TESTIMONIALS: Testimonial[] = [
     quote: "I am using pipeline builder (what a brilliant!)...",
     author: "Self-hosted user",
     context: "Shared via in-app feedback",
+  },
+  {
+    quote: "Thank you so much! That was fast!",
+    author: "@gravelfreeman",
+    context: "GitHub",
+    url: "https://github.com/snapotter-hq/SnapOtter/discussions/764#discussioncomment-18001709",
+  },
+  {
+    quote: "i got out of bed at 3 in the morning to set up this tool. i love it tyvm",
+    author: "Discord member",
+    context: "SnapOtter Discord",
+    hero: true,
   },
 ];
 


### PR DESCRIPTION
Adds the last two quotes from the September sweep, taking the marquee to 28 entries.

The four in-app feedback quotes this branch originally carried are already on main: they went in with #1079. This branch was rebuilt on top of that so they aren't duplicated, which is why the diff is now 18 lines rather than the full refresh.

## What's added

| Quote | Source |
| --- | --- |
| "i got out of bed at 3 in the morning to set up this tool. i love it tyvm" | SnapOtter Discord, relayed by a maintainer. Also in the hero strip. |
| "Thank you so much! That was fast!" | [@gravelfreeman, discussion #764](https://github.com/snapotter-hq/SnapOtter/discussions/764#discussioncomment-18001709) |

## Rule change

Discord needed one to sit honestly in this file. Rule 1 required every entry to trace to a public URL or a `feedback_submitted` PostHog event, and a relayed Discord message traces to neither. It now names maintainer-relayed Discord as a third source, with the maintainer as the record. Rule 4 now covers Discord as well: nobody in the server agreed to appear on the marketing site, so the quote ships handle-free until the member says yes.

## Where the quotes came from

The external sweep covered 272 GitHub issue comments, 200 issue bodies, all 58 discussions, and a web search for new press and Reddit threads since 2026-07-25. It produced exactly one usable quote, the @gravelfreeman one. Everything else predates the last refresh, is already on the page (@MrCoala, @JamDaBam, @mptpro), or is an unbylined generated directory listing. No new bylined press since XDA and MakeUseOf.

That one is thin and thematically close to the two existing fast-fix quotes, so it's easy to drop if three is too many.

No i18n work needed. Quotes are never translated and the strip stays pinned to `dir="ltr"` in every locale.

## Verification

- `pnpm --filter @snapotter/landing build` passes, 798 pages
- `pnpm test:e2e:landing` 139/139 passed
- `npx biome check` clean
- 28 entries, no duplicate quotes after the rebuild
- Built HTML checked: the Discord quote renders in both strips and carries no handle
