### PR TITLE
fix(media): fall back to software when ffmpeg lacks the requested hardware encoder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,11 @@ LIBREOFFICE_TIMEOUT_S=120
 # QPDF_PATH=
 # SOFFICE_PATH=
 # PDFCPU_PATH=
-# SNAPOTTER_HW_ACCEL=  # nvenc|vaapi: hardware encoder family (default software)
+# SNAPOTTER_HW_ACCEL=  # nvenc|vaapi: hardware encoder family (default software).
+                       # Needs an ffmpeg built with that family. The image ships
+                       # a static ffmpeg that has neither, so this falls back to
+                       # software there and says so at startup. Point FFMPEG_PATH
+                       # at your own build to use it.
 
 # Runtime fallback downloads for AI model files, off by default. Bundle installs
 # are unaffected: they verify a pinned sha256 either way. Set 1 to let a tool

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -27,6 +27,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { context, propagation, ROOT_CONTEXT, SpanStatusCode, trace } from "@opentelemetry/api";
+import { HW_ACCEL_FAMILIES, hwAccelStatus } from "@snapotter/media-engine";
 import {
   ANALYTICS_EVENTS,
   extractErrorCode,
@@ -1705,6 +1706,55 @@ export function startWorkers(): void {
 
   logger.info(
     `Workers started: ${POOLS.map((p) => `${p}(${p === "system" || p === "ai" ? 1 : concurrency})`).join(", ")}`,
+  );
+  logHwAccel();
+}
+
+/**
+ * Say what SNAPOTTER_HW_ACCEL actually does on this host. Without it a wrong
+ * value is invisible: encoding silently stays on software and the only symptom
+ * is that nothing got faster (#1054).
+ *
+ * Deliberately says "listed by" rather than "enabled": the probe reads
+ * `ffmpeg -encoders`, which proves the encoder was compiled in, not that it
+ * can run. A general-purpose ffmpeg lists h264_nvenc with or without an
+ * NVIDIA device present (#1089).
+ */
+function logHwAccel(): void {
+  const status = hwAccelStatus();
+  if (!status.requested) return;
+
+  const softwareNote =
+    status.unmapped.length > 0 ? `; ${status.unmapped.join(", ")} always use software` : "";
+
+  if (!status.recognized) {
+    logger.warn(
+      { requested: status.requested, supported: HW_ACCEL_FAMILIES },
+      `SNAPOTTER_HW_ACCEL="${status.requested}" is not a recognised encoder family (${HW_ACCEL_FAMILIES.join(", ")}); using software encoders`,
+    );
+    return;
+  }
+
+  if (status.active.length === 0) {
+    const why = status.probeError ?? "this ffmpeg build lists none of them";
+    logger.warn(
+      { requested: status.requested, missing: status.missing, probeError: status.probeError },
+      `SNAPOTTER_HW_ACCEL="${status.requested}" was requested but ${why}; using software encoders`,
+    );
+    return;
+  }
+
+  if (status.missing.length > 0) {
+    logger.warn(
+      { requested: status.requested, active: status.active, missing: status.missing },
+      `SNAPOTTER_HW_ACCEL="${status.requested}" is partly available; ${status.missing.join(", ")} fall back to software${softwareNote}`,
+    );
+    return;
+  }
+
+  logger.info(
+    { requested: status.requested, active: status.active, unmapped: status.unmapped },
+    `Hardware encoders listed by this ffmpeg build: ${status.active.join(", ")}${softwareNote}`,
   );
 }
 

--- a/packages/media-engine/src/encoders.ts
+++ b/packages/media-engine/src/encoders.ts
@@ -1,3 +1,6 @@
+import { spawnSync } from "node:child_process";
+import { resolveFfmpeg } from "./binaries.js";
+
 export type EncoderTarget = "h264" | "hevc" | "av1" | "vp9" | "aac" | "opus" | "mp3";
 
 const SOFTWARE: Record<EncoderTarget, string> = {
@@ -21,14 +24,189 @@ const VAAPI: Partial<Record<EncoderTarget, string>> = {
   hevc: "hevc_vaapi",
 };
 
+const FAMILIES: Record<string, Partial<Record<EncoderTarget, string>>> = {
+  nvenc: NVENC,
+  vaapi: VAAPI,
+};
+
+/** The values SNAPOTTER_HW_ACCEL accepts. Single source for docs and logs. */
+export const HW_ACCEL_FAMILIES = Object.keys(FAMILIES);
+
+const ALL_TARGETS: EncoderTarget[] = ["h264", "hevc", "av1", "vp9", "aac", "opus", "mp3"];
+
 /**
- * Hardware-acceleration seam (spec 4.5): SNAPOTTER_HW_ACCEL selects an
- * encoder family; a CUDA/NVENC deployment is a Dockerfile change, not a
- * code change. Unknown values fall back to software.
+ * The configured family map, or undefined.
+ *
+ * `Object.hasOwn` rather than a bare index: FAMILIES is an object literal, so
+ * `FAMILIES["constructor"]` and `FAMILIES["__proto__"]` are truthy inherited
+ * values. Without the guard, SNAPOTTER_HW_ACCEL=constructor reports as a
+ * recognised family and the admin gets told their ffmpeg is deficient rather
+ * than that they have a typo.
+ */
+function requestedFamily(): {
+  name: string | null;
+  map: Partial<Record<EncoderTarget, string>> | undefined;
+} {
+  const accel = (process.env.SNAPOTTER_HW_ACCEL ?? "").toLowerCase();
+  if (!accel) return { name: null, map: undefined };
+  return { name: accel, map: Object.hasOwn(FAMILIES, accel) ? FAMILIES[accel] : undefined };
+}
+
+/**
+ * A row of the `ffmpeg -encoders` table: one leading space, six flag columns,
+ * then the encoder name.
+ *
+ *     V....D libx264              libx264 H.264 / AVC ...
+ *
+ * The legend printed above the table has the same flag shape:
+ *
+ *     V..... = Video
+ *
+ * so matching on flags alone records "=" as an encoder. Requiring the name to
+ * start alphanumeric rejects the legend without depending on the ` ------ `
+ * separator, which is not guaranteed across builds.
+ *
+ * Fails safe: a future ffmpeg that adds a seventh flag column matches nothing,
+ * which reads as "inventory unavailable" and sends callers to software.
+ */
+const ENCODER_ROW = /^\s[VAS][.A-Z]{5}\s+([A-Za-z0-9][\w.-]*)\s/;
+
+const PROBE_TIMEOUT_MS = 10_000;
+const PROBE_MAX_BUFFER = 4 * 1024 * 1024;
+
+/** Encoder names listed by `ffmpeg -encoders`. */
+export function parseEncoderNames(stdout: string): Set<string> {
+  const names = new Set<string>();
+  for (const line of stdout.split("\n")) {
+    const match = ENCODER_ROW.exec(line);
+    if (match) names.add(match[1]);
+  }
+  return names;
+}
+
+interface Probe {
+  /** Null when the list could not be read; callers treat that as "absent". */
+  names: ReadonlySet<string> | null;
+  /** Why it could not be read. Null on success. */
+  error: string | null;
+}
+
+let probe: Probe | undefined;
+
+function runProbe(): Probe {
+  const bin = resolveFfmpeg();
+  if (!bin) return { names: null, error: "no ffmpeg binary found (set FFMPEG_PATH)" };
+
+  const res = spawnSync(bin, ["-hide_banner", "-encoders"], {
+    encoding: "utf8",
+    timeout: PROBE_TIMEOUT_MS,
+    maxBuffer: PROBE_MAX_BUFFER,
+  });
+  // Distinguish the failure modes: a missing path, a non-executable binary, a
+  // timeout and a crash all need different fixes from the admin, and a bare
+  // "could not read" sends them looking in the wrong place.
+  if (res.error) return { names: null, error: `${bin}: ${res.error.message}` };
+  if (res.status !== 0) {
+    const detail = (res.stderr ?? "").trim().slice(-200);
+    const how = res.status === null ? `signal ${res.signal ?? "unknown"}` : `code ${res.status}`;
+    return { names: null, error: `${bin} -encoders exited ${how}${detail ? `: ${detail}` : ""}` };
+  }
+  const names = parseEncoderNames(res.stdout ?? "");
+  return names.size > 0
+    ? { names, error: null }
+    : { names: null, error: `${bin} -encoders printed no recognisable encoder rows` };
+}
+
+/**
+ * Cached for the process. A failed probe is cached too: retrying a 10s
+ * blocking spawn on every call would turn a slow boot into a slow every-job.
+ * The cost is that a transient failure pins the process to software until it
+ * restarts, which the startup warning reports.
+ */
+function encoderProbe(): Probe {
+  if (probe === undefined) probe = runProbe();
+  return probe;
+}
+
+/** Pin the inventory instead of probing. `undefined` restores real probing. */
+export function setEncoderInventoryForTests(names: ReadonlySet<string> | null | undefined): void {
+  probe = names === undefined ? undefined : { names, error: names ? null : "pinned by test" };
+}
+
+/**
+ * Hardware-acceleration seam (spec 4.5): SNAPOTTER_HW_ACCEL selects an encoder
+ * family. Unknown values, and families this ffmpeg build cannot actually run,
+ * fall back to software.
+ *
+ * The availability check is not belt-and-braces. The published image's static
+ * ffmpeg ships QSV and v4l2m2m only, with no NVENC or VAAPI on either arch or
+ * inside the CUDA image, so a documented `SNAPOTTER_HW_ACCEL=nvenc` used to
+ * resolve to `h264_nvenc` and kill every re-encoding job with
+ * `Unknown encoder 'h264_nvenc'` (#1054).
  */
 export function resolveEncoder(target: EncoderTarget): string {
-  const accel = (process.env.SNAPOTTER_HW_ACCEL ?? "").toLowerCase();
-  if (accel === "nvenc") return NVENC[target] ?? SOFTWARE[target];
-  if (accel === "vaapi") return VAAPI[target] ?? SOFTWARE[target];
-  return SOFTWARE[target];
+  const hardware = requestedFamily().map?.[target];
+  // No accel configured, unrecognised family, or no hardware encoder for this
+  // target. Returning here keeps the default path free of a probe spawn.
+  if (!hardware) return SOFTWARE[target];
+  return encoderProbe().names?.has(hardware) ? hardware : SOFTWARE[target];
+}
+
+export interface HwAccelStatus {
+  /** The configured family, lowercased. Null when unset or empty. */
+  requested: string | null;
+  /** Whether `requested` names a family this seam knows about. */
+  recognized: boolean;
+  /** Hardware encoders this build lists, so they will be used. */
+  active: string[];
+  /** Hardware encoders this family maps to that the build does not list. */
+  missing: string[];
+  /** Targets the family has no hardware encoder for; they stay on software. */
+  unmapped: EncoderTarget[];
+  /**
+   * Why the encoder list could not be read, when a probe was attempted. Null
+   * when it read fine, and when no probe was needed.
+   */
+  probeError: string | null;
+}
+
+/**
+ * What the current SNAPOTTER_HW_ACCEL setting will actually do. Callers log
+ * this at startup so an admin who sets a family this build cannot run learns
+ * it from the boot log rather than from unchanged encode times.
+ *
+ * "Active" means the build lists the encoder, which is not the same as being
+ * able to run it: a general-purpose ffmpeg lists h264_nvenc whether or not an
+ * NVIDIA device is present. Word any message accordingly.
+ */
+export function hwAccelStatus(): HwAccelStatus {
+  const { name, map } = requestedFamily();
+  if (!map) {
+    return {
+      requested: name,
+      recognized: false,
+      active: [],
+      missing: [],
+      unmapped: [],
+      probeError: null,
+    };
+  }
+
+  const { names, error } = encoderProbe();
+  const active: string[] = [];
+  const missing: string[] = [];
+  for (const target of ALL_TARGETS) {
+    const hardware = map[target];
+    if (!hardware) continue;
+    if (names?.has(hardware)) active.push(hardware);
+    else missing.push(hardware);
+  }
+  return {
+    requested: name,
+    recognized: true,
+    active,
+    missing,
+    unmapped: ALL_TARGETS.filter((t) => !map[t]),
+    probeError: error,
+  };
 }

--- a/packages/media-engine/src/index.ts
+++ b/packages/media-engine/src/index.ts
@@ -1,5 +1,11 @@
 export { ffmpegAvailable, resolveFfmpeg, resolveFfprobe } from "./binaries.js";
-export { type EncoderTarget, resolveEncoder } from "./encoders.js";
+export {
+  type EncoderTarget,
+  HW_ACCEL_FAMILIES,
+  type HwAccelStatus,
+  hwAccelStatus,
+  resolveEncoder,
+} from "./encoders.js";
 export { type RunFfmpegOptions, runFfmpeg } from "./ffmpeg.js";
 export { type MediaInfo, type MediaStreamInfo, type ProbeOptions, probeMedia } from "./ffprobe.js";
 export { type FontRef, resolveFontFile } from "./fonts.js";

--- a/packages/media-engine/tests/encoder-availability.test.ts
+++ b/packages/media-engine/tests/encoder-availability.test.ts
@@ -1,0 +1,177 @@
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import { ffmpegAvailable, resolveFfmpeg } from "../src/binaries.js";
+import {
+  type EncoderTarget,
+  parseEncoderNames,
+  resolveEncoder,
+  setEncoderInventoryForTests,
+} from "../src/encoders.js";
+
+/**
+ * Regression cover for #1054. `resolveEncoder` used to return the mapped
+ * hardware name without checking that the binary provides it, so
+ * SNAPOTTER_HW_ACCEL=nvenc on the published image (QSV only, no NVENC and no
+ * VAAPI on either arch) sent `-c:v h264_nvenc` to ffmpeg and every
+ * re-encoding job died with `Unknown encoder 'h264_nvenc'`.
+ */
+
+afterEach(() => {
+  delete process.env.SNAPOTTER_HW_ACCEL;
+  setEncoderInventoryForTests(undefined);
+});
+
+/**
+ * Shape of real `ffmpeg -encoders` output. The legend rows above the table
+ * carry the same leading-flag pattern as real rows, which is the trap a naive
+ * parser falls into: it records "=" as an encoder.
+ *
+ * This particular inventory is the published image's: libx264/libx265/QSV and
+ * v4l2m2m, no NVENC, no VAAPI.
+ */
+const SHIPPED_QSV_ONLY = `Encoders:
+ V..... = Video
+ A..... = Audio
+ S..... = Subtitle
+ .F.... = Frame-level multithreading
+ ..S... = Slice-level multithreading
+ ...X.. = Codec is experimental
+ ....B. = Supports draw_horiz_band
+ .....D = Supports direct rendering method 1
+ ------
+ V....D libx264              libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
+ V....D libx264rgb           libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 RGB (codec h264)
+ V..... h264_qsv             H.264 / AVC (Intel Quick Sync Video acceleration) (codec h264)
+ V..... h264_v4l2m2m         V4L2 mem2mem H.264 encoder wrapper (codec h264)
+ V....D libx265              libx265 H.265 / HEVC (codec hevc)
+ V..... hevc_qsv             HEVC (Intel Quick Sync Video acceleration) (codec hevc)
+ V....D libsvtav1            SVT-AV1 encoder (codec av1)
+ V....D libvpx-vp9           libvpx VP9 (codec vp9)
+ A....D aac                  AAC (Advanced Audio Coding)
+ A....D libopus              libopus Opus (codec opus)
+ A....D libmp3lame           libmp3lame MP3 (MPEG audio layer 3) (codec mp3)
+`;
+
+/** Same shape, but from a build that really was compiled with NVENC. */
+const WITH_NVENC = `${SHIPPED_QSV_ONLY} V....D h264_nvenc           NVIDIA NVENC H.264 encoder (codec h264)
+ V....D hevc_nvenc           NVIDIA NVENC hevc encoder (codec hevc)
+ V....D av1_nvenc            NVIDIA NVENC av1 encoder (codec av1)
+`;
+
+describe("parseEncoderNames", () => {
+  it("reads the encoder names out of the table", () => {
+    const names = parseEncoderNames(SHIPPED_QSV_ONLY);
+    expect(names.has("libx264")).toBe(true);
+    expect(names.has("libx265")).toBe(true);
+    expect(names.has("h264_qsv")).toBe(true);
+    expect(names.has("libvpx-vp9")).toBe(true);
+    expect(names.has("aac")).toBe(true);
+    expect(names.has("libmp3lame")).toBe(true);
+  });
+
+  it("does not invent encoders from the legend rows", () => {
+    const names = parseEncoderNames(SHIPPED_QSV_ONLY);
+    // " V..... = Video" matches on flags alone; the name column holds "=".
+    expect(names.has("=")).toBe(false);
+    expect(names.has("Video")).toBe(false);
+    expect(names.has("Audio")).toBe(false);
+    expect(names.has("Subtitle")).toBe(false);
+    expect(names.has("------")).toBe(false);
+  });
+
+  it("reports absent families as absent", () => {
+    const names = parseEncoderNames(SHIPPED_QSV_ONLY);
+    expect(names.has("h264_nvenc")).toBe(false);
+    expect(names.has("hevc_nvenc")).toBe(false);
+    expect(names.has("h264_vaapi")).toBe(false);
+  });
+
+  it("returns an empty set for output that is not an encoder table", () => {
+    expect(parseEncoderNames("").size).toBe(0);
+    expect(parseEncoderNames("ffmpeg: command not found").size).toBe(0);
+  });
+});
+
+describe("resolveEncoder falls back when the binary lacks the encoder (#1054)", () => {
+  it("nvenc requested on a QSV-only build gives software, not h264_nvenc", () => {
+    setEncoderInventoryForTests(parseEncoderNames(SHIPPED_QSV_ONLY));
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    expect(resolveEncoder("h264")).toBe("libx264");
+    expect(resolveEncoder("hevc")).toBe("libx265");
+    expect(resolveEncoder("av1")).toBe("libsvtav1");
+  });
+
+  it("vaapi requested on a QSV-only build gives software", () => {
+    setEncoderInventoryForTests(parseEncoderNames(SHIPPED_QSV_ONLY));
+    process.env.SNAPOTTER_HW_ACCEL = "vaapi";
+    expect(resolveEncoder("h264")).toBe("libx264");
+    expect(resolveEncoder("hevc")).toBe("libx265");
+  });
+
+  it("still uses hardware when the build really has it", () => {
+    setEncoderInventoryForTests(parseEncoderNames(WITH_NVENC));
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    expect(resolveEncoder("h264")).toBe("h264_nvenc");
+    expect(resolveEncoder("hevc")).toBe("hevc_nvenc");
+    expect(resolveEncoder("av1")).toBe("av1_nvenc");
+  });
+
+  it("treats an unreadable inventory as absent rather than assuming presence", () => {
+    setEncoderInventoryForTests(null);
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    expect(resolveEncoder("h264")).toBe("libx264");
+  });
+
+  it("leaves audio targets on software regardless of inventory", () => {
+    setEncoderInventoryForTests(parseEncoderNames(WITH_NVENC));
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    expect(resolveEncoder("aac")).toBe("aac");
+    expect(resolveEncoder("opus")).toBe("libopus");
+    expect(resolveEncoder("mp3")).toBe("libmp3lame");
+  });
+
+  it("does not consult the inventory when no accel is configured", () => {
+    // A null inventory means "nothing is available". Software targets must
+    // still resolve, which proves the default path never reaches the gate.
+    setEncoderInventoryForTests(null);
+    delete process.env.SNAPOTTER_HW_ACCEL;
+    expect(resolveEncoder("h264")).toBe("libx264");
+    expect(resolveEncoder("vp9")).toBe("libvpx-vp9");
+  });
+});
+
+/**
+ * The seam tests above pin the logic; this one pins reality. It runs only
+ * where ffmpeg exists (CI integration shards have no ffmpeg), and asserts the
+ * property that actually matters: whatever resolveEncoder hands back, this
+ * ffmpeg can run it.
+ */
+describe.runIf(ffmpegAvailable())("resolveEncoder against the real ffmpeg binary", () => {
+  const TARGETS: EncoderTarget[] = ["h264", "hevc", "av1", "vp9", "aac", "opus", "mp3"];
+  // One spawn for the whole block: this used to shell out once per target.
+  const installed = parseEncoderNames(realEncoderOutput());
+
+  for (const accel of ["", "nvenc", "vaapi", "quantum"]) {
+    it(`every target resolves to an encoder this build has (SNAPOTTER_HW_ACCEL=${accel || "unset"})`, () => {
+      setEncoderInventoryForTests(undefined);
+      if (accel) process.env.SNAPOTTER_HW_ACCEL = accel;
+      else delete process.env.SNAPOTTER_HW_ACCEL;
+
+      for (const target of TARGETS) {
+        const chosen = resolveEncoder(target);
+        expect(
+          installed.has(chosen),
+          `${target} resolved to "${chosen}", which this ffmpeg does not list. ` +
+            "If that is a software encoder, this build is leaner than the shipped " +
+            "one and the gap is #1092, not the hardware gate.",
+        ).toBe(true);
+      }
+    });
+  }
+});
+
+function realEncoderOutput(): string {
+  const bin = resolveFfmpeg();
+  if (!bin) return "";
+  return spawnSync(bin, ["-hide_banner", "-encoders"], { encoding: "utf8" }).stdout ?? "";
+}

--- a/packages/media-engine/tests/encoders.test.ts
+++ b/packages/media-engine/tests/encoders.test.ts
@@ -1,13 +1,28 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { type EncoderTarget, resolveEncoder } from "../src/encoders.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type EncoderTarget,
+  resolveEncoder,
+  setEncoderInventoryForTests,
+} from "../src/encoders.js";
 
 /**
  * resolveEncoder reads process.env.SNAPOTTER_HW_ACCEL at call time, so each
  * test sets or clears it. Assertions are exact strings: an existence-only test
  * would leave every map-entry mutant alive.
+ *
+ * These tests cover the family mapping, so they pin an inventory that has
+ * every hardware encoder. Whether a real build provides them is a separate
+ * concern, covered in encoder-availability.test.ts (#1054).
  */
+const ALL_HARDWARE = new Set(["h264_nvenc", "hevc_nvenc", "av1_nvenc", "h264_vaapi", "hevc_vaapi"]);
+
+beforeEach(() => {
+  setEncoderInventoryForTests(ALL_HARDWARE);
+});
+
 afterEach(() => {
   delete process.env.SNAPOTTER_HW_ACCEL;
+  setEncoderInventoryForTests(undefined);
 });
 
 const ALL_TARGETS: EncoderTarget[] = ["h264", "hevc", "av1", "vp9", "aac", "opus", "mp3"];

--- a/tests/unit/media-engine/encoders.test.ts
+++ b/tests/unit/media-engine/encoders.test.ts
@@ -1,11 +1,50 @@
-import { resolveEncoder } from "@snapotter/media-engine";
-import { afterEach, describe, expect, it } from "vitest";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  HW_ACCEL_FAMILIES,
+  hwAccelStatus,
+  parseEncoderNames,
+  resolveEncoder,
+  setEncoderInventoryForTests,
+} from "../../../packages/media-engine/src/encoders.js";
 
