### PR TITLE
fix(search): surface favicon for ICO queries

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -162,6 +162,7 @@ const BASE_TOOLS: Tool[] = [
     id: "favicon",
     name: "Favicon Generator",
     description: "Generate all favicon and app icon sizes",
+    keywords: ["ico", "jpg to ico", "png to ico"],
     category: "optimization",
     icon: "AppWindow",
     route: "/favicon",

--- a/tests/unit/landing/tool-search.test.ts
+++ b/tests/unit/landing/tool-search.test.ts
@@ -338,6 +338,16 @@ describe("landing searchTools with real catalog metadata", () => {
     expect(result.results[0]?.item.id).toBe("pdf-to-jpg");
   });
 
+  it.each(["ico", "jpg to ico", "jpg2ico", "png to ico", "png2ico"])(
+    "surfaces the favicon tool for %s",
+    (query) => {
+      const result = searchTools(realTools, { query, modality: "all", limit: 5 });
+
+      expect(result.results[0]?.item.id).toBe("favicon");
+      expect(result.hasConfidentMatch).toBe(true);
+    },
+  );
+
   it("does not create confident results for same-format alias conversions", () => {
     const result = searchTools(realTools, { query: "jpg to jpeg", modality: "all", limit: 8 });
 

--- a/tests/unit/web/fuse-search.test.ts
+++ b/tests/unit/web/fuse-search.test.ts
@@ -15,6 +15,11 @@ describe("app fuzzy search finds converters by variation", () => {
     ["heic jpg", "heic-to-jpg"],
     ["mov mp4", "mov-to-mp4"],
     ["convert mp4 to mp3", "mp4-to-mp3"],
+    ["ico", "favicon"],
+    ["jpg to ico", "favicon"],
+    ["jpg2ico", "favicon"],
+    ["png to ico", "favicon"],
+    ["png2ico", "favicon"],
   ])("%s finds %s", (q, id) => {
     expect(search(q).slice(0, 5)).toContain(id);
   });


### PR DESCRIPTION
## What does this PR do?

Adds ICO-oriented search aliases to the existing favicon tool metadata, so the app and landing-page search surface that tool for `ico`, JPG-to-ICO, and PNG-to-ICO queries (including compact `jpg2ico`/`png2ico` forms).

Fixes #1100

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New translation or i18n update
- [ ] Documentation update
- [ ] Test improvement
- [ ] Refactor (no functional change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/snapotter-hq/snapotter/blob/main/CONTRIBUTING.md)
- [ ] I have signed the [CLA](https://github.com/snapotter-hq/snapotter/blob/main/CLA.md) (the bot will prompt you if not)
- [x] My changes follow the project's code style (Biome passes)
- [x] I have added or updated tests for my changes
- [ ] All existing tests pass locally (`pnpm test`)
- [ ] TypeScript compiles without errors (`pnpm typecheck`)
- [x] My PR is focused on a single concern (under 400 lines of change)
- [x] I have not modified CI, release, or linter configuration files

## Validation

- focused Vitest run for `tests/unit/web/fuse-search.test.ts` and `tests/unit/landing/tool-search.test.ts` (60 passed)
- `pnpm exec biome check packages/shared/src/constants.ts tests/unit/web/fuse-search.test.ts tests/unit/landing/tool-search.test.ts`
- `pnpm --filter @snapotter/shared typecheck`
- `pnpm --filter @snapotter/web typecheck`
- `pnpm --filter @snapotter/landing exec tsc --noEmit`

The full repository test and typecheck commands were not run in this sparse local checkout; the affected packages and search suites pass.

## Screenshots (if applicable)

Not applicable; this changes search metadata without changing layout.
