### PR TITLE
fix(image): expose every supported camera RAW format

### DIFF
--- a/apps/api/src/lib/file-storage.ts
+++ b/apps/api/src/lib/file-storage.ts
@@ -3,7 +3,7 @@ import { mkdir, open, readFile, statfs, unlink, writeFile } from "node:fs/promis
 import { basename, extname, isAbsolute, join } from "node:path";
 import type { Readable } from "node:stream";
 import type { S3StorageModule } from "@snapotter/enterprise";
-import { SafeError } from "@snapotter/shared";
+import { CAMERA_RAW_INPUTS, SafeError } from "@snapotter/shared";
 import { env } from "../config.js";
 
 const MIN_FREE_BYTES = 100 * 1024 * 1024;
@@ -41,12 +41,7 @@ const SAFE_STORAGE_EXTENSIONS = new Set([
   ".heif",
   ".jxl",
   ".ico",
-  ".dng",
-  ".cr2",
-  ".nef",
-  ".arw",
-  ".orf",
-  ".rw2",
+  ...CAMERA_RAW_INPUTS,
   ".tga",
   ".psd",
   ".exr",

--- a/apps/api/src/lib/file-validation.ts
+++ b/apps/api/src/lib/file-validation.ts
@@ -1,3 +1,4 @@
+import { CAMERA_RAW_INPUTS } from "@snapotter/shared";
 import sharp from "sharp";
 import { env } from "../config.js";
 import { isSvgBuffer } from "./svg-sanitize.js";
@@ -129,31 +130,7 @@ export interface ValidationError {
 }
 
 /** Camera RAW extensions that share TIFF magic bytes. */
-const RAW_EXTENSIONS = new Set([
-  "dng",
-  "cr2",
-  "cr3",
-  "nef",
-  "nrw",
-  "arw",
-  "orf",
-  "rw2",
-  "raf",
-  "pef",
-  "3fr",
-  "iiq",
-  "srw",
-  "x3f",
-  "rwl",
-  "gpr",
-  "fff",
-  "mrw",
-  "mef",
-  "kdc",
-  "dcr",
-  "erf",
-  "ptx",
-]);
+const RAW_EXTENSIONS = new Set(CAMERA_RAW_INPUTS.map((ext) => ext.slice(1)));
 
 /** Formats that Sharp cannot decode natively — skip dimension check. */
 const CLI_DECODED_FORMATS = new Set([

--- a/packages/shared/src/modality.ts
+++ b/packages/shared/src/modality.ts
@@ -27,6 +27,33 @@ export const MODALITY_POOL: Record<Modality, "image" | "media" | "docs"> = {
   file: "docs",
 };
 
+/** Camera RAW extensions supported by the image decoder (with dots). */
+export const CAMERA_RAW_INPUTS = [
+  ".dng",
+  ".cr2",
+  ".cr3",
+  ".nef",
+  ".nrw",
+  ".arw",
+  ".orf",
+  ".rw2",
+  ".raf",
+  ".pef",
+  ".3fr",
+  ".iiq",
+  ".srw",
+  ".x3f",
+  ".rwl",
+  ".gpr",
+  ".fff",
+  ".mrw",
+  ".mef",
+  ".kdc",
+  ".dcr",
+  ".erf",
+  ".ptx",
+] as const;
+
 // Default accepted input extensions per modality (with dots; drives the
 // file picker accept attribute and docs). Tools may narrow this.
 export const IMAGE_INPUTS = [
@@ -50,12 +77,7 @@ export const IMAGE_INPUTS = [
   ".tga",
   ".exr",
   ".hdr",
-  ".dng",
-  ".cr2",
-  ".nef",
-  ".arw",
-  ".orf",
-  ".rw2",
+  ...CAMERA_RAW_INPUTS,
   ".ppm",
   ".pgm",
   ".pbm",

--- a/tests/unit/api/file-storage.test.ts
+++ b/tests/unit/api/file-storage.test.ts
@@ -115,6 +115,15 @@ describe("saveFile", () => {
     }
   });
 
+  it("preserves every supported camera RAW extension", async () => {
+    const { CAMERA_RAW_INPUTS } = await import("@snapotter/shared");
+    const { saveFile } = await importModule();
+    for (const ext of CAMERA_RAW_INPUTS) {
+      const name = await saveFile(Buffer.from("x"), `photo${ext}`);
+      expect(name).toMatch(new RegExp(`\\${ext}$`));
+    }
+  });
+
   it("lowercases extensions", async () => {
     const { saveFile } = await importModule();
     const name = await saveFile(Buffer.from("x"), "PHOTO.PNG");

--- a/tests/unit/shared/modality-helpers.test.ts
+++ b/tests/unit/shared/modality-helpers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { TOOLS } from "../../../packages/shared/src/constants.js";
 import {
+  CAMERA_RAW_INPUTS,
+  IMAGE_INPUTS,
   modalityForExtension,
   toolInputModality,
   toolOutputModality,
@@ -23,6 +25,14 @@ describe("modalityForExtension", () => {
   it("is case-insensitive and tolerates a missing dot", () => {
     expect(modalityForExtension("PNG")).toBe("image");
     expect(modalityForExtension(".JPG")).toBe("image");
+  });
+  it("exposes every supported camera RAW extension through image tool metadata", () => {
+    const resizeInputs = tool("resize").acceptedInputs;
+    for (const ext of CAMERA_RAW_INPUTS) {
+      expect(IMAGE_INPUTS).toContain(ext);
+      expect(resizeInputs).toContain(ext);
+      expect(modalityForExtension(ext)).toBe("image");
+    }
   });
   it("returns null for unknown extensions", () => {
     expect(modalityForExtension(".xyz")).toBeNull();


### PR DESCRIPTION
## What does this PR do?

Makes the shared image input metadata expose all 23 camera RAW formats already supported by the API decoder, so formats such as CR3 and RAF are no longer rejected by the picker or drag-and-drop filter. It also reuses the same shared list for API validation and library storage to prevent the lists drifting again.

Fixes #1095

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New translation or i18n update
- [ ] Documentation update
- [ ] Test improvement
- [ ] Refactor (no functional change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/snapotter-hq/snapotter/blob/main/CONTRIBUTING.md)
- [ ] I have signed the [CLA](https://github.com/snapotter-hq/snapotter/blob/main/CLA.md) (the bot will prompt you if not)
- [x] My changes follow the project's code style (Biome passes)
- [x] I have added or updated tests for my changes
- [ ] All existing tests pass locally (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] My PR is focused on a single concern (under 400 lines of change)
- [x] I have not modified CI, release, or linter configuration files

## Validation

- `pnpm --filter @snapotter/shared typecheck`
- `pnpm --filter @snapotter/api typecheck`
- `pnpm --filter @snapotter/web typecheck`
- Biome on all touched files
- 175 shared/API validation tests
- focused storage regression for all 23 RAW extensions
- existing 67-test web dropzone suite and tool-registry/shared metadata suites

The full repository test command was not available on this Windows host because the stock Vitest global setup requires Docker-backed PostgreSQL and Redis. Focused tests ran without global services; the existing POSIX `chmod`/`EACCES` cases remain platform-specific.

## Screenshots (if applicable)

Not applicable; this changes accepted file extensions without changing layout.
