### PR TITLE
feat(landing): fetch the GHCR download count instead of hand-copying it

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,9 +9,10 @@ on:
       - "packages/shared/src/analytics/public-site.ts"
   # Daily rebuild so the build-time GitHub star count refreshes even when no
   # docs files changed (mirrors deploy-landing.yml, offset an hour so the two
-  # scheduled deploys don't fire at once).
+  # scheduled deploys don't fire at once, and off the top of the hour for the
+  # queueing reason described there).
   schedule:
-    - cron: "0 8 * * *"
+    - cron: "23 8 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -7,10 +7,14 @@ on:
       - "apps/landing/**"
       # What the site captures lives in shared; a change there must go live too.
       - "packages/shared/src/analytics/public-site.ts"
-  # Daily rebuild so the build-time GitHub stars / Docker Hub pull-count fetches
+  # Daily rebuild so the build-time GitHub stars / Docker Hub / GHCR fetches
   # refresh even when no landing files changed.
+  #
+  # Deliberately off the top of the hour. GitHub queues scheduled workflows and
+  # the on-the-hour slots are the most contended, so "0 7" was consistently
+  # firing between 11:00 and 13:00 UTC.
   schedule:
-    - cron: "0 7 * * *"
+    - cron: "17 7 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/apps/landing/src/lib/stats.ts
+++ b/apps/landing/src/lib/stats.ts
@@ -4,15 +4,18 @@
 // fetchers degrade to a maintained constant if the upstream API is unreachable
 // (or rate-limited), so a build never ships an empty number.
 
-// ghcr.io exposes no pull-count API (`gh api orgs/snapotter-hq/packages/
-// container/snapotter` 404s), but the count IS visible on the package page at
-// github.com/orgs/snapotter-hq/packages. So this is read off by hand and cannot
-// be fetched at build time like the Docker Hub figure below.
+// ghcr.io exposes no pull-count API. The REST packages endpoint does answer
+// for this account (under /users, not the /orgs path an earlier comment here
+// blamed for the 404: snapotter-hq is a user), but the response carries no
+// download field at all. The total exists only on the package page, so it is
+// parsed out of that markup at build time by parseGhcrDownloads below.
 //
-// OBSERVED 2026-09-12: 176,000. A previous value sat at 36,000 long enough to
-// understate the real number by more than half, so re-read the package page
-// whenever you touch this file and update the date with it.
-const GHCR_ESTIMATE = 176_000;
+// This was a hand-copied constant until 2026-09-12, and it drifted every time:
+// 36,000 against a real number more than twice that, then 122,000 against
+// 176,180. A scheduled rebuild cannot refresh a number no build ever reads.
+const GHCR_PACKAGE_URL =
+  "https://github.com/users/snapotter-hq/packages/container/package/snapotter";
+const GHCR_FALLBACK = 176_000; // live 2026-09-12: 176,180
 
 // Fallbacks for when an upstream fetch fails. These are a safety net, not a
 // source of truth: a successful build overwrites them with live values, and the
@@ -61,6 +64,26 @@ export function formatPulls(total: number): string {
   return `${Math.floor(total / 10_000) * 10}K+`;
 }
 
+/**
+ * Pull the exact GHCR download total out of the package page.
+ *
+ * The page renders the rounded figure as text ("176K") and keeps the real
+ * number in the heading's title attribute, so the match is anchored on the
+ * "Total downloads" label rather than on the markup around it: the Issues
+ * counter directly above uses the identical `<h3 title="...">` shape, and a
+ * looser pattern reports the issue count as downloads.
+ *
+ * Returns undefined rather than a guess when the label, the heading, or the
+ * title attribute is missing, which is what a GitHub redesign looks like from
+ * here. The caller then falls back to the constant and says so in the log.
+ */
+export function parseGhcrDownloads(html: string): number | undefined {
+  const match = html.match(/Total downloads<\/span>\s*<h3[^>]*\stitle="(\d+)"/);
+  if (!match) return undefined;
+  const total = Number(match[1]);
+  return Number.isFinite(total) && total > 0 ? total : undefined;
+}
+
 // Both stats are read from Astro frontmatter, and Navbar/TrustSignals render on
 // every page, so an un-memoized fetch fires once PER PAGE: ~800 GitHub calls per
 // full build. That blows through the unauthenticated 60 req/hr limit almost
