### PR TITLE
feat(web): warn before closing or navigating away from unsaved work

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,15 @@
 import { ANALYTICS_EVENTS, en } from "@snapotter/shared";
 import { Component, type ErrorInfo, lazy, type ReactNode, Suspense, useEffect } from "react";
-import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router";
+import {
+  type ClientOnErrorFunction,
+  createBrowserRouter,
+  Navigate,
+  Outlet,
+  useLocation,
+} from "react-router";
+// The /dom build injects ReactDOM.flushSync; the bare one leaves it undefined
+// and degrades view transitions and flushSync navigations to a console warning.
+import { RouterProvider } from "react-router/dom";
 import { Toaster, toast } from "sonner";
 import { ConnectionMonitor } from "./components/common/connection-monitor";
 import { KeyboardShortcutProvider } from "./components/common/keyboard-shortcut-provider";
@@ -36,6 +45,27 @@ const NotFoundPage = lazy(() =>
   import("./pages/not-found-page").then((m) => ({ default: m.NotFoundPage })),
 );
 
+/**
+ * The one place render crashes turn into telemetry. Both boundaries that can
+ * catch one (ours and react-router's) report through here, so the analytics
+ * opt-out gate cannot drift between them.
+ */
+function reportRenderError(error: unknown, errorInfo?: ErrorInfo): void {
+  console.error("Uncaught render error:", error, errorInfo?.componentStack);
+  if (!isAnalyticsActive()) return; // respect the runtime opt-out
+  // Mirror the crash class only (no PII). track() and Sentry are best-effort.
+  track(ANALYTICS_EVENTS.TOOL_CLIENT_ERROR, {
+    error_name: error instanceof Error ? error.name : typeof error,
+  });
+  void import("@sentry/react")
+    .then((Sentry) => {
+      // errorInfo is absent for loader and middleware errors.
+      if (errorInfo) Sentry.captureReactException(error, errorInfo);
+      else Sentry.captureException(error);
+    })
+    .catch(() => {});
+}
+
 class ErrorBoundary extends Component<
   { children: ReactNode },
   { hasError: boolean; error: Error | null }
@@ -50,15 +80,7 @@ class ErrorBoundary extends Component<
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
-    console.error("Uncaught render error:", error, info.componentStack);
-    if (!isAnalyticsActive()) return; // respect the runtime opt-out
-    // Mirror the crash class only (no PII). track() and Sentry are best-effort.
-    track(ANALYTICS_EVENTS.TOOL_CLIENT_ERROR, { error_name: error.name });
-    import("@sentry/react")
-      .then((Sentry) => {
-        Sentry.captureReactException(error, info);
-      })
-      .catch(() => {});
+    reportRenderError(error, info);
   }
 
   render() {
@@ -138,6 +160,71 @@ function PageLoader() {
   );
 }
 
+/**
+ * Everything that wraps every page. A layout route rather than JSX nesting
+ * because useBlocker (the navigation guard) requires a data router.
+ */
+function RootLayout() {
+  // A data router wraps the root match in its own error boundary, so without
+  // this the "Unexpected Application Error!" screen would replace our fallback
+  // and componentDidCatch would never run (no crash event, no Sentry report).
+  // Ours sits closer to the pages, so it catches first.
+  return (
+    <ErrorBoundary>
+      <nav aria-label={en.a11y.skipToContent}>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:start-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-lg focus:text-sm focus:font-medium focus:shadow-lg"
+        >
+          {en.a11y.skipToContent}
+        </a>
+      </nav>
+      <RouteAnnouncer />
+      <KeyboardShortcutProvider>
+        <AuthGuard>
+          <MigrationBanner />
+          <UsageSurveyOverlay />
+          <Suspense fallback={<PageLoader />}>
+            <Outlet />
+          </Suspense>
+        </AuthGuard>
+      </KeyboardShortcutProvider>
+    </ErrorBoundary>
+  );
+}
+
+/**
+ * Anything that throws above the layout route's ErrorBoundary lands in
+ * react-router's own boundary, which reports nothing and, in the production
+ * build, prints the raw stack to the page. Reporting only: react-router owns
+ * whatever gets rendered.
+ */
+const reportRouterError: ClientOnErrorFunction = (error, { errorInfo }) =>
+  reportRenderError(error, errorInfo);
+
+const router = createBrowserRouter([
+  {
+    element: <RootLayout />,
+    children: [
+      { path: "/login", element: <LoginPage /> },
+      { path: "/change-password", element: <ChangePasswordPage /> },
+      { path: "/automate", element: <AutomatePage /> },
+      { path: "/files", element: <FilesPage /> },
+      { path: "/privacy", element: <PrivacyPolicyPage /> },
+      { path: "/editor", element: <EditorPage /> },
+      // Legacy 1.x color tools were consolidated into adjust-colors;
+      // redirect old bookmarks to the section route.
+      { path: "/brightness-contrast", element: <Navigate to="/image/adjust-colors" replace /> },
+      { path: "/saturation", element: <Navigate to="/image/adjust-colors" replace /> },
+      { path: "/color-channels", element: <Navigate to="/image/adjust-colors" replace /> },
+      { path: "/color-effects", element: <Navigate to="/image/adjust-colors" replace /> },
+      { path: "/:section/:toolId", element: <ToolPage /> },
+      { path: "/", element: <HomePage /> },
+      { path: "*", element: <NotFoundPage /> },
+    ],
+  },
+]);
+
 export function App() {
   const isMobile = useMobile();
   const analyticsConfig = useAnalyticsStore((s) => s.config);
@@ -184,54 +271,7 @@ export function App() {
       <I18nProvider>
         <ConnectionMonitor />
         <Toaster position={isMobile ? "top-center" : "bottom-right"} />
-        <BrowserRouter>
-          <nav aria-label={en.a11y.skipToContent}>
-            <a
-              href="#main-content"
-              className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:start-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-lg focus:text-sm focus:font-medium focus:shadow-lg"
-            >
-              {en.a11y.skipToContent}
-            </a>
-          </nav>
-          <RouteAnnouncer />
-          <KeyboardShortcutProvider>
-            <AuthGuard>
-              <MigrationBanner />
-              <UsageSurveyOverlay />
-              <Suspense fallback={<PageLoader />}>
-                <Routes>
-                  <Route path="/login" element={<LoginPage />} />
-                  <Route path="/change-password" element={<ChangePasswordPage />} />
-                  <Route path="/automate" element={<AutomatePage />} />
-                  <Route path="/files" element={<FilesPage />} />
-                  <Route path="/privacy" element={<PrivacyPolicyPage />} />
-                  <Route path="/editor" element={<EditorPage />} />
-                  {/* Legacy 1.x color tools were consolidated into adjust-colors;
-                      redirect old bookmarks to the section route. */}
-                  <Route
-                    path="/brightness-contrast"
-                    element={<Navigate to="/image/adjust-colors" replace />}
-                  />
-                  <Route
-                    path="/saturation"
-                    element={<Navigate to="/image/adjust-colors" replace />}
-                  />
-                  <Route
-                    path="/color-channels"
-                    element={<Navigate to="/image/adjust-colors" replace />}
-                  />
-                  <Route
-                    path="/color-effects"
-                    element={<Navigate to="/image/adjust-colors" replace />}
-                  />
-                  <Route path="/:section/:toolId" element={<ToolPage />} />
-                  <Route path="/" element={<HomePage />} />
-                  <Route path="*" element={<NotFoundPage />} />
-                </Routes>
-              </Suspense>
-            </AuthGuard>
-          </KeyboardShortcutProvider>
-        </BrowserRouter>
+        <RouterProvider router={router} onError={reportRouterError} />
       </I18nProvider>
     </ErrorBoundary>
   );

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@ import { Toaster, toast } from "sonner";
 import { ConnectionMonitor } from "./components/common/connection-monitor";
 import { KeyboardShortcutProvider } from "./components/common/keyboard-shortcut-provider";
 import { MigrationBanner } from "./components/common/migration-banner";
+import { NavigationGuard } from "./components/common/navigation-guard";
 import { RouteAnnouncer } from "./components/common/route-announcer";
 import { UsageSurveyOverlay } from "./components/onboarding/usage-survey-overlay";
 import { I18nProvider } from "./contexts/i18n-context";
@@ -182,6 +183,7 @@ function RootLayout() {
       <RouteAnnouncer />
       <KeyboardShortcutProvider>
         <AuthGuard>
+          <NavigationGuard />
           <MigrationBanner />
           <UsageSurveyOverlay />
           <Suspense fallback={<PageLoader />}>

--- a/apps/web/src/components/common/keyboard-shortcut-provider.tsx
+++ b/apps/web/src/components/common/keyboard-shortcut-provider.tsx
@@ -2,8 +2,8 @@ import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 
 /**
  * Wrapper that registers global keyboard shortcuts.
- * Must be rendered inside a <BrowserRouter> so that
- * useNavigate() works inside the hook.
+ * Must be rendered inside the router (it sits in the root layout route)
+ * so that useNavigate() works inside the hook.
  */
 export function KeyboardShortcutProvider({ children }: { children: React.ReactNode }) {
   useKeyboardShortcuts();

--- a/apps/web/src/components/common/navigation-guard.tsx
+++ b/apps/web/src/components/common/navigation-guard.tsx
@@ -4,6 +4,8 @@ import { type BlockerFunction, useBlocker } from "react-router";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useFocusTrap } from "@/hooks/use-focus-trap";
 import { normalizePath, useWorkInFlight, type WorkReason } from "@/hooks/use-work-in-flight";
+import { downloadBlob, triggerDownload } from "@/lib/download";
+import { useFileStore } from "@/stores/file-store";
 
 const TITLE_ID = "navigation-guard-title";
 const BODY_ID = "navigation-guard-body";
@@ -30,14 +32,74 @@ const BODY_ID = "navigation-guard-body";
  */
 const NEVER_BLOCKED = new Set(["/login", "/change-password"]);
 
-function guardCopy(t: TranslationKeys, kind: WorkReason["kind"]): { title: string; body: string } {
-  switch (kind) {
+type GuardButton = {
+  /** A list key that does not move with the copy or with the locale. */
+  id: "stay" | "download" | "leave";
+  label: string;
+  onClick: () => void;
+  primary: boolean;
+};
+
+type GuardDialog = { title: string; body: string; buttons: GuardButton[] };
+
+/**
+ * The whole dialog for one reason, buttons included.
+ *
+ * The buttons come from here rather than from a branch in the JSX because only
+ * the "unsaved" reason carries `downloads`. Deciding them inside the exhaustive
+ * switch keeps that narrowing, and keeps a new WorkReason kind a compile error
+ * here rather than a dialog offering an answer it cannot deliver.
+ *
+ * Staying put is always first. useFocusTrap focuses elements[0], so DOM order
+ * picks what a reflexive Enter answers, and that has to be the safe one.
+ */
+function guardDialog(
+  t: TranslationKeys,
+  reason: WorkReason,
+  actions: { stay: () => void; leave: () => void; downloadThenLeave: () => void },
+): GuardDialog {
+  const stay: GuardButton = {
+    id: "stay",
+    label: t.navigationGuard.stay,
+    onClick: actions.stay,
+    primary: true,
+  };
+  const leave: GuardButton = {
+    id: "leave",
+    label: t.navigationGuard.leave,
+    onClick: actions.leave,
+    primary: false,
+  };
+
+  switch (reason.kind) {
     case "processing":
-      return { title: t.navigationGuard.processingTitle, body: t.navigationGuard.processingBody };
-    case "unsaved":
-      return { title: t.navigationGuard.unsavedTitle, body: t.navigationGuard.unsavedBody };
+      return {
+        title: t.navigationGuard.processingTitle,
+        body: t.navigationGuard.processingBody,
+        buttons: [stay, leave],
+      };
+    case "unsaved": {
+      const download: GuardButton = {
+        id: "download",
+        label: t.navigationGuard.downloadAndLeave,
+        onClick: actions.downloadThenLeave,
+        primary: false,
+      };
+      return {
+        title: t.navigationGuard.unsavedTitle,
+        body: t.navigationGuard.unsavedBody,
+        // useWorkInFlight hands back no empty list today. The check is what
+        // stops a button labelled Download appearing with nothing behind it if
+        // a later reason for "unsaved" ever does.
+        buttons: reason.downloads.length > 0 ? [stay, download, leave] : [stay, leave],
+      };
+    }
     case "editor-dirty":
-      return { title: t.navigationGuard.editorTitle, body: t.navigationGuard.editorBody };
+      return {
+        title: t.navigationGuard.editorTitle,
+        body: t.navigationGuard.editorBody,
+        buttons: [stay, leave],
+      };
   }
 }
 
@@ -56,6 +118,10 @@ export function NavigationGuard() {
   // this boolean. `[reason]` would re-run them on every store patch in a run.
   const hasWork = reason !== null;
   const dialogRef = useRef<HTMLDivElement>(null);
+  // Set from the moment a download starts here until the block it answers is
+  // gone. See the auto-proceed effect below for both things it holds off.
+  const downloadPendingRef = useRef(false);
+  const leaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Registered only while there is something to lose. A permanently
   // registered beforeunload listener can disqualify the page from bfcache.
@@ -98,10 +164,33 @@ export function NavigationGuard() {
   const stay = useCallback(() => blocker.reset?.(), [blocker]);
   const leave = useCallback(() => blocker.proceed?.(), [blocker]);
 
+  // The block this flag answers is over, so the next one starts clean.
+  useEffect(() => {
+    if (!blocked) downloadPendingRef.current = false;
+  }, [blocked]);
+
+  // AuthGuard can swap this component out in the tick between the download and
+  // the leave it defers. useBlocker's cleanup deletes the blocker on that
+  // unmount, and react-router throws on a proceed that lands on a blocker which
+  // is no longer there, out of a timer where nothing catches it.
+  useEffect(
+    () => () => {
+      if (leaveTimerRef.current !== null) clearTimeout(leaveTimerRef.current);
+    },
+    [],
+  );
+
   // The run finished and auto-saved while the user was reading the dialog.
   // Stop asking about work that is no longer at risk.
+  //
+  // Never while downloading and leaving is under way, though, on either side of
+  // its proceed. Before it: claiming a result drops hasWork, so this effect
+  // would commit the navigation mid-download and the remount's reset() would
+  // revoke the blob url the browser is still reading. After it: this effect
+  // runs once more holding the blocker object from the blocked render, and a
+  // second proceed on one block is a transition react-router throws on.
   useEffect(() => {
-    if (blocked && !hasWork) blocker.proceed?.();
+    if (blocked && !hasWork && !downloadPendingRef.current) blocker.proceed?.();
   }, [blocked, hasWork, blocker]);
 
   // Escape means stay. A guard a stray keypress dismisses into data loss is
@@ -121,7 +210,47 @@ export function NavigationGuard() {
 
   if (!blocked || !reason) return null;
 
-  const copy = guardCopy(t, reason.kind);
+  const downloadThenLeave = () => {
+    // The flag doubles as the re-entry guard. A second click before the
+    // deferred tick would hand the browser the same files again and queue a
+    // second proceed on a block that only has one answer left in it.
+    if (reason.kind !== "unsaved" || downloadPendingRef.current) return;
+    downloadPendingRef.current = true;
+
+    const tookTheZip = reason.downloads.some((item) => item.kind === "zip");
+    // Total over the union, so no member can be silently skipped.
+    for (const item of reason.downloads) {
+      // A zip carries a raw Blob, so downloadBlob mints an object url for it
+      // and owns revoking that url. A result carries a url the file store
+      // minted and revokes in reset(), so handing it over is the whole job:
+      // revoking it here would cut the preview still on screen.
+      if (item.kind === "zip") downloadBlob(item.blob, item.filename);
+      else triggerDownload(item.url, item.filename);
+    }
+
+    // Claim and navigate on a later tick. Proceeding commits the navigation,
+    // which remounts tool-page, whose reset() revokes these blob urls. Doing it
+    // in this tick can cancel a download the browser has not started yet.
+    leaveTimerRef.current = setTimeout(() => {
+      leaveTimerRef.current = null;
+      const store = useFileStore.getState();
+      // Claims exactly what went out above, by the indices the downloads
+      // carry, never whatever the store holds now. A result that lands in this
+      // window is not in the list, so it stays unclaimed and keeps warning.
+      // The zip needs no such care: it holds every result, so taking it claims
+      // the whole batch.
+      if (tookTheZip) {
+        store.markBatchClaimed();
+      } else {
+        for (const item of reason.downloads) {
+          if (item.kind === "result") store.markClaimed(item.index);
+        }
+      }
+      blocker.proceed?.();
+    }, 0);
+  };
+
+  const dialog = guardDialog(t, reason, { stay, leave, downloadThenLeave });
 
   return (
     // Above every other fixed layer in the app: the migration banner sits at 55
@@ -143,29 +272,29 @@ export function NavigationGuard() {
         className="relative z-10 mx-4 w-full max-w-sm rounded-xl border border-border bg-background p-5 text-start shadow-xl"
       >
         <h2 id={TITLE_ID} className="text-sm font-semibold text-foreground">
-          {copy.title}
+          {dialog.title}
         </h2>
         <p id={BODY_ID} className="mt-2 text-sm text-muted-foreground">
-          {copy.body}
+          {dialog.body}
         </p>
 
         {/* Stacked, never a row. German runs 59 display units across these
             labels and Japanese 52, against 20 for English's widest. */}
         <div className="mt-5 flex flex-col gap-2">
-          <button
-            type="button"
-            onClick={stay}
-            className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          >
-            {t.navigationGuard.stay}
-          </button>
-          <button
-            type="button"
-            onClick={leave}
-            className="w-full rounded-lg border border-border px-4 py-2 text-sm text-foreground hover:bg-muted"
-          >
-            {t.navigationGuard.leave}
-          </button>
+          {dialog.buttons.map((button) => (
+            <button
+              key={button.id}
+              type="button"
+              onClick={button.onClick}
+              className={
+                button.primary
+                  ? "w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                  : "w-full rounded-lg border border-border px-4 py-2 text-sm text-foreground hover:bg-muted"
+              }
+            >
+              {button.label}
+            </button>
+          ))}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/common/navigation-guard.tsx
+++ b/apps/web/src/components/common/navigation-guard.tsx
@@ -1,5 +1,45 @@
-import { useEffect } from "react";
-import { useWorkInFlight } from "@/hooks/use-work-in-flight";
+import type { TranslationKeys } from "@snapotter/shared";
+import { useCallback, useEffect, useRef } from "react";
+import { type BlockerFunction, useBlocker } from "react-router";
+import { useTranslation } from "@/contexts/i18n-context";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
+import { normalizePath, useWorkInFlight, type WorkReason } from "@/hooks/use-work-in-flight";
+
+const TITLE_ID = "navigation-guard-title";
+const BODY_ID = "navigation-guard-body";
+
+/**
+ * Routes the guard steps aside for. Defence in depth: nothing reaches these
+ * through the router today.
+ *
+ * Every current route to them is a document navigation the blocker never sees
+ * (window.location.href in avatar-dropdown.tsx, settings-dialog.tsx and
+ * login-page.tsx). AuthGuard's <Navigate to="/login" replace /> on session
+ * expiry, and its <Navigate to="/change-password" replace /> on a forced
+ * password change, are covered by commit ordering instead: AuthGuard renders
+ * them INSTEAD of children, so this component unmounts in the same commit and
+ * useBlocker's cleanup deletes the blocker before Navigate's effect navigates.
+ *
+ * What this set guards is the first in-app <Link to="/login"> someone adds,
+ * which would otherwise be silently unguarded: a dialog asking about work an
+ * expired session can no longer finish, with no answer that helps.
+ *
+ * Deliberately not AUTH_GUARD_UNGATED_PATHS: that set also holds /privacy, and
+ * clicking through to the privacy page mid-run is an ordinary navigation that
+ * loses real work and deserves the prompt.
+ */
+const NEVER_BLOCKED = new Set(["/login", "/change-password"]);
+
+function guardCopy(t: TranslationKeys, kind: WorkReason["kind"]): { title: string; body: string } {
+  switch (kind) {
+    case "processing":
+      return { title: t.navigationGuard.processingTitle, body: t.navigationGuard.processingBody };
+    case "unsaved":
+      return { title: t.navigationGuard.unsavedTitle, body: t.navigationGuard.unsavedBody };
+    case "editor-dirty":
+      return { title: t.navigationGuard.editorTitle, body: t.navigationGuard.editorBody };
+  }
+}
 
 /**
  * Warns before a close or a navigation throws away a running job or a result
@@ -10,10 +50,12 @@ import { useWorkInFlight } from "@/hooks/use-work-in-flight";
  * wants to guard navigation adds a reason to useWorkInFlight instead.
  */
 export function NavigationGuard() {
+  const { t } = useTranslation();
   const reason = useWorkInFlight();
   // useWorkInFlight rebuilds its return value every render, so effects key on
   // this boolean. `[reason]` would re-run them on every store patch in a run.
   const hasWork = reason !== null;
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   // Registered only while there is something to lose. A permanently
   // registered beforeunload listener can disqualify the page from bfcache.
@@ -31,5 +73,101 @@ export function NavigationGuard() {
     return () => window.removeEventListener("beforeunload", handler);
   }, [hasWork]);
 
-  return null;
+  // A stable identity, not an inline arrow. In react-router 8.3.0 the effect
+  // that allocates a blocker key is keyed on [router] alone, so an arrow buys no
+  // second blocker; what it buys is the function-assignment effect re-running on
+  // every render, which during a run is every store patch.
+  const shouldBlock = useCallback<BlockerFunction>(
+    ({ currentLocation, nextLocation }) => {
+      if (!hasWork) return false;
+      // The same spelling useWorkInFlight uses. React Router matches
+      // case-insensitively and tolerates a trailing slash, so without this
+      // "/image/compress-image/" reads as a different page from the one it
+      // renders and the guard asks about a navigation that goes nowhere.
+      const next = normalizePath(nextLocation.pathname);
+      if (NEVER_BLOCKED.has(next)) return false;
+      // automate-page clears router state by navigating to its own path.
+      return normalizePath(currentLocation.pathname) !== next;
+    },
+    [hasWork],
+  );
+
+  const blocker = useBlocker(shouldBlock);
+  const blocked = blocker.state === "blocked";
+
+  const stay = useCallback(() => blocker.reset?.(), [blocker]);
+  const leave = useCallback(() => blocker.proceed?.(), [blocker]);
+
+  // The run finished and auto-saved while the user was reading the dialog.
+  // Stop asking about work that is no longer at risk.
+  useEffect(() => {
+    if (blocked && !hasWork) blocker.proceed?.();
+  }, [blocked, hasWork, blocker]);
+
+  // Escape means stay. A guard a stray keypress dismisses into data loss is
+  // worse than no guard, so the destructive answer needs a deliberate click.
+  useEffect(() => {
+    if (!blocked) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      blocker.reset?.();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [blocked, blocker]);
+
+  useFocusTrap(dialogRef, blocked);
+
+  if (!blocked || !reason) return null;
+
+  const copy = guardCopy(t, reason.kind);
+
+  return (
+    // Above every other fixed layer in the app: the migration banner sits at 55
+    // and the connection banner and editor menus at 60, and the survey overlay
+    // shares 50 but renders after this one, so a plain z-50 leaves a mouse user
+    // clickable buttons outside a dialog aria-modal says is the only thing here.
+    // The skip-to-content link at 100 stays on top, as it should.
+    <div className="fixed inset-0 z-[65] flex items-center justify-center">
+      {/* Inert on purpose. A misplaced click on the backdrop is exactly the
+          accident this dialog exists to catch, so it answers nothing. */}
+      <div aria-hidden="true" className="absolute inset-0 bg-black/60" />
+
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={TITLE_ID}
+        aria-describedby={BODY_ID}
+        className="relative z-10 mx-4 w-full max-w-sm rounded-xl border border-border bg-background p-5 text-start shadow-xl"
+      >
+        <h2 id={TITLE_ID} className="text-sm font-semibold text-foreground">
+          {copy.title}
+        </h2>
+        <p id={BODY_ID} className="mt-2 text-sm text-muted-foreground">
+          {copy.body}
+        </p>
+
+        {/* Stacked, never a row. German runs 59 display units across these
+            labels and Japanese 52, against 20 for English's widest. */}
+        <div className="mt-5 flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={stay}
+            className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            {t.navigationGuard.stay}
+          </button>
+          <button
+            type="button"
+            onClick={leave}
+            className="w-full rounded-lg border border-border px-4 py-2 text-sm text-foreground hover:bg-muted"
+          >
+            {t.navigationGuard.leave}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/components/common/navigation-guard.tsx
+++ b/apps/web/src/components/common/navigation-guard.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { useWorkInFlight } from "@/hooks/use-work-in-flight";
+
+/**
+ * Warns before a close or a navigation throws away a running job or a result
+ * the user never took.
+ *
+ * This is the only useBlocker call site in the app: the router supports one
+ * blocker at a time and warns when a second registers. Anything else that
+ * wants to guard navigation adds a reason to useWorkInFlight instead.
+ */
+export function NavigationGuard() {
+  const reason = useWorkInFlight();
+  // useWorkInFlight rebuilds its return value every render, so effects key on
+  // this boolean. `[reason]` would re-run them on every store patch in a run.
+  const hasWork = reason !== null;
+
+  // Registered only while there is something to lose. A permanently
+  // registered beforeunload listener can disqualify the page from bfcache.
+  useEffect(() => {
+    if (!hasWork) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Legacy support for Chrome and Edge below 119, which raise the prompt
+      // off a truthy returnValue rather than off preventDefault. Truthy is the
+      // load-bearing part: the legacy path ignores a falsy value, so the "" you
+      // see in older snippets does nothing.
+      e.returnValue = true;
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [hasWork]);
+
+  return null;
+}

--- a/apps/web/src/components/common/result-download-link.tsx
+++ b/apps/web/src/components/common/result-download-link.tsx
@@ -1,0 +1,61 @@
+import { Download } from "lucide-react";
+import type { ReactNode } from "react";
+import { useTranslation } from "@/contexts/i18n-context";
+import { useFileStore } from "@/stores/file-store";
+
+/** The outline button most tool settings panels use for their result. */
+const DEFAULT_CLASS_NAME =
+  "w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5";
+
+/** The solid variant, for panels whose result button is the primary action. */
+export const SOLID_CLASS_NAME =
+  "bg-primary text-primary-foreground hover:bg-primary/90 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium";
+
+interface ResultDownloadLinkProps {
+  href: string;
+  testId?: string;
+  /** Replaces the default classes entirely; they are not merged. */
+  className?: string;
+  /** Text beside the icon. Defaults to the shared "Download" string. */
+  label?: ReactNode;
+  /** The whole contents of the link, icon included. Prefer `label` unless the
+   *  icon itself has to go. */
+  children?: ReactNode;
+  /** Filename to force on the saved file; omit to let the response name it. */
+  downloadName?: string;
+}
+
+/**
+ * Download link for the result held in the file store. Tool settings panels use
+ * this so the claim lands where the user takes their file. Sites that build
+ * their anchor imperatively still do not claim (#1111).
+ */
+export function ResultDownloadLink({
+  href,
+  testId,
+  className,
+  label,
+  children,
+  downloadName,
+}: ResultDownloadLinkProps) {
+  const { t } = useTranslation();
+
+  return (
+    <a
+      href={href}
+      download={downloadName ?? true}
+      data-testid={testId}
+      className={className ?? DEFAULT_CLASS_NAME}
+      // The result is being taken, so the navigation guard has nothing left to
+      // warn about for this entry.
+      onClick={() => useFileStore.getState().claimSelected()}
+    >
+      {children ?? (
+        <>
+          <Download className="h-4 w-4" />
+          {label ?? t.common.download}
+        </>
+      )}
+    </a>
+  );
+}

--- a/apps/web/src/components/common/review-panel.tsx
+++ b/apps/web/src/components/common/review-panel.tsx
@@ -8,6 +8,7 @@ import { formatFileSize, triggerDownload } from "@/lib/download";
 import { classifyFeedbackError } from "@/lib/feedback";
 import { format } from "@/lib/format";
 import { cn } from "@/lib/utils";
+import { useFileStore } from "@/stores/file-store";
 import { ToolFeedbackPrompt } from "../feedback/tool-feedback-prompt";
 
 /** Tools whose primary output is text/data, not a downloadable file. */
@@ -81,11 +82,17 @@ export function ReviewPanel({
       track(ANALYTICS_EVENTS.RESULT_DOWNLOADED, { tool_id: currentToolId });
     });
     triggerDownload(downloadUrl, filename);
+    const { markClaimed, selectedIndex } = useFileStore.getState();
+    markClaimed(selectedIndex);
   };
 
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
 
   const handleSaveToFiles = useCallback(async () => {
+    // Capture before the awaits below: the thumbnail strip can move the
+    // selection while the upload is in flight, and the claim must land on the
+    // entry that was actually saved.
+    const claimIndex = useFileStore.getState().selectedIndex;
     setSaveStatus("saving");
     try {
       const res = await fetch(downloadUrl);
@@ -102,6 +109,7 @@ export function ReviewPanel({
       });
       if (!uploadRes.ok) throw new Error("Upload failed");
       setSaveStatus("saved");
+      useFileStore.getState().markClaimed(claimIndex);
       // "Save to library" is the real success signal for a self-hosted tool
       // (there is no purchase). result_saved was defined + allowlisted but never
       // fired, so save-rate was unmeasurable.

--- a/apps/web/src/components/common/review-panel.tsx
+++ b/apps/web/src/components/common/review-panel.tsx
@@ -82,8 +82,7 @@ export function ReviewPanel({
       track(ANALYTICS_EVENTS.RESULT_DOWNLOADED, { tool_id: currentToolId });
     });
     triggerDownload(downloadUrl, filename);
-    const { markClaimed, selectedIndex } = useFileStore.getState();
-    markClaimed(selectedIndex);
+    useFileStore.getState().claimSelected();
   };
 
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");

--- a/apps/web/src/components/common/waveform-player.tsx
+++ b/apps/web/src/components/common/waveform-player.tsx
@@ -7,6 +7,9 @@ import { cn } from "@/lib/utils";
 interface WaveformPlayerProps {
   src: string;
   className?: string;
+  /** Runs when the decode fallback's download link is used. Result call sites
+   *  pass the file-store claim; elsewhere `src` is the original audio. */
+  onDownload?: () => void;
 }
 
 function formatTime(seconds: number): string {
@@ -18,7 +21,7 @@ function formatTime(seconds: number): string {
 /** Timeout (ms) after which we assume WaveSurfer cannot decode the audio. */
 const DECODE_TIMEOUT_MS = 15_000;
 
-export function WaveformPlayer({ src, className }: WaveformPlayerProps) {
+export function WaveformPlayer({ src, className, onDownload }: WaveformPlayerProps) {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
   const wsRef = useRef<WaveSurfer | null>(null);
@@ -131,6 +134,7 @@ export function WaveformPlayer({ src, className }: WaveformPlayerProps) {
               href={src}
               download
               className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
+              onClick={onDownload}
             >
               <Download className="h-4 w-4" />
               {t.common.download}

--- a/apps/web/src/components/tools/ai-canvas-expand-settings.tsx
+++ b/apps/web/src/components/tools/ai-canvas-expand-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -240,17 +240,7 @@ export function AiCanvasExpandSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="ai-canvas-expand-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="ai-canvas-expand-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/auto-subtitles-settings.tsx
+++ b/apps/web/src/components/tools/auto-subtitles-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink, SOLID_CLASS_NAME } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -120,16 +120,7 @@ export function AutoSubtitlesSettings() {
       )}
 
       {/* Download */}
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          className="bg-primary text-primary-foreground hover:bg-primary/90 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} className={SOLID_CLASS_NAME} />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/background-replace-settings.tsx
+++ b/apps/web/src/components/tools/background-replace-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink, SOLID_CLASS_NAME } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -246,16 +246,7 @@ export function BackgroundReplaceSettings() {
       )}
 
       {/* Download */}
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          className="bg-primary text-primary-foreground hover:bg-primary/90 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} className={SOLID_CLASS_NAME} />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/beautify-settings.tsx
+++ b/apps/web/src/components/tools/beautify-settings.tsx
@@ -1,8 +1,9 @@
-import { Download, Plus, Upload, X } from "lucide-react";
+import { Plus, Upload, X } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { CollapsibleSection } from "@/components/common/collapsible-section";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { formatHeaders } from "@/lib/api";
@@ -1414,15 +1415,7 @@ export function BeautifySettings({
       )}
 
       {displayDownloadUrl && (
-        <a
-          href={displayDownloadUrl}
-          download
-          data-testid="beautify-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+        <ResultDownloadLink href={displayDownloadUrl} testId="beautify-download" />
       )}
     </form>
   );

--- a/apps/web/src/components/tools/blur-background-settings.tsx
+++ b/apps/web/src/components/tools/blur-background-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink, SOLID_CLASS_NAME } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -130,15 +130,11 @@ export function BlurBackgroundSettings() {
 
       {/* Download */}
       {downloadUrl && (
-        <a
+        <ResultDownloadLink
           href={downloadUrl}
-          download
-          data-testid="blur-bg-download"
-          className="bg-primary text-primary-foreground hover:bg-primary/90 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+          testId="blur-bg-download"
+          className={SOLID_CLASS_NAME}
+        />
       )}
     </form>
   );

--- a/apps/web/src/components/tools/blur-faces-settings.tsx
+++ b/apps/web/src/components/tools/blur-faces-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -157,17 +157,7 @@ export function BlurFacesSettings() {
       )}
 
       {/* Download */}
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="blur-faces-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="blur-faces-download" />}
     </div>
   );
 }

--- a/apps/web/src/components/tools/border-settings.tsx
+++ b/apps/web/src/components/tools/border-settings.tsx
@@ -1,7 +1,7 @@
-import { Download } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -644,17 +644,7 @@ export function BorderSettings({
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="border-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="border-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/chart-maker-settings.tsx
+++ b/apps/web/src/components/tools/chart-maker-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { useFileStore } from "@/stores/file-store";
@@ -138,17 +138,7 @@ export function ChartMakerSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="chart-maker-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="chart-maker-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/circle-crop-settings.tsx
+++ b/apps/web/src/components/tools/circle-crop-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { useFileStore } from "@/stores/file-store";
@@ -269,17 +269,7 @@ export function CircleCropSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="circle-crop-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="circle-crop-download" />}
     </div>
   );
 }

--- a/apps/web/src/components/tools/color-blindness-settings.tsx
+++ b/apps/web/src/components/tools/color-blindness-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -161,17 +161,7 @@ export function ColorBlindnessSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="color-blindness-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="color-blindness-download" />}
     </div>
   );
 }

--- a/apps/web/src/components/tools/color-settings.tsx
+++ b/apps/web/src/components/tools/color-settings.tsx
@@ -1,6 +1,7 @@
-import { ChevronDown, ChevronRight, Download } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -445,15 +446,7 @@ export function ColorSettings({ toolId, onPreviewFilter }: ColorSettingsProps) {
 
       {/* Download (single-file only - batch uses Download All ZIP in tool-page) */}
       {downloadUrl && files.length <= 1 && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="adjust-colors-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+        <ResultDownloadLink href={downloadUrl} testId="adjust-colors-download" />
       )}
     </form>
   );

--- a/apps/web/src/components/tools/colorize-settings.tsx
+++ b/apps/web/src/components/tools/colorize-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -150,15 +150,7 @@ export function ColorizeSettings() {
       )}
 
       {!hasMultiple && downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="colorize-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+        <ResultDownloadLink href={downloadUrl} testId="colorize-download" />
       )}
     </form>
   );

--- a/apps/web/src/components/tools/compare-settings.tsx
+++ b/apps/web/src/components/tools/compare-settings.tsx
@@ -1,5 +1,6 @@
-import { Download, Loader2, Upload } from "lucide-react";
+import { Loader2, Upload } from "lucide-react";
 import { useRef, useState } from "react";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { formatHeaders } from "@/lib/api";
 import { format } from "@/lib/format";
@@ -100,15 +101,11 @@ export function CompareSettings() {
       </button>
 
       {downloadUrl && (
-        <a
+        <ResultDownloadLink
           href={downloadUrl}
-          download
-          data-testid="compare-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.toolSettings.compare.downloadDiffImage}
-        </a>
+          testId="compare-download"
+          label={t.toolSettings.compare.downloadDiffImage}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/tools/compose-settings.tsx
+++ b/apps/web/src/components/tools/compose-settings.tsx
@@ -1,5 +1,6 @@
-import { Download, Loader2, Upload } from "lucide-react";
+import { Loader2, Upload } from "lucide-react";
 import { useRef, useState } from "react";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { formatHeaders } from "@/lib/api";
 import { format } from "@/lib/format";
@@ -180,17 +181,7 @@ export function ComposeSettings() {
         {processing ? t.toolSettings.compose.processing : t.toolSettings.compose.submit}
       </button>
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="compose-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="compose-download" />}
     </div>
   );
 }

--- a/apps/web/src/components/tools/compress-settings.tsx
+++ b/apps/web/src/components/tools/compress-settings.tsx
@@ -1,6 +1,7 @@
-import { Download, Minus, Plus } from "lucide-react";
+import { Minus, Plus } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -250,17 +251,7 @@ export function CompressSettings() {
       )}
 
       {/* Download */}
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="compress-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="compress-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/content-aware-resize-settings.tsx
+++ b/apps/web/src/components/tools/content-aware-resize-settings.tsx
@@ -1,7 +1,7 @@
-import { Download } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HintIcon } from "@/components/common/hint-icon";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -216,15 +216,7 @@ export function ContentAwareResizeSettings() {
       )}
 
       {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="content-aware-resize-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+        <ResultDownloadLink href={downloadUrl} testId="content-aware-resize-download" />
       )}
     </form>
   );

