### PR TITLE
chore(landing,docs): refresh the stats constants against the live counts

### DIFF
--- a/apps/docs/.vitepress/theme/github-stars.data.ts
+++ b/apps/docs/.vitepress/theme/github-stars.data.ts
@@ -12,7 +12,7 @@ const GITHUB_REPO = "snapotter-hq/SnapOtter";
 // Fallback used when the upstream fetch fails. Keep roughly current so a
 // degraded build still shows a believable figure (matches STAR_FALLBACK in
 // apps/landing/src/lib/stats.ts).
-const STAR_FALLBACK = 1720;
+const STAR_FALLBACK = 2630;
 
 export interface GitHubStarsData {
   /** Compact star count for display, e.g. "1.7k". */

--- a/apps/landing/src/lib/stats.ts
+++ b/apps/landing/src/lib/stats.ts
@@ -9,10 +9,10 @@
 // github.com/orgs/snapotter-hq/packages. So this is read off by hand and cannot
 // be fetched at build time like the Docker Hub figure below.
 //
-// OBSERVED 2026-08-18: 122,000. A previous value sat at 36,000 long enough to
+// OBSERVED 2026-09-12: 176,000. A previous value sat at 36,000 long enough to
 // understate the real number by more than half, so re-read the package page
 // whenever you touch this file and update the date with it.
-const GHCR_ESTIMATE = 122_000;
+const GHCR_ESTIMATE = 176_000;
 
 // Fallbacks for when an upstream fetch fails. These are a safety net, not a
 // source of truth: a successful build overwrites them with live values, and the
@@ -20,13 +20,13 @@ const GHCR_ESTIMATE = 122_000;
 // "+", a stale constant understates rather than overstates, so a degraded build
 // is never a false claim, just a quieter one.
 //
-// REFRESHED 2026-08-18 against the live APIs. They had drifted badly once
+// REFRESHED 2026-09-12 against the live APIs. They had drifted badly once
 // before (104K against a real 232K, understating pulls by ~55%), because a
 // failed fetch degraded silently and nothing ever surfaced the gap. `warnStale`
 // below now puts it in the build log. Re-check these whenever you touch this
 // file.
-const STAR_FALLBACK = 2_210; // live 2026-08-18: 2,217
-const DOCKER_FALLBACK = 353_000; // live 2026-08-18: 353,906
+const STAR_FALLBACK = 2_630; // live 2026-09-12: 2,636
+const DOCKER_FALLBACK = 486_000; // live 2026-09-12: 486,567
 
 const GITHUB_REPO = "snapotter-hq/SnapOtter";
 const DOCKERHUB_REPO = "snapotter/snapotter";


### PR DESCRIPTION
GHCR exposes no pull-count API, so that figure is read off the package page by hand. It was last read at 122,000 on 2026-08-18; today it is 176,000.

The Docker Hub and star fallbacks only surface when a build's fetch fails, but both had drifted far enough to understate the site badly when they do: 353,000 against a live 486,567 pulls, 2,210 against 2,636 stars. The docs navbar keeps its own star fallback, with a comment saying it matches the landing one, and it had fallen to 1,720. Moved it with the rest.

Landing now renders 660K+ pulls and 2.6k stars, up from 600K+.

Verified: `pnpm vitest run tests/unit/landing/stats.test.ts` (14 passed), `biome check` clean on both files, and a live call to `getImagePulls()` returning 662,572, which formats to "660K+".