@@ -105,9 +128,9 @@ async function fetchStarCount(): Promise<number> {
 }
 
 /**
- * Total image pulls = live Docker Hub pull_count + the GHCR estimate.
- * Returns the raw total and a display string. Docker Hub degrades to
- * DOCKER_FALLBACK if the API is unreachable.
+ * Total image pulls across both registries, fetched once per build. Each half
+ * degrades to its own constant if that upstream is unreachable, so a partial
+ * outage costs one registry's freshness rather than the whole figure.
  */
 export function getImagePulls(): Promise<{ total: number; display: string }> {
   imagePullsPromise ??= fetchImagePulls();
@@ -115,16 +138,19 @@ export function getImagePulls(): Promise<{ total: number; display: string }> {
 }
 
 async function fetchImagePulls(): Promise<{ total: number; display: string }> {
-  let dockerPulls = DOCKER_FALLBACK;
+  // One registry being down must not cost the other its live number.
+  const [dockerPulls, ghcrPulls] = await Promise.all([fetchDockerPulls(), fetchGhcrPulls()]);
+  const total = dockerPulls + ghcrPulls;
+  return { total, display: formatPulls(total) };
+}
+
+async function fetchDockerPulls(): Promise<number> {
   try {
     const res = await fetch(`https://hub.docker.com/v2/repositories/${DOCKERHUB_REPO}/`);
     if (res.ok) {
       const data = await res.json();
-      if (typeof data.pull_count === "number" && data.pull_count > 0) {
-        dockerPulls = data.pull_count;
-      } else {
-        warnStale("Docker Hub pulls", "response missing pull_count", DOCKER_FALLBACK);
-      }
+      if (typeof data.pull_count === "number" && data.pull_count > 0) return data.pull_count;
+      warnStale("Docker Hub pulls", "response missing pull_count", DOCKER_FALLBACK);
     } else {
       warnStale("Docker Hub pulls", `HTTP ${res.status}`, DOCKER_FALLBACK);
     }
@@ -135,6 +161,21 @@ async function fetchImagePulls(): Promise<{ total: number; display: string }> {
       DOCKER_FALLBACK,
     );
   }
-  const total = dockerPulls + GHCR_ESTIMATE;
-  return { total, display: formatPulls(total) };
+  return DOCKER_FALLBACK;
+}
+
+async function fetchGhcrPulls(): Promise<number> {
+  try {
+    const res = await fetch(GHCR_PACKAGE_URL, { headers: { "User-Agent": "SnapOtter-Landing" } });
+    if (res.ok) {
+      const total = parseGhcrDownloads(await res.text());
+      if (total !== undefined) return total;
+      warnStale("GHCR downloads", "response missing the Total downloads figure", GHCR_FALLBACK);
+    } else {
+      warnStale("GHCR downloads", `HTTP ${res.status}`, GHCR_FALLBACK);
+    }
+  } catch (err) {
+    warnStale("GHCR downloads", err instanceof Error ? err.message : "fetch threw", GHCR_FALLBACK);
+  }
+  return GHCR_FALLBACK;
 }

--- a/tests/unit/landing/stats.test.ts
+++ b/tests/unit/landing/stats.test.ts
@@ -1,4 +1,4 @@
-import { formatCompact, formatPulls } from "@landing/lib/stats";
+import { formatCompact, formatPulls, parseGhcrDownloads } from "@landing/lib/stats";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // getStarCount/getImagePulls memoize per module instance so a build fetches once
@@ -14,6 +14,38 @@ async function freshStats() {
 // pattern CodeQL flags, and it is worth not teaching that shape in test code.
 function isDockerHub(url: string): boolean {
   return new URL(url).hostname === "hub.docker.com";
+}
+
+function isGhcrPage(url: string): boolean {
+  return new URL(url).hostname === "github.com";
+}
+
+// Trimmed from the live package page. The Issues counter really does sit
+// directly above the downloads block with the same <h3 title="..."> shape, so
+// it belongs in the fixture: a regex that just looks for the nearest title
+// attribute silently reports 193 downloads and nothing ever notices.
+const GHCR_PAGE_FIXTURE = `
+  <div class="lh-condensed d-flex flex-column flex-items-baseline tmp-pr-1">
+    <span class="d-block color-fg-muted text-small mb-1">Issues</span>
+    <h3 title="193">193</h3>
+  </div>
+  <div class="container-lg tmp-my-3 d-flex clearfix">
+    <div class="lh-condensed d-flex flex-column flex-items-baseline tmp-pr-1">
+      <span class="d-block color-fg-muted text-small tmp-mb-1">Total downloads</span>
+      <h3 title="176180">176K</h3>
+    </div>
+  </div>
+`;
+
+/** An upstream stub that answers all three fetchers with live-looking data. */
+function okResponse(url: string) {
+  if (isGhcrPage(url)) {
+    return { ok: true, status: 200, text: async () => GHCR_PAGE_FIXTURE };
+  }
+  if (isDockerHub(url)) {
+    return { ok: true, status: 200, json: async () => ({ pull_count: 500_000 }) };
+  }
+  return { ok: true, status: 200, json: async () => ({ stargazers_count: 4242 }) };
 }
 
 describe("formatCompact", () => {
@@ -86,7 +118,7 @@ describe("stat fetchers when upstream is unavailable", () => {
 
     expect(stars).toBeGreaterThan(0);
     expect(pulls.total).toBeGreaterThan(0);
-    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(3);
     expect(warn.mock.calls.flat().join(" ")).toContain("simulated outage");
   });
 
@@ -100,38 +132,34 @@ describe("stat fetchers when upstream is unavailable", () => {
     await stats.getStarCount();
     await stats.getImagePulls();
 
-    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(3);
     expect(warn.mock.calls.flat().join(" ")).toContain("HTTP 503");
   });
 
   it("warns when the response parses but omits the field it needs", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })),
+      vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}), text: async () => "" })),
     );
 
     const stats = await freshStats();
     await stats.getStarCount();
     await stats.getImagePulls();
 