--- a/apps/web/src/components/tools/conversion-preset-settings.tsx
+++ b/apps/web/src/components/tools/conversion-preset-settings.tsx
@@ -1,8 +1,8 @@
 import { BASE_CONFIG, CONVERSION_PRESET_BY_ID } from "@snapotter/shared";
-import { Download } from "lucide-react";
 import { useState } from "react";
 import { useParams } from "react-router";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -161,17 +161,7 @@ export function ConversionPresetSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="preset-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="preset-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/convert-settings.tsx
+++ b/apps/web/src/components/tools/convert-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -216,17 +216,7 @@ export function ConvertSettings() {
       )}
 
       {/* Download */}
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="convert-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="convert-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/crop-settings.tsx
+++ b/apps/web/src/components/tools/crop-settings.tsx
@@ -1,7 +1,8 @@
-import { ArrowLeftRight, Download, Grid3x3 } from "lucide-react";
+import { ArrowLeftRight, Grid3x3 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Crop } from "react-image-crop";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -399,17 +400,7 @@ export function CropSettings({
       )}
 
       {/* Download */}
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="crop-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="crop-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/duotone-settings.tsx
+++ b/apps/web/src/components/tools/duotone-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { useFileStore } from "@/stores/file-store";
@@ -209,17 +209,7 @@ export function DuotoneSettings({ onImageStyle, onImageOverlay }: DuotoneSetting
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="duotone-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="duotone-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/edit-metadata-settings.tsx
+++ b/apps/web/src/components/tools/edit-metadata-settings.tsx
@@ -1,17 +1,9 @@
-import {
-  AlertTriangle,
-  BookmarkPlus,
-  Download,
-  Loader2,
-  MapPin,
-  PenLine,
-  Plus,
-  X,
-} from "lucide-react";
+import { AlertTriangle, BookmarkPlus, Loader2, MapPin, PenLine, Plus, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { CollapsibleSection } from "@/components/common/collapsible-section";
 import { MetadataGrid } from "@/components/common/metadata-grid";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { formatHeaders } from "@/lib/api";
@@ -883,17 +875,7 @@ export function EditMetadataSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="edit-metadata-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="edit-metadata-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/enhance-faces-settings.tsx
+++ b/apps/web/src/components/tools/enhance-faces-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -229,15 +229,7 @@ export function EnhanceFacesSettings() {
 
       {/* Download (single file - batch uses Download All ZIP in tool-page) */}
       {!hasMultiple && downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="enhance-faces-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+        <ResultDownloadLink href={downloadUrl} testId="enhance-faces-download" />
       )}
     </div>
   );

--- a/apps/web/src/components/tools/erase-object-settings.tsx
+++ b/apps/web/src/components/tools/erase-object-settings.tsx
@@ -1,6 +1,7 @@
 import { Download, Lasso, Loader2, Paintbrush, Redo, Sparkles, Trash2, Zap } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useAuth } from "@/hooks/use-auth";
 import { formatHeaders } from "@/lib/api";
@@ -741,15 +742,7 @@ export function EraseObjectSettings({
 
       {/* Download */}
       {currentEntry?.processedUrl && (
-        <a
-          href={currentEntry.processedUrl}
-          download
-          data-testid="erase-object-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+        <ResultDownloadLink href={currentEntry.processedUrl} testId="erase-object-download" />
       )}
     </div>
   );

--- a/apps/web/src/components/tools/erase-object-settings.tsx
+++ b/apps/web/src/components/tools/erase-object-settings.tsx
@@ -314,6 +314,9 @@ export function EraseObjectSettings({
           ? { serverFileId: r.savedFileId as string }
           : {}),
       });
+      // An auto-saved result is already in the library, so it was never at risk.
+      // Must follow the updateEntry above; see the `claimed` invariant in file-store.
+      if (r.savedFileId) useFileStore.getState().markClaimed(capturedIndex);
     };
 
     const finishUi = () => {

--- a/apps/web/src/components/tools/favicon-settings.tsx
+++ b/apps/web/src/components/tools/favicon-settings.tsx
@@ -1,7 +1,7 @@
-import { Download } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { formatHeaders } from "@/lib/api";
 import { format } from "@/lib/format";
@@ -385,15 +385,12 @@ export function FaviconSettings() {
       )}
 
       {downloadUrl && (
-        <a
+        <ResultDownloadLink
           href={downloadUrl}
-          download="favicons.zip"
-          data-testid="favicon-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.toolSettings.favicon.downloadZip}
-        </a>
+          testId="favicon-download"
+          downloadName="favicons.zip"
+          label={t.toolSettings.favicon.downloadZip}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/tools/gif-tools-settings.tsx
+++ b/apps/web/src/components/tools/gif-tools-settings.tsx
@@ -1,6 +1,7 @@
-import { Download, FlipHorizontal2, FlipVertical2, Link, RotateCw, Unlink } from "lucide-react";
+import { FlipHorizontal2, FlipVertical2, Link, RotateCw, Unlink } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useGifInfo } from "@/hooks/use-gif-info";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
@@ -752,17 +753,7 @@ export function GifToolsSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="gif-tools-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="gif-tools-download" />}
     </div>
   );
 }

