### PR TITLE
docs: use the standard phrasing for the README sponsor line

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If SnapOtter has replaced a paid subscription or two in your workflow, a small s
 
 <!-- sponsors -->
 <p align="center">
-  SnapOtter is free under the AGPL and always will be. These people sponsor it anyway. Thank you.
+  SnapOtter is free and open source, made possible by the people below.
 </p>
 
 <p align="center">


### PR DESCRIPTION
Third pass on the sponsors block, after #1078 filled it and #1079 rewrote it.

The line is now the phrasing Vite and Astro both use:

> SnapOtter is free and open source, made possible by the people below.

The previous version leaned on the AGPL to find an angle. This one does not need an angle; a reader parses it without stopping.

One note for whoever touches this next: the paragraph opening the section already says "no venture capital or corporate backing" and "stays free and open for everyone," so "free and open source" now appears twice within a few lines. Trimming the intro is a separate call and not made here.

Markdown only. No tests affected.