-    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(3);
     expect(warn.mock.calls.flat().join(" ")).toContain("missing");
   });
 
   it("uses live values and stays quiet when upstream responds", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (url: string) =>
-        isDockerHub(url)
-          ? { ok: true, status: 200, json: async () => ({ pull_count: 500_000 }) }
-          : { ok: true, status: 200, json: async () => ({ stargazers_count: 4242 }) },
-      ),
+      vi.fn(async (url: string) => okResponse(url)),
     );
 
     const stats = await freshStats();
     expect(await stats.getStarCount()).toBe(4242);
-    // Live Docker Hub count plus the GHCR estimate, so assert the floor, not equality.
-    expect((await stats.getImagePulls()).total).toBeGreaterThanOrEqual(500_000);
+    // Both registries live now, so the total is exact: 500,000 + 176,180.
+    expect((await stats.getImagePulls()).total).toBe(676_180);
     expect(warn).not.toHaveBeenCalled();
   });
 
@@ -140,11 +168,7 @@ describe("stat fetchers when upstream is unavailable", () => {
   // build. GitHub 403s after 60, so early pages baked in the live count and
   // later ones baked in the fallback: one site, two different star numbers.
   it("fetches once per build no matter how many pages ask", async () => {
-    const fetchSpy = vi.fn(async (url: string) =>
-      isDockerHub(url)
-        ? { ok: true, status: 200, json: async () => ({ pull_count: 500_000 }) }
-        : { ok: true, status: 200, json: async () => ({ stargazers_count: 4242 }) },
-    );
+    const fetchSpy = vi.fn(async (url: string) => okResponse(url));
     vi.stubGlobal("fetch", fetchSpy);
     const stats = await freshStats();
 
@@ -154,8 +178,8 @@ describe("stat fetchers when upstream is unavailable", () => {
 
     expect(new Set(stars)).toEqual(new Set([4242]));
     expect(new Set(pulls.map((p) => p.display)).size).toBe(1);
-    // One call for GitHub, one for Docker Hub. Not 100.
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    // One call each for stars, Docker Hub, and the GHCR page. Not 150.
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
 
   it("keeps the degraded figure conservative rather than inflated", async () => {
@@ -169,5 +193,84 @@ describe("stat fetchers when upstream is unavailable", () => {
     const { total, display } = await (await freshStats()).getImagePulls();
     // formatPulls rounds down and appends "+", so a stale build understates.
     expect(Number(display.replace(/[^\d.]/g, "")) * 1000).toBeLessThanOrEqual(total);
+  });
+});
+
+// ghcr.io has no pull-count API: the REST packages endpoint answers for this
+// account (under /users, not /orgs, which is what the old comment got wrong)
+// but carries no download field at all. The figure exists only on the package
+// page, so it gets parsed out of the markup. It used to be copied in by hand,
+// which is how it sat at 122,000 against a real 176,180 and at 36,000 before
+// that, understating the headline stat by more than half.
+describe("parseGhcrDownloads", () => {
+  it("reads the exact total out of the package-page markup", () => {
+    expect(parseGhcrDownloads(GHCR_PAGE_FIXTURE)).toBe(176_180);
+  });
+
+  it("ignores the other counters on the page", () => {
+    // The Issues h3 (193) sits directly above the downloads h3 in the fixture.
+    expect(parseGhcrDownloads(GHCR_PAGE_FIXTURE)).not.toBe(193);
+  });
+
+  it("gives up when the markup no longer carries the label", () => {
+    expect(parseGhcrDownloads('<h3 title="176180">176K</h3>')).toBeUndefined();
+  });
+
+  it("gives up when the total is rendered without its title attribute", () => {
+    const abbreviated = GHCR_PAGE_FIXTURE.replace(' title="176180"', "");
+    // "176K" alone is not worth guessing at; the fallback constant is better.
+    expect(parseGhcrDownloads(abbreviated)).toBeUndefined();
+  });
+
+  it("returns undefined for an error page rather than throwing", () => {
+    expect(parseGhcrDownloads("")).toBeUndefined();
+    expect(parseGhcrDownloads("<html><body>Not Found</body></html>")).toBeUndefined();
+  });
+});
+
+describe("GHCR downloads when the package page changes shape", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  // The whole risk of parsing HTML is that GitHub restyles the page and the
+  // number quietly vanishes. That must degrade to the constant and say so,
+  // never zero out the GHCR half of the headline figure.
+  it("falls back to the constant and warns when the label is gone", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) =>
+        isGhcrPage(url)
+          ? { ok: true, status: 200, text: async () => "<html>redesigned</html>" }
+          : okResponse(url),
+      ),
+    );
+
+    const { total } = await (await freshStats()).getImagePulls();
+
+    expect(total).toBeGreaterThan(500_000);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls.flat().join(" ")).toContain("GHCR");
+  });
+
+  it("keeps the Docker Hub half live when only the GHCR page is down", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) =>
+        isGhcrPage(url) ? { ok: false, status: 500, text: async () => "" } : okResponse(url),
+      ),
+    );
+
+    const { total } = await (await freshStats()).getImagePulls();
+
+    // 500,000 live from Docker Hub, plus whatever the GHCR constant is.
+    expect(total).toBeGreaterThan(500_000);
   });
 });