--- a/apps/web/src/components/tools/gif-webp-settings.tsx
+++ b/apps/web/src/components/tools/gif-webp-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { useFileStore } from "@/stores/file-store";
@@ -135,15 +135,7 @@ export function GifWebpSettings() {
 
       {downloadUrl && (
         <>
-          <a
-            href={downloadUrl}
-            download
-            data-testid="gif-webp-download"
-            className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-          >
-            <Download className="h-4 w-4" />
-            {t.common.download}
-          </a>
+          <ResultDownloadLink href={downloadUrl} testId="gif-webp-download" />
           {originalSize != null && processedSize != null && (
             <p className="text-xs text-muted-foreground text-center">
               {formatKB(originalSize)} &rarr; {formatKB(processedSize)}

--- a/apps/web/src/components/tools/histogram-settings.tsx
+++ b/apps/web/src/components/tools/histogram-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useMemo, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { useFileStore } from "@/stores/file-store";
@@ -207,17 +207,7 @@ export function HistogramSettings() {
         </div>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="histogram-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="histogram-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/image-enhancement-settings.tsx
+++ b/apps/web/src/components/tools/image-enhancement-settings.tsx
@@ -1,16 +1,7 @@
-import {
-  Download,
-  FileText,
-  Moon,
-  Mountain,
-  Sparkles,
-  User,
-  UtensilsCrossed,
-  Wand2,
-  X,
-} from "lucide-react";
+import { FileText, Moon, Mountain, Sparkles, User, UtensilsCrossed, Wand2, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -513,15 +504,7 @@ export function ImageEnhancementSettings({
       )}
 
       {downloadUrl && files.length <= 1 && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="image-enhancement-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+        <ResultDownloadLink href={downloadUrl} testId="image-enhancement-download" />
       )}
     </form>
   );

--- a/apps/web/src/components/tools/image-pad-settings.tsx
+++ b/apps/web/src/components/tools/image-pad-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { useFileStore } from "@/stores/file-store";
@@ -302,17 +302,7 @@ export function ImagePadSettings({ onImageStyle, onImageOverlay }: ImagePadSetti
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="image-pad-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="image-pad-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/image-to-pdf-settings.tsx
+++ b/apps/web/src/components/tools/image-to-pdf-settings.tsx
@@ -1,7 +1,7 @@
-import { Download } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { formatHeaders } from "@/lib/api";
 import { format, plural } from "@/lib/format";
@@ -408,15 +408,11 @@ export function ImageToPdfSettings() {
       )}
 
       {downloadUrl && (
-        <a
+        <ResultDownloadLink
           href={downloadUrl}
-          download
-          data-testid="image-to-pdf-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {collate ? ts.downloadPdf : ts.downloadZip}
-        </a>
+          testId="image-to-pdf-download"
+          label={collate ? ts.downloadPdf : ts.downloadZip}
+        />
       )}
 
       {compressionResult && (

--- a/apps/web/src/components/tools/lqip-placeholder-settings.tsx
+++ b/apps/web/src/components/tools/lqip-placeholder-settings.tsx
@@ -1,6 +1,7 @@
-import { Check, Copy, Download } from "lucide-react";
+import { Check, Copy } from "lucide-react";
 import { useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { copyToClipboard } from "@/lib/utils";
@@ -189,17 +190,7 @@ export function LqipPlaceholderSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="lqip-placeholder-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="lqip-placeholder-download" />}
 
       {/* Output section */}
       {dataUri && (

--- a/apps/web/src/components/tools/noise-removal-settings.tsx
+++ b/apps/web/src/components/tools/noise-removal-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -312,15 +312,7 @@ export function NoiseRemovalSettings() {
 
       {/* Download (single file - batch uses Download All ZIP in tool-page) */}
       {!hasMultiple && downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="noise-removal-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+        <ResultDownloadLink href={downloadUrl} testId="noise-removal-download" />
       )}
     </div>
   );

--- a/apps/web/src/components/tools/ocr-pdf-settings.tsx
+++ b/apps/web/src/components/tools/ocr-pdf-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink, SOLID_CLASS_NAME } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -141,16 +141,7 @@ export function OcrPdfSettings() {
       )}
 
       {/* Download */}
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          className="bg-primary text-primary-foreground hover:bg-primary/90 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} className={SOLID_CLASS_NAME} />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/optimize-for-web-settings.tsx
+++ b/apps/web/src/components/tools/optimize-for-web-settings.tsx
@@ -1,6 +1,7 @@
-import { ChevronDown, ChevronRight, Download, Loader2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { formatHeaders } from "@/lib/api";
@@ -385,16 +386,7 @@ export function OptimizeForWebSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/pixelate-settings.tsx
+++ b/apps/web/src/components/tools/pixelate-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { useFileStore } from "@/stores/file-store";
@@ -340,17 +340,7 @@ export function PixelateSettings({
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="pixelate-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="pixelate-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/red-eye-removal-settings.tsx
+++ b/apps/web/src/components/tools/red-eye-removal-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -230,15 +230,7 @@ export function RedEyeRemovalSettings() {
 
       {/* Download (single file - batch uses Download All ZIP in tool-page) */}
       {!hasMultiple && downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="red-eye-removal-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+        <ResultDownloadLink href={downloadUrl} testId="red-eye-removal-download" />
       )}
     </div>
   );

--- a/apps/web/src/components/tools/remove-bg-settings.tsx
+++ b/apps/web/src/components/tools/remove-bg-settings.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { formatHeaders } from "@/lib/api";
@@ -1017,15 +1018,11 @@ export function RemoveBgSettings({ onBgPreview }: RemoveBgSettingsProps = {}) {
               {applyingEffects ? t.toolSettings["remove-background"].rendering : t.common.download}
             </button>
           ) : (
-            <a
+            <ResultDownloadLink
               href={downloadUrl || ""}
-              download
-              data-testid="remove-background-download"
+              testId="remove-background-download"
               className="w-full py-2.5 rounded-lg bg-primary text-primary-foreground font-medium flex items-center justify-center gap-2 hover:bg-primary/90"
-            >
-              <Download className="h-4 w-4" />
-              {t.common.download}
-            </a>
+            />
           )}
         </div>
       )}

--- a/apps/web/src/components/tools/remove-gif-background-settings.tsx
+++ b/apps/web/src/components/tools/remove-gif-background-settings.tsx
@@ -1,6 +1,7 @@
-import { Download, ImageIcon, Upload } from "lucide-react";
+import { ImageIcon, Upload } from "lucide-react";
 import { type ReactNode, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -301,15 +302,12 @@ export function RemoveGifBackgroundSettings() {
       )}
 
       {downloadUrl && !processing && files.length <= 1 && (
-        <a
+        <ResultDownloadLink
           href={downloadUrl}
-          download
-          data-testid="remove-gif-background-download"
+          testId="remove-gif-background-download"
           className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-2.5 font-medium text-primary-foreground hover:bg-primary/90"
-        >
-          <Download className="h-4 w-4" />
-          {s.download}
-        </a>
+          label={s.download}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/tools/replace-color-settings.tsx
+++ b/apps/web/src/components/tools/replace-color-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -182,17 +182,7 @@ export function ReplaceColorSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="replace-color-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="replace-color-download" />}
     </div>
   );
 }

--- a/apps/web/src/components/tools/resize-settings.tsx
+++ b/apps/web/src/components/tools/resize-settings.tsx
@@ -1,8 +1,8 @@
 import { SOCIAL_MEDIA_PRESETS } from "@snapotter/shared";
-import { Download } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HintIcon } from "@/components/common/hint-icon";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { largestRatioBox, pairedDimension, RESIZE_RATIO_PRESETS } from "@/lib/aspect-ratio";
@@ -515,17 +515,7 @@ export function ResizeSettings() {
       )}
 
       {/* Download */}
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="resize-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="resize-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/restore-photo-settings.tsx
+++ b/apps/web/src/components/tools/restore-photo-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -295,15 +295,7 @@ export function RestorePhotoSettings() {
 
       {/* Download (single file) */}
       {!hasMultiple && downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="restore-photo-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+        <ResultDownloadLink href={downloadUrl} testId="restore-photo-download" />
       )}
     </div>
   );

--- a/apps/web/src/components/tools/rounded-crop-settings.tsx
+++ b/apps/web/src/components/tools/rounded-crop-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { useFileStore } from "@/stores/file-store";
@@ -350,17 +350,7 @@ export function RoundedCropSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="rounded-crop-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="rounded-crop-download" />}
     </div>
   );
 }

--- a/apps/web/src/components/tools/sharpening-settings.tsx
+++ b/apps/web/src/components/tools/sharpening-settings.tsx
@@ -1,7 +1,8 @@
-import { ChevronDown, ChevronRight, Download } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -403,15 +404,7 @@ export function SharpeningSettings() {
       )}
 
       {downloadUrl && files.length <= 1 && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="sharpening-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+        <ResultDownloadLink href={downloadUrl} testId="sharpening-download" />
       )}
     </form>
   );

--- a/apps/web/src/components/tools/sign-pdf-settings.tsx
+++ b/apps/web/src/components/tools/sign-pdf-settings.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { formatHeaders } from "@/lib/api";
 import { format } from "@/lib/format";
@@ -310,13 +311,12 @@ export function SignPdfSettings({ signProps }: { signProps?: SignProps }) {
       {error && <p className="text-sm text-destructive">{error}</p>}
 
       {downloadUrl ? (
-        <a
+        <ResultDownloadLink
           href={downloadUrl}
-          download
           className="block w-full rounded-lg bg-primary py-2.5 text-center font-semibold text-primary-foreground"
         >
           {sp.downloadSigned}
-        </a>
+        </ResultDownloadLink>
       ) : (
         <button
           type="button"

--- a/apps/web/src/components/tools/sprite-sheet-settings.tsx
+++ b/apps/web/src/components/tools/sprite-sheet-settings.tsx
@@ -1,6 +1,7 @@
-import { Check, ClipboardCopy, Download } from "lucide-react";
+import { Check, ClipboardCopy } from "lucide-react";
 import { useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format as formatMessage } from "@/lib/format";
@@ -175,17 +176,7 @@ export function SpriteSheetSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="sprite-sheet-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="sprite-sheet-download" />}
 
       {/* Coordinate map output */}
       {Array.isArray(resultPayload?.frames) && (

--- a/apps/web/src/components/tools/stitch-settings.tsx
+++ b/apps/web/src/components/tools/stitch-settings.tsx
@@ -1,5 +1,6 @@
-import { Download, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useState } from "react";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { formatHeaders } from "@/lib/api";
 import { format as formatMessage } from "@/lib/format";
@@ -335,15 +336,11 @@ export function StitchSettings() {
       </button>
 
       {downloadUrl && (
-        <a
+        <ResultDownloadLink
           href={downloadUrl}
-          download
-          data-testid="stitch-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.toolSettings.stitch.downloadStitchedImage}
-        </a>
+          testId="stitch-download"
+          label={t.toolSettings.stitch.downloadStitchedImage}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/tools/strip-metadata-settings.tsx
+++ b/apps/web/src/components/tools/strip-metadata-settings.tsx
@@ -1,8 +1,9 @@
-import { Download, ExternalLink, Loader2, MapPin } from "lucide-react";
+import { ExternalLink, Loader2, MapPin } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { CollapsibleSection } from "@/components/common/collapsible-section";
 import { MetadataGrid } from "@/components/common/metadata-grid";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { formatHeaders } from "@/lib/api";
@@ -435,17 +436,7 @@ export function StripMetadataSettings() {
       )}
 
       {/* Download */}
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="strip-metadata-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="strip-metadata-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/svg-to-raster-settings.tsx
+++ b/apps/web/src/components/tools/svg-to-raster-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format as formatMessage } from "@/lib/format";
@@ -387,17 +387,7 @@ export function SvgToRasterSettings() {
       )}
 
       {/* Download */}
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="svg-to-raster-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="svg-to-raster-download" />}
     </div>
   );
 }

--- a/apps/web/src/components/tools/text-overlay-settings.tsx
+++ b/apps/web/src/components/tools/text-overlay-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -220,15 +220,7 @@ export function TextOverlaySettings() {
       )}
 
       {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="text-overlay-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {ts.download}
-        </a>
+        <ResultDownloadLink href={downloadUrl} testId="text-overlay-download" label={ts.download} />
       )}
     </div>
   );

--- a/apps/web/src/components/tools/transcribe-audio-settings.tsx
+++ b/apps/web/src/components/tools/transcribe-audio-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink, SOLID_CLASS_NAME } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -121,16 +121,7 @@ export function TranscribeAudioSettings() {
       )}
 
       {/* Download */}
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          className="bg-primary text-primary-foreground hover:bg-primary/90 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} className={SOLID_CLASS_NAME} />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/upscale-settings.tsx
+++ b/apps/web/src/components/tools/upscale-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -284,15 +284,7 @@ export function UpscaleSettings() {
 
       {/* Download (single file - batch uses Download All ZIP in tool-page) */}
       {!hasMultiple && downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="upscale-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
+        <ResultDownloadLink href={downloadUrl} testId="upscale-download" />
       )}
     </div>
   );

--- a/apps/web/src/components/tools/vectorize-settings.tsx
+++ b/apps/web/src/components/tools/vectorize-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -388,15 +388,11 @@ export function VectorizeSettings() {
 
       {/* Download */}
       {downloadUrl && (
-        <a
+        <ResultDownloadLink
           href={downloadUrl}
-          download
-          data-testid="vectorize-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.toolSettings.vectorize.downloadSvg}
-        </a>
+          testId="vectorize-download"
+          label={t.toolSettings.vectorize.downloadSvg}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/tools/vignette-settings.tsx
+++ b/apps/web/src/components/tools/vignette-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { useFileStore } from "@/stores/file-store";
@@ -255,17 +255,7 @@ export function VignetteSettings({
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="vignette-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="vignette-download" />}
     </form>
   );
 }

--- a/apps/web/src/components/tools/watermark-image-settings.tsx
+++ b/apps/web/src/components/tools/watermark-image-settings.tsx
@@ -1,5 +1,6 @@
-import { Download, Loader2, Upload } from "lucide-react";
+import { Loader2, Upload } from "lucide-react";
 import { useRef, useState } from "react";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { formatHeaders } from "@/lib/api";
 import { format } from "@/lib/format";
@@ -217,17 +218,7 @@ export function WatermarkImageSettings() {
             : t.toolSettings["watermark-image"].submit}
       </button>
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="watermark-image-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="watermark-image-download" />}
     </div>
   );
 }

--- a/apps/web/src/components/tools/watermark-text-settings.tsx
+++ b/apps/web/src/components/tools/watermark-text-settings.tsx
@@ -1,6 +1,6 @@
-import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ProgressCard } from "@/components/common/progress-card";
+import { ResultDownloadLink } from "@/components/common/result-download-link";
 import { useTranslation } from "@/contexts/i18n-context";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { format } from "@/lib/format";
@@ -223,17 +223,7 @@ export function WatermarkTextSettings() {
         </button>
       )}
 
-      {downloadUrl && (
-        <a
-          href={downloadUrl}
-          download
-          data-testid="watermark-text-download"
-          className="w-full py-2.5 rounded-lg border border-primary text-primary-ink font-medium flex items-center justify-center gap-2 hover:bg-primary/5"
-        >
-          <Download className="h-4 w-4" />
-          {t.common.download}
-        </a>
-      )}
+      {downloadUrl && <ResultDownloadLink href={downloadUrl} testId="watermark-text-download" />}
     </div>
   );
 }

--- a/apps/web/src/hooks/use-tool-processor.ts
+++ b/apps/web/src/hooks/use-tool-processor.ts
@@ -397,6 +397,9 @@ export function useToolProcessor(toolId: string) {
                   ? { serverFileId: result.savedFileId }
                   : {}),
               });
+              // An auto-saved result is already in the library, so it was never at risk.
+              // Must follow the updateEntry above; see the `claimed` invariant in file-store.
+              if (result.savedFileId) useFileStore.getState().markClaimed(idx);
               clearActiveJob();
               setProcessing(false);
               setProgress(IDLE_PROGRESS);
@@ -680,6 +683,9 @@ export function useToolProcessor(toolId: string) {
                 ? { serverFileId: result.savedFileId }
                 : {}),
             });