-const ORIGINAL = process.env.SNAPOTTER_HW_ACCEL;
+/**
+ * PR CI runs tests/unit and tests/integration only, never packages/ * /tests,
+ * so the regression cover for #1054 has to live here to gate a merge. The
+ * fuller behavioural suite is packages/media-engine/tests/encoder-availability.
+ *
+ * Inventories are pinned rather than probed: the CI shards have no ffmpeg, and
+ * a test that reads the ambient binary would assert nothing there.
+ */
+
+const ORIGINAL_ACCEL = process.env.SNAPOTTER_HW_ACCEL;
+const ORIGINAL_FFMPEG = process.env.FFMPEG_PATH;
+
 afterEach(() => {
-  if (ORIGINAL === undefined) delete process.env.SNAPOTTER_HW_ACCEL;
-  else process.env.SNAPOTTER_HW_ACCEL = ORIGINAL;
+  if (ORIGINAL_ACCEL === undefined) delete process.env.SNAPOTTER_HW_ACCEL;
+  else process.env.SNAPOTTER_HW_ACCEL = ORIGINAL_ACCEL;
+  if (ORIGINAL_FFMPEG === undefined) delete process.env.FFMPEG_PATH;
+  else process.env.FFMPEG_PATH = ORIGINAL_FFMPEG;
+  setEncoderInventoryForTests(undefined);
+  vi.resetModules();
 });