### PR DESCRIPTION
The daily rebuild already refreshes stars and Docker Hub pulls on its own. It could never refresh GHCR, because that half of the headline figure was a constant someone had to read off the package page and paste in. It drifted every time it sat there: 36,000 against a real number more than twice that, then 122,000 against a live 176,180 this morning.

## What changed

ghcr.io still has no pull-count API. Worth correcting the record in the old comment though: the REST packages endpoint does answer for this account, under `/users` rather than the `/orgs` path it blamed for the 404, because `snapotter-hq` is a user. It carries no download field either way, so the conclusion held even though the reason was wrong.

The total lives only in the package page markup:

```html
<span ...>Total downloads</span>
<h3 title="176180">176K</h3>
```

`parseGhcrDownloads` reads the exact number out of that title attribute, anchored on the "Total downloads" label. That anchor is the whole design: the Issues counter sits directly above with an identical `<h3 title="...">` shape, so a pattern that just grabs the nearest title attribute reports the issue count as downloads and nothing ever notices. The fixture in the test keeps both blocks for that reason.

When the label, the heading, or the title attribute is missing, the parser returns undefined rather than guessing from the rounded "176K" text. The fetcher then falls back to the constant and logs through `warnStale`, the same way the Docker Hub and star fetchers already degrade. Docker Hub and GHCR fetch in parallel now, so one registry being unreachable costs the other nothing.

Both deploy crons also move off the top of the hour. That slot is the most contended in GitHub's scheduled-workflow queue, and the landing rebuild has fired between 11:00 and 13:00 UTC against its 07:00 cron every day this month. No promise that fixes the lag, but the top of the hour is the worst place to ask from.

## The tradeoff

This parses HTML, so a GitHub redesign will break it. That failure is quiet by design: the build logs a `[stats]` warning and ships the constant, and because `formatPulls` rounds down and appends "+", a stale constant understates rather than overstates. The alternative was keeping a number that has been wrong by 30% or more every time anyone looked at it.

## Verified

- `pnpm vitest run tests/unit/landing/stats.test.ts`: 21 passed, 5 of them new. Written first and watched fail (`parseGhcrDownloads is not a function`, and `expected 676000 to be 676180`, which is the constant against the live figure).
- Live parse of the real package page returns 176,180.
- `pnpm --filter @snapotter/landing build`: 798 pages, no `[stats]` warnings, so all three fetches succeeded in a real build. Every locale index carries the same `660K+`, which is the guard against the old split-number bug.
- `pnpm typecheck` clean, Biome clean.