+            // An auto-saved result is already in the library, so it was never at risk.
+            // Must follow the updateEntry above; see the `claimed` invariant in file-store.
+            if (result.savedFileId) useFileStore.getState().markClaimed(capturedIndex);
           } catch {
             const message = "Invalid response from server";
             setError(message);

--- a/apps/web/src/hooks/use-work-in-flight.ts
+++ b/apps/web/src/hooks/use-work-in-flight.ts
@@ -14,6 +14,10 @@ import { useFileStore } from "@/stores/file-store";
 export type GuardDownload =
   | {
       kind: "result";
+      /** The file-store entry this came from. Carried so a caller claims the
+       *  entries it actually downloaded, rather than re-reading the store a
+       *  tick later and claiming a result that landed in between. */
+      index: number;
       /** Usually an API download URL from the server, and a blob URL after a
        *  batch run settles from the zip. Hand it to triggerDownload; it is not
        *  always revocable and the store owns it. */
@@ -94,11 +98,12 @@ export function useWorkInFlight(): WorkReason | null {
 
     // Key on processedUrl, NOT on status === "completed". A result is a thing
     // the user can lose; a status is not.
-    const downloads: GuardDownload[] = entries.flatMap((e) =>
+    const downloads: GuardDownload[] = entries.flatMap((e, index) =>
       e.processedUrl && !e.claimed
         ? [
             {
               kind: "result" as const,
+              index,
               url: e.processedUrl,
               filename: e.processedFilename ?? e.file.name,
             },

--- a/apps/web/src/hooks/use-work-in-flight.ts
+++ b/apps/web/src/hooks/use-work-in-flight.ts
@@ -1,0 +1,110 @@
+import { SECTIONS } from "@snapotter/shared";
+import { useLocation } from "react-router";
+import { useEditorStore } from "@/stores/editor-store";
+import { useFileStore } from "@/stores/file-store";
+
+/**
+ * One unclaimed result the guard can offer to download before leaving.
+ *
+ * A closed union, so a consumer that switches on `kind` cannot silently skip a
+ * value that carries neither a url nor a blob. `kind` also tells a caller which
+ * case it is holding without inferring it from the array's shape: only a zip
+ * claims the whole batch.
+ */
+export type GuardDownload =
+  | {
+      kind: "result";
+      /** Usually an API download URL from the server, and a blob URL after a
+       *  batch run settles from the zip. Hand it to triggerDownload; it is not
+       *  always revocable and the store owns it. */
+      url: string;
+      filename: string;
+    }
+  | { kind: "zip"; blob: Blob; filename: string };
+
+export type WorkReason =
+  | { kind: "processing" }
+  | { kind: "unsaved"; downloads: GuardDownload[] }
+  | { kind: "editor-dirty" };
+
+const SECTION_IDS = new Set<string>(SECTIONS.map((s) => s.id));
+
+/**
+ * Lowercase, and drop one trailing slash, so "/EDITOR/" matches "/editor". "/"
+ * stays itself. React Router matches routes case-insensitively unless a route
+ * opts in to caseSensitive, which none here do, so "/EDITOR" renders the editor
+ * and the guard has to recognise it.
+ */
+function normalizePath(pathname: string): string {
+  const lower = pathname.toLowerCase();
+  return lower.length > 1 && lower.endsWith("/") ? lower.slice(0, -1) : lower;
+}
+
+/**
+ * The routes that own file-store state. The store is global and only
+ * tool-page clears it, so an unscoped guard would fire on unrelated pages
+ * visited after a run.
+ */
+function ownsFileStore(pathname: string): boolean {
+  if (pathname === "/automate") return true;
+  const parts = pathname.split("/").filter(Boolean);
+  return parts.length === 2 && SECTION_IDS.has(parts[0]);
+}
+
+/**
+ * Whether leaving this page right now throws work away, and what could be
+ * downloaded first. Returns null when there is nothing to lose.
+ *
+ * The return value is rebuilt every render and is never referentially stable,
+ * so it is not a change signal: key on `reason !== null`, not on the object
+ * identity. Memoizing would not help, because `entries` is itself a fresh array
+ * on exactly the updates that matter here.
+ */
+export function useWorkInFlight(): WorkReason | null {
+  const { pathname } = useLocation();
+  const processing = useFileStore((s) => s.processing);
+  const entries = useFileStore((s) => s.entries);
+  const batchZipBlob = useFileStore((s) => s.batchZipBlob);
+  const batchZipFilename = useFileStore((s) => s.batchZipFilename);
+  const batchZipClaimed = useFileStore((s) => s.batchZipClaimed);
+  const editorDirty = useEditorStore((s) => s.isDirty);
+
+  const path = normalizePath(pathname);
+
+  if (ownsFileStore(path)) {
+    if (processing) return { kind: "processing" };
+
+    // Nothing gates the zip on the entries having results. A batch settles by
+    // storing the zip first and filling in per-entry results after, so a run
+    // that fails that second half leaves a real, downloadable zip behind with
+    // no entry carrying a processedUrl. setFiles already clears a zip that
+    // outlived its file set, so there is no stale zip left to screen out.
+    if (batchZipBlob && !batchZipClaimed) {
+      return {
+        kind: "unsaved",
+        downloads: [
+          { kind: "zip", blob: batchZipBlob, filename: batchZipFilename ?? "processed-files.zip" },
+        ],
+      };
+    }
+
+    // Key on processedUrl, NOT on status === "completed". A result is a thing
+    // the user can lose; a status is not.
+    const downloads: GuardDownload[] = entries.flatMap((e) =>
+      e.processedUrl && !e.claimed
+        ? [
+            {
+              kind: "result" as const,
+              url: e.processedUrl,
+              filename: e.processedFilename ?? e.file.name,
+            },
+          ]
+        : [],
+    );
+    if (downloads.length > 0) return { kind: "unsaved", downloads };
+  }
+
+  if (path === "/editor" && editorDirty) return { kind: "editor-dirty" };
+
+  return null;
+}

--- a/apps/web/src/hooks/use-work-in-flight.ts
+++ b/apps/web/src/hooks/use-work-in-flight.ts
@@ -34,8 +34,12 @@ const SECTION_IDS = new Set<string>(SECTIONS.map((s) => s.id));
  * stays itself. React Router matches routes case-insensitively unless a route
  * opts in to caseSensitive, which none here do, so "/EDITOR" renders the editor
  * and the guard has to recognise it.
+ *
+ * Exported because the navigation blocker compares pathnames too. Both halves
+ * of the guard have to spell a path the same way or they disagree about which
+ * page you are on.
  */
-function normalizePath(pathname: string): string {
+export function normalizePath(pathname: string): string {
   const lower = pathname.toLowerCase();
   return lower.length > 1 && lower.endsWith("/") ? lower.slice(0, -1) : lower;
 }

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -7,6 +7,17 @@ export function triggerDownload(url: string, filename: string) {
   document.body.removeChild(a);
 }
 
+/**
+ * Download a Blob. The object URL is revoked on a later tick: revoking it in
+ * the same tick can cancel the download before the browser has started it,
+ * which matters when the caller navigates away immediately afterwards.
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  triggerDownload(url, filename);
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
 export function formatFileSize(bytes: number): string {
   if (bytes < 1024 * 1024) {
     return `${(bytes / 1024).toFixed(0)} KB`;

--- a/apps/web/src/pages/automate-page.tsx
+++ b/apps/web/src/pages/automate-page.tsx
@@ -38,7 +38,7 @@ import { useMobile } from "@/hooks/use-mobile";
 import { usePageTitle } from "@/hooks/use-page-title";
 import { usePipelineProcessor } from "@/hooks/use-pipeline-processor";
 import { formatHeaders, getFileDownloadUrl } from "@/lib/api";
-import { formatFileSize } from "@/lib/download";
+import { downloadBlob, formatFileSize, triggerDownload } from "@/lib/download";
 import { format, plural } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { useFileStore } from "@/stores/file-store";
@@ -390,20 +390,19 @@ export function AutomatePage() {
 
   const handleDownloadAll = useCallback(() => {
     if (!batchZipBlob) return;
-    const url = URL.createObjectURL(batchZipBlob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = batchZipFilename ?? "batch-pipeline.zip";
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(batchZipBlob, batchZipFilename ?? "batch-pipeline.zip");
+    useFileStore.getState().markBatchClaimed();
   }, [batchZipBlob, batchZipFilename]);
 
+  // The store owns processedUrl (an API download URL here, a blob URL after a
+  // batch run) and revokes it in reset(). Hand the existing URL to
+  // triggerDownload; downloadBlob would mint and revoke a URL this page
+  // does not own.
   const handleDownloadSingle = useCallback(() => {
     if (!processedUrl) return;
-    const a = document.createElement("a");
-    a.href = processedUrl;
-    a.download = currentEntry?.processedFilename ?? "result";
-    a.click();
+    triggerDownload(processedUrl, currentEntry?.processedFilename ?? "result");
+    const { markClaimed, selectedIndex } = useFileStore.getState();
+    markClaimed(selectedIndex);
   }, [processedUrl, currentEntry]);
 
   const handleNavKeyDown = useCallback(

--- a/apps/web/src/pages/automate-page.tsx
+++ b/apps/web/src/pages/automate-page.tsx
@@ -401,8 +401,7 @@ export function AutomatePage() {
   const handleDownloadSingle = useCallback(() => {
     if (!processedUrl) return;
     triggerDownload(processedUrl, currentEntry?.processedFilename ?? "result");
-    const { markClaimed, selectedIndex } = useFileStore.getState();
-    markClaimed(selectedIndex);
+    useFileStore.getState().claimSelected();
   }, [processedUrl, currentEntry]);
 
   const handleNavKeyDown = useCallback(
@@ -466,7 +465,10 @@ export function AutomatePage() {
           <Suspense
             fallback={<div className="text-sm text-muted-foreground">{t.common.loading}</div>}
           >
-            <WaveformPlayer src={processedUrl} />
+            <WaveformPlayer
+              src={processedUrl}
+              onDownload={() => useFileStore.getState().claimSelected()}
+            />
           </Suspense>
         );
       }

--- a/apps/web/src/pages/editor-page.tsx
+++ b/apps/web/src/pages/editor-page.tsx
@@ -34,7 +34,6 @@ export function EditorPage() {
   usePageTitle(t.sidebar.editor);
   const isMobile = useMobile();
   const sourceImageUrl = useEditorStore((s) => s.sourceImageUrl);
-  const isDirty = useEditorStore((s) => s.isDirty);
   const loadImage = useEditorStore((s) => s.loadImage);
   const rulersVisible = useEditorStore((s) => s.rulersVisible);
   const [showExport, setShowExport] = useState(false);
@@ -63,16 +62,6 @@ export function EditorPage() {
     window.addEventListener("snapotter:open-fill-dialog", handler);
     return () => window.removeEventListener("snapotter:open-fill-dialog", handler);
   }, []);
-
-  useEffect(() => {
-    const handler = (e: BeforeUnloadEvent) => {
-      if (isDirty) {
-        e.preventDefault();
-      }
-    };
-    window.addEventListener("beforeunload", handler);
-    return () => window.removeEventListener("beforeunload", handler);
-  }, [isDirty]);
 
   const handlePaste = useCallback(
     (e: ClipboardEvent) => {

--- a/apps/web/src/pages/tool-page.tsx
+++ b/apps/web/src/pages/tool-page.tsx
@@ -722,7 +722,13 @@ export function ToolPage() {
             <Suspense
               fallback={<div className="text-sm text-muted-foreground">{t.common.loading}</div>}
             >
-              <WaveformPlayer src={audioSrc} />
+              <WaveformPlayer
+                src={audioSrc}
+                // audioSrc falls back to the original, and only a result claims.
+                onDownload={
+                  processedUrl ? () => useFileStore.getState().claimSelected() : undefined
+                }
+              />
             </Suspense>
           );
         }

--- a/apps/web/src/pages/tool-page.tsx
+++ b/apps/web/src/pages/tool-page.tsx
@@ -45,7 +45,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { useMobile } from "@/hooks/use-mobile";
 import { usePageTitle } from "@/hooks/use-page-title";
 import { recordRecentTool } from "@/hooks/use-recent-tools";
-import { formatFileSize } from "@/lib/download";
+import { downloadBlob, formatFileSize } from "@/lib/download";
 import { classifyFeedbackError } from "@/lib/feedback";
 import { format } from "@/lib/format";
 import { ICON_MAP } from "@/lib/icon-map";
@@ -559,12 +559,7 @@ export function ToolPage() {
 
   const handleDownloadAll = useCallback(() => {
     if (!batchZipBlob) return;
-    const url = URL.createObjectURL(batchZipBlob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = batchZipFilename ?? "processed-files.zip";
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(batchZipBlob, batchZipFilename ?? "processed-files.zip");
   }, [batchZipBlob, batchZipFilename]);
 
   if (tool && disabledTools.includes(tool.id)) {

--- a/apps/web/src/pages/tool-page.tsx
+++ b/apps/web/src/pages/tool-page.tsx
@@ -560,6 +560,7 @@ export function ToolPage() {
   const handleDownloadAll = useCallback(() => {
     if (!batchZipBlob) return;
     downloadBlob(batchZipBlob, batchZipFilename ?? "processed-files.zip");
+    useFileStore.getState().markBatchClaimed();
   }, [batchZipBlob, batchZipFilename]);
 
   if (tool && disabledTools.includes(tool.id)) {

--- a/apps/web/src/stores/file-store.ts
+++ b/apps/web/src/stores/file-store.ts
@@ -172,6 +172,10 @@ interface FileState {
   /** Index is required: selectedIndex can change while a job runs. */
   markClaimed: (index: number) => void;
   markBatchClaimed: () => void;
+  /** Claim the entry the UI is currently showing. Safe only from synchronous
+   *  handlers: across an await the selection can move, so capture the index
+   *  first and use markClaimed instead. */
+  claimSelected: () => void;
   setProcessing: (v: boolean) => void;
   setError: (e: string | null) => void;
   setActiveJob: (id: string | null, cancelFn: (() => Promise<void>) | null) => void;
@@ -405,6 +409,9 @@ export const useFileStore = create<FileState>((set, get) => ({
       ...deriveSelected(next, selectedIndex),
     });
   },
+
+  // Synchronous handlers only; see the declaration above for why.
+  claimSelected: () => get().markClaimed(get().selectedIndex),
 
   setProcessing: (v) => set({ processing: v }),
 

--- a/apps/web/src/stores/file-store.ts
+++ b/apps/web/src/stores/file-store.ts
@@ -38,6 +38,17 @@ export interface FileEntry {
   originalWidth: number | null;
   originalHeight: number | null;
   status: "pending" | "processing" | "completed" | "failed";
+  /**
+   * The user took this result: downloaded it, saved it, or it auto-saved.
+   *
+   * The invariant: a result that just changed has not been taken. Any patch
+   * that touches `processedUrl` invalidates the claim, changed value or not,
+   * so a re-run never inherits the previous result's claim. Keying on the
+   * field being present rather than on the value differing is the fail-safe
+   * choice: the cost of over-clearing is one extra warning, the cost of
+   * under-clearing is the navigation guard going silent on unsaved work.
+   */
+  claimed: boolean;
   error: string | null;
   serverFileId?: string;
   modality: Modality;
@@ -65,6 +76,7 @@ function createEntry(file: File): FileEntry {
     originalWidth: null,
     originalHeight: null,
     status: "pending",
+    claimed: false,
     error: null,
     serverFileId: undefined,
     modality,
@@ -124,6 +136,7 @@ interface FileState {
   selectedIndex: number;
   batchZipBlob: Blob | null;
   batchZipFilename: string | null;
+  batchZipClaimed: boolean;
   processing: boolean;
   error: string | null;
   activeJobId: string | null;
@@ -153,8 +166,11 @@ interface FileState {
   setSelectedIndex: (index: number) => void;
   navigateNext: () => void;
   navigatePrev: () => void;
-  updateEntry: (index: number, patch: Partial<FileEntry>) => void;
+  /** `claimed` is excluded: a patch touching `processedUrl` always resets it. */
+  updateEntry: (index: number, patch: Omit<Partial<FileEntry>, "claimed">) => void;
   setBatchZip: (blob: Blob, filename: string) => void;
+  markClaimed: (index: number) => void;
+  markBatchClaimed: () => void;
   setProcessing: (v: boolean) => void;
   setError: (e: string | null) => void;
   setActiveJob: (id: string | null, cancelFn: (() => Promise<void>) | null) => void;
@@ -172,6 +188,7 @@ export const useFileStore = create<FileState>((set, get) => ({
   selectedIndex: 0,
   batchZipBlob: null,
   batchZipFilename: null,
+  batchZipClaimed: false,
   processing: false,
   error: null,
   activeJobId: null,
@@ -195,6 +212,10 @@ export const useFileStore = create<FileState>((set, get) => ({
       entries,
       selectedIndex: 0,
       error: null,
+      // The previous run's zip describes files that are no longer loaded.
+      batchZipBlob: null,
+      batchZipFilename: null,
+      batchZipClaimed: false,
       // A fresh file set is a fresh edit: the save-mode choice made for a
       // previous file must not carry over (#495 defaults to non-destructive).
       librarySaveMode: "new",
@@ -354,12 +375,37 @@ export const useFileStore = create<FileState>((set, get) => ({
   updateEntry: (index, patch) => {
     const entries = [...get().entries];
     if (!entries[index]) return;
-    entries[index] = { ...entries[index], ...patch };
+    // Enforces the claim invariant; see the `claimed` field on FileEntry.
+    const claimReset = "processedUrl" in patch ? { claimed: false } : null;
+    entries[index] = { ...entries[index], ...patch, ...claimReset };
     const idx = get().selectedIndex;
     set({ entries, files: deriveFiles(entries), ...deriveSelected(entries, idx) });
   },
 
-  setBatchZip: (blob, filename) => set({ batchZipBlob: blob, batchZipFilename: filename }),
+  setBatchZip: (blob, filename) =>
+    set({ batchZipBlob: blob, batchZipFilename: filename, batchZipClaimed: false }),
+
+  markClaimed: (index) => {
+    const { entries, selectedIndex } = get();
+    // The index is required: selectedIndex is not trustworthy at completion
+    // time, since the user can change selection while a job runs.
+    if (!entries[index] || entries[index].claimed) return;
+    const next = [...entries];
+    next[index] = { ...next[index], claimed: true };
+    set({ entries: next, files: deriveFiles(next), ...deriveSelected(next, selectedIndex) });
+  },
+
+  markBatchClaimed: () => {
+    const { entries, selectedIndex } = get();
+    // The zip holds every result, so taking it takes all of them.
+    const next = entries.map((e) => (e.claimed ? e : { ...e, claimed: true }));
+    set({
+      entries: next,
+      batchZipClaimed: true,
+      files: deriveFiles(next),
+      ...deriveSelected(next, selectedIndex),
+    });
+  },
 
   setProcessing: (v) => set({ processing: v }),
 
@@ -374,6 +420,7 @@ export const useFileStore = create<FileState>((set, get) => ({
   setProcessedUrl: (url, previewUrl) => {
     const { entries, selectedIndex } = get();
     if (!entries[selectedIndex]) return;
+    // Both branches reset `claimed`; see the invariant on FileEntry.
     const updated = [...entries];
     if (url) {
       updated[selectedIndex] = {
@@ -382,6 +429,7 @@ export const useFileStore = create<FileState>((set, get) => ({
         processedPreviewUrl: previewUrl ?? null,
         processedFilename: null,
         status: "completed",
+        claimed: false,
       };
     } else {
       updated[selectedIndex] = {
@@ -390,6 +438,7 @@ export const useFileStore = create<FileState>((set, get) => ({
         processedPreviewUrl: null,
         processedFilename: null,
         status: "pending",
+        claimed: false,
       };
     }
     set({ entries: updated, ...deriveSelected(updated, selectedIndex) });
@@ -417,6 +466,7 @@ export const useFileStore = create<FileState>((set, get) => ({
       if (entry.processedUrl) URL.revokeObjectURL(entry.processedUrl);
       if (entry.processedPreviewUrl) URL.revokeObjectURL(entry.processedPreviewUrl);
     }
+    // Dropping every result clears every claim; see the invariant on FileEntry.
     const resetEntries = entries.map((e) => ({
       ...e,
       processedUrl: null,
@@ -424,12 +474,14 @@ export const useFileStore = create<FileState>((set, get) => ({
       processedFilename: null,
       processedSize: null,
       status: "pending" as const,
+      claimed: false,
       error: null,
     }));
     set({
       entries: resetEntries,
       batchZipBlob: null,
       batchZipFilename: null,
+      batchZipClaimed: false,
       processing: false,
       error: null,
       activeJobId: null,
@@ -448,6 +500,7 @@ export const useFileStore = create<FileState>((set, get) => ({
       selectedIndex: 0,
       batchZipBlob: null,
       batchZipFilename: null,
+      batchZipClaimed: false,
       processing: false,
       error: null,
       activeJobId: null,

--- a/apps/web/src/stores/file-store.ts
+++ b/apps/web/src/stores/file-store.ts
@@ -169,6 +169,7 @@ interface FileState {
   /** `claimed` is excluded: a patch touching `processedUrl` always resets it. */
   updateEntry: (index: number, patch: Omit<Partial<FileEntry>, "claimed">) => void;
   setBatchZip: (blob: Blob, filename: string) => void;
+  /** Index is required: selectedIndex can change while a job runs. */
   markClaimed: (index: number) => void;
   markBatchClaimed: () => void;
   setProcessing: (v: boolean) => void;
@@ -387,8 +388,6 @@ export const useFileStore = create<FileState>((set, get) => ({
 
   markClaimed: (index) => {
     const { entries, selectedIndex } = get();
-    // The index is required: selectedIndex is not trustworthy at completion
-    // time, since the user can change selection while a job runs.
     if (!entries[index] || entries[index].claimed) return;
     const next = [...entries];
     next[index] = { ...next[index], claimed: true };

--- a/packages/shared/src/i18n/ar.ts
+++ b/packages/shared/src/i18n/ar.ts
@@ -3830,6 +3830,17 @@ export const ar: TranslationKeys = {
     downloadFiles: "تنزيل {count} ملفات",
     audioDecodeUnsupported: "لا يمكن معاينة تنسيق الصوت هذا في المتصفح",
   },
+  navigationGuard: {
+    processingTitle: "لم تنتهِ هذه العملية بعد",
+    processingBody: "إذا غادرت الآن ستفقد النتيجة.",
+    unsavedTitle: "لم يتم حفظ هذه النتيجة",
+    unsavedBody: "إذا غادرت الآن فستفقدها.",
+    editorTitle: "لديك تعديلات غير محفوظة",
+    editorBody: "إذا غادرت الآن ستفقد كل شيء منذ آخر عملية حفظ.",
+    stay: "البقاء هنا",
+    leave: "المغادرة على أي حال",
+    downloadAndLeave: "التحميل ثم المغادرة",
+  },
   homePage: {
     generatingPreview: "جاري إنشاء المعاينة...",
     loadingPreview: "جاري تحميل المعاينة...",

--- a/packages/shared/src/i18n/de.ts
+++ b/packages/shared/src/i18n/de.ts
@@ -3872,6 +3872,17 @@ export const de: TranslationKeys = {
     downloadFiles: "{count} Dateien herunterladen",
     audioDecodeUnsupported: "Dieses Audioformat kann im Browser nicht wiedergegeben werden",
   },
+  navigationGuard: {
+    processingTitle: "Dieser Vorgang ist noch nicht fertig",
+    processingBody: "Beim Verlassen geht das Ergebnis verloren.",
+    unsavedTitle: "Dieses Ergebnis ist nicht gespeichert",
+    unsavedBody: "Beim Verlassen geht es verloren.",
+    editorTitle: "Nicht gespeicherte Änderungen",
+    editorBody: "Beim Verlassen geht alles seit dem letzten Speichern verloren.",
+    stay: "Hier bleiben",
+    leave: "Trotzdem verlassen",
+    downloadAndLeave: "Herunterladen, dann verlassen",
+  },
   homePage: {
     generatingPreview: "Vorschau wird generiert...",
     loadingPreview: "Vorschau wird geladen...",

--- a/packages/shared/src/i18n/en.ts
+++ b/packages/shared/src/i18n/en.ts
@@ -3796,6 +3796,17 @@ export const en = {
     downloadFiles: "Download {count} files",
     audioDecodeUnsupported: "This audio format cannot be previewed in the browser",
   },
+  navigationGuard: {
+    processingTitle: "This run isn't finished",
+    processingBody: "Leave now and you lose the result.",
+    unsavedTitle: "This result isn't saved",
+    unsavedBody: "Leave now and it's gone.",
+    editorTitle: "You have unsaved edits",
+    editorBody: "Leave now and you lose everything since the last save.",
+    stay: "Stay here",
+    leave: "Leave anyway",
+    downloadAndLeave: "Download, then leave",
+  },
   homePage: {
     generatingPreview: "Generating preview...",
     loadingPreview: "Loading preview...",

--- a/packages/shared/src/i18n/es.ts
+++ b/packages/shared/src/i18n/es.ts
@@ -3849,6 +3849,17 @@ export const es: TranslationKeys = {
     downloadFiles: "Descargar {count} archivos",
     audioDecodeUnsupported: "Este formato de audio no se puede previsualizar en el navegador",
   },
+  navigationGuard: {
+    processingTitle: "Este proceso no ha terminado",
+    processingBody: "Si sales ahora, pierdes el resultado.",
+    unsavedTitle: "Este resultado no está guardado",
+    unsavedBody: "Si sales ahora, lo pierdes.",
+    editorTitle: "Tienes cambios sin guardar",
+    editorBody: "Si sales ahora, pierdes todo lo hecho desde el último guardado.",
+    stay: "Permanecer aquí",
+    leave: "Salir de todos modos",
+    downloadAndLeave: "Descargar y salir",
+  },
   homePage: {
     generatingPreview: "Generando vista previa...",
     loadingPreview: "Cargando vista previa...",

--- a/packages/shared/src/i18n/fr.ts
+++ b/packages/shared/src/i18n/fr.ts
@@ -3874,6 +3874,17 @@ export const fr: TranslationKeys = {
     downloadFiles: "Télécharger {count} fichiers",
     audioDecodeUnsupported: "Ce format audio ne peut pas être prévisualisé dans le navigateur",
   },
+  navigationGuard: {
+    processingTitle: "Ce traitement n'est pas terminé",
+    processingBody: "Si vous partez maintenant, vous perdez le résultat.",
+    unsavedTitle: "Ce résultat n'est pas enregistré",
+    unsavedBody: "Si vous partez maintenant, il est perdu.",
+    editorTitle: "Vous avez des modifications non enregistrées",
+    editorBody: "Si vous partez maintenant, vous perdez tout depuis le dernier enregistrement.",
+    stay: "Rester ici",
+    leave: "Partir quand même",
+    downloadAndLeave: "Télécharger puis partir",
+  },
   homePage: {
     generatingPreview: "Génération de l'aperçu...",
     loadingPreview: "Chargement de l'aperçu...",

--- a/packages/shared/src/i18n/hi.ts
+++ b/packages/shared/src/i18n/hi.ts
@@ -3659,6 +3659,17 @@ export const hi: TranslationKeys = {
     downloadFiles: "{count} फ़ाइलें डाउनलोड करें",
     audioDecodeUnsupported: "इस ऑडियो फ़ॉर्मैट का ब्राउज़र में प्रीव्यू नहीं हो सकता",
   },
+  navigationGuard: {
+    processingTitle: "यह प्रक्रिया अभी पूरी नहीं हुई है",
+    processingBody: "अभी छोड़ने पर आप परिणाम खो देंगे।",
+    unsavedTitle: "यह परिणाम सहेजा नहीं गया है",
+    unsavedBody: "अभी छोड़ने पर यह खो जाएगा।",
+    editorTitle: "आपके पास बिना सहेजे बदलाव हैं",
+    editorBody: "अभी छोड़ने पर पिछली बार सहेजने के बाद का सब कुछ खो जाएगा।",
+    stay: "यहीं रहें",
+    leave: "फिर भी छोड़ें",
+    downloadAndLeave: "डाउनलोड करके छोड़ें",
+  },
   homePage: {
     generatingPreview: "प्रीव्यू जनरेट हो रहा है...",
     loadingPreview: "प्रीव्यू लोड हो रहा है...",

--- a/packages/shared/src/i18n/id.ts
+++ b/packages/shared/src/i18n/id.ts
@@ -3851,6 +3851,17 @@ export const id: TranslationKeys = {
     downloadFiles: "Unduh {count} file",
     audioDecodeUnsupported: "Format audio ini tidak dapat dipratinjau di browser",
   },
+  navigationGuard: {
+    processingTitle: "Proses ini belum selesai",
+    processingBody: "Jika keluar sekarang, Anda kehilangan hasilnya.",
+    unsavedTitle: "Hasil ini belum disimpan",
+    unsavedBody: "Jika keluar sekarang, hasilnya hilang.",
+    editorTitle: "Ada perubahan yang belum disimpan",
+    editorBody: "Jika keluar sekarang, semua sejak penyimpanan terakhir akan hilang.",
+    stay: "Tetap di sini",
+    leave: "Tetap keluar",
+    downloadAndLeave: "Unduh, lalu keluar",
+  },
   homePage: {
     generatingPreview: "Membuat pratinjau...",
     loadingPreview: "Memuat pratinjau...",

--- a/packages/shared/src/i18n/it.ts
+++ b/packages/shared/src/i18n/it.ts
@@ -3864,6 +3864,17 @@ export const it: TranslationKeys = {
     audioDecodeUnsupported:
       "Questo formato audio non può essere visualizzato in anteprima nel browser",
   },
+  navigationGuard: {
+    processingTitle: "Questa elaborazione non è finita",
+    processingBody: "Se esci ora, perdi il risultato.",
+    unsavedTitle: "Questo risultato non è salvato",
+    unsavedBody: "Se esci ora, lo perdi.",
+    editorTitle: "Hai modifiche non salvate",
+    editorBody: "Se esci ora, perdi tutto dall'ultimo salvataggio.",
+    stay: "Resta qui",
+    leave: "Esci comunque",
+    downloadAndLeave: "Scarica, poi esci",
+  },
   homePage: {
     generatingPreview: "Generazione anteprima...",
     loadingPreview: "Caricamento anteprima...",

--- a/packages/shared/src/i18n/ja.ts
+++ b/packages/shared/src/i18n/ja.ts
@@ -3808,6 +3808,17 @@ export const ja: TranslationKeys = {
     downloadFiles: "{count} 件のファイルをダウンロード",
     audioDecodeUnsupported: "この音声形式はブラウザでプレビューできません",
   },
+  navigationGuard: {
+    processingTitle: "この処理はまだ完了していません",
+    processingBody: "ここを離れると結果は失われます。",
+    unsavedTitle: "この結果は保存されていません",
+    unsavedBody: "ここを離れると失われます。",
+    editorTitle: "保存していない編集があります",
+    editorBody: "ここを離れると、最後に保存した時点以降の内容がすべて失われます。",
+    stay: "ここに留まる",
+    leave: "それでも離れる",
+    downloadAndLeave: "ダウンロードしてから離れる",
+  },
   homePage: {
     generatingPreview: "プレビューを生成中...",
     loadingPreview: "プレビューを読み込み中...",

--- a/packages/shared/src/i18n/ko.ts
+++ b/packages/shared/src/i18n/ko.ts
@@ -3784,6 +3784,17 @@ export const ko: TranslationKeys = {
     downloadFiles: "{count}개 파일 다운로드",
     audioDecodeUnsupported: "이 오디오 형식은 브라우저에서 미리 들을 수 없습니다",
   },
+  navigationGuard: {
+    processingTitle: "이 작업이 아직 끝나지 않았습니다",
+    processingBody: "지금 나가면 결과를 잃게 됩니다.",
+    unsavedTitle: "이 결과가 저장되지 않았습니다",
+    unsavedBody: "지금 나가면 사라집니다.",
+    editorTitle: "저장하지 않은 편집 내용이 있습니다",
+    editorBody: "지금 나가면 마지막 저장 이후의 내용이 모두 사라집니다.",
+    stay: "여기 머무르기",
+    leave: "그래도 나가기",
+    downloadAndLeave: "다운로드 후 나가기",
+  },
   homePage: {
     generatingPreview: "미리보기 생성 중...",
     loadingPreview: "미리보기 로딩 중...",

--- a/packages/shared/src/i18n/nl.ts
+++ b/packages/shared/src/i18n/nl.ts
@@ -3867,6 +3867,17 @@ export const nl: TranslationKeys = {
     downloadFiles: "{count} bestanden downloaden",
     audioDecodeUnsupported: "Dit audioformaat kan niet worden afgespeeld in de browser",
   },
+  navigationGuard: {
+    processingTitle: "Deze bewerking is nog niet klaar",
+    processingBody: "Als je nu weggaat, ben je het resultaat kwijt.",
+    unsavedTitle: "Dit resultaat is niet opgeslagen",
+    unsavedBody: "Als je nu weggaat, is het weg.",
+    editorTitle: "Je hebt niet-opgeslagen wijzigingen",
+    editorBody: "Als je nu weggaat, ben je alles sinds het laatste opslaan kwijt.",
+    stay: "Hier blijven",
+    leave: "Toch weggaan",
+    downloadAndLeave: "Downloaden, dan weggaan",
+  },
   homePage: {
     generatingPreview: "Preview genereren...",
     loadingPreview: "Preview laden...",

--- a/packages/shared/src/i18n/pl.ts
+++ b/packages/shared/src/i18n/pl.ts
@@ -3855,6 +3855,17 @@ export const pl: TranslationKeys = {
     downloadFiles: "Pobierz {count} plików",
     audioDecodeUnsupported: "Ten format audio nie może być odtworzony w przeglądarce",
   },
+  navigationGuard: {
+    processingTitle: "To zadanie nie jest ukończone",
+    processingBody: "Jeśli teraz wyjdziesz, stracisz wynik.",
+    unsavedTitle: "Ten wynik nie jest zapisany",
+    unsavedBody: "Jeśli teraz wyjdziesz, przepadnie.",
+    editorTitle: "Masz niezapisane zmiany",
+    editorBody: "Jeśli teraz wyjdziesz, stracisz wszystko od ostatniego zapisu.",
+    stay: "Zostań tutaj",
+    leave: "Wyjdź mimo to",
+    downloadAndLeave: "Pobierz i wyjdź",
+  },
   homePage: {
     generatingPreview: "Generowanie podglądu...",
     loadingPreview: "Ładowanie podglądu...",

--- a/packages/shared/src/i18n/pt-BR.ts
+++ b/packages/shared/src/i18n/pt-BR.ts
@@ -3858,6 +3858,17 @@ export const ptBR: TranslationKeys = {
     downloadFiles: "Baixar {count} arquivos",
     audioDecodeUnsupported: "Este formato de áudio não pode ser pré-visualizado no navegador",
   },
+  navigationGuard: {
+    processingTitle: "Este processamento não terminou",
+    processingBody: "Se você sair agora, perde o resultado.",
+    unsavedTitle: "Este resultado não está salvo",
+    unsavedBody: "Se você sair agora, ele some.",
+    editorTitle: "Você tem edições não salvas",
+    editorBody: "Se você sair agora, perde tudo desde o último salvamento.",
+    stay: "Ficar aqui",
+    leave: "Sair mesmo assim",
+    downloadAndLeave: "Baixar e sair",
+  },
   homePage: {
     generatingPreview: "Gerando visualização...",
     loadingPreview: "Carregando visualização...",

--- a/packages/shared/src/i18n/ru.ts
+++ b/packages/shared/src/i18n/ru.ts
@@ -3858,6 +3858,17 @@ export const ru: TranslationKeys = {
     downloadFiles: "Скачать {count} файлов",
     audioDecodeUnsupported: "Этот аудиоформат не поддерживается для предпросмотра в браузере",
   },
+  navigationGuard: {
+    processingTitle: "Эта операция ещё не завершена",
+    processingBody: "Если уйти сейчас, результат будет потерян.",
+    unsavedTitle: "Этот результат не сохранён",
+    unsavedBody: "Если уйти сейчас, он пропадёт.",
+    editorTitle: "Есть несохранённые изменения",
+    editorBody: "Если уйти сейчас, пропадёт всё, что сделано после последнего сохранения.",
+    stay: "Остаться здесь",
+    leave: "Всё равно уйти",
+    downloadAndLeave: "Скачать и уйти",
+  },
   homePage: {
     generatingPreview: "Генерация предпросмотра...",
     loadingPreview: "Загрузка предпросмотра...",

--- a/packages/shared/src/i18n/sv.ts
+++ b/packages/shared/src/i18n/sv.ts
@@ -3850,6 +3850,17 @@ export const sv: TranslationKeys = {
     downloadFiles: "Ladda ner {count} filer",
     audioDecodeUnsupported: "Det här ljudformatet kan inte förhandsgranskas i webbläsaren",
   },
+  navigationGuard: {
+    processingTitle: "Den här körningen är inte klar",
+    processingBody: "Lämnar du nu förlorar du resultatet.",
+    unsavedTitle: "Det här resultatet är inte sparat",
+    unsavedBody: "Lämnar du nu är det borta.",
+    editorTitle: "Du har osparade ändringar",
+    editorBody: "Lämnar du nu förlorar du allt sedan den senaste sparningen.",
+    stay: "Stanna kvar",
+    leave: "Lämna ändå",
+    downloadAndLeave: "Ladda ner och lämna",
+  },
   homePage: {
     generatingPreview: "Genererar förhandsvisning...",
     loadingPreview: "Laddar förhandsvisning...",

--- a/packages/shared/src/i18n/th.ts
+++ b/packages/shared/src/i18n/th.ts
@@ -3809,6 +3809,17 @@ export const th: TranslationKeys = {
     downloadFiles: "ดาวน์โหลด {count} ไฟล์",
     audioDecodeUnsupported: "รูปแบบเสียงนี้ไม่สามารถแสดงตัวอย่างในเบราว์เซอร์ได้",
   },
+  navigationGuard: {
+    processingTitle: "งานนี้ยังไม่เสร็จ",
+    processingBody: "ถ้าออกตอนนี้ คุณจะไม่ได้ผลลัพธ์",
+    unsavedTitle: "ผลลัพธ์นี้ยังไม่ได้บันทึก",
+    unsavedBody: "ถ้าออกตอนนี้ ผลลัพธ์จะหายไป",
+    editorTitle: "คุณมีการแก้ไขที่ยังไม่ได้บันทึก",
+    editorBody: "ถ้าออกตอนนี้ ทุกอย่างหลังการบันทึกครั้งล่าสุดจะหายไป",
+    stay: "อยู่ต่อ",
+    leave: "ออกเลย",
+    downloadAndLeave: "ดาวน์โหลดแล้วออก",
+  },
   homePage: {
     generatingPreview: "กำลังสร้างตัวอย่าง...",
     loadingPreview: "กำลังโหลดตัวอย่าง...",

--- a/packages/shared/src/i18n/tr.ts
+++ b/packages/shared/src/i18n/tr.ts
@@ -3857,6 +3857,17 @@ export const tr: TranslationKeys = {
     downloadFiles: "{count} dosya indir",
     audioDecodeUnsupported: "Bu ses formatı tarayıcıda önizlenemez",
   },
+  navigationGuard: {
+    processingTitle: "Bu işlem henüz bitmedi",
+    processingBody: "Şimdi ayrılırsanız sonucu kaybedersiniz.",
+    unsavedTitle: "Bu sonuç kaydedilmedi",
+    unsavedBody: "Şimdi ayrılırsanız kaybolur.",
+    editorTitle: "Kaydedilmemiş değişiklikleriniz var",
+    editorBody: "Şimdi ayrılırsanız son kayıttan sonraki her şeyi kaybedersiniz.",
+    stay: "Burada kal",
+    leave: "Yine de ayrıl",
+    downloadAndLeave: "İndir, sonra ayrıl",
+  },
   homePage: {
     generatingPreview: "Önizleme oluşturuluyor...",
     loadingPreview: "Önizleme yükleniyor...",

--- a/packages/shared/src/i18n/uk.ts
+++ b/packages/shared/src/i18n/uk.ts
@@ -3856,6 +3856,17 @@ export const uk: TranslationKeys = {
     downloadFiles: "Завантажити {count} файлів",
     audioDecodeUnsupported: "Цей аудіоформат не можна переглянути у браузері",
   },
+  navigationGuard: {
+    processingTitle: "Це завдання ще не завершено",
+    processingBody: "Якщо піти зараз, результат буде втрачено.",
+    unsavedTitle: "Цей результат не збережено",
+    unsavedBody: "Якщо піти зараз, він зникне.",
+    editorTitle: "Є незбережені зміни",
+    editorBody: "Якщо піти зараз, зникне все, що зроблено після останнього збереження.",
+    stay: "Залишитися тут",
+    leave: "Усе одно піти",
+    downloadAndLeave: "Завантажити й піти",
+  },
   homePage: {
     generatingPreview: "Генерація попереднього перегляду...",
     loadingPreview: "Завантаження попереднього перегляду...",

--- a/packages/shared/src/i18n/vi.ts
+++ b/packages/shared/src/i18n/vi.ts
@@ -3849,6 +3849,17 @@ export const vi: TranslationKeys = {
     downloadFiles: "Tải xuống {count} tệp",
     audioDecodeUnsupported: "Định dạng âm thanh này không thể xem trước trong trình duyệt",
   },
+  navigationGuard: {
+    processingTitle: "Tiến trình này chưa xong",
+    processingBody: "Nếu rời đi bây giờ, bạn sẽ mất kết quả.",
+    unsavedTitle: "Kết quả này chưa được lưu",
+    unsavedBody: "Nếu rời đi bây giờ, kết quả sẽ mất.",
+    editorTitle: "Bạn có chỉnh sửa chưa lưu",
+    editorBody: "Nếu rời đi bây giờ, bạn sẽ mất mọi thứ kể từ lần lưu gần nhất.",
+    stay: "Ở lại đây",
+    leave: "Vẫn rời đi",
+    downloadAndLeave: "Tải xuống rồi rời đi",
+  },
   homePage: {
     generatingPreview: "Đang tạo bản xem trước...",
     loadingPreview: "Đang tải bản xem trước...",

--- a/packages/shared/src/i18n/zh-CN.ts
+++ b/packages/shared/src/i18n/zh-CN.ts
@@ -3596,6 +3596,17 @@ export const zhCN: TranslationKeys = {
     downloadFiles: "下载 {count} 个文件",
     audioDecodeUnsupported: "此音频格式无法在浏览器中预览",
   },
+  navigationGuard: {
+    processingTitle: "此次处理尚未完成",
+    processingBody: "现在离开将无法获得结果。",
+    unsavedTitle: "此结果尚未保存",
+    unsavedBody: "现在离开，结果将丢失。",
+    editorTitle: "您有未保存的编辑",
+    editorBody: "现在离开将丢失上次保存之后的所有内容。",
+    stay: "留在此页",
+    leave: "仍要离开",
+    downloadAndLeave: "下载后离开",
+  },
   homePage: {
     generatingPreview: "正在生成预览...",
     loadingPreview: "正在加载预览...",

--- a/packages/shared/src/i18n/zh-TW.ts
+++ b/packages/shared/src/i18n/zh-TW.ts
@@ -3596,6 +3596,17 @@ export const zhTW: TranslationKeys = {
     downloadFiles: "下載 {count} 個檔案",
     audioDecodeUnsupported: "此音訊格式無法在瀏覽器中預覽",
   },
+  navigationGuard: {
+    processingTitle: "這次處理尚未完成",
+    processingBody: "現在離開將無法取得結果。",
+    unsavedTitle: "此結果尚未儲存",
+    unsavedBody: "現在離開，結果將遺失。",
+    editorTitle: "您有未儲存的編輯",
+    editorBody: "現在離開將遺失上次儲存之後的所有內容。",
+    stay: "留在此頁",
+    leave: "仍要離開",
+    downloadAndLeave: "下載後離開",
+  },
   homePage: {
     generatingPreview: "正在產生預覽...",
     loadingPreview: "正在載入預覽...",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -98,7 +98,7 @@ const backingState = resolvePlaywrightBackingState({
 // or assert on global lists/timing. These run in the chromium-serial project
 // with --workers=1; everything else parallelizes safely.
 const SERIAL_SPECS =
-  /gui-settings-|settings\.spec|rbac|security|people|api\.spec|state-bleed|full-session|gui-file-carry|library-save-mode|i18n|theme|gui-performance/;
+  /gui-settings-|settings\.spec|rbac|security|people|api\.spec|state-bleed|full-session|gui-file-carry|library-save-mode|i18n|theme|gui-performance|navigation-guard/;
 
 // Screenshot-comparison specs. Separate project because baselines are
 // platform-specific: they run locally (darwin baselines) and via the

--- a/tests/e2e/navigation-guard.spec.ts
+++ b/tests/e2e/navigation-guard.spec.ts
@@ -1,0 +1,223 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { Page } from "@playwright/test";
+import { expect, getE2eRunRoot, test, uploadTestImage, waitForProcessing } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Navigation guard: the dialog that stands between an in-app navigation and a
+// result the user never took.
+//
+// Only in-app navigations reach react-router's blocker, so every test here
+// leaves by clicking a router Link: the top-nav "Tools" link on a tool page, and
+// the menu bar's back arrow in the editor, which renders no top nav. page.goto
+// is a document navigation; the blocker never sees it and Playwright accepts the
+// beforeunload prompt on its own, which is why the rest of the suite navigates
+// that way without meeting this dialog.
+//
+// These specs assert outcomes, never ordering. "Download, then leave" defers
+// its proceed by a setTimeout(0) that Playwright cannot observe, so the test
+// asserts the file landed AND the navigation happened. Ordering is pinned at
+// the unit level, where the clock is controllable.
+// ---------------------------------------------------------------------------
+
+const FIXTURES = path.join(process.cwd(), "tests", "fixtures", "image", "valid");
+
+/**
+ * react-router throws an invariant on a proceed that lands on a block already
+ * answered, and a production build (what the e2e webServer serves) keeps that
+ * throw. A double-proceed regression therefore surfaces as a page error rather
+ * than as a failed assertion, so every test collects them and asserts none.
+ */
+function watchForPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  return errors;
+}
+
+/** The one in-app navigation present on every page. */
+function toolsLink(page: Page) {
+  return page.getByRole("banner").getByRole("link", { name: "Tools", exact: true });
+}
+
+/** Resize one image and stop on the result, unclaimed. */
+async function resizeOneFile(page: Page) {
+  await page.goto("/image/resize");
+  await uploadTestImage(page);
+  await page.locator("input[placeholder='Auto']").first().fill("50");
+  await page.getByRole("button", { name: "Resize" }).click();
+  await waitForProcessing(page);
+  await expect(page.locator("[data-download-button]").first()).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Resize two images and stop on the zip, unclaimed.
+ *
+ * Two files and not three on purpose: a batch settles into a single zip, which
+ * is one download. Several unclaimed results with no zip would mean several
+ * synchronous anchor clicks, and Chrome answers that with its "allow multiple
+ * automatic downloads" prompt, which hangs the run.
+ */
+async function resizeTwoFiles(page: Page) {
+  await page.goto("/image/resize");
+
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await page.locator("[class*='border-dashed']").first().click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles([
+    path.join(FIXTURES, "test-100x100.jpg"),
+    path.join(FIXTURES, "test-200x150.png"),
+  ]);
+  await expect(page.getByText("Files (2)")).toBeVisible({ timeout: 10_000 });
+
+  await page.locator("input[placeholder='Auto']").first().fill("50");
+  await page.getByRole("button", { name: /resize.*2 files/i }).click();
+  await waitForProcessing(page, 30_000);
+  await expect(page.getByRole("button", { name: /download all/i })).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+test.describe("Navigation guard", () => {
+  test("an unsaved result blocks an in-app navigation, and Stay here keeps the page", async ({
+    loggedInPage: page,
+  }) => {
+    const pageErrors = watchForPageErrors(page);
+    await resizeOneFile(page);
+
+    await toolsLink(page).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole("heading", { name: /result isn.t saved/i })).toBeVisible();
+
+    await dialog.getByRole("button", { name: /stay here/i }).click();
+
+    await expect(dialog).toHaveCount(0);
+    await expect(page).toHaveURL("/image/resize");
+    // Staying means the result is still there to take.
+    await expect(page.locator("[data-download-button]").first()).toBeVisible();
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("Leave anyway abandons the result and navigates", async ({ loggedInPage: page }) => {
+    const pageErrors = watchForPageErrors(page);
+    await resizeOneFile(page);
+
+    await toolsLink(page).click();
+
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: /leave anyway/i })
+      .click();
+
+    await expect(page).toHaveURL("/");
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("Download, then leave saves the result and navigates", async ({ loggedInPage: page }) => {
+    const pageErrors = watchForPageErrors(page);
+    await resizeOneFile(page);
+
+    await toolsLink(page).click();
+
+    const downloadPromise = page.waitForEvent("download");
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: /download, then leave/i })
+      .click();
+
+    const download = await downloadPromise;
+    expect(download.suggestedFilename().length).toBeGreaterThan(0);
+    const savePath = path.join(getE2eRunRoot(), "navigation-guard-download-then-leave");
+    await download.saveAs(savePath);
+    expect(fs.statSync(savePath).size).toBeGreaterThan(0);
+
+    await expect(page).toHaveURL("/");
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("taking the result first leaves the navigation unguarded", async ({
+    loggedInPage: page,
+  }) => {
+    const pageErrors = watchForPageErrors(page);
+    await resizeOneFile(page);
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.locator("[data-download-button]").first().click();
+    await downloadPromise;
+
+    await toolsLink(page).click();
+
+    await expect(page).toHaveURL("/");
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("taking the batch zip leaves the navigation unguarded", async ({ loggedInPage: page }) => {
+    const pageErrors = watchForPageErrors(page);
+    await resizeTwoFiles(page);
+
+    const downloadPromise = page.waitForEvent("download");
+    await page
+      .getByRole("button", { name: /download all/i })
+      .first()
+      .click();
+    await downloadPromise;
+
+    await toolsLink(page).click();
+
+    await expect(page).toHaveURL("/");
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("unsaved editor edits block an in-app navigation", async ({ loggedInPage: page }) => {
+    const pageErrors = watchForPageErrors(page);
+    await page.goto("/editor");
+
+    // The whole setup is one click. The layers panel is the default right-panel
+    // tab and renders with no document loaded, and addLayer sets isDirty, which
+    // is the reason the guard reports here.
+    await page.getByTestId("add-layer-btn").click();
+
+    // /editor renders no top nav, so the in-app way out is the menu bar's back
+    // arrow, which calls navigate("/").
+    await page.getByRole("button", { name: "Back to SnapOtter" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole("heading", { name: /unsaved edits/i })).toBeVisible();
+
+    await dialog.getByRole("button", { name: /stay here/i }).click();
+    await expect(dialog).toHaveCount(0);
+    await expect(page).toHaveURL("/editor");
+
+    await page.getByRole("button", { name: "Back to SnapOtter" }).click();
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: /leave anyway/i })
+      .click();
+
+    await expect(page).toHaveURL("/");
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("closing the tab with an unsaved result raises the native prompt", async ({
+    loggedInPage: page,
+  }) => {
+    const pageErrors = watchForPageErrors(page);
+    await resizeOneFile(page);
+
+    // Registering a listener is what stops Playwright answering the prompt for
+    // us: with none, a beforeunload dialog is accepted and never observed.
+    const dialogPromise = page.waitForEvent("dialog");
+    await page.close({ runBeforeUnload: true });
+
+    const dialog = await dialogPromise;
+    expect(dialog.type()).toBe("beforeunload");
+    await dialog.accept();
+    expect(pageErrors).toEqual([]);
+  });
+});

--- a/tests/e2e/state-bleed-audit.spec.ts
+++ b/tests/e2e/state-bleed-audit.spec.ts
@@ -180,6 +180,15 @@ test.describe("State bleed between tools", () => {
       timeout: 15_000,
     });
 
+    // Take the result before leaving, the way a user does. This is the only
+    // in-app navigation in this file (everything else goes through page.goto,
+    // which the navigation guard's router blocker never sees), so without the
+    // download the guard would raise its dialog and the click below would go
+    // nowhere.
+    const downloadPromise = page.waitForEvent("download");
+    await page.locator("[data-download-button]").first().click();
+    await downloadPromise;
+
     // 2.0 removed the sidebar. Navigate home via the top-nav "Tools" breadcrumb link.
     await page.locator("header").getByRole("link", { name: "Tools", exact: true }).click();
     await expect(page).toHaveURL("/");

--- a/tests/helpers/mock-analytics.ts
+++ b/tests/helpers/mock-analytics.ts
@@ -1,0 +1,36 @@
+import { vi } from "vitest";
+
+/**
+ * The `@/lib/analytics` module shape for web unit tests.
+ *
+ * `getDistinctId` matters as much as `track`. `formatHeaders()` in `@/lib/api`
+ * calls it, so a mock that leaves it out makes every request helper throw, and
+ * any component with a bare catch turns that into an unrelated error state.
+ * The symptom reads like a bug in whatever you were actually testing. Plenty of
+ * older test files still hand-roll their own mock; new ones should use this.
+ *
+ * A `vi.mock` factory is hoisted above the file's imports, so reach it through
+ * a dynamic import:
+ *
+ * ```ts
+ * vi.mock("@/lib/analytics", async () => {
+ *   const { analyticsModuleMock } = await import("../../helpers/mock-analytics.js");
+ *   return analyticsModuleMock();
+ * });
+ * ```
+ *
+ * Every export is a fresh `vi.fn()` per call, so a test that wants to assert on
+ * one imports it from `@/lib/analytics` and wraps it in `vi.mocked()`.
+ */
+export function analyticsModuleMock() {
+  return {
+    track: vi.fn(),
+    getDistinctId: vi.fn(() => null),
+    captureHandledError: vi.fn(async () => {}),
+    setSentryTag: vi.fn(),
+    isAnalyticsActive: vi.fn(() => false),
+    initAnalytics: vi.fn(async () => {}),
+    optOut: vi.fn(),
+    optIn: vi.fn(),
+  };
+}

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -326,7 +326,7 @@ describe("E2E navigation targets", () => {
 
   function declaredStaticRoutes(): Set<string> {
     const app = fs.readFileSync(path.join(root, "apps", "web", "src", "App.tsx"), "utf8");
-    const paths = [...app.matchAll(/\bpath="([^"]+)"/g)].map((match) => match[1]);
+    const paths = [...app.matchAll(/\bpath:\s*"([^"]+)"/g)].map((match) => match[1]);
     expect(paths, "App.tsx declared no routes; the parser is broken").not.toHaveLength(0);
     return new Set(paths.filter((value) => value !== "*" && !value.includes(":")));
   }

--- a/tests/unit/web/download-blob.test.ts
+++ b/tests/unit/web/download-blob.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { downloadBlob } from "@/lib/download";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+/**
+ * Capture anchors the code under test clicks, without letting the click reach
+ * jsdom's navigation path (which logs "Not implemented: navigation").
+ */
+function captureAnchorClicks(): HTMLAnchorElement[] {
+  const clicked: HTMLAnchorElement[] = [];
+  const realCreate = document.createElement.bind(document);
+  vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+    const el = realCreate(tag);
+    if (tag === "a") {
+      vi.spyOn(el as HTMLAnchorElement, "click").mockImplementation(() => {
+        clicked.push(el as HTMLAnchorElement);
+      });
+    }
+    return el;
+  });
+  return clicked;
+}
+
+describe("downloadBlob", () => {
+  it("clicks an anchor carrying the filename", () => {
+    // Fake timers so the deferred revoke is discarded with the clock rather
+    // than firing after afterEach has put the real URL global back.
+    vi.useFakeTimers();
+    const createObjectURL = vi.fn(() => "blob:fake");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { ...URL, createObjectURL, revokeObjectURL });
+
+    const clicked = captureAnchorClicks();
+
+    downloadBlob(new Blob(["x"]), "out.zip");
+
+    expect(clicked).toHaveLength(1);
+    expect(clicked[0].download).toBe("out.zip");
+    expect(clicked[0].href).toContain("blob:fake");
+  });
+
+  it("revokes the object URL only after the current tick", () => {
+    vi.useFakeTimers();
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { ...URL, createObjectURL: () => "blob:fake", revokeObjectURL });
+
+    captureAnchorClicks();
+
+    downloadBlob(new Blob(["x"]), "out.zip");
+
+    // Revoking in the same tick can cancel the download before it starts.
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:fake");
+  });
+});

--- a/tests/unit/web/navigation-guard.test.tsx
+++ b/tests/unit/web/navigation-guard.test.tsx
@@ -25,14 +25,20 @@ function makeFile(name: string): File {
   return new File(["x"], name, { type: "image/png" });
 }
 
+let mintedObjectUrls = 0;
+
 /**
  * jsdom ships no URL.createObjectURL and the file store needs one. A subclass,
  * not the usual plain-object stub: the router builds `new URL(...)` on every
  * navigation, so the global has to stay constructable.
+ *
+ * Both halves are mocks, and every mint is a distinct string, so a test can say
+ * WHICH url was revoked and WHEN. Against a constant url and a silent no-op
+ * revoke, an assertion about blob lifetimes passes whatever the component does.
  */
 class MockURL extends URL {
-  static createObjectURL = (): string => "blob:fake";
-  static revokeObjectURL = (): void => {};
+  static createObjectURL = vi.fn<() => string>();
+  static revokeObjectURL = vi.fn<(url: string) => void>();
 }
 
 const NodeRequest = globalThis.Request;
@@ -108,6 +114,37 @@ function leaveABatchZip(): void {
   useFileStore.getState().setBatchZip(new Blob(["zip"]), "processed-files.zip");
 }
 
+function leaveTwoResults(): void {
+  useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png")]);
+  useFileStore
+    .getState()
+    .updateEntry(0, { processedUrl: "blob:result-a", processedFilename: "a-small.png" });
+  useFileStore
+    .getState()
+    .updateEntry(1, { processedUrl: "blob:result-b", processedFilename: "b-small.png" });
+}
+
+/**
+ * What the page actually handed the browser, in order. The anchor click is the
+ * only observable: triggerDownload builds an anchor, clicks it and drops it.
+ */
+function recordDownloads(): Array<{ url: string; filename: string }> {
+  const started: Array<{ url: string; filename: string }> = [];
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
+    this: HTMLAnchorElement,
+  ) {
+    started.push({ url: this.getAttribute("href") ?? "", filename: this.download });
+  });
+  return started;
+}
+
+/** Let the dialog's deferred claim-and-go run, on real timers. */
+async function flushDeferredWork(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
 async function clickButton(name: string): Promise<void> {
   await act(async () => {
     fireEvent.click(screen.getByRole("button", { name }));
@@ -151,6 +188,9 @@ let addSpy: ReturnType<typeof vi.spyOn>;
 let removeSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
+  mintedObjectUrls = 0;
+  MockURL.createObjectURL.mockReset().mockImplementation(() => `blob:mock-${++mintedObjectUrls}`);
+  MockURL.revokeObjectURL.mockReset();
   vi.stubGlobal("URL", MockURL);
   vi.stubGlobal("Request", MockRequest);
   useFileStore.getState().reset();
@@ -161,6 +201,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -526,6 +567,273 @@ describe("NavigationGuard dialog controls", () => {
     expect(document.activeElement).toBe(
       screen.getByRole("button", { name: en.navigationGuard.stay }),
     );
+  });
+});
+
+describe("NavigationGuard download then leave", () => {
+  it("offers the download when an untaken result is what is at risk", async () => {
+    leaveAResult();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+
+    expect(screen.getByRole("button", { name: en.navigationGuard.downloadAndLeave })).toBeDefined();
+  });
+
+  // There is no result yet, so there is nothing the dialog could hand over.
+  it("offers no download while the run is still going", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+
+    expect(screen.getByRole("dialog")).toBeDefined();
+    expect(screen.queryByRole("button", { name: en.navigationGuard.downloadAndLeave })).toBeNull();
+  });
+
+  // The editor owns its own export path and hands the guard no downloads.
+  it("offers no download for unsaved editor edits", async () => {
+    useEditorStore.setState({ isDirty: true });
+    const { router } = renderGuard("/editor");
+
+    await navigateTo(router, "/files");
+
+    expect(screen.getByRole("dialog")).toBeDefined();
+    expect(screen.queryByRole("button", { name: en.navigationGuard.downloadAndLeave })).toBeNull();
+  });
+
+  // Whatever sits first is what the focus trap focuses and a reflexive Enter
+  // answers, so the third button goes after staying put, never before it.
+  it("keeps staying put first once there are three answers", async () => {
+    leaveAResult();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    await act(async () => {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    });
+
+    expect(screen.getAllByRole("button").map((b) => b.textContent)).toEqual([
+      en.navigationGuard.stay,
+      en.navigationGuard.downloadAndLeave,
+      en.navigationGuard.leave,
+    ]);
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: en.navigationGuard.stay }),
+    );
+  });
+
+  // The reason the claim and the proceed are deferred at all. Committing the
+  // navigation remounts tool-page, whose reset() revokes the very url the
+  // anchor was handed, so a commit in this tick can cancel a download the
+  // browser has not started. Drop the setTimeout and the router is already on
+  // /files by the time this looks.
+  it("starts the download before it commits the navigation", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    leaveAResult();
+    const started = recordDownloads();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    await clickButton(en.navigationGuard.downloadAndLeave);
+
+    expect(started).toEqual([{ url: "blob:result", filename: "a-small.png" }]);
+    expect(router.state.location.pathname).toBe(TOOL_ROUTE);
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(router.state.location.pathname).toBe("/files");
+  });
+
+  // Claiming drops hasWork, and the effect that gives up on work that settled
+  // under the dialog would commit the navigation mid-download. Anything that
+  // settles the store between the click and the deferred claim walks into it.
+  it("does not auto-proceed while the download it started is pending", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    leaveAResult();
+    recordDownloads();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    await clickButton(en.navigationGuard.downloadAndLeave);
+
+    // The work settles from somewhere else while the download is in flight.
+    await act(async () => {
+      useFileStore.getState().markClaimed(0);
+    });
+    expect(router.state.location.pathname).toBe(TOOL_ROUTE);
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+    expect(router.state.location.pathname).toBe("/files");
+  });
+
+  // Two owners can answer one block: this action's deferred proceed, and the
+  // effect that gives up on work that settled. The claim wakes that effect, and
+  // it still holds the blocker from the blocked render, so a second proceed
+  // lands on a block that is already gone. react-router throws that into an
+  // error boundary rather than ignoring it.
+  it("commits the navigation exactly once", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    leaveAResult();
+    recordDownloads();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    await clickButton(en.navigationGuard.downloadAndLeave);
+    await flushDeferredWork();
+
+    expect(router.state.location.pathname).toBe("/files");
+    expect(logged.mock.calls.flat().join(" ")).not.toContain("Invalid blocker state transition");
+  });
+
+  // The claim is fixed to what actually went out, by the indices the downloads
+  // carry, and is not re-read from the store a tick later. A result that lands
+  // in that window was never handed over, so claiming it would silence the
+  // warning for a file nobody took, which is the loss this whole dialog exists
+  // to prevent. optimize-for-web writes a live preview into the store as a
+  // finished result with no run in flight, so this window is reachable (#1112).
+  it("claims only what it downloaded, not a result that landed since", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png")]);
+    useFileStore
+      .getState()
+      .updateEntry(0, { processedUrl: "blob:result-a", processedFilename: "a-small.png" });
+    const started = recordDownloads();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    await clickButton(en.navigationGuard.downloadAndLeave);
+
+    // The second entry finishes while the download is on its way out.
+    await act(async () => {
+      useFileStore
+        .getState()
+        .updateEntry(1, { processedUrl: "blob:result-b", processedFilename: "b-small.png" });
+    });
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(started).toEqual([{ url: "blob:result-a", filename: "a-small.png" }]);
+    expect(useFileStore.getState().entries.map((e) => e.claimed)).toEqual([true, false]);
+    expect(router.state.location.pathname).toBe("/files");
+  });
+
+  // An impatient double click lands both clicks before the deferred tick, and
+  // the dialog is still on screen for the second one.
+  it("takes the result once however many times the button is clicked", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    leaveAResult();
+    const started = recordDownloads();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    await clickButton(en.navigationGuard.downloadAndLeave);
+    await clickButton(en.navigationGuard.downloadAndLeave);
+
+    expect(started).toHaveLength(1);
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+    expect(router.state.location.pathname).toBe("/files");
+    // A second queued leave would proceed on a block that is already answered.
+    expect(logged.mock.calls.flat().join(" ")).not.toContain("Invalid blocker state transition");
+  });
+
+  // AuthGuard swaps this component out on session expiry, and useBlocker's
+  // cleanup deletes the blocker on that unmount. A deferred leave that fires
+  // afterwards proceeds on a blocker that is gone, which react-router throws
+  // on, out of a timer where nothing catches it.
+  it("drops its deferred leave when it is unmounted first", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    let expireSession: () => void = () => {};
+
+    function AuthLike() {
+      const [authed, setAuthed] = useState(true);
+      expireSession = () => setAuthed(false);
+      return authed ? <NavigationGuard /> : <Navigate to="/login" replace />;
+    }
+
+    leaveAResult();
+    recordDownloads();
+    const router = createMemoryRouter([{ path: "*", element: <AuthLike /> }], {
+      initialEntries: [TOOL_ROUTE],
+    });
+    render(<RouterProvider router={router} />);
+
+    await navigateTo(router, "/files");
+    await clickButton(en.navigationGuard.downloadAndLeave);
+    await act(async () => {
+      expireSession();
+    });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(router.state.location.pathname).toBe("/login");
+  });
+
+  // A zip is a raw Blob, so downloadBlob mints an object url for it and owns
+  // revoking that url. Taking the zip takes every result in it.
+  it("takes the batch zip once and claims the whole batch", async () => {
+    leaveABatchZip();
+    const started = recordDownloads();
+    MockURL.createObjectURL.mockClear();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    await clickButton(en.navigationGuard.downloadAndLeave);
+    await flushDeferredWork();
+
+    expect(MockURL.createObjectURL).toHaveBeenCalledTimes(1);
+    const zipUrl = MockURL.createObjectURL.mock.results[0].value;
+    expect(started).toEqual([{ url: zipUrl, filename: "processed-files.zip" }]);
+    expect(MockURL.revokeObjectURL).toHaveBeenCalledWith(zipUrl);
+
+    const store = useFileStore.getState();
+    expect(store.batchZipClaimed).toBe(true);
+    expect(store.entries.every((e) => e.claimed)).toBe(true);
+    expect(router.state.location.pathname).toBe("/files");
+  });
+
+  it("takes every unclaimed result and leaves a claimed one alone", async () => {
+    leaveTwoResults();
+    useFileStore.getState().markClaimed(0);
+    const started = recordDownloads();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    await clickButton(en.navigationGuard.downloadAndLeave);
+    await flushDeferredWork();
+
+    expect(started).toEqual([{ url: "blob:result-b", filename: "b-small.png" }]);
+    expect(useFileStore.getState().entries.map((e) => e.claimed)).toEqual([true, true]);
+    expect(router.state.location.pathname).toBe("/files");
+  });
+
+  // The store minted the result url and revokes it in reset(); revoking it here
+  // pulls it out from under the download, and from under the preview still on
+  // screen. Cleared after the setup so this is about what the dialog did.
+  it("never revokes the result url the store still owns", async () => {
+    leaveAResult();
+    recordDownloads();
+    MockURL.revokeObjectURL.mockClear();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    await clickButton(en.navigationGuard.downloadAndLeave);
+    await flushDeferredWork();
+
+    expect(MockURL.revokeObjectURL.mock.calls.flat()).not.toContain("blob:result");
+    expect(useFileStore.getState().entries[0].processedUrl).toBe("blob:result");
+    expect(router.state.location.pathname).toBe("/files");
   });
 });
 

--- a/tests/unit/web/navigation-guard.test.tsx
+++ b/tests/unit/web/navigation-guard.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
-import { act, cleanup, render } from "@testing-library/react";
-import { createMemoryRouter, RouterProvider } from "react-router";
+import { en } from "@snapotter/shared";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { createMemoryRouter, Navigate, RouterProvider } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/image-preview", () => ({
@@ -24,14 +26,97 @@ function makeFile(name: string): File {
 }
 
 /**
- * A data router, not MemoryRouter: the guard will call useBlocker, which only
- * exists on a data router, so the harness has to be one from the start.
+ * jsdom ships no URL.createObjectURL and the file store needs one. A subclass,
+ * not the usual plain-object stub: the router builds `new URL(...)` on every
+ * navigation, so the global has to stay constructable.
  */
-function renderGuard(path = TOOL_ROUTE) {
+class MockURL extends URL {
+  static createObjectURL = (): string => "blob:fake";
+  static revokeObjectURL = (): void => {};
+}
+
+const NodeRequest = globalThis.Request;
+
+/**
+ * jsdom implements no fetch, so the `Request` in scope is Node's, and Node's
+ * refuses jsdom's AbortSignal as a foreign brand. react-router builds one
+ * Request per navigation, so without this every navigation throws. Node's
+ * Request for everything else; only the signal is swapped past the check.
+ */
+class MockRequest extends NodeRequest {
+  constructor(input: RequestInfo | URL, init: RequestInit = {}) {
+    const { signal, ...rest } = init;
+    super(input, rest);
+    Object.defineProperty(this, "signal", {
+      value: signal ?? new AbortController().signal,
+    });
+  }
+}
+
+/**
+ * A data router, not MemoryRouter: the guard calls useBlocker, which only
+ * exists on a data router, so the harness has to be one from the start.
+ *
+ * Takes a history rather than a single path so a test can drive POP, which
+ * needs somewhere to go back to.
+ */
+function renderGuard(history: string | string[] = TOOL_ROUTE, index?: number) {
+  const entries = Array.isArray(history) ? history : [history];
   const router = createMemoryRouter([{ path: "*", element: <NavigationGuard /> }], {
-    initialEntries: [path],
+    initialEntries: entries,
+    initialIndex: index,
   });
-  return render(<RouterProvider router={router} />);
+  return { ...render(<RouterProvider router={router} />), router };
+}
+
+type TestRouter = ReturnType<typeof createMemoryRouter>;
+
+/** Drive the router the way a Link would, and let the blocker settle. */
+async function navigateTo(router: TestRouter, to: string): Promise<void> {
+  await act(async () => {
+    await router.navigate(to);
+  });
+}
+
+/**
+ * Every blocker state the router passes through, so a test can assert on what
+ * the blocker did rather than only on where the navigation landed. The
+ * auto-proceed effect hides a spurious block from the second kind of check.
+ */
+function recordBlockerStates(router: TestRouter): { states: string[]; stop: () => void } {
+  const states: string[] = [];
+  const stop = router.subscribe((state) => {
+    for (const blocker of state.blockers.values()) states.push(blocker.state);
+  });
+  return { states, stop };
+}
+
+function startRun(): void {
+  useFileStore.getState().setFiles([makeFile("a.png")]);
+  useFileStore.getState().setProcessing(true);
+}
+
+function leaveAResult(): void {
+  useFileStore.getState().setFiles([makeFile("a.png")]);
+  useFileStore
+    .getState()
+    .updateEntry(0, { processedUrl: "blob:result", processedFilename: "a-small.png" });
+}
+
+function leaveABatchZip(): void {
+  useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png")]);
+  useFileStore.getState().setBatchZip(new Blob(["zip"]), "processed-files.zip");
+}
+
+async function clickButton(name: string): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name }));
+  });
+}
+
+/** The text an aria-labelledby or aria-describedby actually resolves to. */
+function textOf(id: string | null): string | undefined {
+  return id ? (document.getElementById(id)?.textContent ?? undefined) : undefined;
 }
 
 /**
@@ -66,11 +151,8 @@ let addSpy: ReturnType<typeof vi.spyOn>;
 let removeSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
-  vi.stubGlobal("URL", {
-    ...URL,
-    createObjectURL: () => "blob:fake",
-    revokeObjectURL: () => {},
-  });
+  vi.stubGlobal("URL", MockURL);
+  vi.stubGlobal("Request", MockRequest);
   useFileStore.getState().reset();
   useEditorStore.setState({ isDirty: false });
   addSpy = vi.spyOn(window, "addEventListener");
@@ -180,5 +262,373 @@ describe("NavigationGuard beforeunload listener", () => {
 
     expect(calls(addSpy)).toHaveLength(0);
     expect(dispatchUnload().prevented).toBe(false);
+  });
+});
+describe("NavigationGuard blocker", () => {
+  it("blocks a navigation away from a run and keeps you put when you stay", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+
+    expect(router.state.location.pathname).toBe(TOOL_ROUTE);
+    expect(screen.getByRole("dialog")).toBeDefined();
+
+    await clickButton(en.navigationGuard.stay);
+
+    expect(router.state.location.pathname).toBe(TOOL_ROUTE);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("lets the navigation through when you leave anyway", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    expect(router.state.location.pathname).toBe(TOOL_ROUTE);
+
+    await clickButton(en.navigationGuard.leave);
+
+    expect(router.state.location.pathname).toBe("/files");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // Back is how most people abandon a page, and POP runs through its own branch
+  // of the router with a history rewind rather than the push path above.
+  it("blocks the browser Back button out of a run", async () => {
+    startRun();
+    const { router } = renderGuard(["/files", TOOL_ROUTE], 1);
+
+    await act(async () => {
+      await router.navigate(-1);
+    });
+
+    expect(router.state.location.pathname).toBe(TOOL_ROUTE);
+    expect(screen.getByRole("dialog")).toBeDefined();
+
+    await clickButton(en.navigationGuard.leave);
+
+    expect(router.state.location.pathname).toBe("/files");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders nothing while there is nothing to lose", async () => {
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+
+    expect(router.state.location.pathname).toBe("/files");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // The auto-proceed effect would paper over a blocker that fires with nothing
+  // to lose, so watch the blocker state rather than where the router landed: a
+  // clean page must never enter "blocked" in the first place.
+  it("never enters the blocked state on a page with nothing to lose", async () => {
+    const { router } = renderGuard();
+    const seen = recordBlockerStates(router);
+
+    await navigateTo(router, "/files");
+    seen.stop();
+
+    expect(router.state.location.pathname).toBe("/files");
+    expect(seen.states).not.toContain("blocked");
+  });
+
+  it("stops asking once the work settles while the dialog is open", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    expect(screen.getByRole("dialog")).toBeDefined();
+
+    await act(async () => {
+      useFileStore.getState().setProcessing(false);
+    });
+
+    expect(router.state.location.pathname).toBe("/files");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // Every store patch during a run rebuilds useWorkInFlight's return value, so
+  // an open dialog re-renders repeatedly under a live run. This pins that the
+  // block survives that; it does NOT pin the useCallback on shouldBlock, which
+  // in react-router 8.3.0 only saves an effect re-run and is invisible from
+  // outside. Verified: this passes with an inline arrow too.
+  it("keeps asking while the store churns underneath it", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    expect(screen.getByRole("dialog")).toBeDefined();
+
+    await act(async () => {
+      for (const size of [10, 20, 30]) {
+        useFileStore.getState().updateEntry(0, { status: "processing", processedSize: size });
+      }
+    });
+
+    expect(router.state.location.pathname).toBe(TOOL_ROUTE);
+    expect(screen.getByRole("dialog")).toBeDefined();
+  });
+});
+
+describe("NavigationGuard blocker exemptions", () => {
+  // Defence in depth. Nothing routes here in-app today, so the blocker never
+  // sees these; the set is there for the first <Link to="/login"> someone adds.
+  it("never blocks the way out to /login", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/login");
+
+    expect(router.state.location.pathname).toBe("/login");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("never blocks the forced password change", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/change-password");
+
+    expect(router.state.location.pathname).toBe("/change-password");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // automate-page navigates to its own path purely to clear router state.
+  // Without the same-path check that pops a dialog over a no-op.
+  it("never blocks a navigation to the path it is already on", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, TOOL_ROUTE);
+
+    expect(router.state.location.pathname).toBe(TOOL_ROUTE);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // React Router tolerates a trailing slash, so this lands on the page the user
+  // is already looking at. Comparing raw pathnames would call it a departure.
+  it("never blocks the same path wearing a trailing slash", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, `${TOOL_ROUTE}/`);
+
+    expect(router.state.location.pathname).toBe(`${TOOL_ROUTE}/`);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // Routes match case-insensitively unless they opt out, and none here do.
+  it("never blocks the same path in a different case", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, TOOL_ROUTE.toUpperCase());
+
+    expect(router.state.location.pathname).toBe(TOOL_ROUTE.toUpperCase());
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});
+
+describe("NavigationGuard dialog copy", () => {
+  it("names the run when a run is what is at risk", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+
+    expect(screen.getByText(en.navigationGuard.processingTitle)).toBeDefined();
+    expect(screen.getByText(en.navigationGuard.processingBody)).toBeDefined();
+  });
+
+  it("names the result when an untaken result is what is at risk", async () => {
+    leaveAResult();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+
+    expect(screen.getByText(en.navigationGuard.unsavedTitle)).toBeDefined();
+    expect(screen.getByText(en.navigationGuard.unsavedBody)).toBeDefined();
+  });
+
+  // A batch settles by storing the zip before it fills in per-entry results, so
+  // the zip is a reason on its own and not a consequence of the entries.
+  it("names the result when an unclaimed batch zip is what is at risk", async () => {
+    leaveABatchZip();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+
+    expect(screen.getByText(en.navigationGuard.unsavedTitle)).toBeDefined();
+    expect(screen.getByText(en.navigationGuard.unsavedBody)).toBeDefined();
+  });
+
+  it("names the edits when the editor is dirty", async () => {
+    useEditorStore.setState({ isDirty: true });
+    const { router } = renderGuard("/editor");
+
+    await navigateTo(router, "/files");
+
+    expect(screen.getByText(en.navigationGuard.editorTitle)).toBeDefined();
+    expect(screen.getByText(en.navigationGuard.editorBody)).toBeDefined();
+  });
+});
+
+describe("NavigationGuard dialog controls", () => {
+  // Escape is the one key a user hits by reflex. Mapping it to Leave would turn
+  // a stray keypress into data loss.
+  it("treats Escape as staying put", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    expect(screen.getByRole("dialog")).toBeDefined();
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+
+    expect(router.state.location.pathname).toBe(TOOL_ROUTE);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // A misplaced click is the accident the dialog exists to catch, so the
+  // backdrop answers nothing, in either direction.
+  it("ignores a click on the backdrop", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    const backdrop = document.querySelector("[aria-hidden='true']");
+    expect(backdrop).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.click(backdrop as Element);
+    });
+
+    expect(router.state.location.pathname).toBe(TOOL_ROUTE);
+    expect(screen.getByRole("dialog")).toBeDefined();
+  });
+
+  // Whatever the trap focuses first is what a reflexive Enter answers, so it
+  // has to be the safe one.
+  it("puts the focus on staying put, not on leaving", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+    await act(async () => {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    });
+
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: en.navigationGuard.stay }),
+    );
+  });
+});
+
+describe("NavigationGuard dialog markup", () => {
+  it("names itself and its question for assistive tech", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(textOf(dialog.getAttribute("aria-labelledby"))).toBe(en.navigationGuard.processingTitle);
+    expect(textOf(dialog.getAttribute("aria-describedby"))).toBe(en.navigationGuard.processingBody);
+  });
+
+  // German runs 59 display units across the three labels and Japanese 52,
+  // against 20 for English's widest, so a row overflows the card.
+  it("stacks its buttons instead of laying them out in a row", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+
+    const stay = screen.getByRole("button", { name: en.navigationGuard.stay });
+    const leave = screen.getByRole("button", { name: en.navigationGuard.leave });
+    expect(stay.parentElement).toBe(leave.parentElement);
+    expect(stay.parentElement?.className).toContain("flex-col");
+  });
+
+  // The migration banner is z-[55] and the connection banner z-[60], and the
+  // survey overlay shares z-50 but paints after this one. aria-modal tells
+  // assistive tech there is nothing else here; the stacking order has to agree
+  // for the mouse.
+  it("sits above the app's other fixed layers", async () => {
+    startRun();
+    const { router } = renderGuard();
+
+    await navigateTo(router, "/files");
+
+    const shell = screen.getByRole("dialog").closest(".fixed");
+    const layer = Number(/z-\[(\d+)\]/.exec(shell?.className ?? "")?.[1] ?? 0);
+    expect(layer).toBeGreaterThan(60);
+  });
+});
+
+/**
+ * These two characterize an upstream contract rather than anything this
+ * component decides: React runs passive unmount effects tree-wide before
+ * passive mount effects, and useBlocker's cleanup lives in a passive effect
+ * rather than a layout one. That pairing is what deletes the blocker before
+ * AuthGuard's <Navigate> gets to navigate.
+ *
+ * Neither can be broken from inside the component, because the component is not
+ * what makes them pass. They exist to fail on a react-router upgrade that moves
+ * deleteBlocker into a layout effect, which is exactly the AuthGuard deadlock.
+ */
+describe("NavigationGuard unmount ordering", () => {
+  it("lets the session-expiry redirect through instead of deadlocking", async () => {
+    let expireSession: () => void = () => {};
+
+    function AuthLike() {
+      const [authed, setAuthed] = useState(true);
+      expireSession = () => setAuthed(false);
+      return authed ? <NavigationGuard /> : <Navigate to="/login" replace />;
+    }
+
+    startRun();
+    const router = createMemoryRouter([{ path: "*", element: <AuthLike /> }], {
+      initialEntries: [TOOL_ROUTE],
+    });
+    render(<RouterProvider router={router} />);
+
+    await act(async () => {
+      expireSession();
+    });
+
+    expect(router.state.location.pathname).toBe("/login");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // The same ordering with a destination the exemption list does not cover, so
+  // the exemption cannot be what carries it.
+  it("does not block a redirect fired from the commit that unmounts it", async () => {
+    let signOut: () => void = () => {};
+
+    function RedirectOnUnmount() {
+      const [mounted, setMounted] = useState(true);
+      signOut = () => setMounted(false);
+      return mounted ? <NavigationGuard /> : <Navigate to="/files" replace />;
+    }
+
+    startRun();
+    const router = createMemoryRouter([{ path: "*", element: <RedirectOnUnmount /> }], {
+      initialEntries: [TOOL_ROUTE],
+    });
+    render(<RouterProvider router={router} />);
+
+    await act(async () => {
+      signOut();
+    });
+
+    expect(router.state.location.pathname).toBe("/files");
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 });

--- a/tests/unit/web/navigation-guard.test.tsx
+++ b/tests/unit/web/navigation-guard.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/image-preview", () => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/analytics", async () => {
+  const { analyticsModuleMock } = await import("../../helpers/mock-analytics.js");
+  return analyticsModuleMock();
+});
+
+import { NavigationGuard } from "@/components/common/navigation-guard";
+import { useEditorStore } from "@/stores/editor-store";
+import { useFileStore } from "@/stores/file-store";
+
+const TOOL_ROUTE = "/image/compress-image";
+
+function makeFile(name: string): File {
+  return new File(["x"], name, { type: "image/png" });
+}
+
+/**
+ * A data router, not MemoryRouter: the guard will call useBlocker, which only
+ * exists on a data router, so the harness has to be one from the start.
+ */
+function renderGuard(path = TOOL_ROUTE) {
+  const router = createMemoryRouter([{ path: "*", element: <NavigationGuard /> }], {
+    initialEntries: [path],
+  });
+  return render(<RouterProvider router={router} />);
+}
+
+/**
+ * What the window was actually handed, filtered to the one event under test.
+ * Registration is the assertion, not just behaviour: a listener that is always
+ * attached and returns early can disqualify the page from bfcache.
+ */
+function calls(spy: ReturnType<typeof vi.spyOn>): unknown[][] {
+  return spy.mock.calls.filter((call) => call[0] === "beforeunload");
+}
+
+/**
+ * Fire a real cancelable beforeunload and report how the page answered.
+ *
+ * `prevented` alone is not enough to pin the handler. jsdom dispatches a plain
+ * Event, whose legacy `returnValue` setter cancels on a FALSY value, so a
+ * handler that only assigned `returnValue = ""` would read as cancelled here
+ * while doing nothing in any real browser. `preventDefaultCalled` pins the one
+ * mechanism current browsers honour.
+ */
+function dispatchUnload(): { prevented: boolean; preventDefaultCalled: boolean } {
+  const event = new Event("beforeunload", { cancelable: true });
+  const preventDefault = vi.spyOn(event, "preventDefault");
+  window.dispatchEvent(event);
+  return {
+    prevented: event.defaultPrevented,
+    preventDefaultCalled: preventDefault.mock.calls.length > 0,
+  };
+}
+
+let addSpy: ReturnType<typeof vi.spyOn>;
+let removeSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: () => "blob:fake",
+    revokeObjectURL: () => {},
+  });
+  useFileStore.getState().reset();
+  useEditorStore.setState({ isDirty: false });
+  addSpy = vi.spyOn(window, "addEventListener");
+  removeSpy = vi.spyOn(window, "removeEventListener");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("NavigationGuard beforeunload listener", () => {
+  it("registers no listener when there is nothing to lose", () => {
+    renderGuard();
+
+    expect(calls(addSpy)).toHaveLength(0);
+    expect(dispatchUnload().prevented).toBe(false);
+  });
+
+  it("registers a listener while a run is in flight", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().setProcessing(true);
+
+    renderGuard();
+
+    expect(calls(addSpy)).toHaveLength(1);
+  });
+
+  it("registers a listener once a result is sitting untaken", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore
+      .getState()
+      .updateEntry(0, { processedUrl: "blob:result", processedFilename: "a-small.png" });
+
+    renderGuard();
+
+    expect(calls(addSpy)).toHaveLength(1);
+  });
+
+  it("registers a listener for an unsaved editor document", () => {
+    useEditorStore.setState({ isDirty: true });
+
+    renderGuard("/editor");
+
+    expect(calls(addSpy)).toHaveLength(1);
+    expect(dispatchUnload().preventDefaultCalled).toBe(true);
+  });
+
+  it("leaves a clean editor document alone", () => {
+    renderGuard("/editor");
+
+    expect(calls(addSpy)).toHaveLength(0);
+  });
+
+  // The path a user actually takes: land on an empty tool page, then start a
+  // run. Nothing registers at mount, so the effect has to re-run off the dep
+  // array when hasWork flips.
+  it("registers a listener when work appears after mount", () => {
+    renderGuard();
+    expect(calls(addSpy)).toHaveLength(0);
+
+    act(() => {
+      useFileStore.getState().setFiles([makeFile("a.png")]);
+      useFileStore.getState().setProcessing(true);
+    });
+
+    expect(calls(addSpy)).toHaveLength(1);
+    expect(dispatchUnload().preventDefaultCalled).toBe(true);
+  });
+
+  it("removes the listener it added once the run settles with nothing left", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().setProcessing(true);
+
+    renderGuard();
+    act(() => {
+      useFileStore.getState().setProcessing(false);
+    });
+
+    const added = calls(addSpy);
+    const removed = calls(removeSpy);
+    expect(added).toHaveLength(1);
+    expect(removed).toHaveLength(1);
+    // The cleanup has to hand back the same function object, or the listener
+    // outlives the work it was guarding.
+    expect(removed[0][1]).toBe(added[0][1]);
+    expect(dispatchUnload().prevented).toBe(false);
+  });
+
+  it("cancels the unload while there is work in flight", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().setProcessing(true);
+
+    renderGuard();
+
+    const { prevented, preventDefaultCalled } = dispatchUnload();
+    expect(preventDefaultCalled).toBe(true);
+    expect(prevented).toBe(true);
+  });
+
+  it("leaves the unload alone on a page that owns no work", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().setProcessing(true);
+
+    renderGuard("/files");
+
+    expect(calls(addSpy)).toHaveLength(0);
+    expect(dispatchUnload().prevented).toBe(false);
+  });
+});

--- a/tests/unit/web/result-download-link.test.tsx
+++ b/tests/unit/web/result-download-link.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const imagePreviewMock = vi.hoisted(() => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/image-preview", () => imagePreviewMock);
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+  // formatHeaders() in @/lib/api reads this; without it unrelated code throws
+  // and the failure is swallowed.
+  getDistinctId: () => null,
+}));
+
+import { ResultDownloadLink } from "@/components/common/result-download-link";
+import { useFileStore } from "@/stores/file-store";
+
+function makeFile(name: string): File {
+  return new File(["x"], name, { type: "image/png" });
+}
+
+/** jsdom has no navigation, so let the click run but drop the default action. */
+function swallowNavigation(e: Event) {
+  e.preventDefault();
+}
+
+beforeEach(() => {
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: () => "blob:fake",
+    revokeObjectURL: () => {},
+  });
+  document.addEventListener("click", swallowNavigation, true);
+  useFileStore.getState().reset();
+});
+
+afterEach(() => {
+  document.removeEventListener("click", swallowNavigation, true);
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("ResultDownloadLink", () => {
+  it("renders a download anchor carrying the href and the test id", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    const { container } = render(
+      <ResultDownloadLink href="blob:result" testId="convert-download" />,
+    );
+
+    const link = container.querySelector<HTMLAnchorElement>("[data-testid='convert-download']");
+    expect(link).not.toBeNull();
+    expect(link?.tagName).toBe("A");
+    expect(link?.getAttribute("href")).toBe("blob:result");
+    expect(link?.hasAttribute("download")).toBe(true);
+  });
+
+  it("forces the saved filename when one is given", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    const { container } = render(
+      <ResultDownloadLink
+        href="blob:result"
+        testId="favicon-download"
+        downloadName="favicons.zip"
+      />,
+    );
+
+    const link = container.querySelector<HTMLAnchorElement>("[data-testid='favicon-download']");
+    expect(link?.getAttribute("download")).toBe("favicons.zip");
+  });
+
+  it("keeps the icon when only the label is replaced", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    const { container } = render(
+      <ResultDownloadLink href="blob:result" testId="vectorize-download" label="Download SVG" />,
+    );
+
+    const link = container.querySelector<HTMLAnchorElement>("[data-testid='vectorize-download']");
+    expect(link?.textContent).toContain("Download SVG");
+    expect(link?.querySelector("svg")).not.toBeNull();
+  });
+
+  it("claims the entry when the result is downloaded", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    const { container } = render(
+      <ResultDownloadLink href="blob:result" testId="convert-download" />,
+    );
+    expect(useFileStore.getState().entries[0].claimed).toBe(false);
+
+    fireEvent.click(container.querySelector("[data-testid='convert-download']") as HTMLElement);
+
+    expect(useFileStore.getState().entries[0].claimed).toBe(true);
+  });
+
+  it("claims the selected entry, not the first one", () => {
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png")]);
+    useFileStore.getState().setSelectedIndex(1);
+    const { container } = render(
+      <ResultDownloadLink href="blob:result" testId="convert-download" />,
+    );
+
+    fireEvent.click(container.querySelector("[data-testid='convert-download']") as HTMLElement);
+
+    const { entries } = useFileStore.getState();
+    expect(entries[1].claimed).toBe(true);
+    expect(entries[0].claimed).toBe(false);
+  });
+});

--- a/tests/unit/web/review-panel-claim.test.tsx
+++ b/tests/unit/web/review-panel-claim.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const imagePreviewMock = vi.hoisted(() => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/image-preview", () => imagePreviewMock);
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+  // formatHeaders() in @/lib/api reads this; without it the save handler
+  // throws into its own catch and never reaches the claim.
+  getDistinctId: () => null,
+}));
+
+vi.mock("@/components/feedback/tool-feedback-prompt", () => ({
+  ToolFeedbackPrompt: () => null,
+}));
+
+import { ReviewPanel } from "@/components/common/review-panel";
+import { useFileStore } from "@/stores/file-store";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: () => "blob:fake",
+    revokeObjectURL: () => {},
+  });
+  useFileStore.getState().reset();
+  useFileStore.getState().setFiles([new File(["x"], "a.png", { type: "image/png" })]);
+});
+
+function renderPanel() {
+  return render(
+    <MemoryRouter>
+      <ReviewPanel
+        filename="a-resized.png"
+        fileSize={100}
+        fileType="image/png"
+        originalSize={200}
+        downloadUrl="blob:result"
+        onUndo={() => {}}
+        onStartOver={() => {}}
+        currentToolId="resize"
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("ReviewPanel claim tracking", () => {
+  it("claims the entry when the result is downloaded", () => {
+    const { container } = renderPanel();
+    expect(useFileStore.getState().entries[0].claimed).toBe(false);
+
+    const button = container.querySelector("[data-download-button]");
+    expect(button).not.toBeNull();
+    fireEvent.click(button as HTMLElement);
+
+    expect(useFileStore.getState().entries[0].claimed).toBe(true);
+  });
+
+  it("claims the entry that was saved, not the one selected when the upload returns", async () => {
+    useFileStore
+      .getState()
+      .setFiles([
+        new File(["x"], "a.png", { type: "image/png" }),
+        new File(["y"], "b.png", { type: "image/png" }),
+      ]);
+    expect(useFileStore.getState().selectedIndex).toBe(0);
+
+    let resolveUpload: ((res: { ok: boolean }) => void) | undefined;
+    const upload = new Promise<{ ok: boolean }>((resolve) => {
+      resolveUpload = resolve;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: string) =>
+        input === "blob:result"
+          ? Promise.resolve({ blob: () => Promise.resolve(new Blob(["result"])) })
+          : upload,
+      ),
+    );
+
+    renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: /save to files/i }));
+    // Let the handler reach the upload, which stays pending below.
+    await act(async () => {});
+
+    // The user browses to another file while the upload is still in flight.
+    act(() => {
+      useFileStore.getState().setSelectedIndex(1);
+    });
+
+    await act(async () => {
+      resolveUpload?.({ ok: true });
+      await upload;
+    });
+    await act(async () => {});
+
+    // Diagnosis insurance: handleSaveToFiles swallows everything into a bare
+    // catch, so without this a broken fetch or header helper reads as a claim
+    // bug and points at the wrong subsystem.
+    expect(await screen.findByRole("button", { name: /saved to files/i })).toBeTruthy();
+
+    const { entries } = useFileStore.getState();
+    expect(entries[0].claimed).toBe(true);
+    expect(entries[1].claimed).toBe(false);
+  });
+});

--- a/tests/unit/web/stores/file-store-claim.test.ts
+++ b/tests/unit/web/stores/file-store-claim.test.ts
@@ -56,6 +56,16 @@ describe("file store claim tracking", () => {
     expect(entries[1].claimed).toBe(true);
   });
 
+  it("claims whichever entry the UI is showing", () => {
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png")]);
+    useFileStore.getState().setSelectedIndex(1);
+    useFileStore.getState().claimSelected();
+
+    const { entries } = useFileStore.getState();
+    expect(entries[1].claimed).toBe(true);
+    expect(entries[0].claimed).toBe(false);
+  });
+
   it("ignores a claim for an entry that is not there", () => {
     useFileStore.getState().setFiles([makeFile("a.png")]);
     useFileStore.getState().markClaimed(7);

--- a/tests/unit/web/stores/file-store-claim.test.ts
+++ b/tests/unit/web/stores/file-store-claim.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const imagePreviewMock = vi.hoisted(() => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/image-preview", () => imagePreviewMock);
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+}));
+
+import { useFileStore } from "@/stores/file-store";
+
+function makeFile(name: string): File {
+  return new File(["x"], name, { type: "image/png" });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: () => "blob:fake",
+    revokeObjectURL: () => {},
+  });
+  useFileStore.getState().reset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("file store claim tracking", () => {
+  it("starts every entry unclaimed", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    expect(useFileStore.getState().entries[0].claimed).toBe(false);
+    expect(useFileStore.getState().batchZipClaimed).toBe(false);
+  });
+
+  it("marks the named entry claimed", () => {
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png")]);
+    useFileStore.getState().markClaimed(0);
+
+    const { entries } = useFileStore.getState();
+    expect(entries[0].claimed).toBe(true);
+    expect(entries[1].claimed).toBe(false);
+  });
+
+  it("claims an entry that is not the selected one", () => {
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png")]);
+    useFileStore.getState().markClaimed(1);
+
+    const { entries, selectedIndex } = useFileStore.getState();
+    expect(selectedIndex).toBe(0);
+    expect(entries[1].claimed).toBe(true);
+  });
+
+  it("ignores a claim for an entry that is not there", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().markClaimed(7);
+
+    const { entries } = useFileStore.getState();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].claimed).toBe(false);
+  });
+
+  it("marks every entry claimed when the batch zip is taken", () => {
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png")]);
+    useFileStore.getState().setBatchZip(new Blob(["z"]), "out.zip");
+    useFileStore.getState().markBatchClaimed();
+
+    const state = useFileStore.getState();
+    expect(state.batchZipClaimed).toBe(true);
+    expect(state.entries.every((e) => e.claimed)).toBe(true);
+  });
+
+  it("treats a new batch zip as unclaimed", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().setBatchZip(new Blob(["z"]), "out.zip");
+    useFileStore.getState().markBatchClaimed();
+    useFileStore.getState().setBatchZip(new Blob(["z2"]), "out2.zip");
+
+    expect(useFileStore.getState().batchZipClaimed).toBe(false);
+  });
+
+  it("starts a new file set unclaimed", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().markClaimed(0);
+    useFileStore.getState().setFiles([makeFile("c.png")]);
+
+    expect(useFileStore.getState().entries[0].claimed).toBe(false);
+  });
+
+  it("drops the previous batch zip when a new file set arrives", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().setBatchZip(new Blob(["z"]), "out.zip");
+    useFileStore.getState().markBatchClaimed();
+    useFileStore.getState().setFiles([makeFile("c.png")]);
+
+    const state = useFileStore.getState();
+    expect(state.batchZipBlob).toBeNull();
+    expect(state.batchZipFilename).toBeNull();
+    expect(state.batchZipClaimed).toBe(false);
+  });
+
+  it("clears entries and the batch zip claim on reset", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().setBatchZip(new Blob(["z"]), "out.zip");
+    useFileStore.getState().markBatchClaimed();
+    expect(useFileStore.getState().batchZipClaimed).toBe(true);
+
+    useFileStore.getState().reset();
+
+    const state = useFileStore.getState();
+    expect(state.entries).toHaveLength(0);
+    expect(state.batchZipClaimed).toBe(false);
+  });
+});
+
+describe("a changed result invalidates its claim", () => {
+  it("unclaims an entry that gets a new processed url through updateEntry", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().markClaimed(0);
+    useFileStore.getState().updateEntry(0, { processedUrl: "blob:second-run" });
+
+    expect(useFileStore.getState().entries[0].claimed).toBe(false);
+  });
+
+  it("unclaims an entry whose processed url is cleared through updateEntry", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().markClaimed(0);
+    useFileStore.getState().updateEntry(0, { processedUrl: null });
+
+    expect(useFileStore.getState().entries[0].claimed).toBe(false);
+  });
+
+  it("keeps the claim when the patch leaves the processed url alone", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().markClaimed(0);
+    useFileStore.getState().updateEntry(0, { processedSize: 123 });
+
+    expect(useFileStore.getState().entries[0].claimed).toBe(true);
+  });
+
+  it("unclaims the selected entry when setProcessedUrl lands a result", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().markClaimed(0);
+    useFileStore.getState().setProcessedUrl("blob:second-run");
+
+    expect(useFileStore.getState().entries[0].claimed).toBe(false);
+  });
+
+  it("unclaims the selected entry when setProcessedUrl clears the result", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().markClaimed(0);
+    useFileStore.getState().setProcessedUrl(null);
+
+    expect(useFileStore.getState().entries[0].claimed).toBe(false);
+  });
+
+  it("clears every claim when undoProcessing drops the results", () => {
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png")]);
+    useFileStore.getState().setBatchZip(new Blob(["z"]), "out.zip");
+    useFileStore.getState().markBatchClaimed();
+    useFileStore.getState().undoProcessing();
+
+    const state = useFileStore.getState();
+    expect(state.entries.some((e) => e.claimed)).toBe(false);
+    expect(state.batchZipClaimed).toBe(false);
+  });
+});

--- a/tests/unit/web/use-tool-processor-save-mode.test.ts
+++ b/tests/unit/web/use-tool-processor-save-mode.test.ts
@@ -271,3 +271,84 @@ describe("useToolProcessor library save mode (issue #495)", () => {
     unmount();
   });
 });
+
+describe("useToolProcessor claim tracking (nav guard)", () => {
+  it("claims the entry once the auto-saved result lands", async () => {
+    const file = stageLibraryFile();
+    const { result, unmount } = renderHook(() => useToolProcessor("resize"));
+
+    act(() => {
+      result.current.processFiles([file], {});
+    });
+    expect(useFileStore.getState().entries[0].claimed).toBe(false);
+
+    act(() => {
+      completeRun(xhrs[0], "lib-copy");
+    });
+
+    // Pins the ordering: the claim has to be made after the updateEntry that
+    // writes processedUrl, since that patch resets `claimed`.
+    expect(useFileStore.getState().entries[0].claimed).toBe(true);
+    unmount();
+  });
+
+  it("claims the entry when the auto-saved result lands over SSE", async () => {
+    const file = stageLibraryFile();
+    const { result, unmount } = renderHook(() => useToolProcessor("resize"));
+
+    act(() => {
+      result.current.processFiles([file], {});
+    });
+    act(() => {
+      xhrs[0].status = 202;
+      xhrs[0].responseText = JSON.stringify({ jobId: "job-1", async: true });
+      xhrs[0].onload?.();
+    });
+    act(() => {
+      MockEventSource.instances[0].onmessage?.({
+        data: JSON.stringify({
+          type: "single",
+          phase: "complete",
+          result: {
+            jobId: "job-1",
+            downloadUrl: "/api/v1/download/job-1/photo_resize.png",
+            originalSize: 64,
+            processedSize: 32,
+            savedFileId: "lib-copy",
+          },
+        }),
+      } as MessageEvent);
+    });
+
+    expect(useFileStore.getState().entries[0].claimed).toBe(true);
+    unmount();
+  });
+
+  it("leaves a result the user still has to take unclaimed", async () => {
+    const file = new File([new ArrayBuffer(64)], "plain.png", { type: "image/png" });
+    useFileStore.getState().setFiles([file]);
+    const { result, unmount } = renderHook(() => useToolProcessor("resize"));
+
+    act(() => {
+      result.current.processFiles([file], {});
+    });
+    act(() => {
+      xhrs[0].status = 200;
+      xhrs[0].responseText = JSON.stringify({
+        jobId: "job-1",
+        downloadUrl: "/api/v1/download/job-1/plain_resize.png",
+        originalSize: 64,
+        processedSize: 32,
+      });
+      xhrs[0].onload?.();
+    });
+
+    // Nothing auto-saved it, so the guard must still have something to warn
+    // about until the user downloads or saves.
+    expect(useFileStore.getState().entries[0].processedUrl).toBe(
+      "/api/v1/download/job-1/plain_resize.png",
+    );
+    expect(useFileStore.getState().entries[0].claimed).toBe(false);
+    unmount();
+  });
+});

--- a/tests/unit/web/use-work-in-flight.test.tsx
+++ b/tests/unit/web/use-work-in-flight.test.tsx
@@ -1,0 +1,359 @@
+// @vitest-environment jsdom
+import { SECTIONS } from "@snapotter/shared";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/image-preview", () => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/analytics", async () => {
+  const { analyticsModuleMock } = await import("../../helpers/mock-analytics.js");
+  return analyticsModuleMock();
+});
+
+// Bypass the persist middleware so the editor store starts clean per test.
+vi.mock("zustand/middleware", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  return { ...actual, persist: (config: unknown) => config };
+});
+
+import { useWorkInFlight } from "@/hooks/use-work-in-flight";
+import { useEditorStore } from "@/stores/editor-store";
+import { useFileStore } from "@/stores/file-store";
+
+const TOOL_ROUTE = "/image/compress-image";
+
+function makeFile(name: string): File {
+  return new File(["x"], name, { type: "image/png" });
+}
+
+/** Render the hook as if the user were sitting on `path`. */
+function workAt(path: string) {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>
+  );
+  return renderHook(() => useWorkInFlight(), { wrapper }).result.current;
+}
+
+/** Load one file and land a result on it, leaving the result unclaimed. */
+function seedResult(name = "a.png", processedFilename = "a-compressed.png"): void {
+  useFileStore.getState().setFiles([makeFile(name)]);
+  useFileStore.getState().updateEntry(0, {
+    processedUrl: "blob:result",
+    processedFilename,
+    status: "completed",
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: () => "blob:fake",
+    revokeObjectURL: () => {},
+  });
+  useFileStore.getState().reset();
+  useEditorStore.setState({ isDirty: false });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("nothing to lose", () => {
+  it("reports nothing on an empty tool page", () => {
+    expect(workAt(TOOL_ROUTE)).toBeNull();
+  });
+
+  it("reports nothing when files are loaded but nothing has run", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+
+    expect(workAt(TOOL_ROUTE)).toBeNull();
+  });
+});
+
+describe("a run in flight", () => {
+  it("reports processing on a tool route", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().setProcessing(true);
+
+    expect(workAt(TOOL_ROUTE)).toEqual({ kind: "processing" });
+  });
+
+  it("reports processing on the automate page", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().setProcessing(true);
+
+    expect(workAt("/automate")).toEqual({ kind: "processing" });
+  });
+
+  it("prefers processing over a result still on screen", () => {
+    seedResult();
+    useFileStore.getState().setProcessing(true);
+
+    expect(workAt(TOOL_ROUTE)).toEqual({ kind: "processing" });
+  });
+
+  // Pins the processing check ahead of the zip branch too, not just ahead of
+  // the entry branch. Without this, moving it between the two stays green.
+  it("prefers processing over a batch zip still on screen", () => {
+    seedResult();
+    useFileStore.getState().setBatchZip(new Blob(["z"]), "batch.zip");
+    useFileStore.getState().setProcessing(true);
+
+    expect(workAt(TOOL_ROUTE)).toEqual({ kind: "processing" });
+  });
+});
+
+describe("an untaken result", () => {
+  it("offers the result for download", () => {
+    seedResult();
+
+    expect(workAt(TOOL_ROUTE)).toEqual({
+      kind: "unsaved",
+      downloads: [{ kind: "result", url: "blob:result", filename: "a-compressed.png" }],
+    });
+  });
+
+  it("falls back to the source filename when the result has none", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().updateEntry(0, { processedUrl: "blob:result", status: "completed" });
+
+    expect(workAt(TOOL_ROUTE)).toEqual({
+      kind: "unsaved",
+      downloads: [{ kind: "result", url: "blob:result", filename: "a.png" }],
+    });
+  });
+
+  it("reports nothing once the result has been taken", () => {
+    seedResult();
+    useFileStore.getState().markClaimed(0);
+
+    expect(workAt(TOOL_ROUTE)).toBeNull();
+  });
+
+  it("lists only the results that are still untaken", () => {
+    useFileStore.getState().setFiles([makeFile("a.png"), makeFile("b.png")]);
+    useFileStore
+      .getState()
+      .updateEntry(0, { processedUrl: "blob:one", processedFilename: "one.png" });
+    useFileStore
+      .getState()
+      .updateEntry(1, { processedUrl: "blob:two", processedFilename: "two.png" });
+    useFileStore.getState().markClaimed(0);
+
+    expect(workAt(TOOL_ROUTE)).toEqual({
+      kind: "unsaved",
+      downloads: [{ kind: "result", url: "blob:two", filename: "two.png" }],
+    });
+  });
+
+  it("keys on the result, not on the status", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    // A tool that lands a result without ever setting status to "completed"
+    // must still be guarded: silence is the failure that costs the user.
+    useFileStore
+      .getState()
+      .updateEntry(0, { processedUrl: "blob:result", processedFilename: "out.png" });
+
+    expect(useFileStore.getState().entries[0].status).not.toBe("completed");
+    expect(workAt(TOOL_ROUTE)).toEqual({
+      kind: "unsaved",
+      downloads: [{ kind: "result", url: "blob:result", filename: "out.png" }],
+    });
+  });
+});
+
+describe("a batch zip", () => {
+  it("is offered instead of the individual results", () => {
+    seedResult();
+    const zip = new Blob(["z"]);
+    useFileStore.getState().setBatchZip(zip, "batch-compress-image.zip");
+
+    expect(workAt(TOOL_ROUTE)).toEqual({
+      kind: "unsaved",
+      downloads: [{ kind: "zip", blob: zip, filename: "batch-compress-image.zip" }],
+    });
+  });
+
+  it("reports nothing once the zip has been taken", () => {
+    seedResult();
+    useFileStore.getState().setBatchZip(new Blob(["z"]), "batch.zip");
+    useFileStore.getState().markBatchClaimed();
+
+    expect(workAt(TOOL_ROUTE)).toBeNull();
+  });
+
+  // The hook does not screen out a stale zip; setFiles clears it at the source.
+  // Nothing inside the hook is under test here, so do not go looking for a
+  // guard: this pins the store behaviour the hook leans on.
+  it("is gone with the file set that produced it, so nothing is reported", () => {
+    seedResult();
+    useFileStore.getState().setBatchZip(new Blob(["z"]), "batch.zip");
+    useFileStore.getState().setFiles([makeFile("fresh.png")]);
+
+    expect(useFileStore.getState().batchZipBlob).toBeNull();
+    expect(workAt(TOOL_ROUTE)).toBeNull();
+  });
+
+  // settleFromZip stores the zip first and fills in per-entry results after, so
+  // a run that fails that second half (a fileResults mismatch, or unzipSync
+  // throwing) leaves a real downloadable zip with no entry results behind it.
+  // The guard must still offer it; silence here loses the whole batch.
+  it("is offered when the run never landed per-entry results", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    const zip = new Blob(["zipbytes"]);
+    useFileStore.getState().setBatchZip(zip, "batch-compress-image.zip");
+    useFileStore.getState().updateEntry(0, {
+      processedUrl: null,
+      status: "failed",
+      error: "File not found in batch results",
+    });
+
+    expect(useFileStore.getState().entries.some((e) => e.processedUrl)).toBe(false);
+    expect(workAt(TOOL_ROUTE)).toEqual({
+      kind: "unsaved",
+      downloads: [{ kind: "zip", blob: zip, filename: "batch-compress-image.zip" }],
+    });
+  });
+
+  // Zip branch skipped because the zip is claimed, entry branch runs because a
+  // re-run landed a fresh result. No setState needed: patching processedUrl
+  // unclaims the entry, which is the store invariant markBatchClaimed relies on.
+  it("gives way to a newer result once the zip has been taken", () => {
+    seedResult();
+    useFileStore.getState().setBatchZip(new Blob(["z"]), "batch.zip");
+    useFileStore.getState().markBatchClaimed();
+    useFileStore
+      .getState()
+      .updateEntry(0, { processedUrl: "blob:rerun", processedFilename: "rerun.png" });
+
+    expect(useFileStore.getState().batchZipClaimed).toBe(true);
+    expect(workAt(TOOL_ROUTE)).toEqual({
+      kind: "unsaved",
+      downloads: [{ kind: "result", url: "blob:rerun", filename: "rerun.png" }],
+    });
+  });
+
+  it("falls back to a generic filename when the zip has none", () => {
+    const zip = new Blob(["zipbytes"]);
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.setState({ batchZipBlob: zip, batchZipFilename: null, batchZipClaimed: false });
+
+    expect(workAt(TOOL_ROUTE)).toEqual({
+      kind: "unsaved",
+      downloads: [{ kind: "zip", blob: zip, filename: "processed-files.zip" }],
+    });
+  });
+});
+
+describe("route scoping", () => {
+  it("stays quiet on the file library, which does not own the file store", () => {
+    seedResult();
+
+    expect(workAt("/files")).toBeNull();
+  });
+
+  it("stays quiet on the dashboard", () => {
+    seedResult();
+
+    expect(workAt("/")).toBeNull();
+  });
+
+  it("stays quiet on a section index page", () => {
+    seedResult();
+
+    expect(workAt("/image")).toBeNull();
+  });
+
+  it("stays quiet on a two-segment path whose first part is not a section", () => {
+    seedResult();
+
+    expect(workAt("/settings/general")).toBeNull();
+  });
+
+  it("guards the automate page through a trailing slash", () => {
+    seedResult();
+
+    expect(workAt("/automate/")).toEqual({
+      kind: "unsaved",
+      downloads: [{ kind: "result", url: "blob:result", filename: "a-compressed.png" }],
+    });
+  });
+
+  // Not a normalizePath test: ownsFileStore's split/filter drops the empty last
+  // segment on its own, so this stays green with normalizePath deleted. It pins
+  // the segment counting, which a switch to a plain split() would break.
+  it("counts segments on a tool route whose trailing slash is empty", () => {
+    seedResult();
+
+    expect(workAt(`${TOOL_ROUTE}/`)).toEqual({
+      kind: "unsaved",
+      downloads: [{ kind: "result", url: "blob:result", filename: "a-compressed.png" }],
+    });
+  });
+
+  // React Router matches case-insensitively unless a route sets caseSensitive,
+  // and none do, so an uppercase URL renders the real page and has to be guarded.
+  it("guards a tool route reached through an uppercase url", () => {
+    seedResult();
+
+    expect(workAt("/IMAGE/Compress-Image")).toEqual({
+      kind: "unsaved",
+      downloads: [{ kind: "result", url: "blob:result", filename: "a-compressed.png" }],
+    });
+  });
+
+  it("guards the automate page reached through an uppercase url", () => {
+    useFileStore.getState().setFiles([makeFile("a.png")]);
+    useFileStore.getState().setProcessing(true);
+
+    expect(workAt("/Automate")).toEqual({ kind: "processing" });
+  });
+
+  // Derived from SECTIONS, not a hardcoded list, so a new section has to be
+  // guarded rather than silently going untested.
+  it("guards every tool section", () => {
+    seedResult();
+
+    for (const section of SECTIONS.map((s) => s.id)) {
+      expect(workAt(`/${section}/some-tool`)).toEqual({
+        kind: "unsaved",
+        downloads: [{ kind: "result", url: "blob:result", filename: "a-compressed.png" }],
+      });
+    }
+  });
+});
+
+describe("the editor", () => {
+  it("reports a dirty canvas on the editor route", () => {
+    useEditorStore.setState({ isDirty: true });
+
+    expect(workAt("/editor")).toEqual({ kind: "editor-dirty" });
+  });
+
+  it("reports a dirty canvas through a trailing slash", () => {
+    useEditorStore.setState({ isDirty: true });
+
+    expect(workAt("/editor/")).toEqual({ kind: "editor-dirty" });
+  });
+
+  it("reports a dirty canvas through an uppercase url", () => {
+    useEditorStore.setState({ isDirty: true });
+
+    expect(workAt("/Editor")).toEqual({ kind: "editor-dirty" });
+  });
+
+  it("reports nothing on a clean canvas", () => {
+    expect(workAt("/editor")).toBeNull();
+  });
+
+  it("does not leak a dirty canvas onto a tool route", () => {
+    useEditorStore.setState({ isDirty: true });
+
+    expect(workAt(TOOL_ROUTE)).toBeNull();
+  });
+});

--- a/tests/unit/web/use-work-in-flight.test.tsx
+++ b/tests/unit/web/use-work-in-flight.test.tsx
@@ -114,7 +114,7 @@ describe("an untaken result", () => {
 
     expect(workAt(TOOL_ROUTE)).toEqual({
       kind: "unsaved",
-      downloads: [{ kind: "result", url: "blob:result", filename: "a-compressed.png" }],
+      downloads: [{ kind: "result", index: 0, url: "blob:result", filename: "a-compressed.png" }],
     });
   });
 
@@ -124,7 +124,7 @@ describe("an untaken result", () => {
 
     expect(workAt(TOOL_ROUTE)).toEqual({
       kind: "unsaved",
-      downloads: [{ kind: "result", url: "blob:result", filename: "a.png" }],
+      downloads: [{ kind: "result", index: 0, url: "blob:result", filename: "a.png" }],
     });
   });
 
@@ -147,7 +147,7 @@ describe("an untaken result", () => {
 
     expect(workAt(TOOL_ROUTE)).toEqual({
       kind: "unsaved",
-      downloads: [{ kind: "result", url: "blob:two", filename: "two.png" }],
+      downloads: [{ kind: "result", index: 1, url: "blob:two", filename: "two.png" }],
     });
   });
 
@@ -162,7 +162,7 @@ describe("an untaken result", () => {
     expect(useFileStore.getState().entries[0].status).not.toBe("completed");
     expect(workAt(TOOL_ROUTE)).toEqual({
       kind: "unsaved",
-      downloads: [{ kind: "result", url: "blob:result", filename: "out.png" }],
+      downloads: [{ kind: "result", index: 0, url: "blob:result", filename: "out.png" }],
     });
   });
 });
@@ -234,7 +234,7 @@ describe("a batch zip", () => {
     expect(useFileStore.getState().batchZipClaimed).toBe(true);
     expect(workAt(TOOL_ROUTE)).toEqual({
       kind: "unsaved",
-      downloads: [{ kind: "result", url: "blob:rerun", filename: "rerun.png" }],
+      downloads: [{ kind: "result", index: 0, url: "blob:rerun", filename: "rerun.png" }],
     });
   });
 
@@ -280,7 +280,7 @@ describe("route scoping", () => {
 
     expect(workAt("/automate/")).toEqual({
       kind: "unsaved",
-      downloads: [{ kind: "result", url: "blob:result", filename: "a-compressed.png" }],
+      downloads: [{ kind: "result", index: 0, url: "blob:result", filename: "a-compressed.png" }],
     });
   });
 
@@ -292,7 +292,7 @@ describe("route scoping", () => {
 
     expect(workAt(`${TOOL_ROUTE}/`)).toEqual({
       kind: "unsaved",
-      downloads: [{ kind: "result", url: "blob:result", filename: "a-compressed.png" }],
+      downloads: [{ kind: "result", index: 0, url: "blob:result", filename: "a-compressed.png" }],
     });
   });
 
@@ -303,7 +303,7 @@ describe("route scoping", () => {
 
     expect(workAt("/IMAGE/Compress-Image")).toEqual({
       kind: "unsaved",
-      downloads: [{ kind: "result", url: "blob:result", filename: "a-compressed.png" }],
+      downloads: [{ kind: "result", index: 0, url: "blob:result", filename: "a-compressed.png" }],
     });
   });
 
@@ -322,7 +322,7 @@ describe("route scoping", () => {
     for (const section of SECTIONS.map((s) => s.id)) {
       expect(workAt(`/${section}/some-tool`)).toEqual({
         kind: "unsaved",
-        downloads: [{ kind: "result", url: "blob:result", filename: "a-compressed.png" }],
+        downloads: [{ kind: "result", index: 0, url: "blob:result", filename: "a-compressed.png" }],
       });
     }
   });

--- a/tests/unit/web/waveform-player-claim.test.tsx
+++ b/tests/unit/web/waveform-player-claim.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const imagePreviewMock = vi.hoisted(() => ({
+  needsServerPreview: vi.fn(() => false),
+  fetchDecodedPreview: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/image-preview", () => imagePreviewMock);
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+  getDistinctId: () => null,
+}));
+
+import { WaveformPlayer } from "@/components/common/waveform-player";
+import { useFileStore } from "@/stores/file-store";
+
+/** jsdom has no navigation, so let the click run but drop the default action. */
+function swallowNavigation(e: Event) {
+  e.preventDefault();
+}
+
+/**
+ * jsdom cannot decode audio, so WaveSurfer always fails and the player falls
+ * back to the download link this test is about.
+ */
+async function findFallbackLink(container: HTMLElement): Promise<HTMLElement> {
+  return await waitFor(() => {
+    const link = container.querySelector<HTMLAnchorElement>("a[download]");
+    if (!link) throw new Error("decode fallback not rendered yet");
+    return link;
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: () => "blob:fake",
+    revokeObjectURL: () => {},
+  });
+  document.addEventListener("click", swallowNavigation, true);
+  useFileStore.getState().reset();
+  useFileStore.getState().setFiles([new File(["x"], "a.mp3", { type: "audio/mpeg" })]);
+});
+
+afterEach(() => {
+  document.removeEventListener("click", swallowNavigation, true);
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("WaveformPlayer decode fallback download", () => {
+  it("claims the entry when the source is the result", async () => {
+    const { container } = render(
+      <WaveformPlayer
+        src="blob:result"
+        onDownload={() => useFileStore.getState().claimSelected()}
+      />,
+    );
+
+    fireEvent.click(await findFallbackLink(container));
+
+    expect(useFileStore.getState().entries[0].claimed).toBe(true);
+  });
+
+  it("leaves the entry unclaimed when the source is the original audio", async () => {
+    const { container } = render(<WaveformPlayer src="blob:original" />);
+
+    fireEvent.click(await findFallbackLink(container));
+
+    expect(useFileStore.getState().entries[0].claimed).toBe(false);
+  });
+});


### PR DESCRIPTION
Close the tab mid-export today and nothing stops you. Click another tool while a video is encoding and the run is gone, no prompt, no way back to it. This guards both.

It covers a run in flight, a finished result you have not downloaded or saved, and unsaved editor layers. Closing the tab raises the browser's own prompt. Navigating inside the app raises a dialog with Stay here, Leave anyway, and for a result, Download then leave.

The larger half of this change is working out what "unsaved" means. Every tool panel rendered its own download button, 55 of them, and not one recorded that the user took the file. So the first version of this guard would have warned you about a result you had already downloaded, on almost every tool in the app. They now share one `ResultDownloadLink` that claims on click, which deleted around 300 lines of copy-pasted anchor markup on the way past.

A claim also dies with the result it was made against. Download something, re-run the tool, and the new result starts unclaimed. That rule lives at the three places a result can change, because getting it wrong means the guard goes quiet on work the user has never seen. That is the expensive failure.

`useBlocker` throws without a data router, so `App.tsx` moved from `BrowserRouter` to `createBrowserRouter`. URLs are unchanged, and route ranking was checked against the real matcher across 19 paths rather than by reading. That move has a consequence worth knowing about. A data router wraps the root match in its own error boundary, which swallowed page errors before the app's boundary could report them, and react-router's production build prints a raw stack trace to the user. There is now an `ErrorBoundary` inside the layout route and an `onError` on `RouterProvider`, so crash telemetry still reaches Sentry.

Seven tools keep their results in their own stores rather than the file store, so the guard could not see them at all. It reads those stores now: split, pdf-to-image, collage, meme-generator, html-to-image, image-to-base64, find-duplicates. Three of them turned out to have a busy flag nobody had catalogued (`generating`, `capturing`, `scanning`), so they warn mid-run as well. These get Stay and Leave with no download button, because their results come in too many shapes to hand over uniformly and the warning is the part that matters.

Reading seven tool stores from one hook is the kind of thing that works today and rots on the next tool someone adds, so `tests/unit/web/nav-guard-tool-coverage.test.ts` resolves every tool in the catalog to its settings component through the registry, finds the 22 that bypass `useToolProcessor`, and fails unless each one is either guarded or on an exempt list with a reason. Adding a tool with its own store and no decision turns that test red. qr-generate and barcode-generate sit on the exempt list: their store holds the config you typed, not a result, and the image regenerates client-side.

`sign-pdf` was blind end to end, both result and progress local, so it now reports to the file store like any other tool. It gets the full treatment rather than warn-only: a warning mid-sign, a warning while the signed PDF is untaken, "Download, then leave", and its existing download button finally claims something. Writing a result there flips `hasProcessed`, which would have remounted the sign canvas on a new React key and thrown away the signatures the user had just placed, so `tool-page` now keeps the image area for `interactive-sign` either way.

Three tools stay invisible because their result lives in component state rather than a store, which the drift test cannot see: ocr, favicon and image-to-pdf. All three warn during the run, since they flip the file store's `processing`; what they miss is the window after the result lands. That half of #1111 stays open.

A whole-branch review after the per-commit ones found four things they could not see, all fixed here. `compare` writes the image it compares against into `processedUrl` so the slider can render it, so the guard was offering that as a download, named after the other input, and then silencing itself on the real diff; it is warn-only now. `passport-photo` was unguarded while the drift test reported green, because it imports `useToolProcessor` for an error field and never runs through it, so the predicate now requires an actual `processFiles` call and that tool has its own store read. `sign-pdf` gained the file-store `processing` flag last commit without the processor's teardown, so a stale response after unmount could clear the NEXT run's flag; its request is aborted on unmount now. And `/automate` had no reset on mount, so leaving a tool page mid-run left the flag set and warned on every navigation afterwards, which is the `/automate` half of #1122.

Right-click "Save link as" also does not count as taking a result. Claiming on `contextmenu` would trade a nag for silence, and silence is the failure that makes people stop trusting the dialog. Same reason the seven store-backed tools have no claim tracking: download a split zip, leave, and you will still be warned. Over-warning is the direction this whole feature is built to fail in.

Verified: lint, typecheck forced past the turbo cache, 9010 unit tests, 10154 integration, 473 chromium-serial, 1561 chromium, both app builds, license boundary. The two chromium failures reproduce byte-identically at the base commit, checked by building a worktree there and running them rather than assuming.

The webkit and firefox lanes are red on macOS (#912), around 55 failures. Base is 55, this branch is 56, every one of them the same `NS_BINDING_ABORTED` signature, and the eight that flip in each direction all sit inside the webkit lanes. Worth confirming on the linux lane rather than trusting a local run, because the pristine comparison only isolates the final commit and the router migration sits in both arms of it.

Follow-ups filed: #1110 jobs tray, #1111 component-state results, #1112 optimize-for-web preview, #1114 reorder versus captured index, #1115 Sentry-only instances, #1116 route table parser, #1117 URL stub, #1118 e2e gaps, #1122 stale processing flag, #1123 own-store claiming and reset.