+
+/** What the published image's static ffmpeg actually lists: QSV, no NVENC. */
+const QSV_ONLY = new Set([
+  "libx264",
+  "libx265",
+  "libsvtav1",
+  "libvpx-vp9",
+  "aac",
+  "libopus",
+  "libmp3lame",
+  "h264_qsv",
+  "hevc_qsv",
+]);
+
+const WITH_NVENC = new Set([...QSV_ONLY, "h264_nvenc", "hevc_nvenc", "av1_nvenc"]);
 
 describe("resolveEncoder", () => {
   it("defaults to software encoders", () => {
@@ -16,15 +55,234 @@ describe("resolveEncoder", () => {
     expect(resolveEncoder("aac")).toBe("aac");
   });
 
-  it("maps nvenc when SNAPOTTER_HW_ACCEL=nvenc", () => {
-    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
-    expect(resolveEncoder("h264")).toBe("h264_nvenc");
-    expect(resolveEncoder("hevc")).toBe("hevc_nvenc");
-    expect(resolveEncoder("aac")).toBe("aac"); // audio unaffected
-  });
-
   it("falls back to software for unknown accel values", () => {
     process.env.SNAPOTTER_HW_ACCEL = "quantum";
     expect(resolveEncoder("h264")).toBe("libx264");
+  });
+
+  it("leaves audio on software when a video family is selected", () => {
+    setEncoderInventoryForTests(WITH_NVENC);
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    expect(resolveEncoder("aac")).toBe("aac");
+    expect(resolveEncoder("opus")).toBe("libopus");
+  });
+
+  /**
+   * The #1054 regression itself. Deterministic in every lane because the
+   * inventory is pinned: nvenc requested against the published image's
+   * encoder list must not produce `h264_nvenc`.
+   */
+  it("gives software when the build does not list the hardware encoder", () => {
+    setEncoderInventoryForTests(QSV_ONLY);
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    expect(resolveEncoder("h264")).toBe("libx264");
+    expect(resolveEncoder("hevc")).toBe("libx265");
+    expect(resolveEncoder("av1")).toBe("libsvtav1");
+
+    process.env.SNAPOTTER_HW_ACCEL = "vaapi";
+    expect(resolveEncoder("h264")).toBe("libx264");
+    expect(resolveEncoder("hevc")).toBe("libx265");
+  });
+
+  /** The other direction: the gate must not have simply disabled hardware. */
+  it("uses the hardware encoder when the build does list it", () => {
+    setEncoderInventoryForTests(WITH_NVENC);
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    expect(resolveEncoder("h264")).toBe("h264_nvenc");
+    expect(resolveEncoder("hevc")).toBe("hevc_nvenc");
+    expect(resolveEncoder("av1")).toBe("av1_nvenc");
+  });
+
+  it("treats an unreadable inventory as absent", () => {
+    setEncoderInventoryForTests(null);
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    expect(resolveEncoder("h264")).toBe("libx264");
+  });
+});
+
+describe("hwAccelStatus", () => {
+  it("reports nothing requested when the variable is unset", () => {
+    delete process.env.SNAPOTTER_HW_ACCEL;
+    const status = hwAccelStatus();
+    expect(status.requested).toBeNull();
+    expect(status.recognized).toBe(false);
+    expect(status.active).toEqual([]);
+  });
+
+  it("flags an unrecognised family", () => {
+    process.env.SNAPOTTER_HW_ACCEL = "quantum";
+    const status = hwAccelStatus();
+    expect(status.requested).toBe("quantum");
+    expect(status.recognized).toBe(false);
+  });
+
+  /**
+   * FAMILIES is an object literal, so a bare index lookup returns truthy
+   * inherited members and reports a typo as a real family whose encoders are
+   * all missing. That sends the admin to debug their ffmpeg instead of their
+   * config.
+   */
+  it.each(["constructor", "__proto__", "tostring", "valueof"])(
+    "does not treat inherited Object member %s as a family",
+    (value) => {
+      process.env.SNAPOTTER_HW_ACCEL = value;
+      const status = hwAccelStatus();
+      expect(status.recognized).toBe(false);
+      expect(resolveEncoder("h264")).toBe("libx264");
+    },
+  );
+
+  it("lowercases the requested family the same way resolveEncoder does", () => {
+    setEncoderInventoryForTests(WITH_NVENC);
+    process.env.SNAPOTTER_HW_ACCEL = "NVENC";
+    expect(hwAccelStatus().recognized).toBe(true);
+    expect(resolveEncoder("h264")).toBe("h264_nvenc");
+  });
+
+  /**
+   * Asserted by exact contents, not by the union of the two arrays: a union
+   * assertion holds even if active and missing are swapped, which would make
+   * the boot log claim hardware encoding on the very image that lacks it.
+   */
+  it("splits a partial inventory into exactly active and missing", () => {
+    setEncoderInventoryForTests(new Set([...QSV_ONLY, "h264_nvenc"]));
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    const status = hwAccelStatus();
+    expect(status.active).toEqual(["h264_nvenc"]);
+    expect(status.missing).toEqual(["hevc_nvenc", "av1_nvenc"]);
+    expect(status.probeError).toBeNull();
+  });
+
+  it("reports everything missing on the published image's inventory", () => {
+    setEncoderInventoryForTests(QSV_ONLY);
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    const status = hwAccelStatus();
+    expect(status.active).toEqual([]);
+    expect(status.missing).toEqual(["h264_nvenc", "hevc_nvenc", "av1_nvenc"]);
+  });
+
+  it("names the targets a family cannot accelerate at all", () => {
+    setEncoderInventoryForTests(WITH_NVENC);
+    process.env.SNAPOTTER_HW_ACCEL = "vaapi";
+    // VAAPI maps h264 and hevc only, so the rest silently stay on software.
+    expect(hwAccelStatus().unmapped).toEqual(["av1", "vp9", "aac", "opus", "mp3"]);
+  });
+
+  it("exposes the accepted family names for docs and logs", () => {
+    expect(HW_ACCEL_FAMILIES).toEqual(["nvenc", "vaapi"]);
+  });
+});
+
+/**
+ * The probe is the only new I/O in the fix. CI has no ffmpeg, so these point
+ * FFMPEG_PATH at stub scripts and re-import through a fresh module graph, the
+ * way tests/integration/platform/media-engine-unavailable.test.ts does, since
+ * media-engine caches the resolved binary in a module variable.
+ */
+describe("encoder probe against a stub ffmpeg", () => {
+  const dir = mkdtempSync(join(tmpdir(), "snapotter-encoder-probe-"));
+
+  const TABLE = [
+    "Encoders:",
+    " V..... = Video",
+    " ------",
+    " V....D libx264              libx264 H.264 (codec h264)",
+    " V....D h264_nvenc           NVIDIA NVENC H.264 encoder (codec h264)",
+  ];
+
+  /**
+   * A stub ffmpeg. The table goes through a quoted heredoc so the flag columns
+   * and backslashes reach stdout byte for byte.
+   */
+  function stub(
+    name: string,
+    opts: { lines?: string[]; toStderr?: boolean; exit?: number; countTo?: string } = {},
+  ): string {
+    const path = join(dir, name);
+    const parts = ["#!/bin/sh"];
+    if (opts.countTo) parts.push(`echo x >> ${opts.countTo}`);
+    if (opts.lines) {
+      parts.push(`cat <<'FFEOF'${opts.toStderr ? " >&2" : ""}`, ...opts.lines, "FFEOF");
+    }
+    if (opts.exit !== undefined) parts.push(`exit ${opts.exit}`);
+    writeFileSync(path, `${parts.join("\n")}\n`);
+    chmodSync(path, 0o755);
+    return path;
+  }
+
+  async function freshEncoders(ffmpegPath: string) {
+    vi.resetModules();
+    process.env.FFMPEG_PATH = ffmpegPath;
+    return await import("../../../packages/media-engine/src/encoders.js");
+  }
+
+  it("reads the inventory from stdout and uses a listed encoder", async () => {
+    const mod = await freshEncoders(stub("ok.sh", { lines: TABLE }));
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    expect(mod.resolveEncoder("h264")).toBe("h264_nvenc");
+    expect(mod.hwAccelStatus().probeError).toBeNull();
+  });
+
+  it("ignores a table printed on stderr rather than stdout", async () => {
+    const mod = await freshEncoders(stub("stderr.sh", { lines: TABLE, toStderr: true }));
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    expect(mod.resolveEncoder("h264")).toBe("libx264");
+    expect(mod.hwAccelStatus().probeError).toMatch(/no recognisable encoder rows/);
+  });
+
+  it("falls back and explains when the binary exits non-zero", async () => {
+    const mod = await freshEncoders(stub("fail.sh", { exit: 3 }));
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    expect(mod.resolveEncoder("h264")).toBe("libx264");
+    expect(mod.hwAccelStatus().probeError).toMatch(/exited code 3/);
+  });
+
+  it("falls back and explains when the binary does not exist", async () => {
+    const mod = await freshEncoders(join(dir, "definitely-not-here"));
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    expect(mod.resolveEncoder("h264")).toBe("libx264");
+    expect(mod.hwAccelStatus().probeError).toBeTruthy();
+  });
+
+  /**
+   * resolveEncoder is called up to four times while building one ffmpeg
+   * command line, and the probe is a blocking spawn. Without the cache every
+   * call would fork a process on the worker's event loop.
+   */
+  it("probes at most once per process", async () => {
+    const counter = join(dir, "calls.log");
+    const mod = await freshEncoders(stub("count.sh", { lines: TABLE, countTo: counter }));
+    process.env.SNAPOTTER_HW_ACCEL = "nvenc";
+    mod.resolveEncoder("h264");
+    mod.resolveEncoder("hevc");
+    mod.resolveEncoder("h264");
+    mod.hwAccelStatus();
+    expect(readFileSync(counter, "utf8").trim().split("\n")).toHaveLength(1);
+  });
+
+  it("does not spawn at all when no accel is configured", async () => {
+    const counter = join(dir, "calls-unset.log");
+    const mod = await freshEncoders(stub("count-unset.sh", { lines: TABLE, countTo: counter }));
+    delete process.env.SNAPOTTER_HW_ACCEL;
+    mod.resolveEncoder("h264");
+    mod.resolveEncoder("vp9");
+    expect(() => readFileSync(counter, "utf8")).toThrow();
+  });
+});
+
+describe("parseEncoderNames", () => {
+  it("rejects the legend rows above the table", () => {
+    const names = parseEncoderNames(
+      [
+        "Encoders:",
+        " V..... = Video",
+        " A..... = Audio",
+        " ------",
+        " V....D libx264              libx264 H.264 (codec h264)",
+      ].join("\n"),
+    );
+    expect(names.has("libx264")).toBe(true);
+    expect(names.has("=")).toBe(false);
+    expect(names.has("Video")).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #1054.

## What broke

`SNAPOTTER_HW_ACCEL=nvenc` is documented in `.env.example`, and `resolveEncoder()` mapped it to `h264_nvenc`. The ffmpeg we ship has no NVENC and no VAAPI encoder at all. Every video tool that re-encodes then died:

```
Unknown encoder 'h264_nvenc'
Error opening output files: Encoder not found
```

Confirmed against the published image on both arches, and inside the CUDA amd64 image, which copies the same static binary. The only hardware encoders present are QSV and v4l2m2m:

```
$ docker run --rm --entrypoint /usr/local/bin/ffmpeg snapotter/snapotter:latest \
    -hide_banner -encoders | grep -iE 'nvenc|vaapi'
(nothing)
```

Blast radius was every tool routing through `resolveEncoder`: `convert-video`, `compress-video`, `stabilize-video`, `merge-videos`, `burn-subtitles`, `images-to-video`, `gif-to-video`, and `media-tool`'s shared arg builders. Unknown values already fell back to software; a *known* value falling through to an encoder that does not exist was the one case the fallback never covered.

## What changed

`resolveEncoder` now checks the binary before returning a hardware name. It parses `ffmpeg -encoders` once, caches the result for the process, and falls back to software when the mapped encoder is absent or the list cannot be read. An unreadable probe counts as absent, so an unverifiable encoder is never handed to ffmpeg.

The default path is untouched and free: with no accel configured the function returns before it ever looks at the inventory, so nothing spawns a process.

Falling back silently would trade one invisible failure for another, so `startWorkers()` now reports what the setting actually does. A wrong family, a family this build cannot run, partial availability, and an unreadable probe each get a distinct message naming the cause. The log says "listed by this ffmpeg build" rather than "enabled" on purpose: the probe proves the encoder was compiled in, not that it can run, which is #1089.

`.env.example` no longer implies the flag works out of the box.

## Notes on the parsing

The legend above the encoder table has the same leading-flag shape as a real row:

```
 V..... = Video
 ------
 V....D libx264              libx264 H.264 / AVC ...
```

Matching on flags alone records `=` as an encoder, so the name has to start alphanumeric. That is checked against a captured copy of the real table rather than a guess. A future ffmpeg that adds a seventh flag column matches nothing, which reads as "unavailable" and sends callers to software, so it fails in the safe direction.

`hwAccelStatus()` looks the family up with `Object.hasOwn`: `FAMILIES` is an object literal, so a bare index made `SNAPOTTER_HW_ACCEL=constructor` report as a recognised family with every encoder missing, sending an admin to debug their ffmpeg over a typo in their config.

## Verified

Baseline recorded on `main` (528eda8e) before any change, in this worktree:

| | baseline | after |
| --- | --- | --- |
| `pnpm lint` | exit 0, 568 warnings | exit 0, 572 warnings |
| `pnpm typecheck` | exit 0 | exit 0 |
| `pnpm test` | exit 1, **1** failed / 19968 passed | exit 0, **0** failed / 20004 passed |

The single baseline failure was `tests/integration/platform/scim.test.ts > concurrent duplicate group creates return one 201 and one SCIM 409`, a known flaky local-main race unrelated to this change; it passed on the later runs. Zero new failures.

The four extra lint warnings are all `noUndeclaredEnvVars` for `SNAPOTTER_HW_ACCEL` in the expanded test file, a class that file already carried. Declaring the variable in `turbo.json` is build-cache config, so it is #1094 rather than a drive-by here.

Also run:

- `pnpm vitest run tests/integration/tools/video/` (29 files, 70 passed) covering every `resolveEncoder` caller
- `pnpm vitest run tests/integration/platform/worker-branches.test.ts worker-timeout.test.ts` (20 passed) covering the `startWorkers` change
- Teeth check: reverting the availability gate fails 5 tests in `tests/unit/` alone, which is the lane that gates a merge
- The parser run against a captured `ffmpeg -encoders` from the published image: 217 encoders parsed, legend rows rejected, all 7 software encoders present, all 5 hardware encoders absent

## Tests

`packages/media-engine/tests/encoder-availability.test.ts` is new: parser behaviour including the legend trap, the fallback in both directions, and a property check against the real binary gated on `ffmpegAvailable()`.

PR CI runs `tests/unit` and `tests/integration` but not `packages/*/tests`, so the regression cover that actually gates a merge lives in `tests/unit/media-engine/encoders.test.ts`. It pins inventories rather than reading the ambient binary, since the CI shards have no ffmpeg, and drives the probe itself through stub ffmpeg scripts to cover the spawn-failure, non-zero-exit, wrong-stream and missing-binary paths without needing a real one.

## Follow-ups filed

- #1089 a listed encoder is not proof it can run; NVENC needs a driver and VAAPI needs device and filter plumbing no call site emits
- #1090 `-crf` is silently ignored on NVENC, so the chosen quality does nothing
- #1091 neither variable reaches the container from the published Compose files
- #1092 software encoder names are still returned unverified
- #1093 surface hardware-encoding status in admin health, since one boot line rotates out of the logs
- #1094 declare the variable in `turbo.json`
